### PR TITLE
Detect content-type for error pages

### DIFF
--- a/src/tsd/HttpQuery.java
+++ b/src/tsd/HttpQuery.java
@@ -547,10 +547,7 @@ final class HttpQuery {
     }
     final DefaultHttpResponse response =
       new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
-    response.setHeader(HttpHeaders.Names.CONTENT_TYPE,
-                       (status == HttpResponseStatus.OK
-                        ? guessMimeType(buf)
-                        : HTML_CONTENT_TYPE));  // Error pages are in HTML.
+    response.setHeader(HttpHeaders.Names.CONTENT_TYPE, guessMimeType(buf));
     // TODO(tsuna): Server, X-Backend, etc. headers.
     response.setContent(buf);
     final boolean keepalive = HttpHeaders.isKeepAlive(request);


### PR DESCRIPTION
Originally error pages were all HTML so we could hard-code the content-type.  Now that we
can report errors via JSON, we have to detect the content type.
