### PR TITLE
webroot support

### DIFF
--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -99,6 +99,8 @@ final class TSDMain {
     argp.addOption("--auto-metric", "Automatically add metrics to tsdb as they"
                    + " are inserted.  Warning: this may cause unexpected"
                    + " metrics to be tracked");
+    argp.addOption("--webroot", "WEBROOT",
+                   "Web root path for all requests.");
     args = CliOptions.parse(argp, args);
     if (args == null || !argp.has("--port")
         || !argp.has("--staticroot") || !argp.has("--cachedir")) {
@@ -110,6 +112,11 @@ final class TSDMain {
 
     if (argp.has("--auto-metric")) {
       System.setProperty("tsd.core.auto_create_metrics", "true");
+    }
+
+    final String webRoot = argp.get("--webroot", "");
+    if (webRoot.length() > 0 && !webRoot.matches("^(/[a-zA-Z0-9_-]+)+$")) {
+      usage(argp, "Invalid webroot: " + webRoot, 3);
     }
 
     final short flush_interval = getFlushInterval(argp);
@@ -135,7 +142,7 @@ final class TSDMain {
       registerShutdownHook(tsdb);
       final ServerBootstrap server = new ServerBootstrap(factory);
 
-      server.setPipelineFactory(new PipelineFactory(tsdb));
+      server.setPipelineFactory(new PipelineFactory(tsdb, webRoot));
       server.setOption("child.tcpNoDelay", true);
       server.setOption("child.keepAlive", true);
       server.setOption("reuseAddress", true);

--- a/src/tsd/PipelineFactory.java
+++ b/src/tsd/PipelineFactory.java
@@ -51,10 +51,11 @@ public final class PipelineFactory implements ChannelPipelineFactory {
   /**
    * Constructor.
    * @param tsdb The TSDB to use.
+   * @param webRoot The web root to use.
    */
-  public PipelineFactory(final TSDB tsdb) {
+  public PipelineFactory(final TSDB tsdb, final String webRoot) {
     this.tsdb = tsdb;
-    this.rpchandler = new RpcHandler(tsdb);
+    this.rpchandler = new RpcHandler(tsdb, webRoot);
   }
 
   @Override

--- a/src/tsd/client/QueryUi.java
+++ b/src/tsd/client/QueryUi.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Date;
 
 import com.google.gwt.core.client.EntryPoint;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.DomEvent;
@@ -701,7 +702,7 @@ public class QueryUi implements EntryPoint {
             msg += "Cache hit (" + cachehit.isString().stringValue() + "). ";
           }
           if (nplotted != null && nplotted.isNumber().doubleValue() > 0) {
-            graph.setUrl(uri + "&png");
+            graph.setUrl(addWebRoot(uri) + "&png");
             graph.setVisible(true);
             msg += result.get("points").isNumber() + " points retrieved, "
               + nplotted + " points plotted";
@@ -783,8 +784,13 @@ public class QueryUi implements EntryPoint {
     return found_metric;
   }
 
+  static String addWebRoot(final String url) {
+    // URLs passed to this method always begin with a slash
+    return GWT.getHostPageBaseURL() + url.substring(1);
+  }
+
   private void asyncGetJson(final String url, final GotJsonCallback callback) {
-    final RequestBuilder builder = new RequestBuilder(RequestBuilder.GET, url);
+    final RequestBuilder builder = new RequestBuilder(RequestBuilder.GET, addWebRoot(url));
     try {
       builder.sendRequest(null, new RequestCallback() {
         public void onError(final Request request, final Throwable e) {

--- a/src/tsd/client/RemoteOracle.java
+++ b/src/tsd/client/RemoteOracle.java
@@ -145,7 +145,7 @@ final class RemoteOracle extends SuggestOracle {
     }
 
     final RequestBuilder builder = new RequestBuilder(RequestBuilder.GET,
-      SUGGEST_URL + type + "&q=" + last_query);
+      QueryUi.addWebRoot(SUGGEST_URL) + type + "&q=" + last_query);
     try {
       builder.sendRequest(null, new RequestCallback() {
         public void onError(final com.google.gwt.http.client.Request r,


### PR DESCRIPTION
this patch allows the tsd gwt web gui to be started under a URL prefix, like this:

./src/tsd --webroot=/tsd

then the home url becomes:

http://tsdhost:4242/tsd/

instead of http://tsdhost:4242/

All static content and ajax requests are also directed under the URL prefix.

The motivation for this is as follows - I want to expose my opentsd instance to the outside world, on port 80 through my apache web server. I cannot run opentsdb on port 80, because I have other services provided by apache on port 80 that I need. Using the webroot option, I can easily setup apache's http proxy module to redirect requests for the /tsd location to opentsdb at localhost:4242.
