### PR TITLE
SVG support

### DIFF
--- a/src/tsd/client/QueryUi.java
+++ b/src/tsd/client/QueryUi.java
@@ -121,6 +121,7 @@ public class QueryUi implements EntryPoint {
 
   private final Image graph = new Image();
   private final Label graphstatus = new Label();
+  private final Anchor graphsvglink = new Anchor("Download SVG", "javascript:;", "_blank");
   /** Remember the last URI requested to avoid requesting twice the same. */
   private String lastgraphuri;
 
@@ -354,12 +355,18 @@ public class QueryUi implements EntryPoint {
     graphpanel.add(decorator);
     {
       final VerticalPanel graphvbox = new VerticalPanel();
-      graphvbox.add(graphstatus);
+      final HorizontalPanel graphstatushbox = new HorizontalPanel();
+      graphstatushbox.setSpacing(3);
+      graphvbox.add(graphstatushbox);
+      graphstatushbox.add(graphstatus);
+      graphsvglink.setVisible(false);
+      graphstatushbox.add(graphsvglink);
       graph.setVisible(false);
       graphvbox.add(graph);
       graph.addErrorHandler(new ErrorHandler() {
         public void onError(final ErrorEvent event) {
           graphstatus.setText("Oops, failed to load the graph.");
+          graphsvglink.setVisible(false);
         }
       });
       graphpanel.add(graphvbox);
@@ -697,16 +704,20 @@ public class QueryUi implements EntryPoint {
           clearError();
           final JSONValue nplotted = result.get("plotted");
           final JSONValue cachehit = result.get("cachehit");
+          final JSONValue terminal = result.get("terminal");
           if (cachehit != null) {
             msg += "Cache hit (" + cachehit.isString().stringValue() + "). ";
           }
           if (nplotted != null && nplotted.isNumber().doubleValue() > 0) {
-            graph.setUrl(uri + "&png");
+            graph.setUrl(uri + "&" + terminal.isString().stringValue());
             graph.setVisible(true);
             msg += result.get("points").isNumber() + " points retrieved, "
               + nplotted + " points plotted";
+            graphsvglink.setHref(uri + "&svg");
+            graphsvglink.setVisible(true);
           } else {
             graph.setVisible(false);
+            graphsvglink.setVisible(false);
             msg += "Your query didn't return anything";
           }
           final JSONValue timing = result.get("timing");
@@ -840,6 +851,7 @@ public class QueryUi implements EntryPoint {
               pending_requests = 0;
             }
             graphstatus.setText("");
+            graphsvglink.setVisible(false);
           }
         }
       });


### PR DESCRIPTION
This patch adds support for downloading TSD graphs in SVG format. When a graph is generated, a "Download SVG" link appears next to the message "xxx points plotted in xxx ms."
This is useful for exporting a graph to embed inside a presentation or PDF where a resolution-independent vector graphic format is preferrable to PNG.

I considered adding a drop-down to select between PNG/SVG for the in-place graph. There is a problem, however, when dealing with graphs with lots of points - gnuplot will easily plot 1 million points to a PNG within a couple of dozen seconds (this happens to me frequently, when I expand the time range before downsampling).
While gnuplot will also happily generate an SVG with 1 million datapoints, there are 2 problems:
- the svg will be extremely large
- in my testing most browsers take a minute or more to render an svg with 100K datapoints, IE9 downright freezes

So, ideally the link will display a warning before submitting a request for an SVG with too many datapoints. This is not in the patch, however.

On the server-side SVG download is backed by extensible support for different gnuplot terminal types. Support is restricted to png and svg at this point, but support for additional terminals can be easily enabled by modifying Plot.SUPPORTED_TERMINALS and (if necessary) Plot.getFileExtensionForTerminal(). This takes you 99% of the way to full support, with the remaining 1% being the mime-type detection code and help message of the command-line tool and whatever else it is that I am forgetting.

Cheers,
-Nikolay
