### PR TITLE
Added a success sign off to telnet put

### DIFF
--- a/src/tsd/PutDataPointRpc.java
+++ b/src/tsd/PutDataPointRpc.java
@@ -53,7 +53,13 @@ final class PutDataPointRpc implements TelnetRpc {
           return "report error to channel";
         }
       }
-      return importDataPoint(tsdb, cmd).addErrback(new PutErrback());
+
+      Deferred<Object> result = importDataPoint(tsdb, cmd).addErrback(new PutErrback());
+      if(chan.isConnected()) {
+        chan.write("ok");
+      }
+
+      return result;
     } catch (NumberFormatException x) {
       errmsg = "put: invalid value: " + x.getMessage() + '\n';
       invalid_values.incrementAndGet();


### PR DESCRIPTION
When coding against the telent interface the only way I knew a record was added successfully was the absence of an error message. This meant sending a 'put' operation then attempting to read from the socket and timing out after some duration to give the db an opportunity to respond with an error if there was one. This allows me to write and read in transactional sets.
