### PR TITLE
Add 'xformat' query parameter

### DIFF
--- a/src/graph/Plot.java
+++ b/src/graph/Plot.java
@@ -223,8 +223,6 @@ public final class Plot {
         .append(Short.toString(height)).append("\n"
                 + "set xdata time\n"
                 + "set timefmt \"%s\"\n"
-                + "set format x \"").append(xFormat())
-                                    .append("\"\n"
                 + "set xtic rotate\n"
                 + "set output \"").append(basepath + ".png").append("\"\n"
                 + "set xrange [\"")
@@ -232,6 +230,9 @@ public final class Plot {
         .append("\":\"")
         .append(String.valueOf(end_time + utc_offset))
         .append("\"]\n");
+      if (!params.containsKey("format x")) {
+        gp.append("set format x \"").append(xFormat()).append("\"\n");
+      }
       final int nseries = datapoints.size();
       if (nseries > 0) {
         gp.write("set grid\n"

--- a/src/tsd/GraphHandler.java
+++ b/src/tsd/GraphHandler.java
@@ -663,6 +663,9 @@ final class GraphHandler implements HttpRpc {
     if ((value = popParam(querystring, "y2format")) != null) {
       params.put("format y2", stringify(value));
     }
+    if ((value = popParam(querystring, "xformat")) != null) {
+      params.put("format x", stringify(value));
+    }
     if ((value = popParam(querystring, "ylog")) != null) {
       params.put("logscale", "y");
     }


### PR DESCRIPTION
This parameter passes down to gnuplot as 'format x' and overrides the default, allowing users to specify a custom X axis format.  This is not currently exposed in the UI.

This is for issue #28.
