### PR TITLE
Fix fetchdep to work when MKDIR_P is a relative path

### DIFF
--- a/build-aux/fetchdep.sh.in
+++ b/build-aux/fetchdep.sh.in
@@ -7,6 +7,10 @@ CURL="@CURL@"
 # The ".." is because we need to go out of the build-aux directory.
 srcdir="@abs_srcdir@/.."
 
+case $MKDIR_P in
+  .*) MKDIR_P=`dirname $0`/$MKDIR_P ;;
+esac
+
 f=`basename "$2"`
 d=`dirname "$2"`
 


### PR DESCRIPTION
On my development env (OS X 10.6) MKDIR_P was set to
"../../build-aux/install-sh -c -d", however this script is not called
from the directory that it's in so the relative path does not resolve.
