### PR TITLE
Just some minor portability fixes

### DIFF
--- a/build-aux/fetchdep.sh.in
+++ b/build-aux/fetchdep.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 # Getting this value out of Autoconf is not a good idea, because it might be
 # set to a relative path to install-sh.  We don't install `install-sh' during

--- a/build-aux/gen_build_data.sh
+++ b/build-aux/gen_build_data.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Generates BuildData.java
 # Usage: gen_build_data.sh path/to/BuildData.java my.package.name
 # Author: Benoit Sigoure (tsuna@stumbleupon.com)

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Set this to be GNU make.
+MAKE=${MAKE-'make'}
+
 set -xe
 test -f configure || ./bootstrap
 test -d build || mkdir build
 cd build
 test -f Makefile || ../configure "$@"
-exec make "$@"
+exec ${MAKE} "$@"

--- a/tsdb.in
+++ b/tsdb.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 me=${0##*/}


### PR DESCRIPTION
This will allow building of OpenTSDB on systems where
/bin/sh != bash and make != GNUmake.
