### PR TITLE
tightening up tsdb.in a little more!

### DIFF
--- a/tsdb.in
+++ b/tsdb.in
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 set -e
-me=`basename "$0"`
-mydir=`dirname "$0"`
+me="$(basename "$0")"
+mydir="$(dirname "$0")"
 # Either:
 #  abs_srcdir and abs_builddir are set: we're running in a dev tree
 #  or pkgdatadir is set: we've been installed, we respect that.
@@ -12,17 +12,17 @@ pkgdatadir='@pkgdatadir@'
 # Either we've been installed and pkgdatadir exists, or we haven't been
 # installed and abs_srcdir / abs_builddir aren't empty.
 test -d "$pkgdatadir" || test -n "$abs_srcdir$abs_builddir" || {
-  echo >&2 "$me: Uh-oh, \`$pkgdatadir' doesn't exist, is OpenTSDB properly installed?"
+  echo >&2 "${me}: Uh-oh, \`${pkgdatadir}' doesn't exist, is OpenTSDB properly installed?"
   exit 1
 }
 
 if test -n "$pkgdatadir"; then
   localdir="$pkgdatadir"
   for jar in "$pkgdatadir"/*.jar; do
-    CLASSPATH="$CLASSPATH:$jar"
+    CLASSPATH="${CLASSPATH}:${jar}"
   done
   # Add pkgdatadir itself so we can find logback.xml
-  CLASSPATH="$CLASSPATH:$pkgdatadir"
+  CLASSPATH="${CLASSPATH}:${pkgdatadir}"
 else
   localdir="$abs_builddir"
   # If we're running out of the build tree, it's especially important that we
@@ -32,26 +32,26 @@ else
   # specific version of each jar prevents this problem.
   # TODO(tsuna): Once we jarjar all the dependencies together, this will no
   # longer be an issue.  See issue #23.
-  for jar in `make -C "$abs_builddir" printdeps | sed '/third_party.*jar/!d'`; do
+  for jar in $(make -C "$abs_builddir" printdeps | sed '/third_party.*jar/!d'); do
     for dir in "$abs_builddir" "$abs_srcdir"; do
-      test -f "$dir/$jar" && CLASSPATH="$CLASSPATH:$dir/$jar" && continue 2
+      test -f "${dir}/${jar}" && CLASSPATH="${CLASSPATH}:${dir}/${jar}" && continue 2
     done
-    echo >&2 "$me: error: Couldn't find \`$jar' either under \`$abs_builddir' or \`$abs_srcdir'."
+    echo >&2 "${me}: error: Couldn't find \`${jar}' either under \`${abs_builddir}' or \`${abs_srcdir}'."
     exit 2
   done
   # Add the src dir so we can find logback.xml
-  CLASSPATH="$CLASSPATH:$abs_srcdir/src"
+  CLASSPATH="${CLASSPATH}:${abs_srcdir}/src"
 fi
 # Remove any leading colon.
 CLASSPATH="${CLASSPATH#:}"
 
 usage() {
-  echo >&2 "usage: $me <command> [args]"
+  echo >&2 "usage: ${me} <command> [args]"
   echo 'Valid commands: fsck, import, mkmetric, query, tsd, scan, uid'
   exit 1
 }
 
-case $1 in
+case "$1" in
   (fsck)
     MAINCLASS=Fsck
     ;;
@@ -76,7 +76,7 @@ case $1 in
     MAINCLASS=UidManager
     ;;
   (*)
-    echo >&2 "$me: error: unknown command '$1'"
+    echo >&2 "${me}: error: unknown command '${1}'"
     usage
     ;;
 esac
@@ -84,5 +84,5 @@ shift
 
 JAVA=${JAVA-'java'}
 JVMARGS=${JVMARGS-'-enableassertions -enablesystemassertions'}
-test -r "$localdir/tsdb.local" && . "$localdir/tsdb.local"
-exec $JAVA $JVMARGS -classpath "$CLASSPATH" net.opentsdb.tools.$MAINCLASS "$@"
+test -r "${localdir}/tsdb.local" && . "${localdir}/tsdb.local"
+exec $JAVA $JVMARGS -classpath "$CLASSPATH" "net.opentsdb.tools.${MAINCLASS}" "$@"


### PR DESCRIPTION
cleaner looking command substitution,  and added more parameter expansion for safety in `tsdb.in`.

This is a small commit to tighten up some quoting in the `tsdb.in` script.  I also added more parameter expansion stuff just to be safe and ensure variables aren't misinterpreted.
