### PR TITLE
Fix for issue #92 - 'logscale' for both y axes takes duplicate hashmap key.

### DIFF
--- a/src/tsd/GraphHandler.java
+++ b/src/tsd/GraphHandler.java
@@ -669,10 +669,10 @@ final class GraphHandler implements HttpRpc {
       params.put("format x", stringify(value));
     }
     if ((value = popParam(querystring, "ylog")) != null) {
-      params.put("logscale", "y");
+      params.put("logscale y", "");
     }
     if ((value = popParam(querystring, "y2log")) != null) {
-      params.put("logscale", "y2");
+      params.put("logscale y2", "");
     }
     if ((value = popParam(querystring, "key")) != null) {
       params.put("key", value);


### PR DESCRIPTION
This is a fix for #92, where 'logscale' key in params hashmap for y1 axis is overridden whenever y2 logscale checkbox is also selected.
