### PR TITLE
Fix for 30d integer overflow in DateTimeBox.

### DIFF
--- a/src/tsd/client/DateTimeBox.java
+++ b/src/tsd/client/DateTimeBox.java
@@ -75,7 +75,7 @@ final class DateTimeBox extends DateBox {
             case 'y': interval *= 3600 * 24 * 365; break;  // years
           }
           final Date d = new Date();
-          d.setTime(d.getTime() - interval * 1000);
+          d.setTime(d.getTime() - interval * 1000L);
           return d;
         } else if (text.length() == 5) {  // "HH:MM"
           try {
@@ -156,7 +156,7 @@ final class DateTimeBox extends DateBox {
             }
             d = new Date();
           }
-          d.setTime(d.getTime() + seconds * 1000);
+          d.setTime(d.getTime() + seconds * 1000L);
           d.setSeconds(0);
           setDate(d);
         }


### PR DESCRIPTION
When selecting the 30d in TSD's DateTimeBox in the UI, the date shifts by over 500 years instead of the expected 30 days. This is due to an integer overflow in the following piece of code:

```
d.setTime(d.getTime() + seconds * 1000);
```

where `seconds` is declared as an integer. 30 days in seconds multiplied by 1k equals to 2,592,000,000 seconds. The integer range ends at 2,147,483,647, hence the overflow.

Changing 1000 to 1000L returns long as opposed to integer product and fixes the issue.
