### PR TITLE
allow to specify number of threads usable by netty for asynchronous io

### DIFF
--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -95,7 +95,7 @@ final class TSDMain {
                    "Web root from which to serve static files (/s URLs).");
     argp.addOption("--cachedir", "PATH",
                    "Directory under which to cache result of requests.");
-    argp.addOption("--workers", "NUM",
+    argp.addOption("--worker-threads", "NUM",
                    "Number for async io workers (default: cpu * 2).");
     argp.addOption("--async-io", "true|false",
                    "Use async NIO (default true) or traditional blocking io");
@@ -122,7 +122,8 @@ final class TSDMain {
     final ServerSocketChannelFactory factory;
     if (argp.get("--async-io", "true").equalsIgnoreCase("true")) {
       final int workers = Integer.parseInt(
-              argp.get("--workers", Integer.toString(Runtime.getRuntime().availableProcessors() * 2)));
+              argp.get("--worker-threads",
+                      "" + Runtime.getRuntime().availableProcessors() * 2));
       factory = new NioServerSocketChannelFactory(Executors.newCachedThreadPool(),
                                                   Executors.newCachedThreadPool(),
                                                   workers);


### PR DESCRIPTION
Rationale:
1. Typically, tsdb can be collocated with hbase, but with default cpu \* 2 number of workers and high input rate tsdb eats all cpus, leaving no room for hbase.
2. It can be too much cpus on box to give them all to tsdb (netty), so it is more wise to restrict number of tsdb workers to some reasonable value.
