### PR TITLE
Drop redundant call to AC_PROG_MKDIR_P

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,8 +22,6 @@ AC_CONFIG_FILES([
 ])
 AC_CONFIG_FILES([build-aux/fetchdep.sh], [chmod +x build-aux/fetchdep.sh])
 
-# For people with Automake <= 1.9.6
-AC_PROG_MKDIR_P
 TSDB_FIND_PROG([md5], [md5sum md5 gmd5sum digest])
 if test x`basename "$MD5"` = x'digest'; then
   MD5='digest -a md5'


### PR DESCRIPTION
This reverts commit fc792d9edf4cb8b08cbad5bdf349a0c5b99228e6.

After 70b8d1c, Automake's mkdir_p is now used. Automake provides mkdir_p
via AM_INIT_AUTOMAKE since 1.7b [1]; Automake >= 1.10 provides mkdir_p too,
by wrapping around Autoconf's MKDIR_P (via AC_PROG_MKDIR_P) [2]. Thus we
need not call anything to provide mkdir_p.

[1] http://git.savannah.gnu.org/cgit/automake.git/tree/ChangeLog?id=Release-1-7b#n51
[2] http://git.savannah.gnu.org/cgit/automake.git/tree/ChangeLog?id=Release-1-9b#n219

This also benefits older Autoconfs (ie. < 2.60) which do not provide
AC_PROG_MKDIR_P.

Tested on:
- Solaris, Autoconf 2.59, Automake 1.8.3
- Ubuntu,  Autoconf 2.68, Automake 1.11.3
