### PR TITLE
2.0 Forwards TSDB Table Compatability

### DIFF
--- a/src/core/Span.java
+++ b/src/core/Span.java
@@ -86,6 +86,8 @@ final class Span implements DataPoints {
    */
   void addRow(final KeyValue row) {
     long last_ts = 0;
+    if (row == null)
+      return;
     if (rows.size() != 0) {
       // Verify that we have the same metric id and tags.
       final byte[] key = row.key();


### PR DESCRIPTION
Patch to properly avoid future types of data stored in the tsdb table preparation for 2.0. Annotations will be stored with a 3 byte qualifier in the same row with their associated timeseries. For backwards compatibility, if a user tries 2.0 and decides to downgrade, or run an instance of 1.1 alongside 2.0, they can do so without affecting their data. This patch allows for proper compaction of cell data and leaves future types alone.
