### PR TITLE
RPM spec file

### DIFF
--- a/opentsdb.spec.in
+++ b/opentsdb.spec.in
@@ -1,0 +1,60 @@
+Name:		@PACKAGE@
+Version:	@VERSION@
+Release:	1
+Summary:	A scalable, distributed Time Series Database
+Packager:	@PACKAGE_BUGREPORT@
+BuildArch:	noarch
+ExclusiveArch:	noarch
+ExclusiveOS:	linux
+Group:		Service/Management
+License:	GNU Lesser GPL
+URL:		http://opentsdb.net
+Source:		https://opentsdb.googlecode.com/files/opentsdb-1.1.0_rc1.tar.gz
+BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
+BuildRequires:	gnuplot
+BuildRequires:	autoconf
+BuildRequires:	make
+BuildRequires:	git
+Requires:	gnuplot
+
+%description
+OpenTSDB is a distributed, scalable Time Series Database (TSDB) written on top of HBase. OpenTSDB was written to address a common need: store, index and serve metrics collected from computer systems (network gear, operating systems, applications) at a large scale, and make this data easily accessible and graphable.
+Thanks to HBase's scalability, OpenTSDB allows you to collect many thousands of metrics from thousands of hosts and applications, at a high rate (every few seconds). OpenTSDB will never delete or downsample data and can easily store billions of data points. As a matter of fact, StumbleUpon uses it to keep track of hundred of thousands of time series and collects over 1 billion data points per day in their main production datacenter. Other sites such as Box or Tumblr are pushing tens of billions of data points per day.
+
+Imagine having the ability to quickly plot a graph showing the number of DELETE statements going to your MySQL database along with the number of slow queries and temporary files created, and correlate this with the 99th percentile of your service's latency. OpenTSDB makes generating such graphs on the fly a trivial operation, while manipulating millions of data point for very fine grained, real-time monitoring.
+
+
+%prep
+%setup -q
+
+
+%build
+cd $RPM_BUILD_DIR/%{name}-%{version}
+./build.sh
+
+
+%install
+rm -rf %{buildroot}
+cd $RPM_BUILD_DIR/%{name}-%{version}/build
+make install DESTDIR=%{buildroot}
+mkdir -p %{buildroot}/var/cache/opentsdb
+
+
+%clean
+rm -rf %{buildroot}
+
+
+%files
+%defattr(644,root,root,755)
+%attr(0755,root,root) /usr/local/bin/*
+%attr(0755,root,root) /usr/local/share/opentsdb/*.sh
+%doc
+/usr/local/share/opentsdb
+/usr/local/bin/tsdb
+%dir /var/cache/opentsdb
+
+
+
+%changelog
+


### PR DESCRIPTION
Added an RPM spec file to the build. It is important to note that the version that the RPM spec file uses cannot contain the "-" character. So going forward if there is an RC or some other tag it should probably be separated by an "_".
