### PR TITLE
Update download URL for junit

### DIFF
--- a/third_party/junit/include.mk
+++ b/third_party/junit/include.mk
@@ -15,7 +15,7 @@
 
 JUNIT_VERSION := 4.10
 JUNIT := third_party/junit/junit-$(JUNIT_VERSION).jar
-JUNIT_BASE_URL := http://cloud.github.com/downloads/KentBeck/junit
+JUNIT_BASE_URL := https://github.com/downloads/junit-team/junit
 
 $(JUNIT): $(JUNIT).md5
 	set dummy "$(JUNIT_BASE_URL)" "$(JUNIT)"; shift; $(FETCH_DEPENDENCY)


### PR DESCRIPTION
Kent Beck has transfered ownership of the repo to junit-team yesterday.

Closes #158.
