### PR TITLE
Added count aggregator.

### DIFF
--- a/src/core/Aggregators.java
+++ b/src/core/Aggregators.java
@@ -36,6 +36,9 @@ public final class Aggregators {
   /** Aggregator that returns the Standard Deviation of the data points. */
   public static final Aggregator DEV = new StdDev();
 
+  /** Aggregator that returns the number of data points. */
+  public static final Aggregator COUNT = new Count();
+
   /** Maps an aggregator name to its instance. */
   private static final HashMap<String, Aggregator> aggregators;
 
@@ -46,6 +49,7 @@ public final class Aggregators {
     aggregators.put("max", MAX);
     aggregators.put("avg", AVG);
     aggregators.put("dev", DEV);
+    aggregators.put("count", COUNT);
   }
 
   private Aggregators() {
@@ -242,4 +246,30 @@ public final class Aggregators {
     }
   }
 
+  private static final class Count implements Aggregator {
+
+    @Override
+    public long runLong(Longs values) {
+      long result = 0;
+      while (values.hasNextValue()) {
+        values.nextLongValue();
+        result++;
+      }
+      return result;
+    }
+
+    @Override
+    public double runDouble(Doubles values) {
+      double result = 0;
+      while (values.hasNextValue()) {
+        values.nextDoubleValue();
+        result++;
+      }
+      return result;
+    }
+
+    public String toString() {
+      return "count";
+    }
+  }
 }


### PR DESCRIPTION
What do you think of integrating a `count()` aggregator?

I don't have relevant use case as a global aggregator, but I think it makes senses when downsampling, sometimes. For example, if you're plotting query latencies, you might want to consider min/max/avg/dev over a time period, but you might also want to check the number of requests you've processed.