### PR TITLE
Add bmargin to params

### DIFF
--- a/src/tsd/GraphHandler.java
+++ b/src/tsd/GraphHandler.java
@@ -686,6 +686,9 @@ final class GraphHandler implements HttpRpc {
     if ((value = popParam(querystring, "fgcolor")) != null) {
       params.put("fgcolor", value);
     }
+    if ((value = popParam(querystring, "bmargin")) != null) {
+      params.put("bmargin", value);
+    }
     if ((value = popParam(querystring, "smooth")) != null) {
       params.put("smooth", value);
     }


### PR DESCRIPTION
Workaround for #107. Adds bmargin to the set of query parameters understood by tsd, so you can set it from upstream.
