### PR TITLE
Set Aggregated Tags json field to match API docs

### DIFF
--- a/src/tsd/HttpJsonSerializer.java
+++ b/src/tsd/HttpJsonSerializer.java
@@ -499,7 +499,7 @@ class HttpJsonSerializer extends HttpSerializer {
           }
           json.writeEndObject();
           
-          json.writeFieldName("aggregateTags");
+          json.writeFieldName("aggregated_tags");
           json.writeStartArray();
           if (dps.getAggregatedTags() != null) {
             for (String atag : dps.getAggregatedTags()) {


### PR DESCRIPTION
http://opentsdb.net/docs/build/html/api_http/serializers/json.html#response

Either the docs or the code for this JSON field needs to be modified so they match.

As of this post
- API Docs = `aggregated_tags`
- Code = `aggregateTags`
