### PR TITLE
Force utf8 encoding in the javac args

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -226,7 +226,7 @@ package_dir := $(subst .,/,$(package))
 UNITTESTS := $(test_SRC:test/%.java=$(package_dir)/%.class)
 PLUGINTESTS := $(test_plugin_SRC:test/%.java=$(package_dir)/%.class)
 PLUGINSVCS := $(test_plugin_SVCS:%=-C $(srcdir)/test %)
-AM_JAVACFLAGS = -Xlint -source 6
+AM_JAVACFLAGS = -Xlint -source 6 -encoding utf-8
 JVM_ARGS =
 classes := $(tsdb_SRC:src/%.java=$(package_dir)/%.class) \
         $(builddata_SRC:src/%.java=$(package_dir)/%.class)


### PR DESCRIPTION
I am working on a (Opscode) Chef cookbook to build opentsdb from source to ease the inhouse usage for our developpers.

I found an odd behaviour when compiling the **next** branch inside a chef run, where a lot of errors like "error: unmappable character for encoding ASCII" occured on some unit tests  (in TestJSON.java).

What is odd is that if I ssh into my VM and launch the build, everything is fine. If the build is part of a chef run, it fails (and yes, the **LANG** env var is set to **en_US.UTF-8** in all cases)

The patch that consists in adding **-encoding utf-8** to the javac flags fixes it.

As the unit tests explicitly use utf-8 encoded .java files, I'd like to propose this patch for everyone
