### PR TITLE
fix check_tsd -c/-w options logic

### DIFF
--- a/tools/check_tsd
+++ b/tools/check_tsd
@@ -143,7 +143,7 @@ def main(argv):
       return 2
 
     # if failure...
-    if res.status != 200:
+    if res.status not in (200, 202):
         print ('CRITICAL: status = %d when talking to %s:%d'
                % (res.status, options.host, options.port))
         if options.verbose:


### PR DESCRIPTION
it should fail only if both are None, not the other way around
