### PR TITLE
Request for merge for change that ignores data points that utilize undefined tag values, tag keys, or metric names as opposed to throwing an exception (optional based on query string param)

### DIFF
--- a/src/tsd/GraphHandler.java
+++ b/src/tsd/GraphHandler.java
@@ -342,7 +342,7 @@ final class GraphHandler implements HttpRpc {
     qs.remove("png");
     qs.remove("json");
     qs.remove("ascii");
-    qs.remove("silent");
+    qs.remove("ignore_unknown_tags");
     return cachedir + Integer.toHexString(qs.hashCode());
   }
 
@@ -862,7 +862,7 @@ final class GraphHandler implements HttpRpc {
         // and not results returned for it, as if a tag key, tag value
         // or metric name does not exists there can be no matching
         // data points.
-        if (!query.hasQueryStringParam("silent")) {
+        if (!query.hasQueryStringParam("ignore_unknown_tags")) {
           throw new BadRequestException(e.getMessage());
         } else {
           tsdbquery = null;


### PR DESCRIPTION
## Overview

This change adds a query string parameter, 'silent'. If present then any query that contains a tag key, tag value, or metric name that has not been registered in TSDB is ignored (dropped) as opposed to throwing an exception. Thus an entire query will not fail if a member of it has one of these values that does not exist.
## Justification

A query that specifies tag information or a metric name does not need to fail and should instead return no data as this is essentially the same as specifying a filter that does not match any targets and thus should be treated as that way.

This is very helpful when you are using OpenTSDB to collect data and at time of query you can not determine if a given metric or tag pair has been added (--auto-metric). 

This is also helpful when a single query contains multiple data points some of which are valid (i.e. have valid tag / metric information) and some don't. Instead of the whole query failing, valid data is returned for those data points for which the filter matches targets.
## Backward Compatibility

This capability is activated by the presence of a 'silent' option on the end of the query string, i.e. '&silent'. Thus if this option is not include the existing behavior (exception) will be the default.
