### PR TITLE
Updates to debian init script

### DIFF
--- a/build-aux/deb/init.d/opentsdb
+++ b/build-aux/deb/init.d/opentsdb
@@ -29,7 +29,8 @@ MAX_OPEN_FILES=65535
 JDK_DIRS="/usr/lib/jvm/java-7-oracle /usr/lib/jvm/java-7-openjdk \
    /usr/lib/jvm/java-7-openjdk-amd64/ /usr/lib/jvm/java-7-openjdk-i386/ \
    /usr/lib/jvm/java-6-sun /usr/lib/jvm/java-6-openjdk \
-   /usr/lib/jvm/java-6-openjdk-amd64 /usr/lib/jvm/java-6-openjdk-i386"
+   /usr/lib/jvm/java-6-openjdk-amd64 /usr/lib/jvm/java-6-openjdk-i386 \
+   /usr/lib/jvm/default-java"
 
 # Look for the right JVM to use
 for jdir in $JDK_DIRS; do
@@ -37,6 +38,11 @@ for jdir in $JDK_DIRS; do
     JAVA_HOME="$jdir"
   fi
 done
+
+if [ -r /etc/default/opentsdb ]; then
+    . /etc/default/opentsdb
+fi
+
 export JAVA_HOME
 
 # Define other required variables


### PR DESCRIPTION
- support /etc/default/opentsdb
- Add /usr/lib/default-java as a potential JDK path, this
  is commonly used as a symlink to the default jdk
