### PR TITLE
Fix Debian init script

### DIFF
--- a/build-aux/deb/init.d/opentsdb
+++ b/build-aux/deb/init.d/opentsdb
@@ -76,18 +76,18 @@ start)
       --exec /bin/bash -- -c "$DAEMON $DAEMON_OPTS"
 
     sleep 1
-    if start-stop-daemon --test --start --pidfile "$PID_FILE" \
+    if start-stop-daemon --test --stop --pidfile "$PID_FILE" \
       --user "$TSD_USER" --exec "$JAVA_HOME/bin/java" \
       >/dev/null; then
     
       log_action_end_msg 0
     
     else
-      if [ -f "$PID_FILE"]; then
+      if [ -f "$PID_FILE" ]; then
         rm -f "$PID_FILE"
       fi
 
-      log_action_end_msg "Failed to start the TSD"
+      log_action_end_msg 1
     fi
     
   else


### PR DESCRIPTION
Turns out the Debian init script was still broken.
- Fix bash test syntax error
- Properly test that TSD has started successfully
- Pass appropriate exit code to log_action_end_msg if TSD fails to start
