### PR TITLE
Sometimes System.getProperty("os.name") can be null

### DIFF
--- a/src/tsd/GraphHandler.java
+++ b/src/tsd/GraphHandler.java
@@ -62,7 +62,7 @@ final class GraphHandler implements HttpRpc {
     LoggerFactory.getLogger(GraphHandler.class);
 
   private static final boolean IS_WINDOWS = 
-    System.getProperty("os.name").contains("Windows");
+    System.getProperty("os.name","").contains("Windows");
   
   /** Number of times we had to do all the work up to running Gnuplot. */
   private static final AtomicInteger graphs_generated


### PR DESCRIPTION
The same kind of check is done by apache commons-lang SystemUtils, see http://grepcode.com/file/repo1.maven.org/maven2/commons-lang/commons-lang/2.6/org/apache/commons/lang/SystemUtils.java#SystemUtils.isOSNameMatch%28java.lang.String%2Cjava.lang.String%29

This fixes TestGraphHandler that fails because GraphHandler class cannot be initialized properly
