### PR TITLE
Add status option to Debian init script

### DIFF
--- a/build-aux/deb/init.d/opentsdb
+++ b/build-aux/deb/init.d/opentsdb
@@ -125,7 +125,7 @@ restart|force-reload)
   $0 start
   ;;
 status)
-  status_of_proc -p "$PID_FILE" "$DAEMON" "$NAME" && exit 0 || exit $?
+  status_of_proc -p "$PID_FILE" "$DAEMON" "$NAME"
   ;;
 *)
   echo "Usage: /etc/init.d/opentsdb {start|stop|restart|status}"


### PR DESCRIPTION
[Chef](http://opscode.com) needs an init script 'status' option to reliably determine if a service is running. It otherwise falls back to highly unreliable process table inspection. This commit adds that option, using the Debian-standard `status_of_proc` shell function.

Please note that Ubuntu 12.04 isn't [LSB-compliant](http://refspecs.linuxbase.org/LSB_3.1.1/LSB-Core-generic/LSB-Core-generic/iniscrptact.html) (argh), so `sudo service opentsdb status` will return exit code 4 (unknown service status) if the service is not running. This was fixed in 12.04.2 and up—see [original Debian bug](http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=664621) if you're interested.
