### PR TITLE
remove unhelpful System.out.println

### DIFF
--- a/src/uid/UniqueId.java
+++ b/src/uid/UniqueId.java
@@ -646,7 +646,6 @@ public final class UniqueId implements UniqueIdInterface {
           // start the assignment dance after stashing the deferred
           return new UniqueIdAllocator(name, assignment).tryAllocate();
         }
-        System.out.println("Caught an exception here");
         return e;  // Other unexpected exception, let it bubble up.
       }
     }


### PR DESCRIPTION
I'm assuming this was for debugging? I'm seeing a lot of "Caught an exception here" messages with no context in my logs.
