### PR TITLE
#264 RTPublisher should publish submitted Annotations

### DIFF
--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -965,6 +965,9 @@ public final class TSDB {
     if (search != null) {
       search.indexAnnotation(note).addErrback(new PluginError());
     }
+    if( rt_publisher != null ) {
+    	rt_publisher.publishAnnotation(note);
+    }
   }
   
   /**

--- a/src/tsd/RTPublisher.java
+++ b/src/tsd/RTPublisher.java
@@ -14,12 +14,13 @@ package net.opentsdb.tsd;
 
 import java.util.Map;
 
+import net.opentsdb.core.TSDB;
+import net.opentsdb.meta.Annotation;
+import net.opentsdb.stats.StatsCollector;
+
 import org.hbase.async.Bytes;
 
 import com.stumbleupon.async.Deferred;
-
-import net.opentsdb.core.TSDB;
-import net.opentsdb.stats.StatsCollector;
 
 /**
  * Real Time publisher plugin interface that is used to emit data from a TSD
@@ -137,4 +138,13 @@ public abstract class RTPublisher {
   public abstract Deferred<Object> publishDataPoint(final String metric, 
       final long timestamp, final double value, final Map<String, String> tags, 
       final byte[] tsuid);
+  
+  /**
+   * Called any time a new annotation is published
+   * @param annotation The published annotation
+   * @return A deferred without special meaning to wait on if necessary. The 
+   * value may be null but a Deferred must be returned.
+   */
+  public abstract Deferred<Object> publishAnnotation(Annotation annotation);
+  
 }

--- a/test/tsd/DummyRTPublisher.java
+++ b/test/tsd/DummyRTPublisher.java
@@ -15,6 +15,7 @@ package net.opentsdb.tsd;
 import java.util.Map;
 
 import net.opentsdb.core.TSDB;
+import net.opentsdb.meta.Annotation;
 import net.opentsdb.stats.StatsCollector;
 
 import com.stumbleupon.async.Deferred;
@@ -63,6 +64,11 @@ public final class DummyRTPublisher extends RTPublisher {
   public Deferred<Object> publishDataPoint(String metric, long timestamp,
       double value, Map<String, String> tags, byte[] tsuid) {
     return Deferred.fromResult(new Object());
+  }
+
+  @Override
+  public Deferred<Object> publishAnnotation(Annotation annotation) {
+	  return Deferred.fromResult(new Object());
   }
 
 }

--- a/test/tsd/TestRTPublisher.java
+++ b/test/tsd/TestRTPublisher.java
@@ -16,7 +16,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
+
+import java.util.Collections;
+import java.util.HashMap;
+
 import net.opentsdb.core.TSDB;
+import net.opentsdb.meta.Annotation;
 import net.opentsdb.utils.Config;
 import net.opentsdb.utils.PluginLoader;
 
@@ -99,4 +104,17 @@ public final class TestRTPublisher {
         System.currentTimeMillis(), new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, 
         null, null, (short)0x7));
   }
+  
+  @Test
+  public void publishAnnotation() throws Exception {
+	  Annotation ann = new Annotation();
+	  HashMap<String, String> customMap = new HashMap<String, String>(1);
+	  customMap.put("test-custom-key", "test-custom-value");
+	  ann.setCustom(customMap);
+	  ann.setDescription("A test annotation");
+	  ann.setNotes("Test annotation notes");
+	  ann.setStartTime(System.currentTimeMillis());	  
+	  assertNotNull(rt_publisher.publishAnnotation(ann));
+  }
+  
 }


### PR DESCRIPTION
Added method

``` java
public abstract Deferred<Object> publishAnnotation(Annotation annotation);
```

to net.opentsdb.tsd.RTPublisher. TSDB now calls this method if an RTPublisher plugin is defined.
Added unit test.
