### PR TITLE
Fix for Issue #286

### DIFF
--- a/src/meta/Annotation.java
+++ b/src/meta/Annotation.java
@@ -558,7 +558,7 @@ public final class Annotation implements Comparable<Annotation> {
   }
 
   /** @return the custom key/value map, may be null */
-  public final HashMap<String, String> getCustom() {
+  public final Map<String, String> getCustom() {
     return custom;
   }
 
@@ -597,13 +597,13 @@ public final class Annotation implements Comparable<Annotation> {
   }
 
   /** @param custom the custom key/value map */
-  public void setCustom(final HashMap<String, String> custom) {
+  public void setCustom(final Map<String, String> custom) {
     // equivalency of maps is a pain, users have to submit the whole map
     // anyway so we'll just mark it as changed every time we have a non-null
     // value
     if (this.custom != null || custom != null) {
       changed.put("custom", true);
-      this.custom = custom;
+      this.custom = new HashMap<String, String>(custom);
     }
   }
 }

--- a/src/meta/TSMeta.java
+++ b/src/meta/TSMeta.java
@@ -940,7 +940,7 @@ public final class TSMeta {
   }
 
   /** @return the tag UID meta objects in an array, tagk first, then tagv, etc */
-  public final ArrayList<UIDMeta> getTags() {
+  public final List<UIDMeta> getTags() {
     return tags;
   }
 
@@ -965,7 +965,7 @@ public final class TSMeta {
   }
 
   /** @return optional custom key/value map, may be null */
-  public final HashMap<String, String> getCustom() {
+  public final Map<String, String> getCustom() {
     return custom;
   }
 
@@ -1037,13 +1037,13 @@ public final class TSMeta {
   }
   
   /** @param custom optional key/value map */
-  public final void setCustom(final HashMap<String, String> custom) {
+  public final void setCustom(final Map<String, String> custom) {
     // equivalency of maps is a pain, users have to submit the whole map
     // anyway so we'll just mark it as changed every time we have a non-null
     // value
     if (this.custom != null || custom != null) {
       changed.put("custom", true);
-      this.custom = custom;
+      this.custom = new HashMap<String, String>(custom);
     }
   }
 

--- a/src/meta/UIDMeta.java
+++ b/src/meta/UIDMeta.java
@@ -588,13 +588,13 @@ public final class UIDMeta {
   }
 
   /** @param custom the custom to set */
-  public void setCustom(final HashMap<String, String> custom) {
+  public void setCustom(final Map<String, String> custom) {
     // equivalency of maps is a pain, users have to submit the whole map
     // anyway so we'll just mark it as changed every time we have a non-null
     // value
     if (this.custom != null || custom != null) {
       changed.put("custom", true);
-      this.custom = custom;
+      this.custom = new HashMap<String, String>(custom);
     }
   }
 

--- a/src/tree/TreeBuilder.java
+++ b/src/tree/TreeBuilder.java
@@ -757,7 +757,7 @@ public final class TreeBuilder {
    * @throws IllegalStateException if the tag UIDMetas have not be set
    */
   private void parseTagkRule() {
-    final ArrayList<UIDMeta> tags = meta.getTags();
+    final List<UIDMeta> tags = meta.getTags();
     if (tags == null || tags.isEmpty()) {
       throw new IllegalStateException(
         "Tags for the timeseries meta were null");


### PR DESCRIPTION
There are a small number of inconsistencies in the public API for UIDMeta, TSMeta and Annotation custom maps. This patch makes all the custom methods for all three classes use a plain Map instead of a HashMap and for TSMeta tags, a List instead of an ArrayList.
