### PR TITLE
Added support for deleting UID mappings

### DIFF
--- a/src/tools/UidManager.java
+++ b/src/tools/UidManager.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.hbase.async.Bytes;
 import org.hbase.async.GetRequest;
 import org.hbase.async.HBaseClient;
@@ -105,6 +104,7 @@ final class UidManager {
         + "  assign <kind> <name> [names]:"
         + " Assign an ID for the given name(s).\n"
         + "  rename <kind> <name> <newname>: Renames this UID.\n"
+        + "  delete <kind> <name>: Deletes this UID.\n"
         + "  fsck: Checks the consistency of UIDs.\n"
         + "  [kind] <name>: Lookup the ID of this name.\n"
         + "  [kind] <ID>: Lookup the name of this ID.\n"
@@ -201,6 +201,12 @@ final class UidManager {
         return 2;
       }
       return rename(tsdb.getClient(), table, idwidth, args);
+    } else if (args[0].equals("delete")) {
+      if (nargs != 3) {
+        usage("Wrong number of arguments");
+        return 2;
+      }
+      return delete(tsdb.getClient(), table, idwidth, args);
     } else if (args[0].equals("fsck")) {
       return fsck(tsdb.getClient(), table);
     } else if (args[0].equals("metasync")) {
@@ -413,6 +419,34 @@ final class UidManager {
       return 1;
     }
     System.out.println(kind + ' ' + oldname + " -> " + newname);
+    return 0;
+  }
+  
+  /**
+   * Implements the {@code rename} subcommand.
+   * @param client The HBase client to use.
+   * @param table The name of the HBase table to use.
+   * @param idwidth Number of bytes on which the UIDs should be.
+   * @param args Command line arguments ({@code assign name [names]}).
+   * @return The exit status of the command (0 means success).
+   */
+  private static int delete(final HBaseClient client,
+                            final byte[] table,
+                            final short idwidth,
+                            final String[] args) {
+    final String kind = args[1];
+    final String name = args[2];
+    final UniqueId uid = new UniqueId(client, table, kind, (int) idwidth);
+    try {
+      uid.delete(name);
+    } catch (HBaseException e) {
+      LOG.error("error while processing delete " + name, e);
+      return 3;
+    } catch (NoSuchUniqueName e) {
+      LOG.error(e.getMessage());
+      return 1;
+    }
+    System.out.println(kind + ' ' + name + " deleted.");
     return 0;
   }
 


### PR DESCRIPTION
Right now there's no support built into the CLI tools to delete the UID mappings that show up when you run API commands like `suggest` and `query` - you can delete the data using `tsdb scan --delete` but the metrics will still come back in suggest and in queries (with no data if you delete it all). We have a bunch of old metrics which no longer have data, but they still show up in suggest - this becomes a pain in metrilyx because we can't show only pertinent metrics.

To address this, I've added a command called delete to `tsdb uid`:

`tsdb uid delete metrics sys.cpu.1` would delete the UID forward/reverse mappings for the specified UID. I'm not 100% sure how safe this is or how much data (if any) is left over but this let's you at least permanently remove it. Also, you may have to forcibly call `dropcaches` to get the metric to unregister.

Note: Deleting the UID *before* cleaning up it's data means you cannot use the built in CLI commands like scan on the metric anymore. You will have to clean it up in HBase yourself, so be warned.

Anyways, this is just meant to be an administrative tool for cleaning up garbage like rename is. If there are any caveats to this approach it would be good to know as well.