### PR TITLE
Support long milliseconds

### DIFF
--- a/src/utils/DateTime.java
+++ b/src/utils/DateTime.java
@@ -164,6 +164,8 @@ public class DateTime {
    */
   public static final long parseDuration(final String duration) {
     long interval;
+    long multiplier;
+    double temp;
     int unit = 0;
     while (Character.isDigit(duration.charAt(unit))) {
       unit++;
@@ -181,15 +183,21 @@ public class DateTime {
         if (duration.charAt(duration.length() - 2) == 'm') {
           return interval;
         }
-        return interval * 1000;                    // seconds
-      case 'm': return (interval * 60) * 1000;               // minutes
-      case 'h': return (interval * 3600L) * 1000;             // hours
-      case 'd': return (interval * 3600L * 24) * 1000;        // days
-      case 'w': return (interval * 3600L * 24 * 7) * 1000;    // weeks
-      case 'n': return (interval * 3600L * 24 * 30) * 1000;   // month (average)
-      case 'y': return (interval * 3600L * 24 * 365) * 1000;  // years (screw leap years)
+        multiplier = 1; break;                        // seconds
+      case 'm': multiplier = 60; break;               // minutes
+      case 'h': multiplier = 3600; break;             // hours
+      case 'd': multiplier = 3600 * 24; break;        // days
+      case 'w': multiplier = 3600 * 24 * 7; break;    // weeks
+      case 'n': multiplier = 3600 * 24 * 30; break;   // month (average)
+      case 'y': multiplier = 3600 * 24 * 365; break;  // years (screw leap years)
+      default: throw new IllegalArgumentException("Invalid duration (suffix): " + duration);
     }
-    throw new IllegalArgumentException("Invalid duration (suffix): " + duration);
+    multiplier *= 1000;
+    temp = (double)interval * multiplier;
+    if (temp > Long.MAX_VALUE) {
+      throw new IllegalArgumentException("Duration must be < Long.MAX_VALUE ms: " + duration);
+    }
+    return interval * multiplier;
   }
 
   /**

--- a/test/utils/TestDateTime.java
+++ b/test/utils/TestDateTime.java
@@ -282,6 +282,11 @@ public final class TestDateTime {
     long t = DateTime.parseDuration("4294967296ms");
     assertEquals(1L << 32, t);
   }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void parseDurationTooLong() {
+    DateTime.parseDuration("4611686018427387904y");
+  }
   
   @Test (expected = IllegalArgumentException.class)
   public void parseDurationNegative() {


### PR DESCRIPTION
`1n` to ms is 2592000000ms, which is greater than max int at 2**31-1. This allows any acceptable length of ms to be parsed.
