### PR TITLE
fix downsampling interval overflow issue

### DIFF
--- a/src/core/Query.java
+++ b/src/core/Query.java
@@ -153,7 +153,7 @@ public interface Query {
    * @param downsampler Aggregation function to use to group data points
    * within an interval.
    */
-  void downsample(int interval, Aggregator downsampler);
+  void downsample(long interval, Aggregator downsampler);
 
   /**
    * Runs this query.

--- a/src/core/Span.java
+++ b/src/core/Span.java
@@ -424,7 +424,7 @@ final class Span implements DataPoints {
   }
 
   /** Package private iterator method to access it as a DownsamplingIterator. */
-  Span.DownsamplingIterator downsampler(final int interval,
+  Span.DownsamplingIterator downsampler(final long interval,
                                         final Aggregator downsampler) {
     return new Span.DownsamplingIterator(interval, downsampler);
   }
@@ -447,7 +447,7 @@ final class Span implements DataPoints {
     private static final long TIME_MASK  = 0x7FFFFFFFFFFFFFFFL;
 
     /** The "sampling" interval, in milliseconds. */
-    private final int interval;
+    private final long interval;
 
     /** Function to use to for downsampling. */
     private final Aggregator downsampler;
@@ -473,7 +473,7 @@ final class Span implements DataPoints {
      * @param downsampler The downsampling function to use.
      * @param iterator The iterator to access the underlying data.
      */
-    DownsamplingIterator(final int interval,
+    DownsamplingIterator(final long interval,
                          final Aggregator downsampler) {
       this.interval = interval;
       this.downsampler = downsampler;

--- a/src/core/SpanGroup.java
+++ b/src/core/SpanGroup.java
@@ -92,7 +92,7 @@ final class SpanGroup implements DataPoints {
   private final Aggregator downsampler;
 
   /** Minimum time interval (in seconds) wanted between each data point. */
-  private final int sample_interval;
+  private final long sample_interval;
 
   /**
    * Ctor.
@@ -115,7 +115,7 @@ final class SpanGroup implements DataPoints {
             final Iterable<Span> spans,
             final boolean rate,
             final Aggregator aggregator,
-            final int interval, final Aggregator downsampler) {
+            final long interval, final Aggregator downsampler) {
     this(tsdb, start_time, end_time, spans, rate, new RateOptions(false,
         Long.MAX_VALUE, RateOptions.DEFAULT_RESET_VALUE), aggregator, interval,
         downsampler);
@@ -144,7 +144,7 @@ final class SpanGroup implements DataPoints {
             final Iterable<Span> spans,
             final boolean rate, final RateOptions rate_options,
             final Aggregator aggregator,
-            final int interval, final Aggregator downsampler) {
+            final long interval, final Aggregator downsampler) {
      this.start_time = (start_time & Const.SECOND_MASK) == 0 ? 
          start_time * 1000 : start_time;
      this.end_time = (end_time & Const.SECOND_MASK) == 0 ? 

--- a/src/core/TSQuery.java
+++ b/src/core/TSQuery.java
@@ -135,7 +135,7 @@ public final class TSQuery {
       query.setStartTime(start_time);
       query.setEndTime(end_time);
       if (sub.downsampler() != null) {
-        query.downsample((int)sub.downsampleInterval(), sub.downsampler());
+        query.downsample(sub.downsampleInterval(), sub.downsampler());
       } else if (!ms_resolution) {
         // we *may* have multiple millisecond data points in the set so we have
         // to downsample. use the sub query's aggregator

--- a/src/core/TsdbQuery.java
+++ b/src/core/TsdbQuery.java
@@ -116,7 +116,7 @@ final class TsdbQuery implements Query {
   private Aggregator downsampler;
 
   /** Minimum time interval (in seconds) wanted between each data point. */
-  private int sample_interval;
+  private long sample_interval;
 
   /** Optional list of TSUIDs to fetch and aggregate instead of a metric */
   private List<String> tsuids;
@@ -246,7 +246,7 @@ final class TsdbQuery implements Query {
    * @throws NullPointerException if the aggregation function is null
    * @throws IllegalArgumentException if the interval is not greater than 0
    */
-  public void downsample(final int interval, final Aggregator downsampler) {
+  public void downsample(final long interval, final Aggregator downsampler) {
     if (downsampler == null) {
       throw new NullPointerException("downsampler");
     } else if (interval <= 0) {

--- a/src/tools/CliQuery.java
+++ b/src/tools/CliQuery.java
@@ -222,7 +222,7 @@ final class CliQuery {
       if (downsample) {
         i++;
       }
-      final int interval = downsample ? Integer.parseInt(args[i++]) : 0;
+      final long interval = downsample ? Long.parseLong(args[i++]) : 0;
       final Aggregator sampler = downsample ? Aggregators.get(args[i++]) : null;
       final String metric = args[i++];
       final HashMap<String, String> tags = new HashMap<String, String>();

--- a/src/tsd/GraphHandler.java
+++ b/src/tsd/GraphHandler.java
@@ -876,7 +876,7 @@ final class GraphHandler implements HttpRpc {
           throw new BadRequestException("No such downsampling function: "
                                         + parts[1].substring(dash + 1));
         }
-        final int interval = (int) DateTime.parseDuration(parts[1].substring(0, dash));
+        final long interval = DateTime.parseDuration(parts[1].substring(0, dash));
         tsdbquery.downsample(interval, downsampler);
       } else {
         tsdbquery.downsample(1000, agg);

--- a/src/tsd/client/DateTimeBox.java
+++ b/src/tsd/client/DateTimeBox.java
@@ -54,7 +54,7 @@ final class DateTimeBox extends DateBox {
                         final String text,
                         final boolean report_error) {
         if (text.endsWith(" ago") || text.endsWith("-ago")) { // e.g. "1d ago".
-          int interval;
+          long interval;
           final int lastchar = text.length() - 5;
           try {
             interval = Integer.parseInt(text.substring(0, lastchar));

--- a/src/utils/DateTime.java
+++ b/src/utils/DateTime.java
@@ -163,13 +163,13 @@ public class DateTime {
    * @throws IllegalArgumentException if the interval was malformed.
    */
   public static final long parseDuration(final String duration) {
-    int interval;
+    long interval;
     int unit = 0;
     while (Character.isDigit(duration.charAt(unit))) {
       unit++;
     }
     try {
-      interval = Integer.parseInt(duration.substring(0, unit));
+      interval = Long.parseLong(duration.substring(0, unit));
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException("Invalid duration (number): " + duration);
     }


### PR DESCRIPTION
When the downsampling interval is greater than max integer, it will overflow and the call will fail:
{"error":{"code":500,"message":"interval not > 0: -1702967296","trace":"java.lang.IllegalArgumentException: interval not > 0: -1702967296\n\tat net.opentsdb.core.TsdbQuery.downsample(TsdbQuery.java:253) ~[tsdb-2.0.0.jar:e39d053]\n\tat net.opentsdb.core.TSQuery.buildQueries(TSQuery.java:138) ~[tsdb-2.0.0.jar:e39d053]\n\tat net.opentsdb.tsd.QueryRpc.execute(QueryRpc.java:93) ~[tsdb-2.0.0.jar:e39d053]\n\tat net.opentsdb.tsd.RpcHandler.handleHttpQuery(RpcHandler.java:255) [tsdb-2.0.0.jar:e39d053]\n\tat net.opentsdb.tsd.RpcHandler.messageReceived(RpcHandler.java:163) [tsdb-2.0.0.jar:e39d053]\n\tat org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:560) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:787) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:296) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.handler.codec.frame.FrameDecoder.unfoldAndFireMessageReceived(FrameDecoder.java:459) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.handler.codec.replay.ReplayingDecoder.callDecode(ReplayingDecoder.java:536) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.handler.codec.replay.ReplayingDecoder.messageReceived(ReplayingDecoder.java:435) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:560) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:787) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.SimpleChannelHandler.messageReceived(SimpleChannelHandler.java:142) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.SimpleChannelHandler.handleUpstream(SimpleChannelHandler.java:88) [netty-3.6.2.Final.jar:na]\n\tat net.opentsdb.tsd.ConnectionManager.handleUpstream(ConnectionManager.java:87) [tsdb-2.0.0.jar:e39d053]\n\tat org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:560) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:555) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:268) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:255) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.socket.nio.NioWorker.read(NioWorker.java:88) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.socket.nio.AbstractNioWorker.process(AbstractNioWorker.java:107) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.socket.nio.AbstractNioSelector.run(AbstractNioSelector.java:312) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.socket.nio.AbstractNioWorker.run(AbstractNioWorker.java:88) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:178) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.util.ThreadRenamingRunnable.run(ThreadRenamingRunnable.java:108) [netty-3.6.2.Final.jar:na]\n\tat org.jboss.netty.util.internal.DeadLockProofWorker$1.run(DeadLockProofWorker.java:42) [netty-3.6.2.Final.jar:na]\n\tat java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886) [na:1.6.0_35]\n\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908) [na:1.6.0_35]\n\tat java.lang.Thread.run(Thread.java:662) [na:1.6.0_35]\n"}}
