### PR TITLE
Trivial patch to add hbase_time to log output

### DIFF
--- a/src/core/TsdbQuery.java
+++ b/src/core/TsdbQuery.java
@@ -381,7 +381,7 @@ final class TsdbQuery implements Query {
              hbase_time += (System.nanoTime() - starttime) / 1000000;
              scanlatency.add(hbase_time);
              LOG.info(TsdbQuery.this + " matched " + nrows + " rows in " +
-                 spans.size() + " spans");
+                 spans.size() + " spans in " + hbase_time + "ms");
              if (nrows < 1) {
                results.callback(null);
              } else {


### PR DESCRIPTION
hbase_time is used for the stats histogram, may as well include it in the log output (sometimes useful to quickly compare hbase time vs overall httpquery time)
