### PR TITLE
Return 0 on negative diff on counters if reset < 0

### DIFF
--- a/src/core/SpanGroup.java
+++ b/src/core/SpanGroup.java
@@ -968,6 +968,9 @@ final class SpanGroup implements DataPoints {
               r = (rate_options.getCounterMax() - y1 + y0) / 
                                         ((double)(x0 - x1) / (double)1000);
             }
+            if (rate_options.getResetValue() < 0) {
+              return 0.0;
+            }
             if (rate_options.getResetValue() > RateOptions.DEFAULT_RESET_VALUE
                 && r > rate_options.getResetValue()) {
               return 0.0;


### PR DESCRIPTION
When we are dealing with a counter, we know it always increases. Thus,
a negative diff means either a rollover or a reset. We can detect
rollovers quite well, and the default is reasonable. However, for
resets to be useful, we must specify a reset value. This can be tedious
to determine for all queries. Instead, support a resetValue of -1,
which zeros any data with a negative rate in a counter.
