### PR TITLE
Changed graph/Plot utc_offset from short to int so it doesn't overflow for GMT>9

### DIFF
--- a/src/graph/Plot.java
+++ b/src/graph/Plot.java
@@ -76,7 +76,7 @@ public final class Plot {
    * Gnuplot always renders timestamps in UTC, so we simply apply a delta
    * to get local time.
    */
-  private final short utc_offset;
+  private final int utc_offset;
 
   /**
    * Constructor.
@@ -113,7 +113,7 @@ public final class Plot {
     if (tz == null) {
       tz = DEFAULT_TZ;
     }
-    this.utc_offset = (short) (tz.getOffset(System.currentTimeMillis()) / 1000);
+    this.utc_offset = tz.getOffset(System.currentTimeMillis()) / 1000;
   }
 
   /**


### PR DESCRIPTION
Since the range of short is -32768 to 32767, time zones greater than about GMT+9 or GMT-9 cause this value to overflow. 

The result is that the GNUPlot graph generated has the wrong timestamps.

For example, testing from Sydney, Australia (GMT+10), this offset is 36000 (10 \* 60 \* 60) seconds. Casting to short overflows this value to -29536 (which looked like the GNUPlot graph was drawing timestamps for some US timezone, approx GMT-8)
