### PR TITLE
Create %{_datarootdir}/opentsdb/plugins in rpm.

### DIFF
--- a/opentsdb.spec.in
+++ b/opentsdb.spec.in
@@ -56,6 +56,7 @@ make
 rm -rf %{buildroot}
 make install DESTDIR=%{buildroot}
 mkdir -p %{buildroot}/var/cache/opentsdb
+mkdir -p %{buildroot}%{_datarootdir}/opentsdb/plugins
 # TODO: Use alternatives to manage the init script and configuration.
 
 %clean
@@ -66,6 +67,7 @@ rm -rf %{buildroot}
 %defattr(644,root,root,755)
 %attr(0755,root,root) %{_bindir}/*
 %attr(0755,root,root) %{_datarootdir}/opentsdb/bin/*.sh
+%attr(0755,root,root) %{_datarootdir}/opentsdb/plugins
 %attr(0755,root,root) %{_datarootdir}/opentsdb/tools/*
 %attr(0755,root,root) %{_datarootdir}/opentsdb/etc/init.d/opentsdb
 %config %{_datarootdir}/opentsdb/etc/opentsdb/opentsdb.conf


### PR DESCRIPTION
The folder %{_datarootdir}/opentsdb/plugins is required for opentsdb to
start and should be created by the rpm when installing.
