### PR TITLE
Preload uid caches at startup.

### DIFF
--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableList;
 import com.stumbleupon.async.Callback;
 import com.stumbleupon.async.Deferred;
 import com.stumbleupon.async.DeferredGroupException;
@@ -140,6 +141,12 @@ public final class TSDB {
       metrics.setTSDB(this);
       tag_names.setTSDB(this);
       tag_values.setTSDB(this);
+    }
+    if (config.getBoolean("tsd.core.preload_uid_cache")) {
+      int max_results = config.getInt("tsd.core.preload_uid_cache.max_entries");
+      List<UniqueId> uid_caches = ImmutableList.of(
+          metrics, tag_names, tag_values);
+      UniqueId.preload_uid_cache(client, uidtable, uid_caches, max_results);
     }
     LOG.debug(config.dumpConfiguration());
   }

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -403,6 +403,8 @@ public class Config {
     default_map.put("tsd.core.meta.enable_tsuid_tracking", "false");
     default_map.put("tsd.core.plugin_path", "");
     default_map.put("tsd.core.tree.enable_processing", "false");
+    default_map.put("tsd.core.preload_uid_cache", "false");
+    default_map.put("tsd.core.preload_uid_cache.max_entries", "300000");
     default_map.put("tsd.rtpublisher.enable", "false");
     default_map.put("tsd.rtpublisher.plugin", "");
     default_map.put("tsd.search.enable", "false");


### PR DESCRIPTION
preload uid caches at startup to reduce the latency of fetching many tags for
many spans at query time.
New behavior is enabled by changing opentsdb.conf:
   # preload uid cache at startup
      tsd.core.preload_uid_cache = true

NOTE: Submitted on behalf of third-party contributor:
- Guenther Schmuelling schmuell@pepperdata.com
