### PR TITLE
Add timeout to batch put.

### DIFF
--- a/src/tsd/HttpQuery.java
+++ b/src/tsd/HttpQuery.java
@@ -964,7 +964,14 @@ final class HttpQuery {
   private void done() {
     final int processing_time = processingTimeMillis();
     httplatency.add(processing_time);
-    logInfo("HTTP " + request.getUri() + " done in " + processing_time + "ms");
+    String url = request.getUri();
+    String msg = String.format("HTTP %s done in %d ms", url, processing_time);
+    if (url.startsWith("/api/put") && LOG.isDebugEnabled()) {
+      // NOTE: Suppresses too many log lines from /api/put.
+      LOG.debug(msg);
+    } else {
+      logInfo(msg);
+    }
     deferred.callback(null);
   }
 

--- a/src/tsd/PutDataPointRpc.java
+++ b/src/tsd/PutDataPointRpc.java
@@ -16,14 +16,19 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import com.stumbleupon.async.Callback;
 import com.stumbleupon.async.Deferred;
 
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,12 +40,106 @@ import net.opentsdb.uid.NoSuchUniqueName;
 
 /** Implements the "put" telnet-style command. */
 final class PutDataPointRpc implements TelnetRpc, HttpRpc {
-  private static final Logger LOG = LoggerFactory.getLogger(PutDataPointRpc.class);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(PutDataPointRpc.class);
   private static final AtomicLong requests = new AtomicLong();
   private static final AtomicLong hbase_errors = new AtomicLong();
   private static final AtomicLong invalid_values = new AtomicLong();
   private static final AtomicLong illegal_arguments = new AtomicLong();
   private static final AtomicLong unknown_metrics = new AtomicLong();
+  private static final AtomicLong batch_timeouts = new AtomicLong();
+
+  /** timers to watch the requests */
+  private final static ScheduledExecutorService scheduler =
+      Executors.newScheduledThreadPool(2);
+
+  /** Implements a callback sink to count completion of storage calls */
+  final class RequestCompletion implements Callback<Object, Object> {
+    private final long total;
+    private long success = 0;
+    private long errors = 0;
+    private final boolean show_summary;
+    private final ArrayList<HashMap<String, Object>> details;
+    private final HttpQuery query;
+    private final AtomicBoolean request_complete;
+    private ScheduledFuture<?> taskhandle;
+
+    RequestCompletion(final int timeout_seconds,
+                      final long total,
+                      final boolean show_summary,
+                      final ArrayList<HashMap<String, Object>> details,
+                      final AtomicBoolean request_complete,
+                      final HttpQuery query) {
+
+      this.total = total;
+      this.query = query;
+      this.show_summary = show_summary;
+      this.details = details;
+      this.request_complete = request_complete;
+
+      if (timeout_seconds > 0) {
+        Runnable task  = new Runnable() {
+            public void run() {
+              timeout();
+            }
+        };
+        taskhandle = scheduler.schedule(task, timeout_seconds, TimeUnit.SECONDS);
+      } else  {
+        // 0 or less - timeout directly
+        timeout();
+      }
+    }
+
+    public synchronized Object call(Object result) throws Exception {
+      if (result != null &&  (result instanceof Exception)) {
+        errors++;
+      } else {
+        success++;
+      }
+      if (success + errors >= total) {
+        // all items called back, complete the request
+        if (taskhandle != null) {
+          taskhandle.cancel(false);
+        }
+        final HttpResponseStatus httpcode = (errors > 0) ?
+            HttpResponseStatus.INTERNAL_SERVER_ERROR : HttpResponseStatus.OK;
+
+        execute_complete(query, success, errors, total, show_summary, details,
+            request_complete, httpcode);
+      }
+      return result;
+    }
+
+    private synchronized void timeout() {
+      try {
+        // not all items called back in time - complete it now as timeout.
+        batch_timeouts.incrementAndGet();
+        execute_complete(query, success, errors, total, show_summary, details,
+            request_complete, HttpResponseStatus.REQUEST_TIMEOUT);
+      }
+      catch (Exception e) {
+        LOG.error("Unexpected exception in timeout", e);
+      }
+    }
+  }
+
+  /** parse query args for waitflush argument */
+  private int parseWaitflush(final HttpQuery query) throws IOException {
+    String value = query.getQueryStringParam("waitflush");
+    if (value != null && !value.isEmpty()) {
+      try {
+        final int waitflush = Integer.parseInt(value);
+        if (waitflush < 0 || waitflush > 3600) {
+          throw new BadRequestException("waitflush out of range");
+        }
+        return waitflush;
+      } catch (NumberFormatException unused) {
+        throw new BadRequestException("Unable to parse 'waitflush' as a number");
+      }
+    }
+    return -1;
+  }
+
 
   public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
                                   final String[] cmd) {
@@ -95,21 +194,27 @@ final class PutDataPointRpc implements TelnetRpc, HttpRpc {
           "Method not allowed", "The HTTP method [" + query.method().getName() +
           "] is not permitted for this endpoint");
     }
-    
+
+    long success = 0;
     final List<IncomingDataPoint> dps = query.serializer().parsePutV1();
-    if (dps.size() < 1) {
+    final long total = dps.size();
+    if (total < 1) {
       throw new BadRequestException("No datapoints found in content");
     }
-    
+
+    final AtomicBoolean request_complete = new AtomicBoolean();
+    final int waitflush = parseWaitflush(query);
     final boolean show_details = query.hasQueryStringParam("details");
     final boolean show_summary = query.hasQueryStringParam("summary");
-    final ArrayList<HashMap<String, Object>> details = show_details
-      ? new ArrayList<HashMap<String, Object>>() : null;
-    long success = 0;
-    long total = 0;
-    
+    final ArrayList<HashMap<String, Object>> details =
+        show_details ? new ArrayList<HashMap<String, Object>>() : null;
+
+    Callback<Object, Object> request_callback = (waitflush < 0) ?
+        Callback.PASSTHROUGH:
+        new RequestCompletion(waitflush, total,  show_summary, details,
+                              request_complete, query);
+
     for (IncomingDataPoint dp : dps) {
-      total++;
       try {
         if (dp.getMetric() == null || dp.getMetric().isEmpty()) {
           if (show_details) {
@@ -139,18 +244,27 @@ final class PutDataPointRpc implements TelnetRpc, HttpRpc {
           LOG.warn("Missing tags: " + dp);
           continue;
         }
+
+        // This will lookup metric and tags synchronous if they are not in
+        // cache. If ID's are not found and we can't auto create them we'll get
+        // a NoSuchUniqueName exception. The code in UniqueId will swallow
+        // HBase exceptions - in case of HBase errors we should get nothing
+        // here. If we create the missing ID, UniqueId will retry and eventually
+        // throws a HBase exception which will bubble up to netty.
         if (Tags.looksLikeInteger(dp.getValue())) {
-          tsdb.addPoint(dp.getMetric(), dp.getTimestamp(), 
-              Tags.parseLong(dp.getValue()), dp.getTags());
+          tsdb.addPoint(dp.getMetric(), dp.getTimestamp(),
+              Tags.parseLong(dp.getValue()), dp.getTags())
+                  .addBoth(request_callback);
         } else {
-          tsdb.addPoint(dp.getMetric(), dp.getTimestamp(), 
-              Float.parseFloat(dp.getValue()), dp.getTags());
+          tsdb.addPoint(dp.getMetric(), dp.getTimestamp(),
+              Float.parseFloat(dp.getValue()), dp.getTags())
+                  .addBoth(request_callback);
         }
         success++;
       } catch (NumberFormatException x) {
         if (show_details) {
-          details.add(this.getHttpDetails("Unable to parse value to a number", 
-              dp));
+          details.add(this.getHttpDetails("Unable to parse value to a number",
+                                          dp));
         }
         LOG.warn("Unable to parse value to a number: " + dp);
         invalid_values.incrementAndGet();
@@ -168,33 +282,76 @@ final class PutDataPointRpc implements TelnetRpc, HttpRpc {
         unknown_metrics.incrementAndGet();
       }
     }
-    
+
     final long failures = total - success;
-    if (!show_summary && !show_details) {
-      if (failures > 0) {
-        throw new BadRequestException(HttpResponseStatus.BAD_REQUEST,
-            "One or more data points had errors", 
-            "Please see the TSD logs or append \"details\" to the put request");
-      } else {
-        query.sendReply(HttpResponseStatus.NO_CONTENT, "".getBytes());
+    if (waitflush < 0 || failures > 0) {
+      // failures at this point are bad arguments
+      final HttpResponseStatus httpcode = (failures > 0) ?
+              HttpResponseStatus.BAD_REQUEST : HttpResponseStatus.OK;
+
+      execute_complete(query, success, failures, total, show_summary, details,
+          request_complete,  httpcode);
+    }
+  }
+
+  /**
+   * Completes the HTTP RPC put requests b sending the response
+   * @param query The HTTP query from the user
+   * @throws IOException if there is an error parsing the query or formatting
+   * the output
+   * @throws BadRequestException if the user supplied bad data
+   * @param success Successful written to hbase
+   * @param failures items that encountered some error
+   * @param total all items in the orignal request (might be > success+failures)
+   * @param show_summary if true, send a short summary of errors/success the
+   * batch
+   * @param details includes a list of detailed errors to be sent in the
+   * response
+   * @since 2.0
+   */
+  void execute_complete(final HttpQuery query,
+                        final long success,
+                        final long failures,
+                        final long total,
+                        final boolean show_summary,
+                        final ArrayList<HashMap<String, Object>> details,
+                        final AtomicBoolean request_complete,
+                        final HttpResponseStatus httpcode)
+                        throws IOException {
+
+    if (request_complete.getAndSet(true)) {
+      // this request has already been completed, do nothing.
+      // Because this CAS is atomic, we can make it past this barrier only once
+      // which prevents multiple writes to the HttpQuery
+      return;
+    }
+
+    if (!show_summary && details == null) {
+      if (httpcode == HttpResponseStatus.OK) {
+          query.sendReply(HttpResponseStatus.NO_CONTENT, "".getBytes());
+      } else if (httpcode == HttpResponseStatus.REQUEST_TIMEOUT ||
+          httpcode == HttpResponseStatus.INTERNAL_SERVER_ERROR ||
+          httpcode == HttpResponseStatus.SERVICE_UNAVAILABLE) {
+          query.sendStatusOnly(httpcode);
+      }
+      else {
+          // for all other errors attach exception
+          query.badRequest(
+              "One or more data points had errors. " +
+              "Please see the TSD logs or append \"details\" to the put request");
       }
     } else {
       final HashMap<String, Object> summary = new HashMap<String, Object>();
+      summary.put("total", total);
       summary.put("success", success);
       summary.put("failed", failures);
-      if (show_details) {
+      if (details != null) {
         summary.put("errors", details);
       }
-      
-      if (failures > 0) {
-        query.sendReply(HttpResponseStatus.BAD_REQUEST, 
-            query.serializer().formatPutV1(summary));
-      } else {
-        query.sendReply(query.serializer().formatPutV1(summary));
-      }
+      query.sendReply(httpcode, query.serializer().formatPutV1(summary));
     }
   }
-  
+
   /**
    * Collects the stats and metrics tracked by this instance.
    * @param collector The collector to use.
@@ -205,6 +362,7 @@ final class PutDataPointRpc implements TelnetRpc, HttpRpc {
     collector.record("rpc.errors", invalid_values, "type=invalid_values");
     collector.record("rpc.errors", illegal_arguments, "type=illegal_arguments");
     collector.record("rpc.errors", unknown_metrics, "type=unknown_metrics");
+    collector.record("rpc.errors", batch_timeouts, "type=batch_timeouts");
   }
 
   /**


### PR DESCRIPTION
Batch put can now be called with with waitflush=timeout_in_seconds. The request
will complete when there are items with errors (http 400), when HBase errors
in /api/put will send http 500 errors (instead of 400), when all requests are
written to HBase (http 200) or after timeout_in_seconds (http 408).
Additionally, moved logging for all urls starting with /api/put calls debug.

NOTE: Submitted on behalf of third-party contributor:
  * Guenther Schmuelling <schmuell@pepperdata.com>