### PR TITLE
Fixes the incomplete CORS support by adding the Allow-Headers header

### DIFF
--- a/src/tsd/RpcHandler.java
+++ b/src/tsd/RpcHandler.java
@@ -94,22 +94,12 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
       }
     }
 
-    final String cors_headers_tmp = tsdb.getConfig().getString("tsd.http.request.cors_headers").trim ();
-    if (cors_headers_tmp == null) {
-      cors_headers = "";
-    } else {
-      HashSet<String> headers_tmp = new HashSet<String>();
-      final String[] headers = cors_headers_tmp.split(",\\s*");
-      for (final String cors_header : headers) {
-        if (! cors_header.matches("^[a-zA-Z0-9._-]+$")) {
-          throw new IllegalArgumentException(
-              "tsd.http.request.cors_headers must be a list of validly-formed "
-              + "HTTP header names. No wildcards are allowed.");
-        }
-        headers_tmp.add(cors_header);
-        LOG.info("Loaded CORS header (" + cors_header + ")");
-      }
-      cors_headers = cors_headers_tmp.toString().replaceAll("^\\[\\s*|\\s*\\]$", "");
+    cors_headers = tsdb.getConfig().getString("tsd.http.request.cors_headers")
+        .trim();
+    if ((cors_headers == null) || !cors_headers.matches("^([a-zA-Z0-9_.-]+,\\s*)*[a-zA-Z0-9_.-]+$")) {
+      throw new IllegalArgumentException(
+          "tsd.http.request.cors_headers must be a list of validly-formed "
+          + "HTTP header names. No wildcards are allowed.");
     }
 
     telnet_commands = new HashMap<String, TelnetRpc>(7);

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -407,7 +407,9 @@ public class Config {
     default_map.put("tsd.http.request.enable_chunked", "false");
     default_map.put("tsd.http.request.max_chunk", "4096");
     default_map.put("tsd.http.request.cors_domains", "");
-    default_map.put("tsd.http.request.cors_headers", "Authorization, Content-Type, Accept, Origin, User-Agent, DNT, Cache-Control, X-Mx-ReqToken, Keep-Alive, X-Requested-With, If-Modified-Since");
+    default_map.put("tsd.http.request.cors_headers", "Authorization, "
+      + "Content-Type, Accept, Origin, User-Agent, DNT, Cache-Control, "
+      + "X-Mx-ReqToken, Keep-Alive, X-Requested-With, If-Modified-Since");
 
     for (Map.Entry<String, String> entry : default_map.entrySet()) {
       if (!properties.containsKey(entry.getKey()))


### PR DESCRIPTION
The current CORS support leaves out an important header: Access-Control-Allow-Headers. Browsers (Chrome and Firefox at minimum) take the missing header as meaning no request headers are allowed, which in turn causes the requests to fail validation. This commit adds the header using a configurable value `tsd.http.request.cors_headers`, though the default I've provided seems to work just just fine when talking to Grafana.

As the configuration value is passed as a simple string so there's no testing to be done. Validation could be done by trimming the string, breaking it up on `/,\s*/`, validating that each element contains only `[a-z0-9_.-]`, and then re-assembling the elements with `,`. It just seemed overkill to me, though it could be added.
