### PR TITLE
Use the versioned python command as PEP-394 suggests

### DIFF
--- a/build-aux/gen_build_data.sh
+++ b/build-aux/gen_build_data.sh
@@ -28,7 +28,7 @@ mkdir -p "$dir"
 TZ=UTC
 export TZ
 # Can't use the system `date' tool because it's not portable.
-sh=`python <<EOF
+sh=`python2 <<EOF
 import time
 t = time.time();
 print "timestamp=%d" % t;

--- a/tools/check_tsd
+++ b/tools/check_tsd
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # Script which queries TSDB with a given metric and alerts based on
 # supplied threshold.  Compatible with Nagios output format, so can be

--- a/tools/opentsdb_restart.py
+++ b/tools/opentsdb_restart.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 """Restart opentsdb. Called using -XX:OnOutOfMemoryError=<this script>
 
 Because it's calling the 'service opentsdb' command, should be run as root.

--- a/tools/tsddrain.py
+++ b/tools/tsddrain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # This little script can be used to replace TSDs while performing prolonged
 # HBase or HDFS maintenances.  It runs a simple, low-end TCP server to accept


### PR DESCRIPTION
I'm on Arch and tried building opentsdb and ran into the same problem as in #83. I updated the command to python2 and the build works just fine. I'm aware that it's Arch that doesn't follow convention to have python 2 as the default but the command python2 should be more portable as it's suggested to use this in [this](http://legacy.python.org/dev/peps/pep-0394/) PEP.

> so python should be used in the shebang line only for scripts that are source compatible with both Python 2 and 3.