### PR TITLE
The symbolic of static content should use relative path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -356,7 +356,7 @@ gwttsd: staticroot
 	$(mkdir_p) $(DEV_TSD_STATICROOT)
 	cp $(dist_static_DATA:%=$(srcdir)/%) $(DEV_TSD_STATICROOT)
 	find -L $(DEV_TSD_STATICROOT) -type l -exec rm {} \;
-	p=`pwd`/gwt/queryui && cd $(DEV_TSD_STATICROOT) \
+	p=../gwt/queryui && cd $(DEV_TSD_STATICROOT) \
 	  && for i in $$p/*; do ln -s -f "$$i" || break; done
 	find -L $(DEV_TSD_STATICROOT)/gwt -type f | xargs touch
 	@touch .staticroot-stamp

--- a/tsdb.in
+++ b/tsdb.in
@@ -6,8 +6,8 @@ mydir=`dirname "$0"`
 # Either:
 #  abs_srcdir and abs_builddir are set: we're running in a dev tree
 #  or pkgdatadir is set: we've been installed, we respect that.
-abs_srcdir='@abs_srcdir@'
-abs_builddir='@abs_builddir@'
+abs_srcdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
+abs_builddir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pkgdatadir='@pkgdatadir@'
 configdir='@configdir@'
 # Either we've been installed and pkgdatadir exists, or we haven't been


### PR DESCRIPTION
The symbolic of the html and js are created in compiling time. The current implementation use absolute path. It means that the compiled binary could only place in the same absolute path with it in the compile machine. It is not convince for use and deploy. So I change the symbolic of static content form absolute path into relative path
