### PR TITLE
Reduce the memory footprint with HBASE append support and randomize metric ids to distribute load evenly across region servers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,6 +30,7 @@ dist_noinst_SCRIPTS = src/create_table.sh src/upgrade_1to2.sh src/mygnuplot.sh \
 dist_noinst_DATA = pom.xml.in build-aux/rpm/opentsdb.conf \
   build-aux/rpm/logback.xml build-aux/rpm/init.d/opentsdb
 tsdb_SRC := \
+	src/core/AppendKeyValue.java	\
 	src/core/Aggregator.java	\
 	src/core/Aggregators.java	\
 	src/core/CompactionQueue.java	\
@@ -105,7 +106,7 @@ tsdb_SRC := \
 	src/tsd/WordSplitter.java	\
 	src/uid/NoSuchUniqueId.java	\
 	src/uid/NoSuchUniqueName.java	\
-    src/uid/RandomUID.java	\
+	src/uid/RandomUID.java	\
 	src/uid/UniqueId.java	\
 	src/uid/UniqueIdInterface.java \
 	src/utils/Config.java \
@@ -150,6 +151,7 @@ test_SRC := \
 	test/stats/TestHistogram.java	\
 	test/storage/MockBase.java	\
 	test/tools/TestDumpSeries.java	\
+	test/tools/TestDumpSeriesAppend.java	\
 	test/tools/TestFsck.java	\
 	test/tools/TestTextImporter.java	\
 	test/tree/TestBranch.java	\

--- a/Makefile.am
+++ b/Makefile.am
@@ -105,6 +105,7 @@ tsdb_SRC := \
 	src/tsd/WordSplitter.java	\
 	src/uid/NoSuchUniqueId.java	\
 	src/uid/NoSuchUniqueName.java	\
+    src/uid/RandomUID.java	\
 	src/uid/UniqueId.java	\
 	src/uid/UniqueIdInterface.java \
 	src/utils/Config.java \
@@ -171,6 +172,7 @@ test_SRC := \
 	test/tsd/TestTreeRpc.java	\
 	test/tsd/TestUniqueIdRpc.java	\
 	test/uid/TestNoSuchUniqueId.java	\
+	test/uid/TestRandomUniqueId.java \
 	test/uid/TestUniqueId.java \
 	test/utils/TestConfig.java \
 	test/utils/TestDateTime.java \

--- a/src/core/AppendKeyValue.java
+++ b/src/core/AppendKeyValue.java
@@ -1,0 +1,250 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2012  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeMap;
+import org.hbase.async.Bytes;
+import org.hbase.async.KeyValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/*
+ * A wrapper class to abstract the format changes required to handle appends
+ */
+
+public class AppendKeyValue {
+  private static final Logger LOG = LoggerFactory.getLogger(AppendKeyValue.class);
+  public static final int AUTO_HEAL_THRESHOLD = 2*3600; //in seconds
+  
+  private byte[] value;
+  private byte[] qualifier;
+  //Tells that whether the KeyValue contains out of order data or not 
+  private boolean outofOrderData = false;
+  //Tells that whether the KeyValue contains duplicate data or not 
+  private boolean hasDuplicates = false;
+  //Tells that whether the KeyValue contains qualifiers with mix of seconds
+  //and milliseconds
+  private boolean hasMixofSecondsAndms = false;
+
+  public AppendKeyValue() {
+  }
+
+  public AppendKeyValue(KeyValue kv, TSDB tsdb) {
+    parseAndFixKeyValue(kv, tsdb, true);
+  }
+
+  public AppendKeyValue(byte[] qualifier, byte[] value) {
+    this.value = value;
+    this.qualifier = qualifier;
+  }
+
+  public byte[] toByteArray() {
+    byte[] bytes = new byte[qualifier.length+value.length];
+    
+    System.arraycopy(this.qualifier, 0, bytes, 0, qualifier.length);
+    System.arraycopy(value, 0, bytes, qualifier.length, value.length);
+    return bytes;
+  }
+  
+  /**
+   * Parses the KeyValue object into Cell objects. It also detects the out of
+   * order and duplicate cells. It update the hbase cell back with the healed 
+   * data if the tsdb is configured with auto heal flag.
+   * @param kv KeyValue object - which stores all the data point in values as
+   *  q1v1q2v2q3v3.....
+   * @param tsdb TSDB object
+   * @param copyFixedCell true - Copy the extracted qualifiers and values into 
+   * current objects qualifier and value byte array like compacted Cell
+   * false - doesn't copy the qualifiers and values
+   * @return List of Cell objects each representing one data point
+   * @since 2.0
+   */
+  public final Collection<Internal.Cell> parseAndFixKeyValue(KeyValue kv, TSDB 
+    tsdb, boolean copyFixedCell) {
+    
+    boolean autoHeal = tsdb.isAutoHealOnRead();
+    
+    if (tsdb == null) {
+      throw new IllegalArgumentException("It expects TSDB object, it can not be null");
+    }
+    
+    long baseTimestamp = Internal.baseTime(tsdb, kv.key());
+
+    if (!Arrays.equals(kv.qualifier(), Const.APPEND_QUALIFIER)) {
+      throw new IllegalArgumentException("Can not parse cell, it is not " +
+        " an appended cell. It has a different qualifier " + 
+        Bytes.pretty(kv.qualifier()) + 
+        ", row key " + Bytes.pretty(kv.key()));
+    }
+    
+    int val_idx = 0;
+    int val_length = 0;
+    int qual_length = 0;
+    int last_delta = -1;  // Time delta, extracted from the qualifier.
+    
+    Map<Integer, Internal.Cell> deltas = new TreeMap<Integer, Internal.Cell>();
+    int qualTime = 0;
+    
+    while (val_idx < kv.value().length) {
+      final byte[] q = Internal.extractQualifier(kv.value(), val_idx);
+      System.arraycopy(kv.value(), val_idx, q, 0, q.length);
+      val_idx=val_idx + q.length;
+      
+      int vlen = Internal.getValueLengthFromQualifier(q);
+      byte[] v = new byte[vlen];
+      System.arraycopy(kv.value(), val_idx, v, 0, vlen);
+      val_idx += vlen;
+      int delta = Internal.getOffsetFromQualifier(q);
+
+      Internal.Cell duplicate = deltas.get(delta);
+      if (duplicate != null) {
+        //This is a duplicate cell, skip it
+        hasDuplicates = true;
+        LOG.info("There are duplicate data points at " + 
+        (baseTimestamp + delta) + ", skiping the duplicates, " +
+        "row key " + Bytes.pretty(kv.key()));
+
+        qual_length -= duplicate.qualifier.length;
+        val_length -= duplicate.value.length;
+      }
+
+      qual_length += q.length;
+      val_length += vlen;
+      final Internal.Cell cell = new Internal.Cell(q, v);
+      deltas.put(delta, cell);
+
+      if (!outofOrderData) {
+        //Data points needs to be sorted if we find atleat one out of order data
+
+        if (delta <= last_delta) {
+          LOG.info("There are out of order data, that needs to be sorted for the row key " + Bytes.pretty(kv.key()));
+          outofOrderData = true;
+        }
+      
+        last_delta = delta;
+      }
+      
+      if (!hasMixofSecondsAndms) {
+        if ((qualTime == 2 && q.length == 4) || (qualTime == 4 && q.length == 2)){
+          hasMixofSecondsAndms = true;
+        }
+        else {
+          qualTime = q.length;
+        }
+      }
+     }
+    
+    if (autoHeal) {
+      if (!outofOrderData && !hasDuplicates) {
+        autoHeal = false;
+      }
+      else {
+        //Check whether this KeyValue is eligible for auto healing
+        long currentBaseTime = (System.currentTimeMillis()/1000) - 
+          ((System.currentTimeMillis()/1000) % Const.MAX_TIMESPAN);
+        
+        if ((currentBaseTime - baseTimestamp) < AUTO_HEAL_THRESHOLD) {
+          //This is recently added row, don't need to heal it
+          autoHeal = false;
+        }
+      }
+    }
+
+    // Check we consumed all the bytes of the value.
+    if (val_idx != kv.value().length) {
+      throw new IllegalDataException("Corrupted value: couldn't break down"
+      + " into individual values (consumed " + val_idx + " bytes, but was"
+      + " expecting to consume " + (kv.value().length) + "): " + kv
+      + ", cells so far: " + deltas.values());
+    }
+
+    val_idx = 0;
+    int qual_idx = 0;
+    byte[] healedCell = null;
+    int healedIndex = 0;
+    
+    if (copyFixedCell) {
+      this.value = new byte[val_length];
+      this.qualifier = new byte[qual_length];
+    }
+    
+    if (autoHeal) {
+      healedCell = new byte[val_length+qual_length];
+    }
+    
+    for (Internal.Cell k:deltas.values()) {
+      if (copyFixedCell) {
+        System.arraycopy(k.qualifier, 0, this.qualifier, qual_idx, k.qualifier.length);
+        qual_idx += k.qualifier.length;
+        System.arraycopy(k.value, 0, this.value, val_idx, k.value.length);
+        val_idx += k.value.length;
+      }
+      
+      if (autoHeal) {
+        System.arraycopy(k.qualifier, 0, healedCell, healedIndex, k.qualifier.length);
+        healedIndex += k.qualifier.length;
+        System.arraycopy(k.value, 0, healedCell, healedIndex, k.value.length);
+        healedIndex += k.value.length;
+      }
+    }
+
+    if (autoHeal) {
+      autoHealOutOfOrderData(kv, healedCell, tsdb);
+    }
+    
+    return deltas.values();
+  }
+
+  public byte[] getValue() {
+    return value;
+  }
+
+  public byte[] getQualifier() {
+    return qualifier;
+  }
+
+  public short getQualifierAsShort() {
+    return (qualifier == null) ? 0 : Bytes.getShort(qualifier);
+  }
+
+  public boolean hasOutOfOrderData() {
+    return outofOrderData;
+  }
+
+  public boolean hasDuplicates() {
+    return hasDuplicates;
+  }
+
+  public boolean hasMixofSecondsAndms() {
+    return hasMixofSecondsAndms;
+  }
+  
+  
+  /**
+   * Auto heal out of data and duplicate data. It accepts the key value with
+   * healed data and put back to hbase. 
+   * @param kv KeyValue object - Use to find the actual cell - row key
+   * @param healedCell stores the healed qualifiers and values like append does
+   * @param tsdb TSDB object
+   * @return List of Cell objects each representing one data point
+   * @since 2.0
+   */
+  private void autoHealOutOfOrderData(KeyValue kv, byte[] healedCell, TSDB tsdb) {
+    LOG.info("Found OOO data or duplicate cells to be healed, auto healing row key " + Bytes.pretty(kv.key()));
+    tsdb.put(kv.key(), kv.qualifier(), healedCell);
+  }
+}

--- a/src/core/Const.java
+++ b/src/core/Const.java
@@ -74,4 +74,11 @@ public final class Const {
    * before losing precision.
    */
   public static final long MAX_INT_IN_DOUBLE = 0xFFE0000000000000L;
+
+  /** Byte used for the qualifier prefix to indicate this is an append */
+  public static final byte APPEND_PREFIX = 0x05;
+  /**
+   * Qualifier shows the cell is created following append logic instead of put
+   */
+  public static final byte[] APPEND_QUALIFIER = new byte[]{APPEND_PREFIX, 0x00, 0x00};
 }

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -126,7 +126,8 @@ public final class TSDB {
     treetable = config.getString("tsd.storage.hbase.tree_table").getBytes(CHARSET);
     meta_table = config.getString("tsd.storage.hbase.meta_table").getBytes(CHARSET);
 
-    metrics = new UniqueId(client, uidtable, METRICS_QUAL, METRICS_WIDTH);
+    metrics = new UniqueId(client, uidtable, METRICS_QUAL, METRICS_WIDTH,
+            config.getBoolean("tsd.core.random_metric_id"));
     tag_names = new UniqueId(client, uidtable, TAG_NAME_QUAL, TAG_NAME_WIDTH);
     tag_values = new UniqueId(client, uidtable, TAG_VALUE_QUAL, TAG_VALUE_WIDTH);
     compactionq = new CompactionQueue(this);
@@ -428,6 +429,7 @@ public final class TSDB {
                      stats.numRpcDelayedDueToNSRE());
 
     compactionq.collectStats(collector);
+    UniqueId.collectStats(collector);
     // Collect Stats from Plugins
     if (rt_publisher != null) {
       try {

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -50,6 +50,7 @@ import net.opentsdb.search.SearchPlugin;
 import net.opentsdb.search.SearchQuery;
 import net.opentsdb.stats.Histogram;
 import net.opentsdb.stats.StatsCollector;
+import org.hbase.async.AppendRequest;
 
 /**
  * Thread-safe implementation of the TSDB client.
@@ -109,6 +110,26 @@ public final class TSDB {
   
   /** List of activated RPC plugins */
   private List<RpcPlugin> rpc_plugins = null;
+  private boolean followAppendRowLogic = true;
+  private boolean returnAppendedResult = false;
+  //Auto heal out of order data and duplicate data per row during read or not
+  private boolean autoHealOnRead = false;
+
+  public boolean isAutoHealOnRead() {
+    return autoHealOnRead;
+  }
+
+  public boolean followAppendRowLogic() {
+    return followAppendRowLogic;
+  }
+
+  public boolean returnAppendedResult() {
+    return returnAppendedResult;
+  }
+
+  public void setReturnAppendedResult(boolean returnAppendedResult) {
+    this.returnAppendedResult = returnAppendedResult;
+  }
   
   /**
    * Constructor
@@ -130,6 +151,12 @@ public final class TSDB {
             config.getBoolean("tsd.core.random_metric_id"));
     tag_names = new UniqueId(client, uidtable, TAG_NAME_QUAL, TAG_NAME_WIDTH);
     tag_values = new UniqueId(client, uidtable, TAG_VALUE_QUAL, TAG_VALUE_WIDTH);
+    followAppendRowLogic = config.getBoolean("tsd.core.enable_append");
+    
+    if (followAppendRowLogic()) {
+      config.setEnable_compactions(false);
+    }
+
     compactionq = new CompactionQueue(this);
 
     if (config.hasProperty("tsd.core.timezone")) {
@@ -142,6 +169,7 @@ public final class TSDB {
       tag_names.setTSDB(this);
       tag_values.setTSDB(this);
     }
+    autoHealOnRead = System.getProperty("tsd.core.auto_heal_metrics") != null;
     LOG.debug(config.dumpConfiguration());
   }
   
@@ -418,6 +446,7 @@ public final class TSDB {
     collector.record("hbase.rpcs", stats.deletes(), "type=delete");
     collector.record("hbase.rpcs", stats.gets(), "type=get");
     collector.record("hbase.rpcs", stats.puts(), "type=put");
+    collector.record("hbase.rpcs", stats.appends(), "type=append");
     collector.record("hbase.rpcs", stats.rowLocks(), "type=rowLock");
     collector.record("hbase.rpcs", stats.scannersOpened(), "type=openScanner");
     collector.record("hbase.rpcs", stats.scans(), "type=scan");
@@ -652,12 +681,24 @@ public final class TSDB {
     }
     
     Bytes.setInt(row, (int) base_time, metrics.width());
-    scheduleForCompaction(row, (int) base_time);
-    final PutRequest point = new PutRequest(table, row, FAMILY, qualifier, value);
+        Deferred<Object> result;
+
+    if (followAppendRowLogic()) {
+      AppendKeyValue kv = new AppendKeyValue(qualifier, value);
+      final AppendRequest point = new AppendRequest(table, row, FAMILY, 
+                Const.APPEND_QUALIFIER, kv.toByteArray());
+      point.setReturnResult(returnAppendedResult);        
+      result = client.append(point);
+    }
+    else {
+      scheduleForCompaction(row, (int) base_time);
+      final PutRequest point = new PutRequest(table, row, FAMILY, qualifier, value);
     
-    // TODO(tsuna): Add a callback to time the latency of HBase and store the
-    // timing in a moving Histogram (once we have a class for this).
-    Deferred<Object> result = client.put(point);
+      // TODO(tsuna): Add a callback to time the latency of HBase and store the
+      // timing in a moving Histogram (once we have a class for this).
+      result = client.put(point);
+    }
+        
     if (!config.enable_realtime_ts() && !config.enable_tsuid_incrementing() && 
         !config.enable_tsuid_tracking() && rt_publisher == null) {
       return result;

--- a/src/opentsdb.conf
+++ b/src/opentsdb.conf
@@ -38,6 +38,9 @@ tsd.http.cachedir =
 # is False
 #tsd.core.auto_create_metrics = false
 
+# Whether or not to create random UIDs for new metric types, default is False
+#tsd.core.random_metric_id = false
+
 # --------- STORAGE ----------
 # Whether or not to enable data compaction in HBase, default is True
 #tsd.storage.enable_compaction = true

--- a/src/opentsdb.conf
+++ b/src/opentsdb.conf
@@ -45,6 +45,11 @@ tsd.http.cachedir =
 # Whether or not to enable data compaction in HBase, default is True
 #tsd.storage.enable_compaction = true
 
+# Use append instead of put and compaction, it will eliminate compaction
+# Carefully enable or disable it during the run, both write data into hbase in
+# different format, false by default
+#tsd.core.enable_append = false
+
 # How often, in milliseconds, to flush the data point queue to storage, 
 # default is 1,000
 # tsd.storage.flush_interval = 1000

--- a/src/tools/CliOptions.java
+++ b/src/tools/CliOptions.java
@@ -65,6 +65,12 @@ final class CliOptions {
                    + " metrics to be tracked");
   }
 
+  /** Adds the --fix flag.  */
+  static void addAutoHealFlag(final ArgP argp) {
+    argp.addOption("--fix", 
+            "Auto heal out of order data and duplicates during read");
+  }
+
   /**
    * Parse the command line arguments with the given options.
    * @param options Options to parse in the given args.
@@ -146,6 +152,8 @@ final class CliOptions {
         config.overrideConfig("tsd.network.async_io", entry.getValue());
       } else if (entry.getKey().toLowerCase().equals("--worker-threads")) {
         config.overrideConfig("tsd.network.worker_threads", entry.getValue());
+      } else if (entry.getKey().toLowerCase().equals("--fix")) {
+        System.setProperty("tsd.core.auto_heal_metrics", "true");
       }
     }
   }

--- a/src/tools/CliQuery.java
+++ b/src/tools/CliQuery.java
@@ -59,6 +59,7 @@ final class CliQuery {
   public static void main(String[] args) throws Exception {
     ArgP argp = new ArgP();
     CliOptions.addCommon(argp);
+    CliOptions.addAutoHealFlag(argp);
     CliOptions.addVerbose(argp);
     argp.addOption("--graph", "BASEPATH",
                    "Output data points to a set of files for gnuplot."

--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -83,6 +83,7 @@ final class TSDMain {
                    "Maximum time for which a new data point can be buffered"
                    + " (default: " + DEFAULT_FLUSH_INTERVAL + ").");
     CliOptions.addAutoMetricFlag(argp);
+    CliOptions.addAutoHealFlag(argp);
     args = CliOptions.parse(argp, args);
     args = null; // free().
 

--- a/src/tools/TextImporter.java
+++ b/src/tools/TextImporter.java
@@ -36,6 +36,7 @@ import net.opentsdb.core.TSDB;
 import net.opentsdb.core.WritableDataPoints;
 import net.opentsdb.stats.StatsCollector;
 import net.opentsdb.utils.Config;
+import org.hbase.async.AppendRequest;
 
 final class TextImporter {
 
@@ -113,6 +114,9 @@ final class TextImporter {
             final HBaseRpc rpc = e.getFailedRpc();
             if (rpc instanceof PutRequest) {
               client.put((PutRequest) rpc);  // Don't lose edits.
+            }
+            else if (rpc instanceof AppendRequest) {
+              client.append((AppendRequest) rpc);  // Don't lose edits.
             }
             return null;
           }

--- a/src/tools/UidManager.java
+++ b/src/tools/UidManager.java
@@ -141,7 +141,7 @@ final class UidManager {
     }   
     final short idwidth = (argp.has("--idwidth")
                            ? Short.parseShort(argp.get("--idwidth"))
-                           : 3);
+                           : TSDB.metrics_width());
     if (idwidth <= 0) {
       usage(argp, "Negative or 0 --idwidth");
       System.exit(3);

--- a/src/uid/RandomUID.java
+++ b/src/uid/RandomUID.java
@@ -19,7 +19,10 @@ import net.opentsdb.core.TSDB;
 
 /*
  * Generate Random UIDs to be used as unique id.
- * Random metric ids help to distribute hotspots evenly to region servers
+ * Random metric ids help to distribute hotspots evenly to region servers.
+ * It is better to decide whether to use random or serial uid for one type when 
+ * the hbase uid table is empty. If the logic to switch between random or serial
+ * uid is changed in between writes it will cause frequent id collisions.
  */
 public class RandomUID {
   private static SecureRandom random = new SecureRandom();

--- a/src/uid/RandomUID.java
+++ b/src/uid/RandomUID.java
@@ -1,0 +1,73 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2012  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.uid;
+
+
+
+import java.security.SecureRandom;
+import net.opentsdb.core.TSDB;
+
+/*
+ * Generate Random UIDs to be used as unique id.
+ * Random metric ids help to distribute hotspots evenly to region servers
+ */
+public class RandomUID {
+  private static SecureRandom random = new SecureRandom();
+  public static final int MAX_WIDTH = 7;
+  
+  /**
+   * Get the next random UID. Right now it uses 3 bytes as the metric with is 
+   * 3. If it is 3 then it can return only upto the max value a 3 byte integer
+   * can return, which is 2^31-1. In that case, even though it is long, 
+   * its range will be between 0 and 2^31-1
+   * @return random UID
+   */
+  public static long getRandomUID() {
+    return getRandomUID(TSDB.metrics_width());
+  }
+
+  /**
+   * Get the next random UID. It creates random bytes, then convert it to an
+   * unsigned long
+   * @param width number of bytes to randomize, it can not be larger 
+   * than a long
+   * @return random UID
+   * @throws throws IllegalArgumentException if the width is larger than 8
+   * bytes
+   */
+  public static long getRandomUID(final int width) {
+    if (width > MAX_WIDTH) {
+      throw new IllegalArgumentException("It expects an unsigned long "
+          + "random integer, it can not be larger than " + MAX_WIDTH + 
+          " bytes width");
+    }
+    byte[] bytes= new byte[width];
+    random.nextBytes(bytes);
+    return convertToUnsignedLong(bytes);
+  }
+
+  /**
+   * Convert byte array with first the most significant to unsigned long
+   * @return long storing unsigned integer value
+   */
+  private static long convertToUnsignedLong(byte[] bytes) {
+    long value = 0;
+    
+    for (int i = 0; i<bytes.length;i++){
+      value <<= 8;
+      value |= bytes[i] & 0xFF;
+    }
+    
+    return value;
+  } 
+}

--- a/src/uid/UniqueId.java
+++ b/src/uid/UniqueId.java
@@ -27,7 +27,7 @@ import javax.xml.bind.DatatypeConverter;
 
 import net.opentsdb.core.TSDB;
 import net.opentsdb.meta.UIDMeta;
-
+import net.opentsdb.stats.StatsCollector;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import org.hbase.async.AtomicIncrementRequest;
 import org.hbase.async.Bytes;
 import org.hbase.async.DeleteRequest;
+import org.hbase.async.Counter;
 import org.hbase.async.GetRequest;
 import org.hbase.async.HBaseClient;
 import org.hbase.async.HBaseException;
@@ -71,12 +72,16 @@ public final class UniqueId implements UniqueIdInterface {
   private static final byte[] MAXID_ROW = { 0 };
   /** How many time do we try to assign an ID before giving up. */
   private static final short MAX_ATTEMPTS_ASSIGN_ID = 3;
+  /** How many time do we try to assign a random ID before giving up. */
+  private static final short MAX_ATTEMPTS_ASSIGN_RANDOM_ID = 10;
   /** How many time do we try to apply an edit before giving up. */
   private static final short MAX_ATTEMPTS_PUT = 6;
   /** Initial delay in ms for exponential backoff to retry failed RPCs. */
   private static final short INITIAL_EXP_BACKOFF_DELAY = 800;
   /** Maximum number of results to return in suggest(). */
   private static final short MAX_SUGGESTIONS = 25;
+  /** Number of random Metric UID collisions.  */
+  private static final Counter random_metricid_collisions = new Counter();
 
   /** HBase client to use.  */
   private final HBaseClient client;
@@ -107,6 +112,8 @@ public final class UniqueId implements UniqueIdInterface {
 
   /** Whether or not to generate new UIDMetas */
   private TSDB tsdb;
+  //Generate random UID or sequential UID
+  private final boolean randomizeId;
   
   /**
    * Constructor.
@@ -119,6 +126,22 @@ public final class UniqueId implements UniqueIdInterface {
    */
   public UniqueId(final HBaseClient client, final byte[] table, final String kind,
                   final int width) {
+    this(client, table, kind, width, false);
+  }
+  
+  /**
+   * Constructor.
+   * @param client The HBase client to use.
+   * @param table The name of the HBase table to use.
+   * @param kind The kind of Unique ID this instance will deal with.
+   * @param width The number of bytes on which Unique IDs should be encoded.
+   * @param randomizeId generate random UID if true. Change this logic carefully
+   * once the tsdb starts writing into hbase.
+   * @throws IllegalArgumentException if width is negative or too small/large
+   * or if kind is an empty string.
+   */
+  public UniqueId(final HBaseClient client, final byte[] table, final String kind,
+                  final int width, final boolean randomizeId) {
     this.client = client;
     this.table = table;
     if (kind.isEmpty()) {
@@ -130,6 +153,7 @@ public final class UniqueId implements UniqueIdInterface {
       throw new IllegalArgumentException("Invalid width: " + width);
     }
     this.id_width = (short) width;
+    this.randomizeId = randomizeId;
   }
 
   /** The number of times we avoided reading from HBase thanks to the cache. */
@@ -330,7 +354,7 @@ public final class UniqueId implements UniqueIdInterface {
   private final class UniqueIdAllocator implements Callback<Object, Object> {
     private final String name;  // What we're trying to allocate an ID for.
     private final Deferred<byte[]> assignment; // deferred to call back
-    private short attempt = MAX_ATTEMPTS_ASSIGN_ID;  // Give up when zero.
+    private short attempt = randomizeId?MAX_ATTEMPTS_ASSIGN_RANDOM_ID:MAX_ATTEMPTS_ASSIGN_ID;  // Give up when zero.
 
     private HBaseException hbe = null;  // Last exception caught.
 
@@ -367,9 +391,11 @@ public final class UniqueId implements UniqueIdInterface {
       }
 
       if (arg instanceof Exception) {
-        final String msg = ("Failed attempt #" + (MAX_ATTEMPTS_ASSIGN_ID - attempt)
-                            + " to assign an UID for " + kind() + ':' + name
-                            + " at step #" + state);
+        final String msg = ("Failed attempt #" + (randomizeId
+            ? (MAX_ATTEMPTS_ASSIGN_RANDOM_ID - attempt) 
+            : (MAX_ATTEMPTS_ASSIGN_ID - attempt))
+            + " to assign an UID for " + kind() + ':' + name
+            + " at step #" + state);
         if (arg instanceof HBaseException) {
           LOG.error(msg, (Exception) arg);
           hbe = (HBaseException) arg;
@@ -391,7 +417,12 @@ public final class UniqueId implements UniqueIdInterface {
       final Deferred d;
       switch (state) {
         case ALLOCATE_UID:
-          d = allocateUid();
+          if (randomizeId) {
+            d = allocateRandomUid();
+          }
+          else {
+            d = allocateUid();
+          }
           break;
         case CREATE_REVERSE_MAPPING:
           d = createReverseMapping(arg);
@@ -417,6 +448,18 @@ public final class UniqueId implements UniqueIdInterface {
                                                                kind));
     }
 
+   /**
+    * Fetch next random UID
+    * @since 2.0
+    */  
+    private Deferred<Long> allocateRandomUid() {
+      Deferred<Long> newId = new Deferred<Long>();
+      newId.callback((long)RandomUID.getRandomUID());
+      LOG.info("Creating a random ID for kind='" + kind()
+               + "' name='" + name + '\'');
+      state = CREATE_REVERSE_MAPPING;
+      return newId;
+    }
 
     /**
      * Create the reverse mapping.
@@ -476,8 +519,15 @@ public final class UniqueId implements UniqueIdInterface {
         throw new IllegalStateException("Expected a Boolean but got " + arg);
       }
       if (!((Boolean) arg)) {  // Previous CAS failed.  Something is really messed up.
-        LOG.error("WTF!  Failed to CAS reverse mapping: " + reverseMapping()
+        if (randomizeId) {
+          //This random Id is already used by another row
+          LOG.error("Detected random id collision and retrying, " + id);
+          random_metricid_collisions.increment();
+        }
+        else {
+          LOG.error("WTF!  Failed to CAS reverse mapping: " + reverseMapping()
                   + " -- run an fsck against the UID table!");
+        }
         return tryAllocate();  // Try again from the beginning.
       }
 
@@ -505,6 +555,12 @@ public final class UniqueId implements UniqueIdInterface {
         // manage to CAS this KV into existence.  The one that loses the
         // race will retry and discover the UID assigned by the winner TSD,
         // and a UID will have been wasted in the process.  No big deal.
+        if (randomizeId) {
+          //This random Id is already used by another row
+          LOG.error("Detected random id collision between two tsdb servers "
+                + "and retrying, " + id);
+          random_metricid_collisions.increment();
+        }
         class GetIdCB implements Callback<Object, byte[]> {
           public Object call(final byte[] row) throws Exception {
             assignment.callback(row);
@@ -1152,5 +1208,14 @@ public final class UniqueId implements UniqueIdInterface {
     get.family(ID_FAMILY);
     get.qualifiers(kinds);
     return tsdb.getClient().get(get).addCallback(new GetCB());
+  }
+ 
+  /**
+   * Collects random uid collisions
+   * @param collector StatsCollector object to collect stats/metrics
+   * @since 2.0
+   */  
+  public static void collectStats(final StatsCollector collector) {
+    collector.record("uid.collisions", random_metricid_collisions, "type=metrics");
   }
 }

--- a/src/uid/UniqueId.java
+++ b/src/uid/UniqueId.java
@@ -34,8 +34,8 @@ import org.slf4j.LoggerFactory;
 
 import org.hbase.async.AtomicIncrementRequest;
 import org.hbase.async.Bytes;
-import org.hbase.async.DeleteRequest;
 import org.hbase.async.Counter;
+import org.hbase.async.DeleteRequest;
 import org.hbase.async.GetRequest;
 import org.hbase.async.HBaseClient;
 import org.hbase.async.HBaseException;

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -282,13 +282,18 @@ public class Config {
    * @throws NullPointerException if the property was not found
    */
   public final boolean getBoolean(final String property) {
-    final String val = this.properties.get(property).toUpperCase();
-    if (val.equals("1"))
-      return true;
-    if (val.equals("TRUE"))
-      return true;
-    if (val.equals("YES"))
-      return true;
+    
+    if (this.properties.containsKey(property)) {
+      final String val = this.properties.get(property).toUpperCase();
+        
+      if (val.equals("1"))
+        return true;
+      if (val.equals("TRUE"))
+        return true;
+      if (val.equals("YES"))
+        return true;
+    }
+    
     return false;
   }
 

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -372,6 +372,10 @@ public class Config {
   public final Map<String, String> getMap() {
     return ImmutableMap.copyOf(properties);
   }
+
+  public void setEnable_compactions(boolean enable_compactions) {
+    this.enable_compactions = enable_compactions;
+  }
   
   /**
    * Loads default entries that were not provided by a file or command line

--- a/test/core/TestCompactionQueue.java
+++ b/test/core/TestCompactionQueue.java
@@ -70,6 +70,7 @@ final class TestCompactionQueue {
     Whitebox.setInternalState(tsdb, "table", TABLE);
     Whitebox.setInternalState(config, "enable_compactions", true);
     Whitebox.setInternalState(tsdb, "config", config);
+    Whitebox.setInternalState(tsdb, "followAppendRowLogic", false);
     // Stub out the compaction thread, so it doesn't even start.
     PowerMockito.whenNew(CompactionQueue.Thrd.class).withNoArguments()
       .thenReturn(mock(CompactionQueue.Thrd.class));

--- a/test/core/TestTsdbQueryDownsample.java
+++ b/test/core/TestTsdbQueryDownsample.java
@@ -134,6 +134,7 @@ public class TestTsdbQueryDownsample {
     when(metrics.width()).thenReturn((short)3);
     when(tag_names.width()).thenReturn((short)3);
     when(tag_values.width()).thenReturn((short)3);
+    tsdb.config.setEnable_compactions(true);
   }
 
   @Test
@@ -484,7 +485,7 @@ public class TestTsdbQueryDownsample {
 
   @SuppressWarnings("unchecked")
   private void setQueryStorage() throws Exception {
-    storage = new MockBase(tsdb, client, true, true, true, true);
+    storage = new MockBase(tsdb, client, true, true, true, true, true);
     storage.setFamily("t".getBytes(MockBase.ASCII()));
 
     PowerMockito.mockStatic(IncomingDataPoints.class);

--- a/test/meta/TestAnnotation.java
+++ b/test/meta/TestAnnotation.java
@@ -39,6 +39,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 @PowerMockIgnore({"javax.management.*", "javax.xml.*",
   "ch.qos.*", "org.slf4j.*",
@@ -59,8 +60,8 @@ public final class TestAnnotation {
     PowerMockito.whenNew(HBaseClient.class)
       .withArguments(anyString(), anyString()).thenReturn(client);
     tsdb = new TSDB(config);
-    
-    storage = new MockBase(tsdb, client, true, true, true, true);
+    Whitebox.setInternalState(tsdb, "followAppendRowLogic", false);
+    storage = new MockBase(tsdb, client, true, true, true, true, true);
     
     // add a global
     storage.addColumn(

--- a/test/meta/TestTSMeta.java
+++ b/test/meta/TestTSMeta.java
@@ -78,7 +78,7 @@ public final class TestTSMeta {
     PowerMockito.whenNew(HBaseClient.class)
       .withArguments(anyString(), anyString()).thenReturn(client);
     tsdb = new TSDB(config);
-    storage = new MockBase(tsdb, client, true, true, true, true);
+    storage = new MockBase(tsdb, client, true, true, true, true, true);
     
     storage.addColumn(new byte[] { 0, 0, 1 },
         NAME_FAMILY,

--- a/test/meta/TestUIDMeta.java
+++ b/test/meta/TestUIDMeta.java
@@ -62,7 +62,7 @@ public final class TestUIDMeta {
       .withArguments(anyString(), anyString()).thenReturn(client);
     tsdb = new TSDB(config);
     
-    storage = new MockBase(tsdb, client, true, true, true, true);
+    storage = new MockBase(tsdb, client, true, true, true, true, true);
 
     storage.addColumn(new byte[] { 0, 0, 1 }, 
         NAME_FAMILY,

--- a/test/tools/TestTextImporter.java
+++ b/test/tools/TestTextImporter.java
@@ -53,6 +53,8 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.stumbleupon.async.Deferred;
+import net.opentsdb.core.Const;
+import net.opentsdb.core.Internal;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({"javax.management.*", "javax.xml.*",
@@ -99,7 +101,7 @@ public class TestTextImporter {
     config = new Config(false);
     tsdb = new TSDB(config);
 
-    storage = new MockBase(tsdb, client, true, true, true, true);
+    storage = new MockBase(tsdb, client, true, true, true, true, true);
     storage.setFamily("t".getBytes(MockBase.ASCII()));
     
     // replace the "real" field objects with mocks
@@ -163,12 +165,12 @@ public class TestTextImporter {
     
     byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 1};
-    byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
+    byte[] value = getCellValue(row, new byte[] { 0, 0 });
     assertNotNull(value);
     assertEquals(0, value[0]);
     row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 2};
-    value = storage.getColumn(row, new byte[] { 0, 0 });
+    value = getCellValue(row, new byte[] { 0, 0 });
     assertNotNull(value);
     assertEquals(127, value[0]);
   }
@@ -184,12 +186,12 @@ public class TestTextImporter {
     
     byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 1};
-    byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
+    byte[] value = getCellValue(row, new byte[] { 0, 0 });
     assertNotNull(value);
     assertEquals(0, value[0]);
     row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 2};
-    value = storage.getColumn(row, new byte[] { 0, 0 });
+    value = getCellValue(row, new byte[] { 0, 0 });
     assertNotNull(value);
     assertEquals(-128, value[0]);
   }
@@ -205,12 +207,12 @@ public class TestTextImporter {
     
     byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 1};
-    byte[] value = storage.getColumn(row, new byte[] { 0, 1 });
+    byte[] value = getCellValue(row, new byte[] { 0, 1 });
     assertNotNull(value);
     assertEquals(128, Bytes.getShort(value));
     row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 2};
-    value = storage.getColumn(row, new byte[] { 0, 1 });
+    value = getCellValue(row, new byte[] { 0, 1 });
     assertNotNull(value);
     assertEquals(32767, Bytes.getShort(value));
   }
@@ -226,12 +228,12 @@ public class TestTextImporter {
     
     byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 1};
-    byte[] value = storage.getColumn(row, new byte[] { 0, 1 });
+    byte[] value = getCellValue(row, new byte[] { 0, 1 });
     assertNotNull(value);
     assertEquals(-129, Bytes.getShort(value));
     row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 2};
-    value = storage.getColumn(row, new byte[] { 0, 1 });
+    value = getCellValue(row, new byte[] { 0, 1 });
     assertNotNull(value);
     assertEquals(-32768, Bytes.getShort(value));
   }
@@ -247,12 +249,12 @@ public class TestTextImporter {
     
     byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 1};
-    byte[] value = storage.getColumn(row, new byte[] { 0, 3 });
+    byte[] value = getCellValue(row, new byte[] { 0, 3 });
     assertNotNull(value);
     assertEquals(32768, Bytes.getInt(value));
     row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 2};
-    value = storage.getColumn(row, new byte[] { 0, 3 });
+    value = getCellValue(row, new byte[] { 0, 3 });
     assertNotNull(value);
     assertEquals(2147483647, Bytes.getInt(value));
   }
@@ -268,12 +270,12 @@ public class TestTextImporter {
     
     byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 1};
-    byte[] value = storage.getColumn(row, new byte[] { 0, 3 });
+    byte[] value = getCellValue(row, new byte[] { 0, 3 });
     assertNotNull(value);
     assertEquals(-32769, Bytes.getInt(value));
     row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 2};
-    value = storage.getColumn(row, new byte[] { 0, 3 });
+    value = getCellValue(row, new byte[] { 0, 3 });
     assertNotNull(value);
     assertEquals(-2147483648, Bytes.getInt(value));
   }
@@ -288,12 +290,12 @@ public class TestTextImporter {
     assertEquals(2, (int)points);
     byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 1};
-    byte[] value = storage.getColumn(row, new byte[] { 0, 7 });
+    byte[] value = getCellValue(row, new byte[] { 0, 7 });
     assertNotNull(value);
     assertEquals(2147483648L, Bytes.getLong(value));
     row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 2};
-    value = storage.getColumn(row, new byte[] { 0, 7 });
+    value = getCellValue(row, new byte[] { 0, 7 });
     assertNotNull(value);
     assertEquals(9223372036854775807L, Bytes.getLong(value));
   }
@@ -309,12 +311,12 @@ public class TestTextImporter {
     
     byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 1};
-    byte[] value = storage.getColumn(row, new byte[] { 0, 7 });
+    byte[] value = getCellValue(row, new byte[] { 0, 7 });
     assertNotNull(value);
     assertEquals(-2147483649L, Bytes.getLong(value));
     row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 2};
-    value = storage.getColumn(row, new byte[] { 0, 7 });
+    value = getCellValue(row, new byte[] { 0, 7 });
     assertNotNull(value);
     assertEquals(-9223372036854775808L, Bytes.getLong(value));
   }
@@ -348,12 +350,12 @@ public class TestTextImporter {
     
     byte[] row = new byte[] { 0, 0, 1, (byte) 0xFF, (byte) 0xFF, (byte) 0xF9, 
         0x60, 0, 0, 1, 0, 0, 1};
-    byte[] value = storage.getColumn(row, new byte[] { 0x69, (byte) 0xF0 });
+    byte[] value = getCellValue(row, new byte[] { 0x69, (byte) 0xF0 });
     assertNotNull(value);
     assertEquals(24, value[0]);
     row = new byte[] { 0, 0, 1, (byte) 0xFF, (byte) 0xFF, (byte) 0xF9, 
         0x60, 0, 0, 1, 0, 0, 2};
-    value = storage.getColumn(row, new byte[] { 0x69, (byte) 0xF0 });
+    value = getCellValue(row, new byte[] { 0x69, (byte) 0xF0 });
     assertNotNull(value);
     assertEquals(42, value[0]);
   }
@@ -369,13 +371,13 @@ public class TestTextImporter {
     
     byte[] row = new byte[] { 0, 0, 1, 0, (byte) 0x41, (byte) 0x88, (byte) 0x90, 
         0, 0, 1, 0, 0, 1};
-    byte[] value = storage.getColumn(row, new byte[] { (byte) 0xF0, (byte) 0xA3, 
+    byte[] value = getCellValue(row, new byte[] { (byte) 0xF0, (byte) 0xA3, 
         0x60, 0 });
     assertNotNull(value);
     assertEquals(24, value[0]);
     row = new byte[] { 0, 0, 1, 0, (byte) 0x41, (byte) 0x88, (byte) 0x90, 0, 
         0, 1, 0, 0, 2};
-    value = storage.getColumn(row, new byte[] { (byte) 0xF0, (byte) 0xA3, 
+    value = getCellValue(row, new byte[] { (byte) 0xF0, (byte) 0xA3, 
         0x60, 0 });
     assertNotNull(value);
     assertEquals(42, value[0]);
@@ -392,12 +394,12 @@ public class TestTextImporter {
     
     byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 1};
-    byte[] value = storage.getColumn(row, new byte[] { (byte) 0xF0, 0, 0x7D, 0 });
+    byte[] value = getCellValue(row, new byte[] { (byte) 0xF0, 0, 0x7D, 0 });
     assertNotNull(value);
     assertEquals(24, value[0]);
     row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 2};
-    value = storage.getColumn(row, new byte[] { (byte) 0xF0, 0, 0x7D, 0 });
+    value = getCellValue(row, new byte[] { (byte) 0xF0, 0, 0x7D, 0 });
     assertNotNull(value);
     assertEquals(42, value[0]);
   }
@@ -431,12 +433,12 @@ public class TestTextImporter {
     
     byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 1};
-    byte[] value = storage.getColumn(row, new byte[] { 0, 11 });
+    byte[] value = getCellValue(row, new byte[] { 0, 11 });
     assertNotNull(value);
     assertEquals(24.5F, Float.intBitsToFloat(Bytes.getInt(value)), 0.0000001);
     row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 2};
-    value = storage.getColumn(row, new byte[] { 0, 11 });
+    value = getCellValue(row, new byte[] { 0, 11 });
     assertNotNull(value);
     assertEquals(42.5F, Float.intBitsToFloat(Bytes.getInt(value)), 0.0000001);
   }
@@ -452,12 +454,12 @@ public class TestTextImporter {
     
     byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 1};
-    byte[] value = storage.getColumn(row, new byte[] { 0, 11 });
+    byte[] value = getCellValue(row, new byte[] { 0, 11 });
     assertNotNull(value);
     assertEquals(-24.5F, Float.intBitsToFloat(Bytes.getInt(value)), 0.0000001);
     row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
         0, 0, 1, 0, 0, 2};
-    value = storage.getColumn(row, new byte[] { 0, 11 });
+    value = getCellValue(row, new byte[] { 0, 11 });
     assertNotNull(value);
     assertEquals(-42.5F, Float.intBitsToFloat(Bytes.getInt(value)), 0.0000001);
   }
@@ -611,5 +613,44 @@ public class TestTextImporter {
     PowerMockito.doReturn(reader).when(TextImporter.class, 
         PowerMockito.method(TextImporter.class, "open", String.class))
         .withArguments(anyString());
+  }
+  
+  /**
+   * Helper to search qualifier from an appended value
+   * @param row row key
+   * @param qualifier qualifier to search
+   */
+  private byte[] getCellValue(byte[] row, byte[] qualifier) {
+    byte[] cellValue = null;
+
+    if (tsdb.followAppendRowLogic()) {
+      final byte[] value = storage.getColumn(row, Const.APPEND_QUALIFIER);
+        
+      if (value != null) {
+        int val_idx = 0;
+        int q1 = (qualifier.length == 4) ?Bytes.getInt(qualifier):Bytes.getShort(qualifier);
+
+        while (val_idx < value.length) {
+          byte[] q = Internal.extractQualifier(value, val_idx);
+          System.arraycopy(value, val_idx, q, 0, q.length);
+          val_idx=val_idx + q.length;
+          int vlen = Internal.getValueLengthFromQualifier(q);
+          int q2 = (q.length == 4) ?Bytes.getInt(q):Bytes.getShort(q);
+
+          if (q1 == q2) {
+            cellValue = new byte[vlen];
+            System.arraycopy(value, val_idx, cellValue, 0, vlen);
+            break;
+          }
+
+          val_idx += vlen;
+        }
+      }
+    }
+    else {
+      cellValue = storage.getColumn(row, qualifier);        
+    }
+    
+    return cellValue;
   }
 }

--- a/test/tree/TestBranch.java
+++ b/test/tree/TestBranch.java
@@ -568,7 +568,7 @@ public final class TestBranch {
     PowerMockito.whenNew(HBaseClient.class)
       .withArguments(anyString(), anyString()).thenReturn(client);
     
-    storage = new MockBase(new TSDB(config), client, true, true, true, true);
+    storage = new MockBase(new TSDB(config), client, true, true, false, true, true);
     
     Branch branch = new Branch(1);
     TreeMap<Integer, String> path = new TreeMap<Integer, String>();

--- a/test/tree/TestLeaf.java
+++ b/test/tree/TestLeaf.java
@@ -62,7 +62,7 @@ public final class TestLeaf {
       .withArguments(anyString(), anyString()).thenReturn(client);
     tsdb = new TSDB(config);
     
-    storage = new MockBase(tsdb, client, true, true, true, true);
+    storage = new MockBase(tsdb, client, true, true, true, true, true);
     
     storage.addColumn(new byte[] { 0, 0, 1 }, NAME_FAMILY,
         "metrics".getBytes(MockBase.ASCII()),

--- a/test/tree/TestTree.java
+++ b/test/tree/TestTree.java
@@ -720,7 +720,7 @@ public final class TestTree {
    */
   private void setupStorage(final boolean default_get, 
       final boolean default_put) throws Exception {
-    storage = new MockBase(default_get, default_put, true, true);
+    storage = new MockBase(default_get, default_put, true, true, true);
     
     byte[] key = new byte[] { 0, 1 };
     // set pre-test values

--- a/test/tree/TestTreeBuilder.java
+++ b/test/tree/TestTreeBuilder.java
@@ -85,7 +85,7 @@ public final class TestTreeBuilder {
   
   @Before
   public void before() throws Exception {
-    storage = new MockBase(true, true, true, true);
+    storage = new MockBase(true, true, true, true, true);
     treebuilder = new TreeBuilder(storage.getTSDB(), tree);
     PowerMockito.spy(Tree.class);
     PowerMockito.doReturn(Deferred.fromResult(tree)).when(Tree.class, 

--- a/test/tree/TestTreeRule.java
+++ b/test/tree/TestTreeRule.java
@@ -405,7 +405,7 @@ public final class TestTreeRule {
    * Mocks classes for testing the storage calls
    */
   private void setupStorage() throws Exception {
-    storage = new MockBase(true, true, true, true);
+    storage = new MockBase(true, true, true, true, true);
 
     final TreeRule stored_rule = new TreeRule(1);
     stored_rule.setLevel(2);

--- a/test/tsd/TestAnnotationRpc.java
+++ b/test/tsd/TestAnnotationRpc.java
@@ -56,7 +56,7 @@ public final class TestAnnotationRpc {
       .withArguments(anyString(), anyString()).thenReturn(client);
     tsdb = new TSDB(config);
     
-    storage = new MockBase(tsdb, client, true, true, true, true);
+    storage = new MockBase(tsdb, client, true, true, true, true, true);
     
     // add a global
     storage.addColumn(

--- a/test/tsd/TestTreeRpc.java
+++ b/test/tsd/TestTreeRpc.java
@@ -124,7 +124,7 @@ public final class TestTreeRpc {
     PowerMockito.whenNew(HBaseClient.class)
       .withArguments(anyString(), anyString()).thenReturn(client);
     tsdb = new TSDB(config);
-    storage = new MockBase(tsdb, client, true, true, true, true);
+    storage = new MockBase(tsdb, client, true, true, true, true, true);
   }
   
   @Test

--- a/test/tsd/TestUniqueIdRpc.java
+++ b/test/tsd/TestUniqueIdRpc.java
@@ -849,7 +849,7 @@ public final class TestUniqueIdRpc {
       .withArguments(anyString(), anyString()).thenReturn(client);
     tsdb = new TSDB(config);
     
-    storage = new MockBase(tsdb, client, true, true, true, true);
+    storage = new MockBase(tsdb, client, true, true, false, true, true);
     
     storage.addColumn(new byte[] { 0, 0, 1 }, 
         NAME_FAMILY,
@@ -880,7 +880,7 @@ public final class TestUniqueIdRpc {
       .withArguments(anyString(), anyString()).thenReturn(client);
     tsdb = new TSDB(config);
     
-    storage = new MockBase(tsdb, client, true, true, true, true);
+    storage = new MockBase(tsdb, client, true, true, false, true, true);
     storage.setFamily(NAME_FAMILY);
     
     storage.addColumn(new byte[] { 0, 0, 1 },

--- a/test/uid/TestRandomUniqueId.java
+++ b/test/uid/TestRandomUniqueId.java
@@ -1,0 +1,72 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2012  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.uid;
+
+
+import net.opentsdb.core.TSDB;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+
+public final class TestRandomUniqueId {
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testInvalidWidth() {
+    long uid = RandomUID.getRandomUID(8);
+  }
+
+  @Test(expected=NegativeArraySizeException.class)
+  public void testNegativeWidth() {
+    long uid = RandomUID.getRandomUID(-1);
+  }
+
+  @Test
+  public void testZeroWidth() {
+    assertEquals(0L, RandomUID.getRandomUID(0));
+  }
+
+  @Test
+  public void testRandomIDQuality1() {
+    for (int i = 0;i <100;i++) {
+      long uid = RandomUID.getRandomUID();
+      assert uid >= 0;
+      assert uid <= getUpperLimitForWidth(TSDB.metrics_width());
+    }
+  }
+
+  @Test
+  public void testRandomIDQuality2() {
+    for (int width = 1; width <= RandomUID.MAX_WIDTH; width++) {
+      long upperLimit = getUpperLimitForWidth(width);
+      
+      for (int i = 0;i <10;i++) {
+        long uid = RandomUID.getRandomUID(width);
+        assert uid >= 0;
+        assert uid <= upperLimit;
+      }
+    }
+  }
+  
+  //Find the upper limit for the given width,
+  //or return the maximum number a random number can be for a given width
+  private static long getUpperLimitForWidth(int width) {
+    long limit = 0;
+      
+    for (int i = 0; i<width;i++){
+      limit <<= 8;
+      limit |= 0xFF;
+    }
+        
+    return limit;
+  }
+}

--- a/test/utils/TestConfig.java
+++ b/test/utils/TestConfig.java
@@ -194,9 +194,9 @@ public final class TestConfig {
     assertFalse(config.getBoolean("tsd.unitest"));
   }
   
-  @Test (expected = NullPointerException.class)
+  @Test
   public void getBoolFalseNull() throws Exception {
-    config.getBoolean("tsd.unitest");
+    assertFalse(config.getBoolean("tsd.unitest"));
   }
   
   @Test


### PR DESCRIPTION
Current sequential metric ids may cause hot spots on same region servers. Random metric ids can shre the load almost equally across the region servers with pre-split regions 