### PR TITLE
Use slf4j string parameterization in logging

### DIFF
--- a/src/core/CompactionQueue.java
+++ b/src/core/CompactionQueue.java
@@ -110,7 +110,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
   public Deferred<ArrayList<Object>> flush() {
     final int size = size();
     if (size > 0) {
-      LOG.info("Flushing all old outstanding rows out of " + size + " rows");
+      LOG.info("Flushing all old outstanding rows out of {} rows", size);
     }
     final long now = System.currentTimeMillis();
     return flush(now / 1000 - Const.MAX_TIMESPAN - 1, Integer.MAX_VALUE);
@@ -409,7 +409,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
           if (qual[0] == Annotation.PREFIX()) {
             annotations.add(JSON.parseToObject(kv.value(), Annotation.class));
           } else {
-            LOG.warn("Ignoring unexpected extended format type " + qual[0]);
+            LOG.warn("Ignoring unexpected extended format type {}", qual[0]);
           }
           continue;
         }
@@ -454,9 +454,11 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
                   + Arrays.toString(existingVal) + ", newer=" + Arrays.toString(discardedVal)
                   + "; set tsd.storage.fix_duplicates=true to fix automatically or run Fsck");
             }
-            LOG.warn("Duplicate timestamp for key=" + Arrays.toString(row.get(0).key())
-                + ", ms_offset=" + ts + ", kept=" + Arrays.toString(existingVal) + ", discarded="
-                + Arrays.toString(discardedVal));
+            LOG.warn("Duplicate timestamp for key={}, ms_offset={}, kept={}, discarded={}",
+                Arrays.toString(row.get(0).key()),
+                ts,
+                Arrays.toString(existingVal),
+                Arrays.toString(discardedVal));
           } else {
             duplicates_same.incrementAndGet();
           }
@@ -624,13 +626,12 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
           add(((HBaseRpc.HasKey) rpc).key());
           return Boolean.TRUE;  // We handled it, so don't return an exception.
         } else {  // Should never get in this clause.
-          LOG.error("WTF?  Cannot retry this RPC, and this shouldn't happen: "
-                    + rpc);
+          LOG.error("WTF?  Cannot retry this RPC, and this shouldn't happen: {}", rpc);
         }
       }
       // `++' is not atomic but doesn't matter if we miss some increments.
       if (++errors % 100 == 1) {  // Basic rate-limiting to not flood logs.
-        LOG.error("Failed to " + what + " a row to re-compact", e);
+        LOG.error("Failed to {} a row to re-compact", what, e);
       }
       return e;
     }
@@ -707,9 +708,8 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
             flush(now / 1000 - Const.MAX_TIMESPAN - 1, maxflushes);
             if (LOG.isDebugEnabled()) {
               final int newsize = size();
-              LOG.debug("flush() took " + (System.currentTimeMillis() - now)
-                        + "ms, new queue size=" + newsize
-                        + " (" + (newsize - size) + ')');
+              LOG.debug("flush() took {}ms, new queue size={} ({})",
+                  System.currentTimeMillis() - now, newsize, newsize - size);
             }
           }
         } catch (Exception e) {
@@ -719,7 +719,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
           final int sz = size.get();
           CompactionQueue.super.clear();
           size.set(0);
-          LOG.error("Discarded the compaction queue, size=" + sz, e);
+          LOG.error("Discarded the compaction queue, size={}", sz, e);
         } catch (Throwable e) {
           LOG.error("Uncaught *Throwable* in compaction thread", e);
           // Catching this kind of error is totally unexpected and is really

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -165,7 +165,7 @@ public final class TSDB {
       try {
         PluginLoader.loadJARs(plugin_path);
       } catch (Exception e) {
-        LOG.error("Error loading plugins from plugin path: " + plugin_path, e);
+        LOG.error("Error loading plugins from plugin path: {}", plugin_path, e);
         throw new RuntimeException("Error loading plugins from plugin path: " + 
             plugin_path, e);
       }
@@ -184,9 +184,8 @@ public final class TSDB {
       } catch (Exception e) {
         throw new RuntimeException("Failed to initialize search plugin", e);
       }
-      LOG.info("Successfully initialized search plugin [" + 
-          search.getClass().getCanonicalName() + "] version: " 
-          + search.version());
+      LOG.info("Successfully initialized search plugin [{}] version: {}",
+          search.getClass().getCanonicalName(), search.version());
     } else {
       search = null;
     }
@@ -206,9 +205,8 @@ public final class TSDB {
         throw new RuntimeException(
             "Failed to initialize real time publisher plugin", e);
       }
-      LOG.info("Successfully initialized real time publisher plugin [" + 
-          rt_publisher.getClass().getCanonicalName() + "] version: " 
-          + rt_publisher.version());
+      LOG.info("Successfully initialized real time publisher plugin [{}] version: {}",
+          rt_publisher.getClass().getCanonicalName(), rt_publisher.version());
     } else {
       rt_publisher = null;
     }
@@ -233,9 +231,8 @@ public final class TSDB {
           rpc_plugins = new ArrayList<RpcPlugin>(1);
         }
         rpc_plugins.add(rpc);
-        LOG.info("Successfully initialized RPC plugin [" + 
-            rpc.getClass().getCanonicalName() + "] version: " 
-            + rpc.version());
+        LOG.info("Successfully initialized RPC plugin [{}] version: {}",
+            rpc.getClass().getCanonicalName(), rpc.version());
       }
     }
   }
@@ -760,19 +757,19 @@ public final class TSDB {
       deferreds.add(compactionq.flush().addCallback(new CompactCB()));
     }
     if (search != null) {
-      LOG.info("Shutting down search plugin: " + 
+      LOG.info("Shutting down search plugin: {}",
           search.getClass().getCanonicalName());
       deferreds.add(search.shutdown());
     }
     if (rt_publisher != null) {
-      LOG.info("Shutting down RT plugin: " + 
+      LOG.info("Shutting down RT plugin: {}",
           rt_publisher.getClass().getCanonicalName());
       deferreds.add(rt_publisher.shutdown());
     }
     
     if (rpc_plugins != null && !rpc_plugins.isEmpty()) {
       for (final RpcPlugin rpc : rpc_plugins) {
-        LOG.info("Shutting down RPC plugin: " + 
+        LOG.info("Shutting down RPC plugin: {}",
             rpc.getClass().getCanonicalName());
         deferreds.add(rpc.shutdown());
       }
@@ -892,7 +889,7 @@ public final class TSDB {
         return this.tag_values.getOrCreateId(name);
       }
     } else {
-      LOG.warn("Unknown type name: " + type);
+      LOG.warn("Unknown type name: {}", type);
       throw new IllegalArgumentException("Unknown type name");
     }
   }

--- a/src/core/TsdbQuery.java
+++ b/src/core/TsdbQuery.java
@@ -393,8 +393,8 @@ final class TsdbQuery implements Query {
            if (rows == null) {
              hbase_time += (System.nanoTime() - starttime) / 1000000;
              scanlatency.add(hbase_time);
-             LOG.info(TsdbQuery.this + " matched " + nrows + " rows in " +
-                 spans.size() + " spans in " + hbase_time + "ms");
+             LOG.info("{} matched {} rows in {} spans in {}ms",
+                 TsdbQuery.this, nrows, spans.size(), hbase_time);
              if (nrows < 1 && !seenAnnotation) {
                results.callback(null);
              } else {
@@ -501,9 +501,9 @@ final class TsdbQuery implements Query {
           i += value_width;
         }
         if (value_id == null) {
-          LOG.error("WTF? Dropping span for row " + Arrays.toString(row)
-                   + " as it had no matching tag from the requested groups,"
-                   + " which is unexpected. Query=" + this);
+          LOG.error("WTF? Dropping span for row {} as it had no matching tag " +
+                    "from the requested groups, which is unexpected. Query={}",
+              Arrays.toString(row), this);
           continue;
         }
         //LOG.info("Span belongs to group " + Arrays.toString(group) + ": " + Arrays.toString(row));

--- a/src/graph/Plot.java
+++ b/src/graph/Plot.java
@@ -369,7 +369,7 @@ public final class Plot {
       }
     } finally {
       gp.close();
-      LOG.info("Wrote Gnuplot script to " + script_path);
+      LOG.info("Wrote Gnuplot script to {}", script_path);
     }
   }
 

--- a/src/meta/Annotation.java
+++ b/src/meta/Annotation.java
@@ -163,7 +163,7 @@ public final class Annotation implements Comparable<Annotation> {
       }
     }
     if (!has_changes) {
-      LOG.debug(this + " does not have changes, skipping sync to storage");
+      LOG.debug("{} does not have changes, skipping sync to storage", this);
       throw new IllegalStateException("No changes detected in Annotation data");
     }
     

--- a/src/meta/TSMeta.java
+++ b/src/meta/TSMeta.java
@@ -231,7 +231,7 @@ public final class TSMeta {
       }
     }
     if (!has_changes) {
-      LOG.debug(this + " does not have changes, skipping sync to storage");
+      LOG.debug("{} does not have changes, skipping sync to storage", this);
       throw new IllegalStateException("No changes detected in TSUID meta data");
     }
 
@@ -586,11 +586,11 @@ public final class TSMeta {
           @Override
           public Deferred<Long> call(Boolean success) throws Exception {
             if (!success) {
-              LOG.warn("Unable to save metadata: " + meta);
+              LOG.warn("Unable to save metadata: {}", meta);
               return Deferred.fromResult(0L);
             }
-            
-            LOG.info("Successfullly created new TSUID entry for: " + meta);
+
+            LOG.info("Successfullly created new TSUID entry for: {}", meta);
             final Deferred<TSMeta> meta = getFromStorage(tsdb, tsuid)
               .addCallbackDeferring(
                 new LoadUIDs(tsdb, UniqueId.uidToString(tsuid)));
@@ -660,7 +660,7 @@ public final class TSMeta {
         }
         
         if (meta == null) {
-          LOG.warn("Found a counter TSMeta column without a meta for TSUID: " + 
+          LOG.warn("Found a counter TSMeta column without a meta for TSUID: {}",
               UniqueId.uidToString(row.get(0).key()));
           return Deferred.fromResult(null);
         }

--- a/src/meta/UIDMeta.java
+++ b/src/meta/UIDMeta.java
@@ -187,7 +187,7 @@ public final class UIDMeta {
       }
     }
     if (!has_changes) {
-      LOG.debug(this + " does not have changes, skipping sync to storage");
+      LOG.debug("{} does not have changes, skipping sync to storage", this);
       throw new IllegalStateException("No changes detected in UID meta data");
     }
     

--- a/src/search/TimeSeriesLookup.java
+++ b/src/search/TimeSeriesLookup.java
@@ -161,8 +161,8 @@ public class TimeSeriesLookup {
               }
               System.out.println(buf.toString());
             } catch (NoSuchUniqueId nsui) {
-              LOG.error("Unable to resolve UID in TSUID (" + 
-                  UniqueId.uidToString(tsuid) + ") " + nsui.getMessage());
+              LOG.error("Unable to resolve UID in TSUID ({}) {}",
+                  UniqueId.uidToString(tsuid), nsui.getMessage());
             }
             buf.setLength(0);   // reset the buffer so we can re-use it
           } else {
@@ -175,9 +175,9 @@ public class TimeSeriesLookup {
     } finally {
       scanner.close();
     }
-    
-    LOG.debug("Lookup query matched " + tsuids.size() + " time series in " +
-        (System.currentTimeMillis() - start) + " ms");
+
+    LOG.debug("Lookup query matched {} time series in {} ms",
+        tsuids.size(), System.currentTimeMillis() - start);
     return tsuids;
   }
   
@@ -198,8 +198,8 @@ public class TimeSeriesLookup {
         !query.getMetric().equals("*")) {
       final byte[] metric_uid = tsdb.getUID(UniqueIdType.METRIC, 
           query.getMetric());
-      LOG.debug("Found UID (" + UniqueId.uidToString(metric_uid) + 
-        ") for metric (" + query.getMetric() + ")");
+      LOG.debug("Found UID ({}) for metric ({})",
+          UniqueId.uidToString(metric_uid), query.getMetric());
       scanner.setStartKey(metric_uid);
       long uid = UniqueId.uidToLong(metric_uid, TSDB.metrics_width());
       uid++; // TODO - see what happens when this rolls over
@@ -261,14 +261,13 @@ public class TimeSeriesLookup {
         // filter on, so we dump the previous regex into the tagv_filter and
         // continue on with a row key
         tagv_filter.append(buf.toString());
-        LOG.debug("Setting tagv filter: " + buf.toString());
+        LOG.debug("Setting tagv filter: {}", buf.toString());
       } else if (index >= pairs.size()) {
         // in this case we don't have any tagks to deal with so we can just
         // pass the previously compiled regex to the rowkey filter of the 
         // scanner
         scanner.setKeyRegexp(buf.toString(), CHARSET);
-        LOG.debug("Setting scanner row key filter with tagvs only: " + 
-            buf.toString());
+        LOG.debug("Setting scanner row key filter with tagvs only: {}", buf.toString());
       }
       
       // catch any left over tagk/tag pairs
@@ -286,7 +285,7 @@ public class TimeSeriesLookup {
               Bytes.memcmp(last_pair.getKey(), pairs.get(index).getKey()) == 0) {
             // tagk=null is a wildcard so we don't need to bother adding 
             // tagk=tagv pairs with the same tagk.
-            LOG.debug("Skipping pair due to wildcard: " + pairs.get(index));
+            LOG.debug("Skipping pair due to wildcard: {}", pairs.get(index));
           } else if (last_pair != null && 
               Bytes.memcmp(last_pair.getKey(), pairs.get(index).getKey()) == 0) {
             // in this case we're ORing e.g. "host=web01|host=web02"
@@ -319,7 +318,7 @@ public class TimeSeriesLookup {
         buf.append(")(?:.{").append(tagsize).append("})*").append("$");
         
         scanner.setKeyRegexp(buf.toString(), CHARSET);
-        LOG.debug("Setting scanner row key filter: " + buf.toString());
+        LOG.debug("Setting scanner row key filter: {}", buf.toString());
       }
     }
     return scanner;

--- a/src/tools/CliQuery.java
+++ b/src/tools/CliQuery.java
@@ -94,9 +94,9 @@ final class CliQuery {
     if (plot != null) {
       try {
         final int npoints = plot.dumpToFiles(basepath);
-        LOG.info("Wrote " + npoints + " for Gnuplot");
+        LOG.info("Wrote {} for Gnuplot", npoints);
       } catch (IOException e) {
-        LOG.error("Failed to write the Gnuplot file under " + basepath, e);
+        LOG.error("Failed to write the Gnuplot file under {}", basepath, e);
         System.exit(1);
       }
     }

--- a/src/tools/MetaPurge.java
+++ b/src/tools/MetaPurge.java
@@ -82,12 +82,12 @@ final class MetaPurge extends Thread {
     long purged_columns;
     try {
       purged_columns = purgeUIDMeta().joinUninterruptibly();
-      LOG.info("Thread [" + thread_id + "] finished. Purged [" + 
-          purged_columns + "] UIDMeta columns from storage");
+      LOG.info("Thread [{}] finished. Purged [{}] UIDMeta columns from storage",
+          thread_id, purged_columns);
       
       purged_columns = purgeTSMeta().joinUninterruptibly();
-      LOG.info("Thread [" + thread_id + "] finished. Purged [" + 
-          purged_columns + "] TSMeta columns from storage");
+      LOG.info("Thread [{}] finished. Purged [{}] TSMeta columns from storage",
+          thread_id, purged_columns);
     } catch (Exception e) {
       LOG.error("Unexpected exception", e);
     }
@@ -177,8 +177,7 @@ final class MetaPurge extends Thread {
           @Override
           public Deferred<Long> call(ArrayList<Object> deletes)
               throws Exception {
-            LOG.debug("[" + thread_id + "] Processed [" + deletes.size() 
-                + "] delete calls");
+            LOG.debug("[{}] Processed [{}] delete calls", thread_id, deletes.size());
             delete_calls.clear();
             return scan();
           }
@@ -275,8 +274,7 @@ final class MetaPurge extends Thread {
           @Override
           public Deferred<Long> call(ArrayList<Object> deletes)
               throws Exception {
-            LOG.debug("[" + thread_id + "] Processed [" + deletes.size() 
-                + "] delete calls");
+            LOG.debug("[{}] Processed [{}] delete calls", thread_id, deletes.size());
             delete_calls.clear();
             return scan();
           }

--- a/src/tools/MetaSync.java
+++ b/src/tools/MetaSync.java
@@ -148,8 +148,8 @@ final class MetaSync extends Thread {
           UIDMeta new_meta = new UIDMeta(type, uid, name);
           new_meta.setCreated(timestamp);
           tsdb.indexUIDMeta(new_meta);
-          LOG.info("Replacing corrupt UID [" + UniqueId.uidToString(uid) + 
-            "] of type [" + type + "]");
+          LOG.info("Replacing corrupt UID [{}] of type [{}]",
+              UniqueId.uidToString(uid), type);
           
           return new_meta.syncToStorage(tsdb, true);
         }
@@ -163,8 +163,7 @@ final class MetaSync extends Thread {
         // otherwise it's probably an accurate timestamp
         if (meta.getCreated() > (timestamp + 3600) || 
             meta.getCreated() == 0) {
-          LOG.info("Updating UID [" + UniqueId.uidToString(uid) + 
-              "] of type [" + type + "]");
+          LOG.info("Updating UID [{}] of type [{}]", UniqueId.uidToString(uid), type);
           meta.setCreated(timestamp);
           
           // if the UIDMeta object was missing any of these fields, we'll
@@ -177,13 +176,13 @@ final class MetaSync extends Thread {
             // the meta was good, just needed a timestamp update so sync to
             // search and storage
             tsdb.indexUIDMeta(meta);
-            LOG.info("Syncing valid UID [" + UniqueId.uidToString(uid) + 
-              "] of type [" + type + "]");
+            LOG.info("Syncing valid UID [{}] of type [{}]",
+                UniqueId.uidToString(uid), type);
             return meta.syncToStorage(tsdb, false);
           }
         } else {
-          LOG.debug("UID [" + UniqueId.uidToString(uid) + 
-              "] of type [" + type + "] is up to date in storage");
+          LOG.debug("UID [{}] of type [{}] is up to date in storage",
+              UniqueId.uidToString(uid), type);
           return Deferred.fromResult(true);
         }
       }
@@ -228,8 +227,7 @@ final class MetaSync extends Thread {
 
             @Override
             public Deferred<Boolean> call(Long value) throws Exception {
-              LOG.info("Created counter and meta for timeseries [" + 
-                  tsuid_string + "]");
+              LOG.info("Created counter and meta for timeseries [{}]", tsuid_string);
               return Deferred.fromResult(true);
             }
             
@@ -253,8 +251,8 @@ final class MetaSync extends Thread {
               } else {
                 TSMeta new_meta = new TSMeta(tsuid, timestamp);
                 tsdb.indexTSMeta(new_meta);
-                LOG.info("Counter exists but meta was null, creating meta data for timeseries [" + 
-                    tsuid_string + "]");
+                LOG.info("Counter exists but meta was null, creating meta data " +
+                         "for timeseries [{}]", tsuid_string);
                 return new_meta.storeNew(tsdb);    
               }
             }
@@ -271,8 +269,7 @@ final class MetaSync extends Thread {
         // corrupted
         if (meta.getTSUID() == null || 
             meta.getTSUID().isEmpty()) {
-          LOG.warn("Replacing corrupt meta data for timeseries [" + 
-              tsuid_string + "]");
+          LOG.warn("Replacing corrupt meta data for timeseries [{}]", tsuid_string);
           TSMeta new_meta = new TSMeta(tsuid, timestamp);
           tsdb.indexTSMeta(new_meta);
           return new_meta.storeNew(tsdb);
@@ -283,12 +280,11 @@ final class MetaSync extends Thread {
               meta.getCreated() == 0) {
             meta.setCreated(timestamp);
             tsdb.indexTSMeta(meta);
-            LOG.info("Updated created timestamp for timeseries [" + 
-                tsuid_string + "]");
+            LOG.info("Updated created timestamp for timeseries [{}]", tsuid_string);
             return meta.syncToStorage(tsdb, false);
           }
-          
-          LOG.debug("TSUID [" + tsuid_string + "] is up to date in storage");
+
+          LOG.debug("TSUID [{}] is up to date in storage", tsuid_string);
           return Deferred.fromResult(false);
         }
       }
@@ -358,9 +354,9 @@ final class MetaSync extends Thread {
           // parse datapoints, but for now the hourly row time is enough
           final long timestamp = Bytes.getUnsignedInt(row.get(0).key(), 
               TSDB.metrics_width());
-          
-          LOG.debug("[" + thread_id + "] Processing TSUID: " + tsuid_string + 
-              "  row timestamp: " + timestamp);
+
+          LOG.debug("[{}] Processing TSUID: {}  row timestamp: {}",
+              thread_id, tsuid_string, timestamp);
           
           // now process the UID metric meta data
           final byte[] metric_uid_bytes = 
@@ -434,16 +430,16 @@ final class MetaSync extends Thread {
                 ex = ex.getCause();
               }
               if (ex.getClass().equals(IllegalStateException.class)) {
-                LOG.error("Invalid data when processing TSUID [" + 
-                    tsuid_string + "]", ex);
+                LOG.error("Invalid data when processing TSUID [{}]",
+                    tsuid_string, ex);
               } else if (ex.getClass().equals(IllegalArgumentException.class)) {
-                LOG.error("Invalid data when processing TSUID [" + 
-                    tsuid_string + "]", ex);
+                LOG.error("Invalid data when processing TSUID [{}]",
+                    tsuid_string, ex);
               } else if (ex.getClass().equals(NoSuchUniqueId.class)) {
-                LOG.warn("Timeseries [" + tsuid_string + 
-                    "] includes a non-existant UID: " + ex.getMessage());
+                LOG.warn("Timeseries [{}] includes a non-existant UID: {}",
+                    tsuid_string, ex.getMessage());
               } else {
-                LOG.error("Unmatched Exception: " + ex.getClass());
+                LOG.error("Unmatched Exception: {}", ex.getClass());
                 throw e;
               }
               
@@ -495,7 +491,7 @@ final class MetaSync extends Thread {
               }
               ex = ex.getCause();
             }
-            LOG.error("[" + thread_id + "] Upstream Exception: ", ex);
+            LOG.error("[{}] Upstream Exception: ", thread_id, ex);
             return scan();
           }
         }
@@ -513,9 +509,9 @@ final class MetaSync extends Thread {
     try {
       scanner.scan();
       result.joinUninterruptibly();
-      LOG.info("[" + thread_id + "] Complete");
+      LOG.info("[{}] Complete", thread_id);
     } catch (Exception e) {
-      LOG.error("[" + thread_id + "] Scanner Exception", e);
+      LOG.error("[{}] Scanner Exception", thread_id, e);
       throw new RuntimeException("[" + thread_id + "] Scanner exception", e);
     }
   }
@@ -532,8 +528,8 @@ final class MetaSync extends Thread {
     final byte[] end_row = 
       Arrays.copyOfRange(Bytes.fromLong(end_id), 8 - metric_width, 8);
 
-    LOG.debug("[" + thread_id + "] Start row: " + UniqueId.uidToString(start_row));
-    LOG.debug("[" + thread_id + "] End row: " + UniqueId.uidToString(end_row));
+    LOG.debug("[{}] Start row: {}", thread_id, UniqueId.uidToString(start_row));
+    LOG.debug("[{}] End row: {}", thread_id, UniqueId.uidToString(end_row));
     final Scanner scanner = tsdb.getClient().newScanner(tsdb.dataTable());
     scanner.setStartKey(start_row);
     scanner.setStopKey(end_row);

--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -170,7 +170,7 @@ final class TSDMain {
       final InetSocketAddress addr = new InetSocketAddress(bindAddress,
           config.getInt("tsd.network.port"));
       server.bind(addr);
-      log.info("Ready to serve on " + addr);
+      log.info("Ready to serve on {}", addr);
     } catch (Throwable e) {
       factory.releaseExternalResources();
       try {

--- a/src/tools/TextImporter.java
+++ b/src/tools/TextImporter.java
@@ -116,8 +116,7 @@ final class TextImporter {
             }
             return null;
           }
-          LOG.error("Exception caught while processing file "
-                    + path, arg);
+          LOG.error("Exception caught while processing file {}", path, arg);
           System.exit(2);
           return arg;
         }
@@ -173,7 +172,7 @@ final class TextImporter {
           }
           throttle_time = System.nanoTime() - throttle_time;
           if (throttle_time < 1000000000L) {
-            LOG.info("Got throttled for only " + throttle_time + "ns, sleeping a bit now");
+            LOG.info("Got throttled for only {}ns, sleeping a bit now", throttle_time);
             try { Thread.sleep(1000); } catch (InterruptedException e) { throw new RuntimeException("interrupted", e); }
           }
           LOG.info("Done throttling...");
@@ -181,8 +180,7 @@ final class TextImporter {
         }
       }
     } catch (RuntimeException e) {
-        LOG.error("Exception caught while processing file "
-                  + path + " line=" + line);
+      LOG.error("Exception caught while processing file {} line={}", path, line);
         throw e;
     } finally {
       in.close();

--- a/src/tools/TreeSync.java
+++ b/src/tools/TreeSync.java
@@ -101,9 +101,9 @@ final class TreeSync extends Thread {
     final List<Tree> trees;
     try {
       trees = Tree.fetchAllTrees(tsdb).joinUninterruptibly();
-      LOG.info("[" + thread_id + "] Complete");
+      LOG.info("[{}] Complete", thread_id);
     } catch (Exception e) {
-      LOG.error("[" + thread_id + "] Unexpected Exception", e);
+      LOG.error("[{}] Unexpected Exception", thread_id, e);
       throw new RuntimeException("[" + thread_id + "] Unexpected exception", e);
     }
     
@@ -122,7 +122,7 @@ final class TreeSync extends Thread {
         LOG.warn("No enabled trees were found");
         return;
       }
-      LOG.info("Found [" + trees.size() + "] trees");
+      LOG.info("Found [{}] trees", trees.size());
     }
     
     // setup an array for storing the tree processing calls so we can block 
@@ -194,8 +194,8 @@ final class TreeSync extends Thread {
             @Override
             public Deferred<Boolean> call(TSMeta meta) throws Exception {
               if (meta != null) {
-                LOG.debug("Processing TSMeta: " + meta + " w value: " + 
-                    JSON.serializeToString(meta));
+                LOG.debug("Processing TSMeta: {} w value: {}",
+                    meta, JSON.serializeToString(meta));
                 
                 // copy the trees into a tree builder object and iterate through
                 // each builder. We need to do this as a builder is not thread
@@ -233,15 +233,13 @@ final class TreeSync extends Thread {
             public Deferred<Boolean> call(Exception e) throws Exception {
               
               if (e.getClass().equals(IllegalStateException.class)) {
-                LOG.error("Invalid data when processing TSUID [" + tsuid + "]", e);
+                LOG.error("Invalid data when processing TSUID [{}]", tsuid, e);
               } else if (e.getClass().equals(IllegalArgumentException.class)) {
-                LOG.error("Invalid data when processing TSUID [" + tsuid + "]", e);
+                LOG.error("Invalid data when processing TSUID [{}]", tsuid, e);
               } else if (e.getClass().equals(NoSuchUniqueId.class)) {
-                LOG.warn("Timeseries [" + tsuid + 
-                    "] includes a non-existant UID: " + e.getMessage());
+                LOG.warn("Timeseries [{}] includes a non-existant UID: {}", tsuid, e.getMessage());
               } else {
-                LOG.error("[" + thread_id + "] Exception while processing TSUID [" + 
-                    tsuid + "]", e);
+                LOG.error("[{}] Exception while processing TSUID [{}]", thread_id, tsuid, e);
               }
               
               return Deferred.fromResult(false);
@@ -270,7 +268,7 @@ final class TreeSync extends Thread {
           @Override
           public Deferred<Boolean> call(ArrayList<Boolean> tsuids)
               throws Exception {
-            LOG.debug("Processed [" + tsuids.size() + "] tree_calls, continuing");
+            LOG.debug("Processed [{}] tree_calls, continuing", tsuids.size());
             tree_calls.clear();
             return scan();
           }
@@ -305,9 +303,9 @@ final class TreeSync extends Thread {
     tree_scanner.scan().addErrback(new ErrBack());
     try {
       completed.joinUninterruptibly();
-      LOG.info("[" + thread_id + "] Complete");
+      LOG.info("[{}] Complete", thread_id);
     } catch (Exception e) {
-      LOG.error("[" + thread_id + "] Scanner Exception", e);
+      LOG.error("[{}] Scanner Exception", thread_id, e);
       throw new RuntimeException("[" + thread_id + "] Scanner exception", e);
     }
     return;
@@ -324,12 +322,12 @@ final class TreeSync extends Thread {
   public int purgeTree(final int tree_id, final boolean delete_definition) 
     throws Exception {
     if (delete_definition) {
-      LOG.info("Deleting tree branches and definition for: " + tree_id);
+      LOG.info("Deleting tree branches and definition for: {}", tree_id);
     } else {
-      LOG.info("Deleting tree branches for: " + tree_id);
+      LOG.info("Deleting tree branches for: {}", tree_id);
     }
     Tree.deleteTree(tsdb, tree_id, delete_definition).joinUninterruptibly();
-    LOG.info("Completed tree deletion for: " + tree_id);
+    LOG.info("Completed tree deletion for: {}", tree_id);
     return 0;
   }
 
@@ -345,8 +343,8 @@ final class TreeSync extends Thread {
     final byte[] end_row = 
       Arrays.copyOfRange(Bytes.fromLong(end_id), 8 - metric_width, 8);
 
-    LOG.debug("[" + thread_id + "] Start row: " + UniqueId.uidToString(start_row));
-    LOG.debug("[" + thread_id + "] End row: " + UniqueId.uidToString(end_row));
+    LOG.debug("[{}] Start row: {}", thread_id, UniqueId.uidToString(start_row));
+    LOG.debug("[{}] End row: {}", thread_id, UniqueId.uidToString(end_row));
     final Scanner scanner = tsdb.getClient().newScanner(tsdb.metaTable());
     scanner.setStartKey(start_row);
     scanner.setStopKey(end_row);

--- a/src/tools/UidManager.java
+++ b/src/tools/UidManager.java
@@ -352,10 +352,10 @@ final class UidManager {
         }
       }
     } catch (HBaseException e) {
-      LOG.error("Error while scanning HBase, scanner=" + scanner, e);
+      LOG.error("Error while scanning HBase, scanner={}", scanner, e);
       throw e;
     } catch (Exception e) {
-      LOG.error("WTF?  Unexpected exception type, scanner=" + scanner, e);
+      LOG.error("WTF?  Unexpected exception type, scanner={}", scanner, e);
       throw new AssertionError("Should never happen");
     }
     return found ? 0 : 1;
@@ -410,7 +410,7 @@ final class UidManager {
         // Lookup again the ID we've just created and print it.
         extactLookupName(client, table, idwidth, args[1], args[i]);
       } catch (HBaseException e) {
-        LOG.error("error while processing " + args[i], e);
+        LOG.error("error while processing {}", args[i], e);
         return 3;
       }
     }
@@ -436,8 +436,7 @@ final class UidManager {
     try {
       uid.rename(oldname, newname);
     } catch (HBaseException e) {
-      LOG.error("error while processing renaming " + oldname
-                + " to " + newname, e);
+      LOG.error("error while processing renaming {} to {}", oldname, newname, e);
       return 3;
     } catch (NoSuchUniqueName e) {
       LOG.error(e.getMessage());
@@ -459,7 +458,7 @@ final class UidManager {
     if (fix) {
       LOG.info("----------------------------------");
       LOG.info("-    Running fsck in FIX mode    -");
-      LOG.info("-      Remove Unknowns: " + fix_unknowns + "     -");
+      LOG.info("-      Remove Unknowns: {}       -", fix_unknowns);
       LOG.info("----------------------------------");
     } else {
       LOG.info("Running in log only mode");
@@ -492,8 +491,7 @@ final class UidManager {
             toBytes(name));
         client.put(put);
         id2name.put(uid, name);
-        LOG.info("FIX: Restoring " + kind + " reverse mapping: " 
-            + uid + " -> " + name);
+        LOG.info("FIX: Restoring {} reverse mapping: {} -> {}", kind, uid, name);
       }
       
       /*
@@ -516,8 +514,7 @@ final class UidManager {
             UniqueId.stringToUid(uid), NAME_FAMILY, qualifiers);
         client.delete(delete);
         // can't remove from the id2name map as this will be called while looping
-        LOG.info("FIX: Removed " + kind + " reverse mapping: " + uid + " -> "
-            + name);
+        LOG.info("FIX: Removed {} reverse mapping: {} -> {}", kind, uid, name);
       }
     }
 
@@ -545,15 +542,16 @@ final class UidManager {
             if (!Bytes.equals(qualifier, METRICS) &&
                 !Bytes.equals(qualifier, TAGK) &&
                 !Bytes.equals(qualifier, TAGV)) {
-              LOG.warn("Unknown qualifier " + UniqueId.uidToString(qualifier) 
-                  + " in row " + UniqueId.uidToString(kv.key()));
+              LOG.warn("Unknown qualifier {} in row {}",
+                  UniqueId.uidToString(qualifier),
+                  UniqueId.uidToString(kv.key()));
               if (fix && fix_unknowns) {
                 final DeleteRequest delete = new DeleteRequest(table, kv.key(), 
                     kv.family(), qualifier);
                 client.delete(delete);
-                LOG.info("FIX: Removed unknown qualifier " 
-                  + UniqueId.uidToString(qualifier) 
-                  + " in row " + UniqueId.uidToString(kv.key()));
+                LOG.info("FIX: Removed unknown qualifier {} in row {}",
+                    UniqueId.uidToString(qualifier),
+                    UniqueId.uidToString(kv.key()));
               }
               continue;
             }
@@ -575,7 +573,7 @@ final class UidManager {
                 // and store that in the max row.
               } else {
                 uids.maxid = Bytes.getLong(value);
-                LOG.info("Maximum ID for " + kind + ": " + uids.maxid);
+                LOG.info("Maximum ID for {}: {}", kind, uids.maxid);
               }
             } else {
               short idwidth = 0;
@@ -622,10 +620,10 @@ final class UidManager {
         }
       }
     } catch (HBaseException e) {
-      LOG.error("Error while scanning HBase, scanner=" + scanner, e);
+      LOG.error("Error while scanning HBase, scanner={}", scanner, e);
       throw e;
     } catch (Exception e) {
-      LOG.error("WTF?  Unexpected exception type, scanner=" + scanner, e);
+      LOG.error("WTF?  Unexpected exception type, scanner={}", scanner, e);
       throw new AssertionError("Should never happen");
     }
 
@@ -735,8 +733,7 @@ final class UidManager {
                 ID_FAMILY, toBytes(kind));
             client.delete(delete);
             uids.name2id.remove(name);
-            LOG.info("FIX: Removed forward " + kind + " mapping for " + name + " -> " 
-                + id);
+            LOG.info("FIX: Removed forward {} mapping for {} -> {}", kind, name, id);
           }
           
           // write the new forward map
@@ -744,8 +741,8 @@ final class UidManager {
           final PutRequest put = new PutRequest(table, toBytes(fsck_name), 
               ID_FAMILY, toBytes(kind), UniqueId.stringToUid(id));
           client.put(put);
-          LOG.info("FIX: Created forward " + kind + " mapping for fsck'd UID " + 
-              fsck_name + " -> " + collision.getKey());
+          LOG.info("FIX: Created forward {} mapping for fsck'd UID {} -> {}",
+              kind, fsck_name, collision.getKey());
           
           // we still need to fix the uids map for the reverse run through below
           uids.name2id.put(fsck_name, collision.getKey());
@@ -753,8 +750,7 @@ final class UidManager {
           
           LOG.error("----------------------------------");
           LOG.error("-     UID COLLISION DETECTED     -");
-          LOG.error("Corrupted UID [" + collision.getKey() + "] renamed to [" 
-              + fsck_name +"]");
+          LOG.error("Corrupted UID [{}] renamed to [{}]", collision.getKey(), fsck_name);
           LOG.error("----------------------------------");
         }
       }
@@ -766,8 +762,8 @@ final class UidManager {
         final String id = idname.getKey();
         final String found = uids.name2id.get(name);
         if (found == null) {
-          LOG.warn("Reverse " + kind + " mapping is missing forward"
-                   + " mapping: " + name + " -> " + id);
+          LOG.warn("Reverse {} mapping is missing forward mapping: {} -> {}",
+              kind, name, id);
           
           if (fix) {
             uids.removeReverseMap(kind, name, id);
@@ -797,9 +793,8 @@ final class UidManager {
 
       final int maxsize = Math.max(uids.id2name.size(), uids.name2id.size());
       if (uids.maxid > maxsize) {
-        LOG.warn("Max ID for " + kind + " is " + uids.maxid + " but only "
-                 + maxsize + " entries were found.  Maybe "
-                 + (uids.maxid - maxsize) + " IDs were deleted?");
+        LOG.warn("Max ID for {} is {} but only {} entries were found. Maybe " +
+                 "{} IDs were deleted?", kind, uids.maxid, maxsize, uids.maxid - maxsize);
       } else if (uids.maxid < uids.max_found_id) {
         uids.error("We found an ID of " + uids.max_found_id + " for " + kind 
                    + " but the max ID is only " + uids.maxid 
@@ -811,30 +806,30 @@ final class UidManager {
           // put us over a little, but that's OK as it's better to waste a few
           // IDs than to under-run.
           if (uids.max_found_id == Long.MAX_VALUE) {
-            LOG.error("Ran out of UIDs for " + kind + ". Unable to fix max ID");
+            LOG.error("Ran out of UIDs for {}. Unable to fix max ID", kind);
           } else {
             final long diff = uids.max_found_id - uids.maxid;
             final AtomicIncrementRequest air = new AtomicIncrementRequest(table, 
                 MAXID_ROW, ID_FAMILY, toBytes(kind), diff);
             client.atomicIncrement(air);
-            LOG.info("FIX: Updated max ID for " + kind + " to " + uids.max_found_id);
+            LOG.info("FIX: Updated max ID for {} to {}", kind, uids.max_found_id);
           }          
         }
       }
 
       if (uids.errors > 0) {
-        LOG.error(kind + ": Found " + uids.errors + " errors.");
+        LOG.error("{}: Found {} errors.", kind, uids.errors);
         errors += uids.errors;
       }
     }
     final long timing = (System.nanoTime() - start_time) / 1000000;
-    LOG.info(kvcount + " KVs analyzed in " + timing + "ms (~"
-                       + (kvcount * 1000 / timing) + " KV/s)");
+    LOG.info("{} KVs analyzed in {}ms (~{} KV/s)",
+        kvcount, timing, kvcount * 1000 / timing);
     if (errors == 0) {
       LOG.info("No errors found.");
       return 0;
     }
-    LOG.warn(errors + " errors found.");
+    LOG.warn("{} errors found.", errors);
     return errors;
   }
 
@@ -880,10 +875,10 @@ final class UidManager {
     try {
       row = client.get(get).joinUninterruptibly();
     } catch (HBaseException e) {
-      LOG.error("Get failed: " + get, e);
+      LOG.error("Get failed: {}", get, e);
       return 1;
     } catch (Exception e) {
-      LOG.error("WTF?  Unexpected exception type, get=" + get, e);
+      LOG.error("WTF?  Unexpected exception type, get={}", get, e);
       return 42;
     }
     return printResult(row, family, formard) ? 0 : 1;
@@ -1026,9 +1021,9 @@ final class UidManager {
       new ConcurrentHashMap<String, Long>();
     
     long index = 1;
-    
-    LOG.info("Max metric ID is [" + max_id + "]");
-    LOG.info("Spooling up [" + workers + "] worker threads");
+
+    LOG.info("Max metric ID is [{}]", max_id);
+    LOG.info("Spooling up [{}] worker threads", workers);
     final Thread[] threads = new Thread[workers];
     for (int i = 0; i < workers; i++) {
       threads[i] = new MetaSync(tsdb, index, quotient, processed_tsuids, 
@@ -1044,15 +1039,14 @@ final class UidManager {
     // wait till we're all done
     for (int i = 0; i < workers; i++) {
       threads[i].join();
-      LOG.info("[" + i + "] Finished");
+      LOG.info("[{}] Finished", i);
     }
     
     // make sure buffered data is flushed to storage before exiting
     tsdb.flush().joinUninterruptibly();
     
     final long duration = (System.currentTimeMillis() / 1000) - start_time;
-    LOG.info("Completed meta data synchronization in [" + 
-        duration + "] seconds");
+    LOG.info("Completed meta data synchronization in [{}] seconds", duration);
     return 0;
   }
   
@@ -1077,9 +1071,9 @@ final class UidManager {
     final double quotient = (double)max_id / (double)workers;
     
     long index = 1;
-    
-    LOG.info("Max metric ID is [" + max_id + "]");
-    LOG.info("Spooling up [" + workers + "] worker threads");
+
+    LOG.info("Max metric ID is [{}]", max_id);
+    LOG.info("Spooling up [{}] worker threads", workers);
     final Thread[] threads = new Thread[workers];
     for (int i = 0; i < workers; i++) {
       threads[i] = new MetaPurge(tsdb, index, quotient, i);
@@ -1094,15 +1088,14 @@ final class UidManager {
     // wait till we're all done
     for (int i = 0; i < workers; i++) {
       threads[i].join();
-      LOG.info("[" + i + "] Finished");
+      LOG.info("[{}] Finished", i);
     }
     
     // make sure buffered data is flushed to storage before exiting
     tsdb.flush().joinUninterruptibly();
     
     final long duration = (System.currentTimeMillis() / 1000) - start_time;
-    LOG.info("Completed meta data synchronization in [" + 
-        duration + "] seconds");
+    LOG.info("Completed meta data synchronization in [{}] seconds", duration);
     return 0;
   }
   
@@ -1124,9 +1117,9 @@ final class UidManager {
     final double quotient = (double)max_id / (double)workers;
     
     long index = 1;
-    
-    LOG.info("Max metric ID is [" + max_id + "]");
-    LOG.info("Spooling up [" + workers + "] worker threads");
+
+    LOG.info("Max metric ID is [{}]", max_id);
+    LOG.info("Spooling up [{}] worker threads", workers);
     final Thread[] threads = new Thread[workers];
     for (int i = 0; i < workers; i++) {
       threads[i] = new TreeSync(tsdb, index, quotient, i);
@@ -1141,15 +1134,14 @@ final class UidManager {
     // wait till we're all done
     for (int i = 0; i < workers; i++) {
       threads[i].join();
-      LOG.info("[" + i + "] Finished");
+      LOG.info("[{}] Finished", i);
     }
     
     // make sure buffered data is flushed to storage before exiting
     tsdb.flush().joinUninterruptibly();
     
     final long duration = (System.currentTimeMillis() / 1000) - start_time;
-    LOG.info("Completed meta data synchronization in [" + 
-        duration + "] seconds");
+    LOG.info("Completed meta data synchronization in [{}] seconds", duration);
     return 0;
   }
   

--- a/src/tree/Branch.java
+++ b/src/tree/Branch.java
@@ -246,9 +246,9 @@ public final class Branch implements Comparable<Branch> {
         
         // log at info or lower since it's not a system error, rather it's
         // a user issue with the rules or naming schema
-        LOG.warn("Incoming TSUID [" + leaf.getTsuid() + 
-            "] collided with existing TSUID [" + collision.getTsuid() + 
-            "] on display name [" + collision.getDisplayName() + "]");
+        LOG.warn("Incoming TSUID [{}] collided with existing TSUID [{}] on " +
+                 "display name [{}]",
+            leaf.getTsuid(), collision.getTsuid(), collision.getDisplayName());
       }
       return false;
     } else {
@@ -459,8 +459,8 @@ public final class Branch implements Comparable<Branch> {
           ex = ex.getCause();
         }
         if (ex.getClass().equals(NoSuchUniqueId.class)) {
-          LOG.debug("Invalid UID for leaf: " + idToString(qualifier) + 
-              " in branch: " + idToString(branch_id), ex);
+          LOG.debug("Invalid UID for leaf: {} in branch: {}",
+              idToString(qualifier), idToString(branch_id), ex);
         } else {
           throw (Exception)ex;
         }

--- a/src/tree/Leaf.java
+++ b/src/tree/Leaf.java
@@ -209,23 +209,25 @@ public final class Leaf implements Comparable<Leaf> {
           public Deferred<Boolean> call(final Leaf existing_leaf) 
             throws Exception {
             if (existing_leaf == null) {
-              LOG.error(
-                  "Returned leaf was null, stored data may be corrupt for leaf: "
-                  + Branch.idToString(columnQualifier()) + " on branch: "
-                  + Branch.idToString(branch_id));
+              LOG.error("Returned leaf was null, stored data may be corrupt " +
+                        "for leaf: {} on branch: {}",
+                  Branch.idToString(columnQualifier()),
+                  Branch.idToString(branch_id));
               return Deferred.fromResult(false);
             }
             
             if (existing_leaf.tsuid.equals(tsuid)) {
-              LOG.debug("Leaf already exists: " + local_leaf);
+              LOG.debug("Leaf already exists: {}", local_leaf);
               return Deferred.fromResult(true);
             }
             
             tree.addCollision(tsuid, existing_leaf.tsuid);
-            LOG.warn("Branch ID: [" + Branch.idToString(branch_id)  
-                + "] Leaf collision with [" + tsuid + 
-                "] on existing leaf [" + existing_leaf.tsuid + 
-                "] named [" + display_name + "]");
+            LOG.warn("Branch ID: [{}] Leaf collision with [{}] on existing " +
+                     "leaf [{}] named [{}]",
+                Branch.idToString(branch_id),
+                tsuid,
+                existing_leaf.tsuid,
+                display_name);
             return Deferred.fromResult(false);
           }
           
@@ -272,7 +274,7 @@ public final class Leaf implements Comparable<Leaf> {
     
     // if there was an error with the data and the tsuid is missing, dump it
     if (leaf.tsuid == null || leaf.tsuid.isEmpty()) {
-      LOG.warn("Invalid leaf object in row: " + Branch.idToString(column.key()));
+      LOG.warn("Invalid leaf object in row: {}", Branch.idToString(column.key()));
       return Deferred.fromResult(null);
     }
     

--- a/src/tree/Tree.java
+++ b/src/tree/Tree.java
@@ -323,7 +323,7 @@ public final class Tree {
       }
     }
     if (!has_changes) {
-      LOG.debug(this + " does not have changes, skipping sync to storage");
+      LOG.debug("{} does not have changes, skipping sync to storage", this);
       throw new IllegalStateException("No changes detected in the tree");
     }
 
@@ -848,13 +848,13 @@ public final class Tree {
           for (KeyValue column : row) {
             // tree
             if (delete_definition && Bytes.equals(TREE_QUALIFIER, column.qualifier())) {
-              LOG.trace("Deleting tree defnition in row: " + 
+              LOG.trace("Deleting tree defnition in row: {}",
                   Branch.idToString(column.key()));
               qualifiers.add(column.qualifier());
               
             // branches
             } else if (Bytes.equals(Branch.BRANCH_QUALIFIER(), column.qualifier())) {
-              LOG.trace("Deleting branch in row: " + 
+              LOG.trace("Deleting branch in row: {}",
                   Branch.idToString(column.key()));
               qualifiers.add(column.qualifier());
             
@@ -862,7 +862,7 @@ public final class Tree {
             } else if (column.qualifier().length > Leaf.LEAF_PREFIX().length &&
                 Bytes.memcmp(Leaf.LEAF_PREFIX(), column.qualifier(), 0, 
                     Leaf.LEAF_PREFIX().length) == 0) {
-              LOG.trace("Deleting leaf in row: " + 
+              LOG.trace("Deleting leaf in row: {}",
                   Branch.idToString(column.key()));
               qualifiers.add(column.qualifier());
               
@@ -870,7 +870,7 @@ public final class Tree {
             } else if (column.qualifier().length > COLLISION_PREFIX.length && 
                 Bytes.memcmp(COLLISION_PREFIX, column.qualifier(), 0, 
                     COLLISION_PREFIX.length) == 0) {
-              LOG.trace("Deleting collision in row: " + 
+              LOG.trace("Deleting collision in row: {}",
                   Branch.idToString(column.key()));
               qualifiers.add(column.qualifier());
               
@@ -878,7 +878,7 @@ public final class Tree {
             } else if (column.qualifier().length > NOT_MATCHED_PREFIX.length && 
                 Bytes.memcmp(NOT_MATCHED_PREFIX, column.qualifier(), 0, 
                     NOT_MATCHED_PREFIX.length) == 0) {
-              LOG.trace("Deleting not matched in row: " + 
+              LOG.trace("Deleting not matched in row: {}",
                   Branch.idToString(column.key()));
               qualifiers.add(column.qualifier());
               
@@ -886,7 +886,7 @@ public final class Tree {
             } else if (delete_definition && column.qualifier().length > TreeRule.RULE_PREFIX().length && 
                 Bytes.memcmp(TreeRule.RULE_PREFIX(), column.qualifier(), 0, 
                     TreeRule.RULE_PREFIX().length) == 0) {
-              LOG.trace("Deleting tree rule in row: " + 
+              LOG.trace("Deleting tree rule in row: {}",
                   Branch.idToString(column.key()));
               qualifiers.add(column.qualifier());
             } 
@@ -912,7 +912,7 @@ public final class Tree {
           ArrayList<Object>> {
           
           public Deferred<Boolean> call(ArrayList<Object> objects) {
-            LOG.debug("Purged [" + objects.size() + "] columns, continuing");
+            LOG.debug("Purged [{}] columns, continuing", objects.size());
             delete_deferreds.clear();
             // call ourself again to get the next set of rows from the scanner
             return deleteTree();

--- a/src/tree/TreeBuilder.java
+++ b/src/tree/TreeBuilder.java
@@ -227,8 +227,8 @@ public final class TreeBuilder {
           // something was wrong with the rule set that resulted in an empty
           // branch. Since this is likely a user error, log it instead of
           // throwing an exception
-          LOG.warn("Processed TSUID [" + meta + 
-              "] resulted in a null branch on tree: " + tree.getTreeId());
+          LOG.warn("Processed TSUID [{}] resulted in a null branch on tree: {}",
+              meta, tree.getTreeId());
           
         } else if (!is_testing) {
           
@@ -240,7 +240,7 @@ public final class TreeBuilder {
           while (cb != null) {
             if (cb.getLeaves() != null || 
                 !processed_branches.containsKey(cb.getBranchId())) {
-              LOG.debug("Flushing branch to storage: " + cb);
+              LOG.debug("Flushing branch to storage: {}", cb);
 
               /**
                * Since we need to return a deferred group and we can't just
@@ -308,8 +308,9 @@ public final class TreeBuilder {
             }
           }
         }
-        
-        LOG.debug("Completed processing meta [" + meta + "] through tree: " + tree.getTreeId());
+
+        LOG.debug("Completed processing meta [{}] through tree: {}",
+            meta, tree.getTreeId());
         return Deferred.group(storage_calls);
       }
     
@@ -330,12 +331,12 @@ public final class TreeBuilder {
       }
       
     }
-    
-    LOG.debug("Processing meta [" + meta + "] through tree: " + tree.getTreeId());
+
+    LOG.debug("Processing meta [{}] through tree: {}", meta, tree.getTreeId());
     if (root == null) {
       // if this is a new object or the root has been reset, we need to fetch
       // it from storage or initialize it
-      LOG.debug("Fetching root branch for tree: " + tree.getTreeId());
+      LOG.debug("Fetching root branch for tree: {}", tree.getTreeId());
       return loadOrInitializeRoot(tsdb, tree.getTreeId(), is_testing)
         .addCallbackDeferring(new LoadRootCB());
     } else {
@@ -381,7 +382,7 @@ public final class TreeBuilder {
       @Override
       public Deferred<Branch> call(final ArrayList<Boolean> storage_call) 
         throws Exception {
-        LOG.info("Initialized root branch for tree: " + tree_id);
+        LOG.info("Initialized root branch for tree: {}", tree_id);
         tree_roots.put(tree_id, root);
         return Deferred.fromResult(new Branch(root));
       }
@@ -420,11 +421,11 @@ public final class TreeBuilder {
     // if the root is already in cache, return it
     final Branch cached = tree_roots.get(tree_id);
     if (cached != null) {
-      LOG.debug("Loaded cached root for tree: " + tree_id);
+      LOG.debug("Loaded cached root for tree: {}", tree_id);
       return Deferred.fromResult(new Branch(cached));
     }
-    
-    LOG.debug("Loading or initializing root for tree: " + tree_id);
+
+    LOG.debug("Loading or initializing root for tree: {}", tree_id);
     return Branch.fetchBranchOnly(tsdb, Tree.idToBytes(tree_id))
       .addCallbackDeferring(new RootCB());
   }
@@ -471,7 +472,7 @@ public final class TreeBuilder {
           LOG.debug("No trees found to process meta through");
           return Deferred.fromResult(false);
         } else {
-          LOG.debug("Loaded [" + trees.size() + "] trees");
+          LOG.debug("Loaded [{}] trees", trees.size());
         }
         
         processed_trees = 
@@ -1070,8 +1071,7 @@ public final class TreeBuilder {
         // we can't match the {tag_name} token since the rule type is invalid
         // so we'll just blank it
         format = format.replace("{tag_name}", "");
-        LOG.warn("Display rule " + rule + 
-          " was of the wrong type to match on {tag_name}");
+        LOG.warn("Display rule {} was of the wrong type to match on {tag_name}", rule);
         if (test_messages != null) {
           test_messages.add("Display rule " + rule + 
               " was of the wrong type to match on {tag_name}");

--- a/src/tree/TreeRule.java
+++ b/src/tree/TreeRule.java
@@ -263,7 +263,7 @@ public final class TreeRule {
     }
     
     if (!has_changes) {
-      LOG.trace(this + " does not have changes, skipping sync to storage");
+      LOG.trace("{} does not have changes, skipping sync to storage", this);
       throw new IllegalStateException("No changes detected in the rule");
     }
     
@@ -291,7 +291,7 @@ public final class TreeRule {
           stored_rule = local_rule;
         } else {
           if (!stored_rule.copyChanges(local_rule, overwrite)) {
-            LOG.debug(this + " does not have changes, skipping sync to storage");
+            LOG.debug("{} does not have changes, skipping sync to storage", this);
             throw new IllegalStateException("No changes detected in the rule");
           }
         }

--- a/src/tsd/AnnotationRpc.java
+++ b/src/tsd/AnnotationRpc.java
@@ -221,7 +221,7 @@ final class AnnotationRpc implements HttpRpc {
             deferred.addCallbackDeferring(new IndexCB());
         callbacks.add(indexer);
       } catch (IllegalStateException e) {
-        LOG.info("No changes for annotation: " + note);
+        LOG.info("No changes for annotation: {}", note);
       } catch (IllegalArgumentException e) {
         throw new BadRequestException(HttpResponseStatus.BAD_REQUEST, 
             e.getMessage(), "Annotation error: " + note, e);

--- a/src/tsd/ConnectionManager.java
+++ b/src/tsd/ConnectionManager.java
@@ -94,7 +94,7 @@ final class ConnectionManager extends SimpleChannelHandler {
     final Channel chan = ctx.getChannel();
     if (cause instanceof ClosedChannelException) {
       exceptions_closed.incrementAndGet();
-      LOG.warn("Attempt to write to closed channel " + chan);
+      LOG.warn("Attempt to write to closed channel {}", chan);
       return;
     }
     if (cause instanceof IOException) {
@@ -112,7 +112,7 @@ final class ConnectionManager extends SimpleChannelHandler {
       }
     }
     exceptions_unknown.incrementAndGet();
-    LOG.error("Unexpected exception from downstream for " + chan, cause);
+    LOG.error("Unexpected exception from downstream for {}", chan, cause);
     e.getChannel().close();
   }
 

--- a/src/tsd/GraphHandler.java
+++ b/src/tsd/GraphHandler.java
@@ -953,20 +953,20 @@ final class GraphHandler implements HttpRpc {
   // ---------------- //
 
   static void logInfo(final HttpQuery query, final String msg) {
-    LOG.info(query.channel().toString() + ' ' + msg);
+    LOG.info("{} {}", query.channel().toString(), msg);
   }
 
   static void logWarn(final HttpQuery query, final String msg) {
-    LOG.warn(query.channel().toString() + ' ' + msg);
+    LOG.warn("{} {}", query.channel().toString(), msg);
   }
 
   static void logError(final HttpQuery query, final String msg) {
-    LOG.error(query.channel().toString() + ' ' + msg);
+    LOG.error("{} {}", query.channel().toString(), msg);
   }
 
   static void logError(final HttpQuery query, final String msg,
                        final Throwable e) {
-    LOG.error(query.channel().toString() + ' ' + msg, e);
+    LOG.error("{} {}", query.channel().toString(), msg, e);
   }
 
 }

--- a/src/tsd/HttpQuery.java
+++ b/src/tsd/HttpQuery.java
@@ -1259,15 +1259,15 @@ final class HttpQuery {
   // ---------------- //
 
   private void logInfo(final String msg) {
-    LOG.info(chan.toString() + ' ' + msg);
+    LOG.info("{} {}", chan.toString(), msg);
   }
 
   private void logWarn(final String msg) {
-    LOG.warn(chan.toString() + ' ' + msg);
+    LOG.warn("{} {}", chan.toString(), msg);
   }
 
   private void logError(final String msg, final Exception e) {
-    LOG.error(chan.toString() + ' ' + msg, e);
+    LOG.error("{} {}", chan.toString(), msg, e);
   }
 
   // -------------------------------------------- //

--- a/src/tsd/PutDataPointRpc.java
+++ b/src/tsd/PutDataPointRpc.java
@@ -115,28 +115,28 @@ final class PutDataPointRpc implements TelnetRpc, HttpRpc {
           if (show_details) {
             details.add(this.getHttpDetails("Metric name was empty", dp));
           }
-          LOG.warn("Metric name was empty: " + dp);
+          LOG.warn("Metric name was empty: {}", dp);
           continue;
         }
         if (dp.getTimestamp() <= 0) {
           if (show_details) {
             details.add(this.getHttpDetails("Invalid timestamp", dp));
           }
-          LOG.warn("Invalid timestamp: " + dp);
+          LOG.warn("Invalid timestamp: {}", dp);
           continue;
         }
         if (dp.getValue() == null || dp.getValue().isEmpty()) {
           if (show_details) {
             details.add(this.getHttpDetails("Empty value", dp));
           }
-          LOG.warn("Empty value: " + dp);
+          LOG.warn("Empty value: {}", dp);
           continue;
         }
         if (dp.getTags() == null || dp.getTags().size() < 1) {
           if (show_details) {
             details.add(this.getHttpDetails("Missing tags", dp));
           }
-          LOG.warn("Missing tags: " + dp);
+          LOG.warn("Missing tags: {}", dp);
           continue;
         }
         if (Tags.looksLikeInteger(dp.getValue())) {
@@ -152,19 +152,19 @@ final class PutDataPointRpc implements TelnetRpc, HttpRpc {
           details.add(this.getHttpDetails("Unable to parse value to a number", 
               dp));
         }
-        LOG.warn("Unable to parse value to a number: " + dp);
+        LOG.warn("Unable to parse value to a number: {}", dp);
         invalid_values.incrementAndGet();
       } catch (IllegalArgumentException iae) {
         if (show_details) {
           details.add(this.getHttpDetails(iae.getMessage(), dp));
         }
-        LOG.warn(iae.getMessage() + ": " + dp);
+        LOG.warn("{}: {}", iae.getMessage(), dp);
         illegal_arguments.incrementAndGet();
       } catch (NoSuchUniqueName nsu) {
         if (show_details) {
           details.add(this.getHttpDetails("Unknown metric", dp));
         }
-        LOG.warn("Unknown metric: " + dp);
+        LOG.warn("Unknown metric: {}", dp);
         unknown_metrics.incrementAndGet();
       }
     }

--- a/src/tsd/RpcHandler.java
+++ b/src/tsd/RpcHandler.java
@@ -90,7 +90,7 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
               + "a list of specific domains, you cannot mix both.");
         }
         cors_domains.add(domain.trim().toUpperCase());
-        LOG.info("Loaded CORS domain (" + domain + ")");
+        LOG.info("Loaded CORS domain ({})", domain);
       }
     }
 
@@ -101,7 +101,7 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
           "tsd.http.request.cors_headers must be a list of validly-formed "
           + "HTTP header names. No wildcards are allowed.");
     } else {
-      LOG.info("Loaded CORS headers (" + cors_headers + ")");
+      LOG.info("Loaded CORS headers ({})", cors_headers);
     }
 
     telnet_commands = new HashMap<String, TelnetRpc>(7);
@@ -520,7 +520,7 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
 
     /** Drops in memory caches.  */
     private void dropCaches(final TSDB tsdb, final Channel chan) {
-      LOG.warn(chan + " Dropping all in-memory caches.");
+      LOG.warn("{} Dropping all in-memory caches.", chan);
       tsdb.dropCaches();
     }
   }
@@ -584,7 +584,7 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
   //}
 
   private static void logWarn(final HttpQuery query, final String msg) {
-    LOG.warn(query.channel().toString() + ' ' + msg);
+    LOG.warn("{}" + ' ' + "{}", query.channel().toString(), msg);
   }
 
   //private void logWarn(final HttpQuery query, final String msg,
@@ -593,7 +593,7 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
   //}
 
   private void logError(final HttpQuery query, final String msg) {
-    LOG.error(query.channel().toString() + ' ' + msg);
+    LOG.error("{}" + ' ' + "{}", query.channel().toString(), msg);
   }
 
   //private static void logError(final HttpQuery query, final String msg,
@@ -606,7 +606,7 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
   //}
 
   private static void logWarn(final Channel chan, final String msg) {
-    LOG.warn(chan.toString() + ' ' + msg);
+    LOG.warn("{}" + ' ' + "{}", chan.toString(), msg);
   }
 
   //private void logWarn(final Channel chan, final String msg, final Exception e) {
@@ -614,11 +614,11 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
   //}
 
   private void logError(final Channel chan, final String msg) {
-    LOG.error(chan.toString() + ' ' + msg);
+    LOG.error("{}" + ' ' + "{}", chan.toString(), msg);
   }
 
   private void logError(final Channel chan, final String msg, final Exception e) {
-    LOG.error(chan.toString() + ' ' + msg, e);
+    LOG.error("{}" + ' ' + "{}", chan.toString(), msg, e);
   }
 
 }

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -498,12 +498,12 @@ public class Config {
         this.loadHashMap(props);        
       } catch (Exception e) {
         // don't do anything, the file may be missing and that's fine
-        LOG.debug("Unable to find or load " + file, e);
+        LOG.debug("Unable to find or load {}", file, e);
         continue;
       }
 
       // no exceptions thrown, so save the valid path and exit
-      LOG.info("Successfully loaded configuration file: " + file);
+      LOG.info("Successfully loaded configuration file: {}", file);
       this.config_location = file;
       return;
     }
@@ -528,7 +528,7 @@ public class Config {
     this.loadHashMap(props);
 
     // no exceptions thrown, so save the valid path and exit
-    LOG.info("Successfully loaded configuration file: " + file);
+    LOG.info("Successfully loaded configuration file: {}", file);
     this.config_location = file;
   }
 

--- a/src/utils/PluginLoader.java
+++ b/src/utils/PluginLoader.java
@@ -98,7 +98,7 @@ public final class PluginLoader {
     ServiceLoader<T> serviceLoader = ServiceLoader.load(type);
     Iterator<T> it = serviceLoader.iterator();
     if (!it.hasNext()) {
-      LOG.warn("Unable to locate any plugins of the type: " + type.getName());
+      LOG.warn("Unable to locate any plugins of the type: {}", type.getName());
       return null;
     }
     
@@ -108,8 +108,8 @@ public final class PluginLoader {
         return plugin;
       }
     }
-    
-    LOG.warn("Unable to locate plugin: " + name);
+
+    LOG.warn("Unable to locate plugin: {}", name);
     return null;
   }
   
@@ -136,7 +136,7 @@ public final class PluginLoader {
     ServiceLoader<T> serviceLoader = ServiceLoader.load(type);
     Iterator<T> it = serviceLoader.iterator();
     if (!it.hasNext()) {
-      LOG.warn("Unable to locate any plugins of the type: " + type.getName());
+      LOG.warn("Unable to locate any plugins of the type: {}", type.getName());
       return null;
     }
     
@@ -147,8 +147,8 @@ public final class PluginLoader {
     if (plugins.size() > 0) {
       return plugins;
     }
-    
-    LOG.warn("Unable to locate plugins for type: " + type.getName());
+
+    LOG.warn("Unable to locate plugins for type: {}", type.getName());
     return null;
   }
   
@@ -207,7 +207,7 @@ public final class PluginLoader {
     ArrayList<File> jars = new ArrayList<File>();
     searchForJars(file, jars);
     if (jars.size() < 1) {
-      LOG.debug("No JAR files found in path: " + directory);
+      LOG.debug("No JAR files found in path: {}", directory);
       return;
     }
     
@@ -227,13 +227,13 @@ public final class PluginLoader {
     if (file.isFile()) {
       if (file.getAbsolutePath().toLowerCase().endsWith(".jar")) {
         jars.add(file);
-        LOG.debug("Found a jar: " + file.getAbsolutePath());
+        LOG.debug("Found a jar: {}", file.getAbsolutePath());
       }
     } else if (file.isDirectory()) {
       File[] files = file.listFiles();
       if (files == null) {
         // if this is null, it's due to a security issue
-        LOG.warn("Access denied to directory: " + file.getAbsolutePath());
+        LOG.warn("Access denied to directory: {}", file.getAbsolutePath());
       } else {
         for (File f : files) {
           searchForJars(f, jars);
@@ -279,7 +279,7 @@ public final class PluginLoader {
     
     Method method = sysclass.getDeclaredMethod("addURL", PARAMETER_TYPES);
     method.setAccessible(true);
-    method.invoke(sysloader, new Object[]{ url }); 
-    LOG.debug("Successfully added JAR to class loader: " + url.getFile());
+    method.invoke(sysloader, new Object[]{ url });
+    LOG.debug("Successfully added JAR to class loader: {}", url.getFile());
   }
 }


### PR DESCRIPTION
I'm not sure if it was decided to not use the SLF4J string parameterization but i couldn't find anything about it :). Building the logging messages this way is [slightly](http://www.slf4j.org/faq.html#logging_performance) more efficient than the way it's done currently.

Is this something we could merge? Sorry if it became a bit too big...
