### PR TITLE
Compare branch display_name string using equals

### DIFF
--- a/src/tree/Branch.java
+++ b/src/tree/Branch.java
@@ -171,7 +171,7 @@ public final class Branch implements Comparable<Branch> {
     }
     
     final Branch branch = (Branch)obj;
-    return display_name == branch.display_name;
+    return display_name.equals(branch.display_name);
   }
   
   /**


### PR DESCRIPTION
In #270 it was discussed about one case where `==` is used to compare strings. There's another case in `src/tree.Branch.java`. Not sure if this one is correct as it too but it looks wrong to me.
