### PR TITLE
Build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: java
+before_script: ./build.sh pom.xml && mvn dependency:go-offline
+script: mvn test
+jdk:
+  - oraclejdk7
+  - openjdk6
+notifications:
+    email: false


### PR DESCRIPTION
This configures [Travis](https://travis-ci.org/) to build and test all pull requests and pushes to OpenTSDB. You'll need to [enable](https://travis-ci.org/profile/OpenTSDB) the main OpenTSDB repo on Travis for it to work. You can see what it looks like [here](https://travis-ci.org/luuse/opentsdb/jobs/29037241).

It's configured to run on Oracle JDK 7 and OpenJDK 6 (Sun JDK 6) is not available on Travis. It both compiles and executes the tests using maven because that's a bit easier to integrate with other tools for java :).

The tests currently fail. I'm not sure if this is expected or not.

Do we want a badge or link in the README to this?
