### PR TITLE
Extract the local charset constants into a global one

### DIFF
--- a/src/core/Const.java
+++ b/src/core/Const.java
@@ -12,6 +12,10 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
+import com.google.common.base.Charsets;
+
+import java.nio.charset.Charset;
+
 /** Constants used in various places.  */
 public final class Const {
 
@@ -74,4 +78,7 @@ public final class Const {
    * before losing precision.
    */
   public static final long MAX_INT_IN_DOUBLE = 0xFFE0000000000000L;
+
+  /** Charset used to convert Strings to byte arrays and back. */
+  public static final Charset CHARSET_ASCII = Charsets.ISO_8859_1;
 }

--- a/src/core/Internal.java
+++ b/src/core/Internal.java
@@ -12,7 +12,6 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -857,6 +856,6 @@ public final class Internal {
     // Replace the pipe of the last iteration, close and set
     buf.setCharAt(buf.length() - 1, ')');
     buf.append("$");
-    scanner.setKeyRegexp(buf.toString(), Charset.forName("ISO-8859-1"));
+    scanner.setKeyRegexp(buf.toString(), Const.CHARSET_ASCII);
   }
 }

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -12,7 +12,6 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -62,8 +61,6 @@ public final class TSDB {
   
   static final byte[] FAMILY = { 't' };
 
-  /** Charset used to convert Strings to byte arrays and back. */
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
   private static final String METRICS_QUAL = "metrics";
   private static final short METRICS_WIDTH = 3;
   private static final String TAG_NAME_QUAL = "tagk";
@@ -121,10 +118,10 @@ public final class TSDB {
     this.client = client;
 
     this.client.setFlushInterval(config.getShort("tsd.storage.flush_interval"));
-    table = config.getString("tsd.storage.hbase.data_table").getBytes(CHARSET);
-    uidtable = config.getString("tsd.storage.hbase.uid_table").getBytes(CHARSET);
-    treetable = config.getString("tsd.storage.hbase.tree_table").getBytes(CHARSET);
-    meta_table = config.getString("tsd.storage.hbase.meta_table").getBytes(CHARSET);
+    table = config.getString("tsd.storage.hbase.data_table").getBytes(Const.CHARSET_ASCII);
+    uidtable = config.getString("tsd.storage.hbase.uid_table").getBytes(Const.CHARSET_ASCII);
+    treetable = config.getString("tsd.storage.hbase.tree_table").getBytes(Const.CHARSET_ASCII);
+    meta_table = config.getString("tsd.storage.hbase.meta_table").getBytes(Const.CHARSET_ASCII);
 
     metrics = new UniqueId(client, uidtable, METRICS_QUAL, METRICS_WIDTH);
     tag_names = new UniqueId(client, uidtable, TAG_NAME_QUAL, TAG_NAME_WIDTH);
@@ -144,9 +141,9 @@ public final class TSDB {
     
     if (config.getBoolean("tsd.core.preload_uid_cache")) {
       final ByteMap<UniqueId> uid_cache_map = new ByteMap<UniqueId>();
-      uid_cache_map.put(METRICS_QUAL.getBytes(CHARSET), metrics);
-      uid_cache_map.put(TAG_NAME_QUAL.getBytes(CHARSET), tag_names);
-      uid_cache_map.put(TAG_VALUE_QUAL.getBytes(CHARSET), tag_values);
+      uid_cache_map.put(METRICS_QUAL.getBytes(Const.CHARSET_ASCII), metrics);
+      uid_cache_map.put(TAG_NAME_QUAL.getBytes(Const.CHARSET_ASCII), tag_names);
+      uid_cache_map.put(TAG_VALUE_QUAL.getBytes(Const.CHARSET_ASCII), tag_values);
       UniqueId.preloadUidCache(this, uid_cache_map);
     }
     LOG.debug(config.dumpConfiguration());
@@ -378,9 +375,9 @@ public final class TSDB {
    */
   public void collectStats(final StatsCollector collector) {
     final byte[][] kinds = { 
-        METRICS_QUAL.getBytes(CHARSET), 
-        TAG_NAME_QUAL.getBytes(CHARSET), 
-        TAG_VALUE_QUAL.getBytes(CHARSET) 
+        METRICS_QUAL.getBytes(Const.CHARSET_ASCII),
+        TAG_NAME_QUAL.getBytes(Const.CHARSET_ASCII),
+        TAG_VALUE_QUAL.getBytes(Const.CHARSET_ASCII)
       };
     try {
       final Map<String, Long> used_uids = UniqueId.getUsedUIDs(this, kinds)

--- a/src/core/TsdbQuery.java
+++ b/src/core/TsdbQuery.java
@@ -12,7 +12,6 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,12 +54,6 @@ final class TsdbQuery implements Query {
    * 100 ms after we which we switch to exponential buckets.
    */
   static final Histogram scanlatency = new Histogram(16000, (short) 2, 100);
-
-  /**
-   * Charset to use with our server-side row-filter.
-   * We use this one because it preserves every possible byte unchanged.
-   */
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
 
   /** The TSDB we belong to. */
   private final TSDB tsdb;
@@ -680,7 +673,7 @@ final class TsdbQuery implements Query {
     } while (tag != group_by);  // Stop when they both become null.
     // Skip any number of tags before the end.
     buf.append("(?:.{").append(tagsize).append("})*$");
-    scanner.setKeyRegexp(buf.toString(), CHARSET);
+    scanner.setKeyRegexp(buf.toString(), Const.CHARSET_ASCII);
    }
 
   /**
@@ -731,7 +724,7 @@ final class TsdbQuery implements Query {
     // Replace the pipe of the last iteration, close and set
     buf.setCharAt(buf.length() - 1, ')');
     buf.append("$");
-    scanner.setKeyRegexp(buf.toString(), CHARSET);
+    scanner.setKeyRegexp(buf.toString(), Const.CHARSET_ASCII);
   }
   
   /**

--- a/src/meta/Annotation.java
+++ b/src/meta/Annotation.java
@@ -14,7 +14,6 @@ package net.opentsdb.meta;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -74,15 +73,12 @@ import com.stumbleupon.async.Deferred;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class Annotation implements Comparable<Annotation> {
   private static final Logger LOG = LoggerFactory.getLogger(Annotation.class);
-  
-  /** Charset used to convert Strings to byte arrays and back. */
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
-  
+
   /** Byte used for the qualifier prefix to indicate this is an annotation */
   private static final byte PREFIX = 0x01;
     
   /** The single column family used by this class. */
-  private static final byte[] FAMILY = "t".getBytes(CHARSET);
+  private static final byte[] FAMILY = "t".getBytes(Const.CHARSET_ASCII);
   
   /** If the note is associated with a timeseries, represents the ID */
   private String tsuid = "";

--- a/src/meta/TSMeta.java
+++ b/src/meta/TSMeta.java
@@ -14,13 +14,13 @@ package net.opentsdb.meta;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.opentsdb.core.Const;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.uid.UniqueId;
 import net.opentsdb.uid.UniqueId.UniqueIdType;
@@ -73,17 +73,14 @@ import com.stumbleupon.async.Deferred;
 public final class TSMeta {
   private static final Logger LOG = LoggerFactory.getLogger(TSMeta.class);
 
-  /** Charset used to convert Strings to byte arrays and back. */
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
-  
   /** The single column family used by this class. */
-  private static final byte[] FAMILY = "name".getBytes(CHARSET);
+  private static final byte[] FAMILY = "name".getBytes(Const.CHARSET_ASCII);
   
   /** The cell qualifier to use for timeseries meta */
-  private static final byte[] META_QUALIFIER = "ts_meta".getBytes(CHARSET);
+  private static final byte[] META_QUALIFIER = "ts_meta".getBytes(Const.CHARSET_ASCII);
   
   /** The cell qualifier to use for timeseries meta */
-  private static final byte[] COUNTER_QUALIFIER = "ts_ctr".getBytes(CHARSET);
+  private static final byte[] COUNTER_QUALIFIER = "ts_ctr".getBytes(Const.CHARSET_ASCII);
   
   /** Hexadecimal representation of the TSUID this metadata is associated with */
   private String tsuid = "";

--- a/src/meta/TSUIDQuery.java
+++ b/src/meta/TSUIDQuery.java
@@ -12,18 +12,13 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.meta;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
-import net.opentsdb.core.IncomingDataPoint;
-import net.opentsdb.core.Internal;
-import net.opentsdb.core.RowKey;
-import net.opentsdb.core.TSDB;
-import net.opentsdb.core.Tags;
+import net.opentsdb.core.*;
 import net.opentsdb.uid.NoSuchUniqueId;
 import net.opentsdb.uid.NoSuchUniqueName;
 import net.opentsdb.uid.UniqueId;
@@ -48,12 +43,6 @@ import com.stumbleupon.async.DeferredGroupException;
  */
 public class TSUIDQuery {
   private static final Logger LOG = LoggerFactory.getLogger(TSUIDQuery.class);
-  
-  /**
-   * Charset to use with our server-side row-filter.
-   * We use this one because it preserves every possible byte unchanged.
-   */
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
 
   /** ID of the metric being looked up. */
   private byte[] metric;
@@ -513,7 +502,7 @@ public class TSUIDQuery {
       } while (tag != null);  // Stop when they both become null.
       // Skip any number of tags before the end.
       buf.append("(?:.{").append(tagsize).append("})*$");
-      scanner.setKeyRegexp(buf.toString(), CHARSET);
+      scanner.setKeyRegexp(buf.toString(), Const.CHARSET_ASCII);
     }
     
     return scanner;

--- a/src/meta/UIDMeta.java
+++ b/src/meta/UIDMeta.java
@@ -14,11 +14,11 @@ package net.opentsdb.meta;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import net.opentsdb.core.Const;
 import org.hbase.async.DeleteRequest;
 import org.hbase.async.GetRequest;
 import org.hbase.async.HBaseException;
@@ -69,12 +69,9 @@ import net.opentsdb.utils.JSONException;
 @JsonAutoDetect(fieldVisibility = Visibility.PUBLIC_ONLY)
 public final class UIDMeta {
   private static final Logger LOG = LoggerFactory.getLogger(UIDMeta.class);
-  
-  /** Charset used to convert Strings to byte arrays and back. */
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
-  
+
   /** The single column family used by this class. */
-  private static final byte[] FAMILY = "name".getBytes(CHARSET);
+  private static final byte[] FAMILY = "name".getBytes(Const.CHARSET_ASCII);
   
   /** A hexadecimal representation of the UID this metadata is associated with */
   private String uid = "";
@@ -243,7 +240,7 @@ public final class UIDMeta {
           
           final PutRequest put = new PutRequest(tsdb.uidTable(), 
               UniqueId.stringToUid(uid), FAMILY, 
-              (type.toString().toLowerCase() + "_meta").getBytes(CHARSET), 
+              (type.toString().toLowerCase() + "_meta").getBytes(Const.CHARSET_ASCII),
               local_meta.getStorageJSON());
           return tsdb.getClient().compareAndSet(put, original_meta);
         }
@@ -261,7 +258,7 @@ public final class UIDMeta {
         final GetRequest get = new GetRequest(tsdb.uidTable(), 
             UniqueId.stringToUid(uid));
         get.family(FAMILY);
-        get.qualifier((type.toString().toLowerCase() + "_meta").getBytes(CHARSET));
+        get.qualifier((type.toString().toLowerCase() + "_meta").getBytes(Const.CHARSET_ASCII));
         
         // #2 deferred
         return tsdb.getClient().get(get)
@@ -300,7 +297,7 @@ public final class UIDMeta {
 
     final PutRequest put = new PutRequest(tsdb.uidTable(), 
         UniqueId.stringToUid(uid), FAMILY, 
-        (type.toString().toLowerCase() + "_meta").getBytes(CHARSET), 
+        (type.toString().toLowerCase() + "_meta").getBytes(Const.CHARSET_ASCII),
         UIDMeta.this.getStorageJSON());
     return tsdb.getClient().put(put);
   }
@@ -323,7 +320,7 @@ public final class UIDMeta {
 
     final DeleteRequest delete = new DeleteRequest(tsdb.uidTable(), 
         UniqueId.stringToUid(uid), FAMILY, 
-        (type.toString().toLowerCase() + "_meta").getBytes(CHARSET));
+        (type.toString().toLowerCase() + "_meta").getBytes(Const.CHARSET_ASCII));
     return tsdb.getClient().delete(delete);
   }
   
@@ -413,7 +410,7 @@ public final class UIDMeta {
             // fix missing types
             if (meta.type == null) {
               final String qualifier = 
-                new String(row.get(0).qualifier(), CHARSET);
+                new String(row.get(0).qualifier(), Const.CHARSET_ASCII);
               meta.type = UniqueId.stringToUniqueIdType(qualifier.substring(0, 
                   qualifier.indexOf("_meta")));
             }
@@ -425,7 +422,7 @@ public final class UIDMeta {
         
         final GetRequest get = new GetRequest(tsdb.uidTable(), uid);
         get.family(FAMILY);
-        get.qualifier((type.toString().toLowerCase() + "_meta").getBytes(CHARSET));
+        get.qualifier((type.toString().toLowerCase() + "_meta").getBytes(Const.CHARSET_ASCII));
         return tsdb.getClient().get(get).addCallbackDeferring(new FetchMetaCB());
       }
     }

--- a/src/search/TimeSeriesLookup.java
+++ b/src/search/TimeSeriesLookup.java
@@ -12,7 +12,6 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.search;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -73,10 +72,7 @@ import org.slf4j.LoggerFactory;
 public class TimeSeriesLookup {
   private static final Logger LOG = 
       LoggerFactory.getLogger(TimeSeriesLookup.class);
-  
-  /** Charset used to convert Strings to byte arrays and back. */
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
-  
+
   /** The query with metrics and/or tags to use */
   private final SearchQuery query;
   
@@ -135,7 +131,7 @@ public class TimeSeriesLookup {
           // TODO - there MUST be a better way than creating a ton of temp
           // string objects.
           if (tagv_regex != null && 
-              !tagv_regex.matcher(new String(tsuid, CHARSET)).find()) {
+              !tagv_regex.matcher(new String(tsuid, Const.CHARSET_ASCII)).find()) {
             continue;
           }
           
@@ -266,7 +262,7 @@ public class TimeSeriesLookup {
         // in this case we don't have any tagks to deal with so we can just
         // pass the previously compiled regex to the rowkey filter of the 
         // scanner
-        scanner.setKeyRegexp(buf.toString(), CHARSET);
+        scanner.setKeyRegexp(buf.toString(), Const.CHARSET_ASCII);
         LOG.debug("Setting scanner row key filter with tagvs only: " + 
             buf.toString());
       }
@@ -318,7 +314,7 @@ public class TimeSeriesLookup {
         }
         buf.append(")(?:.{").append(tagsize).append("})*").append("$");
         
-        scanner.setKeyRegexp(buf.toString(), CHARSET);
+        scanner.setKeyRegexp(buf.toString(), Const.CHARSET_ASCII);
         LOG.debug("Setting scanner row key filter: " + buf.toString());
       }
     }

--- a/src/tools/CliUtils.java
+++ b/src/tools/CliUtils.java
@@ -14,10 +14,10 @@ package net.opentsdb.tools;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import net.opentsdb.core.Const;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.uid.UniqueId;
 
@@ -36,8 +36,6 @@ final class CliUtils {
   static final Method toBytes;
   /** Function used to convert a byte[] to a String. */
   static final Method fromBytes;
-  /** Charset used to convert Strings to byte arrays and back. */
-  static final Charset CHARSET;
   /** The single column family used by this class. */
   static final byte[] ID_FAMILY;
   /** The single column family used by this class. */
@@ -53,9 +51,6 @@ final class CliUtils {
       // "THIS IS INTERNAL DO NOT USE".  If only Java had C++'s "friend" or
       // a less stupid notion of a package.
       Field f;
-      f = uidclass.getDeclaredField("CHARSET");
-      f.setAccessible(true);
-      CHARSET = (Charset) f.get(null);
       f = uidclass.getDeclaredField("ID_FAMILY");
       f.setAccessible(true);
       ID_FAMILY = (byte[]) f.get(null);
@@ -74,17 +69,17 @@ final class CliUtils {
     }
   }
   /** Qualifier for metrics meta data */
-  static final byte[] METRICS_META = "metric_meta".getBytes(CHARSET);
+  static final byte[] METRICS_META = "metric_meta".getBytes(Const.CHARSET_ASCII);
   /** Qualifier for tagk meta data */
-  static final byte[] TAGK_META = "tagk_meta".getBytes(CHARSET);
+  static final byte[] TAGK_META = "tagk_meta".getBytes(Const.CHARSET_ASCII);
   /** Qualifier for tagv meta data */
-  static final byte[] TAGV_META = "tagv_meta".getBytes(CHARSET);
+  static final byte[] TAGV_META = "tagv_meta".getBytes(Const.CHARSET_ASCII);
   /** Qualifier for metrics UIDs */
-  static final byte[] METRICS = "metrics".getBytes(CHARSET);
+  static final byte[] METRICS = "metrics".getBytes(Const.CHARSET_ASCII);
   /** Qualifier for tagk UIDs */
-  static final byte[] TAGK = "tagk".getBytes(CHARSET);
+  static final byte[] TAGK = "tagk".getBytes(Const.CHARSET_ASCII);
   /** Qualifier for tagv UIDs */
-  static final byte[] TAGV = "tagv".getBytes(CHARSET);
+  static final byte[] TAGV = "tagv".getBytes(Const.CHARSET_ASCII);
 
   /**
    * Returns the max metric ID from the UID table
@@ -98,8 +93,8 @@ final class CliUtils {
     // first up, we need the max metric ID so we can split up the data table
     // amongst threads.
     final GetRequest get = new GetRequest(tsdb.uidTable(), new byte[] { 0 });
-    get.family("id".getBytes(CHARSET));
-    get.qualifier("metrics".getBytes(CHARSET));
+    get.family("id".getBytes(Const.CHARSET_ASCII));
+    get.qualifier("metrics".getBytes(Const.CHARSET_ASCII));
     ArrayList<KeyValue> row;
     try {
       row = tsdb.getClient().get(get).joinUninterruptibly();

--- a/src/tools/DumpSeries.java
+++ b/src/tools/DumpSeries.java
@@ -12,7 +12,6 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.tools;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -268,7 +267,7 @@ final class DumpSeries {
     .append("\t")
     .append(Internal.getOffsetFromQualifier(kv.qualifier(), 1) / 1000)
     .append("\t")
-    .append(new String(kv.value(), Charset.forName("ISO-8859-1")))
+    .append(new String(kv.value(), Const.CHARSET_ASCII))
     .append("\t")
     .append(timestamp)
     .append("\t")

--- a/src/tools/MetaPurge.java
+++ b/src/tools/MetaPurge.java
@@ -12,10 +12,10 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.tools;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import net.opentsdb.core.Const;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.meta.TSMeta;
 
@@ -38,11 +38,9 @@ import com.stumbleupon.async.Deferred;
  */
 final class MetaPurge extends Thread {
   private static final Logger LOG = LoggerFactory.getLogger(MetaPurge.class);
-  
-  /** Charset used to convert Strings to byte arrays and back. */
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
+
   /** Name of the CF where trees and branches are stored */
-  private static final byte[] NAME_FAMILY = "name".getBytes(CHARSET);
+  private static final byte[] NAME_FAMILY = "name".getBytes(Const.CHARSET_ASCII);
   
   /** TSDB to use for storage access */
   private final TSDB tsdb;
@@ -145,13 +143,13 @@ final class MetaPurge extends Thread {
           for (KeyValue column : row) {
             if (Bytes.equals(TSMeta.META_QUALIFIER(), column.qualifier())) {
               qualifiers.add(column.qualifier());
-            } else if (Bytes.equals("metric_meta".getBytes(CHARSET), 
+            } else if (Bytes.equals("metric_meta".getBytes(Const.CHARSET_ASCII),
                 column.qualifier())) {
               qualifiers.add(column.qualifier());
-            } else if (Bytes.equals("tagk_meta".getBytes(CHARSET), 
+            } else if (Bytes.equals("tagk_meta".getBytes(Const.CHARSET_ASCII),
                 column.qualifier())) {
               qualifiers.add(column.qualifier());
-            } else if (Bytes.equals("tagv_meta".getBytes(CHARSET), 
+            } else if (Bytes.equals("tagv_meta".getBytes(Const.CHARSET_ASCII),
                 column.qualifier())) {
               qualifiers.add(column.qualifier());
             }

--- a/src/tools/MetaSync.java
+++ b/src/tools/MetaSync.java
@@ -12,7 +12,6 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.tools;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -537,7 +536,7 @@ final class MetaSync extends Thread {
     final Scanner scanner = tsdb.getClient().newScanner(tsdb.dataTable());
     scanner.setStartKey(start_row);
     scanner.setStopKey(end_row);
-    scanner.setFamily("t".getBytes(Charset.forName("ISO-8859-1")));
+    scanner.setFamily("t".getBytes(Const.CHARSET_ASCII));
     return scanner;
   }
 

--- a/src/tools/TreeSync.java
+++ b/src/tools/TreeSync.java
@@ -12,12 +12,11 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.tools;
 
-import java.lang.reflect.Field;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import net.opentsdb.core.Const;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.meta.TSMeta;
 import net.opentsdb.tree.Tree;
@@ -43,25 +42,6 @@ import com.stumbleupon.async.Deferred;
  */
 final class TreeSync extends Thread {
   private static final Logger LOG = LoggerFactory.getLogger(TreeSync.class);
-  
-  /** Charset used to convert Strings to byte arrays and back. */
-  private static final Charset CHARSET;
-  static {
-    final Class<UniqueId> uidclass = UniqueId.class;
-    try {
-      // Those are all implementation details so they're not part of the
-      // interface.  We access them anyway using reflection.  I think this
-      // is better than marking those public and adding a javadoc comment
-      // "THIS IS INTERNAL DO NOT USE".  If only Java had C++'s "friend" or
-      // a less stupid notion of a package.
-      Field f;
-      f = uidclass.getDeclaredField("CHARSET");
-      f.setAccessible(true);
-      CHARSET = (Charset) f.get(null);
-    } catch (Exception e) {
-      throw new RuntimeException("static initializer failed", e);
-    }
-  }
   
   /** TSDB to use for storage access */
   final TSDB tsdb;
@@ -350,8 +330,8 @@ final class TreeSync extends Thread {
     final Scanner scanner = tsdb.getClient().newScanner(tsdb.metaTable());
     scanner.setStartKey(start_row);
     scanner.setStopKey(end_row);
-    scanner.setFamily("name".getBytes(CHARSET));
-    scanner.setQualifier("ts_meta".getBytes(CHARSET));
+    scanner.setFamily("name".getBytes(Const.CHARSET_ASCII));
+    scanner.setQualifier("ts_meta".getBytes(Const.CHARSET_ASCII));
     return scanner;
   }
 }

--- a/src/tools/UidManager.java
+++ b/src/tools/UidManager.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
+import net.opentsdb.core.Const;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -285,7 +286,7 @@ final class UidManager {
     if (ignorecase) {
       regexp = "(?i)" + regexp;
     }
-    scanner.setKeyRegexp(regexp, CliUtils.CHARSET);
+    scanner.setKeyRegexp(regexp, Const.CHARSET_ASCII);
     boolean found = false;
     try {
       ArrayList<ArrayList<KeyValue>> rows;

--- a/src/tree/Branch.java
+++ b/src/tree/Branch.java
@@ -14,7 +14,6 @@ package net.opentsdb.tree;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -24,6 +23,7 @@ import java.util.TreeSet;
 
 import javax.xml.bind.DatatypeConverter;
 
+import net.opentsdb.core.Const;
 import org.hbase.async.Bytes;
 import org.hbase.async.GetRequest;
 import org.hbase.async.HBaseException;
@@ -87,13 +87,11 @@ import net.opentsdb.utils.JSONException;
 @JsonAutoDetect(fieldVisibility = Visibility.PUBLIC_ONLY)
 public final class Branch implements Comparable<Branch> {
   private static final Logger LOG = LoggerFactory.getLogger(Branch.class);
-  
-  /** Charset used to convert Strings to byte arrays and back. */
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
+
   /** Integer width in bytes */
   private static final short INT_WIDTH = 4;
   /** Name of the branch qualifier ID */
-  private static final byte[] BRANCH_QUALIFIER = "branch".getBytes(CHARSET);
+  private static final byte[] BRANCH_QUALIFIER = "branch".getBytes(Const.CHARSET_ASCII);
   
   /** The tree this branch belongs to */
   private int tree_id;
@@ -685,7 +683,7 @@ public final class Branch implements Comparable<Branch> {
     }
     buf.append("\\E(?:.{").append(INT_WIDTH).append("})?$");
     
-    scanner.setKeyRegexp(buf.toString(), CHARSET);
+    scanner.setKeyRegexp(buf.toString(), Const.CHARSET_ASCII);
     return scanner;
   }
   

--- a/src/tree/Leaf.java
+++ b/src/tree/Leaf.java
@@ -14,12 +14,12 @@ package net.opentsdb.tree;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.opentsdb.core.Const;
 import org.hbase.async.Bytes;
 import org.hbase.async.GetRequest;
 import org.hbase.async.HBaseException;
@@ -56,11 +56,9 @@ import net.opentsdb.utils.JSONException;
  */
 public final class Leaf implements Comparable<Leaf> {
   private static final Logger LOG = LoggerFactory.getLogger(Leaf.class);
-  
-  /** Charset used to convert Strings to byte arrays and back. */
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
+
   /** ASCII Leaf prefix */
-  private static final byte[] LEAF_PREFIX = "leaf:".getBytes(CHARSET);
+  private static final byte[] LEAF_PREFIX = "leaf:".getBytes(Const.CHARSET_ASCII);
 
   /** The metric associated with this TSUID */
   private String metric = "";

--- a/src/tree/Tree.java
+++ b/src/tree/Tree.java
@@ -14,7 +14,6 @@ package net.opentsdb.tree;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -22,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import net.opentsdb.core.Const;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.uid.UniqueId;
 import net.opentsdb.utils.JSON;
@@ -71,25 +71,23 @@ import com.stumbleupon.async.Deferred;
 @JsonAutoDetect(fieldVisibility = Visibility.PUBLIC_ONLY)
 public final class Tree {
   private static final Logger LOG = LoggerFactory.getLogger(Tree.class);
-  
-  /** Charset used to convert Strings to byte arrays and back. */
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
+
   /** Width of tree IDs in bytes */
   private static final short TREE_ID_WIDTH = 2;
   /** Name of the CF where trees and branches are stored */
-  private static final byte[] TREE_FAMILY = "t".getBytes(CHARSET);
+  private static final byte[] TREE_FAMILY = "t".getBytes(Const.CHARSET_ASCII);
   /** The tree qualifier */
-  private static final byte[] TREE_QUALIFIER = "tree".getBytes(CHARSET);
+  private static final byte[] TREE_QUALIFIER = "tree".getBytes(Const.CHARSET_ASCII);
   /** Integer width in bytes */
   private static final short INT_WIDTH = 4;
   /** Byte suffix for collision rows, appended after the tree ID */
   private static byte COLLISION_ROW_SUFFIX = 0x01;
   /** Byte prefix for collision columns */
-  private static byte[] COLLISION_PREFIX = "tree_collision:".getBytes(CHARSET);
+  private static byte[] COLLISION_PREFIX = "tree_collision:".getBytes(Const.CHARSET_ASCII);
   /** Byte suffix for not matched rows, appended after the tree ID */
   private static byte NOT_MATCHED_ROW_SUFFIX = 0x02;
   /** Byte prefix for not matched columns */
-  private static byte[] NOT_MATCHED_PREFIX = "tree_not_matched:".getBytes(CHARSET);
+  private static byte[] NOT_MATCHED_PREFIX = "tree_not_matched:".getBytes(Const.CHARSET_ASCII);
 
   /** The numeric ID of this tree object */
   private int tree_id;
@@ -687,7 +685,7 @@ public final class Tree {
             final byte[] parsed_tsuid = Arrays.copyOfRange(column.qualifier(), 
                 COLLISION_PREFIX.length, column.qualifier().length);
             collisions.put(UniqueId.uidToString(parsed_tsuid), 
-                new String(column.value(), CHARSET));
+                new String(column.value(), Const.CHARSET_ASCII));
           }
         }
         
@@ -767,7 +765,7 @@ public final class Tree {
           final byte[] parsed_tsuid = Arrays.copyOfRange(column.qualifier(), 
               NOT_MATCHED_PREFIX.length, column.qualifier().length);
           not_matched.put(UniqueId.uidToString(parsed_tsuid), 
-              new String(column.value(), CHARSET));
+              new String(column.value(), Const.CHARSET_ASCII));
         }
         
         return Deferred.fromResult(not_matched);
@@ -1057,7 +1055,7 @@ public final class Tree {
     buf.append("(?s)"  // Ensure we use the DOTALL flag.
         + "^\\Q");
     buf.append("\\E(?:.{").append(TREE_ID_WIDTH).append("})$");
-    scanner.setKeyRegexp(buf.toString(), CHARSET);
+    scanner.setKeyRegexp(buf.toString(), Const.CHARSET_ASCII);
     return scanner;
   }
 
@@ -1094,7 +1092,7 @@ public final class Tree {
       System.arraycopy(tsuid, 0, qualifiers[index], 
           COLLISION_PREFIX.length, tsuid.length);
 
-      values[index] = entry.getValue().getBytes(CHARSET);
+      values[index] = entry.getValue().getBytes(Const.CHARSET_ASCII);
       index++;
     }
 
@@ -1152,7 +1150,7 @@ public final class Tree {
       System.arraycopy(tsuid, 0, qualifiers[index], 
           NOT_MATCHED_PREFIX.length, tsuid.length);
       
-      values[index] = entry.getValue().getBytes(CHARSET);
+      values[index] = entry.getValue().getBytes(Const.CHARSET_ASCII);
       index++;
     }
     

--- a/src/tree/TreeRule.java
+++ b/src/tree/TreeRule.java
@@ -12,12 +12,12 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.tree;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import net.opentsdb.core.Const;
 import org.hbase.async.Bytes;
 import org.hbase.async.DeleteRequest;
 import org.hbase.async.GetRequest;
@@ -65,10 +65,8 @@ public final class TreeRule {
   }
   
   private static final Logger LOG = LoggerFactory.getLogger(TreeRule.class);
-  /** Charset used to convert Strings to byte arrays and back. */
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
   /** ASCII Rule prefix. Qualifier is tree_rule:<level>:<order> */
-  private static final byte[] RULE_PREFIX = "tree_rule:".getBytes(CHARSET);
+  private static final byte[] RULE_PREFIX = "tree_rule:".getBytes(Const.CHARSET_ASCII);
   
   /** Type of rule */
   @JsonDeserialize(using = JSON.TreeRuleTypeDeserializer.class)
@@ -505,7 +503,7 @@ public final class TreeRule {
    * @return A byte array with the column qualifier
    */
   public static byte[] getQualifier(final int level, final int order) {
-    final byte[] suffix = (level + ":" + order).getBytes(CHARSET);
+    final byte[] suffix = (level + ":" + order).getBytes(Const.CHARSET_ASCII);
     final byte[] qualifier = new byte[RULE_PREFIX.length + suffix.length];
     System.arraycopy(RULE_PREFIX, 0, qualifier, 0, RULE_PREFIX.length);
     System.arraycopy(suffix, 0, qualifier, RULE_PREFIX.length, suffix.length);

--- a/src/tsd/WordSplitter.java
+++ b/src/tsd/WordSplitter.java
@@ -12,8 +12,7 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.tsd;
 
-import java.nio.charset.Charset;
-
+import net.opentsdb.core.Const;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
@@ -26,8 +25,6 @@ import net.opentsdb.core.Tags;
  */
 final class WordSplitter extends OneToOneDecoder {
 
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
-
   /** Constructor. */
   public WordSplitter() {
   }
@@ -36,7 +33,7 @@ final class WordSplitter extends OneToOneDecoder {
   protected Object decode(final ChannelHandlerContext ctx,
                           final Channel channel,
                           final Object msg) throws Exception {
-    return Tags.splitString(((ChannelBuffer) msg).toString(CHARSET), ' ');
+    return Tags.splitString(((ChannelBuffer) msg).toString(Const.CHARSET_ASCII), ' ');
   }
 
 }

--- a/src/uid/UniqueId.java
+++ b/src/uid/UniqueId.java
@@ -12,7 +12,6 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.uid;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -26,6 +25,7 @@ import javax.xml.bind.DatatypeConverter;
 import com.stumbleupon.async.Callback;
 import com.stumbleupon.async.Deferred;
 
+import net.opentsdb.core.Const;
 import org.hbase.async.AtomicIncrementRequest;
 import org.hbase.async.Bytes;
 import org.hbase.async.DeleteRequest;
@@ -59,9 +59,7 @@ public final class UniqueId implements UniqueIdInterface {
     TAGK,
     TAGV
   }
-  
-  /** Charset used to convert Strings to byte arrays and back. */
-  private static final Charset CHARSET = Charset.forName("ISO-8859-1");
+
   /** The single column family used by this class. */
   private static final byte[] ID_FAMILY = toBytes("id");
   /** The single column family used by this class. */
@@ -957,11 +955,11 @@ public final class UniqueId implements UniqueIdInterface {
   }
 
   private static byte[] toBytes(final String s) {
-    return s.getBytes(CHARSET);
+    return s.getBytes(Const.CHARSET_ASCII);
   }
 
   private static String fromBytes(final byte[] b) {
-    return new String(b, CHARSET);
+    return new String(b, Const.CHARSET_ASCII);
   }
 
   /** Returns a human readable string representation of the object. */
@@ -1274,21 +1272,21 @@ public final class UniqueId implements UniqueIdInterface {
           // and the user hasn't put any metrics in, so log and return 0s
           LOG.info("Could not find the UID assignment row");
           for (final byte[] kind : kinds) {
-            results.put(new String(kind, CHARSET), 0L);
+            results.put(new String(kind, Const.CHARSET_ASCII), 0L);
           }
           return results;
         }
         
         for (final KeyValue column : row) {
-          results.put(new String(column.qualifier(), CHARSET), 
+          results.put(new String(column.qualifier(), Const.CHARSET_ASCII),
               Bytes.getLong(column.value()));
         }
         
         // if the user is starting with a fresh UID table, we need to account
         // for missing columns
         for (final byte[] kind : kinds) {
-          if (results.get(new String(kind, CHARSET)) == null) {
-            results.put(new String(kind, CHARSET), 0L);
+          if (results.get(new String(kind, Const.CHARSET_ASCII)) == null) {
+            results.put(new String(kind, Const.CHARSET_ASCII), 0L);
           }
         }
         return results;

--- a/test/storage/MockBase.java
+++ b/test/storage/MockBase.java
@@ -32,6 +32,7 @@ import java.util.regex.PatternSyntaxException;
 
 import javax.xml.bind.DatatypeConverter;
 
+import net.opentsdb.core.Const;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.utils.Config;
 
@@ -80,7 +81,6 @@ import com.stumbleupon.async.Deferred;
  */
 @Ignore
 public final class MockBase {
-  private static final Charset ASCII = Charset.forName("ISO-8859-1");
   private TSDB tsdb;
   
   //      KEY           Column Family Qualifier     Timestamp     Value
@@ -113,7 +113,7 @@ public final class MockBase {
       final boolean default_scan) {
     this.tsdb = tsdb;
     
-    default_family = "t".getBytes(ASCII);  // set a default
+    default_family = "t".getBytes(Const.CHARSET_ASCII);  // set a default
     
     // replace the "real" field objects with mocks
     Field cl;
@@ -498,23 +498,23 @@ public final class MockBase {
     
     for (Map.Entry<byte[], Bytes.ByteMap<Bytes.ByteMap<TreeMap<Long, byte[]>>>> row : 
       storage.entrySet()) {
-      System.out.println("[Row] " + (ascii ? new String(row.getKey(), ASCII) : 
+      System.out.println("[Row] " + (ascii ? new String(row.getKey(), Const.CHARSET_ASCII) :
           bytesToString(row.getKey())));
       
       for (Map.Entry<byte[], Bytes.ByteMap<TreeMap<Long, byte[]>>> cf : 
         row.getValue().entrySet()) {
         
-        final String family = ascii ? new String(cf.getKey(), ASCII) :
+        final String family = ascii ? new String(cf.getKey(), Const.CHARSET_ASCII) :
           bytesToString(cf.getKey());
         System.out.println("  [CF] " + family);
         
         for (Map.Entry<byte[], TreeMap<Long, byte[]>> column : cf.getValue().entrySet()) {
           System.out.println("    [Qual] " + (ascii ?
-              "\"" + new String(column.getKey(), ASCII) + "\""
+              "\"" + new String(column.getKey(), Const.CHARSET_ASCII) + "\""
               : bytesToString(column.getKey())));
           for (Map.Entry<Long, byte[]> cell : column.getValue().entrySet()) {
             System.out.println("      [TS] " + cell.getKey() + "  [Value] " + 
-                (ascii ?  new String(cell.getValue(), ASCII) 
+                (ascii ?  new String(cell.getValue(), Const.CHARSET_ASCII)
                 : bytesToString(cell.getValue())));
           }
         }
@@ -546,7 +546,7 @@ public final class MockBase {
   
   /** @return Returns the ASCII character set */
   public static Charset ASCII() {
-    return ASCII;
+    return Const.CHARSET_ASCII;
   }
   
   /**
@@ -993,7 +993,7 @@ public final class MockBase {
           continue;
         }
         if (pattern != null) {
-          final String from_bytes = new String(row.getKey(), MockBase.ASCII);
+          final String from_bytes = new String(row.getKey(), Const.CHARSET_ASCII);
           if (!pattern.matcher(from_bytes).find()) {
             continue;
           }


### PR DESCRIPTION
Fixes #359. Not sure it this might cause too many conflicts with what other people are working on though?

This doesn't change any functionality. It just moves the constant to `net.opentsdb.core.Const` and changes all references to point to that.
