### PR TITLE
new TSDB constructor with initialized hbase client

### DIFF
--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -150,10 +150,10 @@ public final class TSDB {
    * @since 2.0
    */
   public TSDB(final Config config) {
-	this(new HBaseClient(
-        	config.getString("tsd.storage.hbase.zk_quorum"),
-        	config.getString("tsd.storage.hbase.zk_basedir")
-		),config);
+    this(new HBaseClient(
+      config.getString("tsd.storage.hbase.zk_quorum"),
+      config.getString("tsd.storage.hbase.zk_basedir")
+      ), config);
   }
   
   /** @return The data point column family name */


### PR DESCRIPTION
Hi Chris, Hi Benoît,

When using OpenTSDB as a java lib, we sometimes need to get several instances of TSDB in the same application, or to use the HBaseClient directly from the same application.

From AsyncHBase readme :

> Unlike HTable, you should have only one instance of HBaseClient in your application, regardless of the number of tables or threads you want to use
