### PR TITLE
add tsd.mode and tsd.no_diediedie

### DIFF
--- a/src/tsd/RpcHandler.java
+++ b/src/tsd/RpcHandler.java
@@ -110,39 +110,32 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
 
     telnet_commands = new HashMap<String, TelnetRpc>();
     http_commands = new HashMap<String, HttpRpc>();
-    if ( mode.equals("rw") || mode.equals("wo") ) {
-      {
-        final PutDataPointRpc put = new PutDataPointRpc();
-        telnet_commands.put("put", put);
-        http_commands.put("api/put", put);
-      }
+    if (mode.equals("rw") || mode.equals("wo")) {
+      final PutDataPointRpc put = new PutDataPointRpc();
+      telnet_commands.put("put", put);
+      http_commands.put("api/put", put);
     }
 
-    if ( mode.equals("rw") || mode.equals("ro") ) {
+    if (mode.equals("rw") || mode.equals("ro")) {
       http_commands.put("", new HomePage());
-      {
         final StaticFileRpc staticfile = new StaticFileRpc();
         http_commands.put("favicon.ico", staticfile);
         http_commands.put("s", staticfile);
-      }
-      {
+
         final StatsRpc stats = new StatsRpc();
         telnet_commands.put("stats", stats);
         http_commands.put("stats", stats);
         http_commands.put("api/stats", stats);
-      }
-      {
+
         final DropCaches dropcaches = new DropCaches();
         telnet_commands.put("dropcaches", dropcaches);
         http_commands.put("dropcaches", dropcaches);
         http_commands.put("api/dropcaches", dropcaches);
-      }
-      {
+
         final ListAggregators aggregators = new ListAggregators();
         http_commands.put("aggregators", aggregators);
         http_commands.put("api/aggregators", aggregators);
-      }
-      {
+
         final SuggestRpc suggest_rpc = new SuggestRpc();
         http_commands.put("suggest", suggest_rpc);
         http_commands.put("api/suggest", suggest_rpc);

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -410,8 +410,8 @@ public class Config {
     // map.put("tsd.network.port", ""); // does not have a default, required
     // map.put("tsd.http.cachedir", ""); // does not have a default, required
     // map.put("tsd.http.staticroot", ""); // does not have a default, required
-    default_map.put("tsd.mode","rw");
-    default_map.put("tsd.no_diediedie","false");
+    default_map.put("tsd.mode", "rw");
+    default_map.put("tsd.no_diediedie", "false");
     default_map.put("tsd.network.bind", "0.0.0.0");
     default_map.put("tsd.network.worker_threads", "");
     default_map.put("tsd.network.async_io", "true");


### PR DESCRIPTION
Hi Chris, Hi Benoît,

Like many people we always deploy tsd in read/write pairs so we added a tsd.mode configuration option to disable read or write rpcs on the tsds.

Also we really don't want the diediedie rpc in our production environment, I used to just comment it out but as it's breaking backward compatibility, I added a config switch.

This is a really simple way to do and I'm sure there is more things we can disable in either mode so it may be worth it to spend more time on this as I know that some already requested that feature in the past.
