### PR TITLE
Close scanner when reached max_results.

### DIFF
--- a/src/uid/UniqueId.java
+++ b/src/uid/UniqueId.java
@@ -762,7 +762,12 @@ public final class UniqueId implements UniqueIdInterface {
         }
         suggestions.add(name);
         if ((short) suggestions.size() >= max_results) {  // We have enough.
-          return suggestions;
+          return scanner.close().addCallback(new Callback<Object, Object>() {
+            @Override
+            public Object call(Object ignored) throws Exception {
+              return suggestions;
+            }
+          });
         }
         row.clear();  // free()
       }


### PR DESCRIPTION
When the suggest scanner has reached max_results, close the scanner.

This requires upstream fix for asynchbase for 0.96+:
https://github.com/OpenTSDB/asynchbase/pull/91
