### PR TITLE
Cleanup output from maven during travis build by using quiet mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
-before_script: ./build.sh pom.xml && mvn dependency:go-offline
-script: mvn test
+before_script: ./build.sh pom.xml
+script: mvn test --quiet
 jdk:
   - oraclejdk7
   - openjdk6


### PR DESCRIPTION
This just makes Maven a lot let verbose. Compare [this](https://travis-ci.org/luuse/opentsdb/jobs/29584279) as it is now with how it looks [after](https://travis-ci.org/luuse/opentsdb/jobs/29599268) this change. With this change it will only output errors and a summary of the executed tests (and more details on errors). Sorry I missed this in the initial PR...
