### PR TITLE
Move metric validation and row key generation to TSUID

### DIFF
--- a/src/core/IncomingDataPoints.java
+++ b/src/core/IncomingDataPoints.java
@@ -12,14 +12,12 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import com.stumbleupon.async.Callback;
 import com.stumbleupon.async.Deferred;
 
 import org.hbase.async.Bytes;
@@ -87,133 +85,16 @@ final class IncomingDataPoints implements WritableDataPoints {
     //this.values = new long[3];
   }
 
-  /**
-   * Validates the given metric and tags.
-   * @throws IllegalArgumentException if any of the arguments aren't valid.
-   */
-  static void checkMetricAndTags(final String metric, final Map<String, String> tags) {
-    if (tags.size() <= 0) {
-      throw new IllegalArgumentException("Need at least one tags (metric="
-          + metric + ", tags=" + tags + ')');
-    } else if (tags.size() > Const.MAX_NUM_TAGS) {
-      throw new IllegalArgumentException("Too many tags: " + tags.size()
-          + " maximum allowed: " + Const.MAX_NUM_TAGS + ", tags: " + tags);
-    }
-
-    Tags.validateString("metric name", metric);
-    for (final Map.Entry<String, String> tag : tags.entrySet()) {
-      Tags.validateString("tag name", tag.getKey());
-      Tags.validateString("tag value", tag.getValue());
-    }
-  }
-
-  /**
-  * Returns a partially initialized row key for this metric and these tags.
-  * The only thing left to fill in is the base timestamp.
-  */
-  static byte[] rowKeyTemplate(final TSDB tsdb,
-                               final String metric,
-                               final Map<String, String> tags) {
-    final short metric_width = tsdb.metrics.width();
-    final short tag_name_width = tsdb.tag_names.width();
-    final short tag_value_width = tsdb.tag_values.width();
-    final short num_tags = (short) tags.size();
-
-    int row_size = (metric_width + Const.TIMESTAMP_BYTES
-                    + tag_name_width * num_tags
-                    + tag_value_width * num_tags);
-    final byte[] row = new byte[row_size];
-
-    short pos = 0;
-
-    copyInRowKey(row, pos, (tsdb.config.auto_metric() ? 
-        tsdb.metrics.getOrCreateId(metric) : tsdb.metrics.getId(metric)));
-    pos += metric_width;
-
-    pos += Const.TIMESTAMP_BYTES;
-
-    for(final byte[] tag : Tags.resolveOrCreateAll(tsdb, tags)) {
-      copyInRowKey(row, pos, tag);
-      pos += tag.length;
-    }
-    return row;
-  }
-  
-  /**
-   * Returns a partially initialized row key for this metric and these tags.
-   * The only thing left to fill in is the base timestamp.
-   * @since 2.0
-   */
-  static Deferred<byte[]> rowKeyTemplateAsync(final TSDB tsdb,
-                                         final String metric,
-                                         final Map<String, String> tags) {
-    final short metric_width = tsdb.metrics.width();
-    final short tag_name_width = tsdb.tag_names.width();
-    final short tag_value_width = tsdb.tag_values.width();
-    final short num_tags = (short) tags.size();
-
-    int row_size = (metric_width + Const.TIMESTAMP_BYTES
-                    + tag_name_width * num_tags
-                    + tag_value_width * num_tags);
-    final byte[] row = new byte[row_size];
-
-    // Lookup or create the metric ID.
-    final Deferred<byte[]> metric_id;
-    if (tsdb.config.auto_metric()) {
-      metric_id = tsdb.metrics.getOrCreateIdAsync(metric);
-    } else {
-      metric_id = tsdb.metrics.getIdAsync(metric);
-    }
-
-    // Copy the metric ID at the beginning of the row key.
-    class CopyMetricInRowKeyCB implements Callback<byte[], byte[]> {
-      public byte[] call(final byte[] metricid) {
-        copyInRowKey(row, (short) 0, metricid);
-        return row;
-      }
-    }
-
-    // Copy the tag IDs in the row key.
-    class CopyTagsInRowKeyCB
-      implements Callback<Deferred<byte[]>, ArrayList<byte[]>> {
-      public Deferred<byte[]> call(final ArrayList<byte[]> tags) {
-        short pos = metric_width;
-        pos += Const.TIMESTAMP_BYTES;
-        for (final byte[] tag : tags) {
-          copyInRowKey(row, pos, tag);
-          pos += tag.length;
-        }
-        // Once we've resolved all the tags, schedule the copy of the metric
-        // ID and return the row key we produced.
-        return metric_id.addCallback(new CopyMetricInRowKeyCB());
-      }
-    }
-
-    // Kick off the resolution of all tags.
-    return Tags.resolveOrCreateAllAsync(tsdb, tags)
-      .addCallbackDeferring(new CopyTagsInRowKeyCB());
-  }
-
   public void setSeries(final String metric, final Map<String, String> tags) {
-    checkMetricAndTags(metric, tags);
+    TSUID.checkMetricAndTags(metric, tags);
     try {
-      row = rowKeyTemplate(tsdb, metric, tags);
+      row = TSUID.rowKeyTemplate(tsdb, metric, tags);
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {
       throw new RuntimeException("Should never happen", e);
     }
     size = 0;
-  }
-
-  /**
-   * Copies the specified byte array at the specified offset in the row key.
-   * @param row The row key into which to copy the bytes.
-   * @param offset The offset in the row key to start writing at.
-   * @param bytes The bytes to copy.
-   */
-  private static void copyInRowKey(final byte[] row, final short offset, final byte[] bytes) {
-    System.arraycopy(bytes, 0, row, offset, bytes.length);
   }
 
   /**

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -660,8 +660,8 @@ public final class TSDB {
           + " to metric=" + metric + ", tags=" + tags);
     }
 
-    IncomingDataPoints.checkMetricAndTags(metric, tags);
-    final byte[] row = IncomingDataPoints.rowKeyTemplate(this, metric, tags);
+    TSUID.checkMetricAndTags(metric, tags);
+    final byte[] row = TSUID.rowKeyTemplate(this, metric, tags);
     final long base_time;
     final byte[] qualifier = Internal.buildQualifier(timestamp, flags);
     

--- a/src/core/TSUID.java
+++ b/src/core/TSUID.java
@@ -1,0 +1,140 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2014  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+
+public class TSUID {
+  /**
+   * Validates the given metric and tags.
+   * @throws IllegalArgumentException if any of the arguments aren't valid.
+   */
+  public static void checkMetricAndTags(final String metric, final Map<String,
+          String> tags) {
+    if (tags.size() <= 0) {
+      throw new IllegalArgumentException("Need at least one tags (metric="
+          + metric + ", tags=" + tags + ')');
+    } else if (tags.size() > Const.MAX_NUM_TAGS) {
+      throw new IllegalArgumentException("Too many tags: " + tags.size()
+          + " maximum allowed: " + Const.MAX_NUM_TAGS + ", tags: " + tags);
+    }
+
+    Tags.validateString("metric name", metric);
+    for (final Map.Entry<String, String> tag : tags.entrySet()) {
+      Tags.validateString("tag name", tag.getKey());
+      Tags.validateString("tag value", tag.getValue());
+    }
+  }
+
+  /**
+  * Returns a partially initialized row key for this metric and these tags.
+  * The only thing left to fill in is the base timestamp.
+  */
+  public static byte[] rowKeyTemplate(final TSDB tsdb,
+                               final String metric,
+                               final Map<String, String> tags) {
+    final short metric_width = tsdb.metrics.width();
+    final short tag_name_width = tsdb.tag_names.width();
+    final short tag_value_width = tsdb.tag_values.width();
+    final short num_tags = (short) tags.size();
+
+    int row_size = (metric_width + Const.TIMESTAMP_BYTES
+                    + tag_name_width * num_tags
+                    + tag_value_width * num_tags);
+    final byte[] row = new byte[row_size];
+
+    short pos = 0;
+
+    copyInRowKey(row, pos, (tsdb.config.auto_metric() ?
+        tsdb.metrics.getOrCreateId(metric) : tsdb.metrics.getId(metric)));
+    pos += metric_width;
+
+    pos += Const.TIMESTAMP_BYTES;
+
+    for(final byte[] tag : Tags.resolveOrCreateAll(tsdb, tags)) {
+      copyInRowKey(row, pos, tag);
+      pos += tag.length;
+    }
+    return row;
+  }
+
+  /**
+   * Returns a partially initialized row key for this metric and these tags.
+   * The only thing left to fill in is the base timestamp.
+   * @since 2.0
+   */
+  static Deferred<byte[]> rowKeyTemplateAsync(final TSDB tsdb,
+                                         final String metric,
+                                         final Map<String, String> tags) {
+    final short metric_width = tsdb.metrics.width();
+    final short tag_name_width = tsdb.tag_names.width();
+    final short tag_value_width = tsdb.tag_values.width();
+    final short num_tags = (short) tags.size();
+
+    int row_size = (metric_width + Const.TIMESTAMP_BYTES
+                    + tag_name_width * num_tags
+                    + tag_value_width * num_tags);
+    final byte[] row = new byte[row_size];
+
+    // Lookup or create the metric ID.
+    final Deferred<byte[]> metric_id;
+    if (tsdb.config.auto_metric()) {
+      metric_id = tsdb.metrics.getOrCreateIdAsync(metric);
+    } else {
+      metric_id = tsdb.metrics.getIdAsync(metric);
+    }
+
+    // Copy the metric ID at the beginning of the row key.
+    class CopyMetricInRowKeyCB implements Callback<byte[], byte[]> {
+      public byte[] call(final byte[] metricid) {
+        copyInRowKey(row, (short) 0, metricid);
+        return row;
+      }
+    }
+
+    // Copy the tag IDs in the row key.
+    class CopyTagsInRowKeyCB
+      implements Callback<Deferred<byte[]>, ArrayList<byte[]>> {
+      public Deferred<byte[]> call(final ArrayList<byte[]> tags) {
+        short pos = metric_width;
+        pos += Const.TIMESTAMP_BYTES;
+        for (final byte[] tag : tags) {
+          copyInRowKey(row, pos, tag);
+          pos += tag.length;
+        }
+        // Once we've resolved all the tags, schedule the copy of the metric
+        // ID and return the row key we produced.
+        return metric_id.addCallback(new CopyMetricInRowKeyCB());
+      }
+    }
+
+    // Kick off the resolution of all tags.
+    return Tags.resolveOrCreateAllAsync(tsdb, tags)
+      .addCallbackDeferring(new CopyTagsInRowKeyCB());
+  }
+
+  /**
+   * Copies the specified byte array at the specified offset in the row key.
+   * @param row The row key into which to copy the bytes.
+   * @param offset The offset in the row key to start writing at.
+   * @param bytes The bytes to copy.
+   */
+  private static void copyInRowKey(final byte[] row, final short offset, final byte[] bytes) {
+    System.arraycopy(bytes, 0, row, offset, bytes.length);
+  }
+}

--- a/test/core/TestTSDB.java
+++ b/test/core/TestTSDB.java
@@ -56,7 +56,8 @@ import com.stumbleupon.async.Deferred;
   "com.sum.*", "org.xml.*"})
 @PrepareForTest({TSDB.class, Config.class, UniqueId.class, HBaseClient.class, 
   CompactionQueue.class, GetRequest.class, PutRequest.class, KeyValue.class, 
-  Scanner.class, AtomicIncrementRequest.class, IncomingDataPoints.class})
+  Scanner.class, AtomicIncrementRequest.class, IncomingDataPoints.class,
+  TSUID.class})
 public final class TestTSDB {
   private Config config;
   private TSDB tsdb;
@@ -526,8 +527,8 @@ public final class TestTSDB {
   @Test (expected = NoSuchUniqueName.class)
   public void addPointNoAutoMetric() throws Exception {
     setupAddPointStorage();
-    when(IncomingDataPoints.rowKeyTemplate((TSDB)any(), anyString(), 
-        (Map<String, String>)any()))
+    when(TSUID.rowKeyTemplate((TSDB) any(), anyString(),
+            (Map<String, String>) any()))
       .thenThrow(new NoSuchUniqueName("sys.cpu.user", "metric"));
     HashMap<String, String> tags = new HashMap<String, String>(1);
     tags.put("host", "web01");
@@ -851,7 +852,7 @@ public final class TestTSDB {
   private void setupAddPointStorage() throws Exception {
     storage = new MockBase(tsdb, client, true, true, true, true);
 
-    PowerMockito.mockStatic(IncomingDataPoints.class);   
+    PowerMockito.mockStatic(TSUID.class);
     final byte[] row = new byte[] { 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1}; 
     PowerMockito.doAnswer(
         new Answer<byte[]>() {
@@ -861,7 +862,7 @@ public final class TestTSDB {
             return row;
           }
         }
-    ).when(IncomingDataPoints.class, "rowKeyTemplate", any(), anyString(), 
+    ).when(TSUID.class, "rowKeyTemplate", any(), anyString(),
         any());
 
     when(metrics.width()).thenReturn((short)3);

--- a/test/core/TestTsdbQuery.java
+++ b/test/core/TestTsdbQuery.java
@@ -70,7 +70,8 @@ import com.stumbleupon.async.Deferred;
 @PrepareForTest({TSDB.class, Config.class, UniqueId.class, HBaseClient.class, 
   CompactionQueue.class, GetRequest.class, PutRequest.class, KeyValue.class, 
   Scanner.class, TsdbQuery.class, DeleteRequest.class, Annotation.class, 
-  RowKey.class, Span.class, SpanGroup.class, IncomingDataPoints.class })
+  RowKey.class, Span.class, SpanGroup.class, IncomingDataPoints.class,
+  TSUID.class})
 public final class TestTsdbQuery {
   private Config config;
   private TSDB tsdb = null;
@@ -2596,7 +2597,7 @@ public final class TestTsdbQuery {
     storage = new MockBase(tsdb, client, true, true, true, true);
     storage.setFamily("t".getBytes(MockBase.ASCII()));
 
-    PowerMockito.mockStatic(IncomingDataPoints.class);   
+    PowerMockito.mockStatic(TSUID.class);
     PowerMockito.doAnswer(
         new Answer<byte[]>() {
           @Override
@@ -2621,7 +2622,7 @@ public final class TestTsdbQuery {
             }
           }
         }
-    ).when(IncomingDataPoints.class, "rowKeyTemplate", any(), anyString(), 
+    ).when(TSUID.class, "rowKeyTemplate", any(), anyString(),
         any());
   }
   

--- a/test/core/TestTsdbQueryDownsample.java
+++ b/test/core/TestTsdbQueryDownsample.java
@@ -62,7 +62,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest({TSDB.class, Config.class, UniqueId.class, HBaseClient.class,
   CompactionQueue.class, GetRequest.class, PutRequest.class, KeyValue.class,
   Scanner.class, TsdbQuery.class, DeleteRequest.class, Annotation.class,
-  RowKey.class, Span.class, SpanGroup.class, IncomingDataPoints.class })
+  RowKey.class, Span.class, SpanGroup.class, IncomingDataPoints.class,
+  TSUID.class})
 public class TestTsdbQueryDownsample {
 
   private Config config;
@@ -625,7 +626,7 @@ public class TestTsdbQueryDownsample {
     storage = new MockBase(tsdb, client, true, true, true, true);
     storage.setFamily("t".getBytes(MockBase.ASCII()));
 
-    PowerMockito.mockStatic(IncomingDataPoints.class);
+    PowerMockito.mockStatic(TSUID.class);
     PowerMockito.doAnswer(
         new Answer<byte[]>() {
           public byte[] answer(final InvocationOnMock args)
@@ -649,7 +650,7 @@ public class TestTsdbQueryDownsample {
             }
           }
         }
-    ).when(IncomingDataPoints.class, "rowKeyTemplate", (TSDB)any(), anyString(),
+    ).when(TSUID.class, "rowKeyTemplate", (TSDB)any(), anyString(),
         (Map<String, String>)any());
   }
 }


### PR DESCRIPTION
This is not a good permanent solution. It's just a straight extraction of a few methods to make them reachable on a few parts we're working on. We're working on some stuff in the package `net.opentsdb.storage` and we need access to this there which we don't currently have.

One solution to this would be to make `net.opentsdb.core.IncomingDataPoints` and the methods public but we're refactoring some other stuff there and that probably won't be merged for a while. Thus why we want to get this stuff out of there and merged so we can try to avoid some conflicts...
