### PR TITLE
fix RTPublisher public  data with reverse logic error

### DIFF
--- a/src/tsd/RTPublisher.java
+++ b/src/tsd/RTPublisher.java
@@ -97,7 +97,7 @@ public abstract class RTPublisher {
   public final Deferred<Object> sinkDataPoint(final String metric, 
       final long timestamp, final byte[] value, final Map<String, String> tags, 
       final byte[] tsuid, final short flags) {
-    if ((flags & Const.FLAG_FLOAT) == 0x0) {
+    if ((flags & Const.FLAG_FLOAT) != 0x0) {
       return publishDataPoint(metric, timestamp, 
           Internal.extractFloatingPointValue(value, 0, (byte) flags), 
           tags, tsuid);


### PR DESCRIPTION
Const.java:35:    

```
     public static final short FLAG_FLOAT = 0x8;
```

TSDB.java:610  

```
public Deferred<Object> addPoint(final String metric,  
                               final long timestamp,   
                               final float value,
                               final Map<String, String> tags) {
if (Float.isNaN(value) || Float.isInfinite(value)) {
  throw new IllegalArgumentException("value is NaN or Infinite: " + value
                                     + " for metric=" + metric
                                     + " timestamp=" + timestamp);
}
final short flags = Const.FLAG_FLOAT | 0x3;  // A float stored on 4 bytes.
```

we know that when  value is float type ,  flags = 0xb   (0x8 | 0x3)   

```
public final Deferred<Object> sinkDataPoint(final String metric,
    final long timestamp, final byte[] value, final Map<String, String> tags,
    final byte[] tsuid, final short flags) {
   if ((flags & Const.FLAG_FLOAT) == 0x0) {
      return publishDataPoint(metric, timestamp,
      Internal.extractFloatingPointValue(value, 0, (byte) flags),
      tags, tsuid);
} else {
  return publishDataPoint(metric, timestamp,
      Internal.extractIntegerValue(value, 0, (byte) flags), tags, tsuid);
}
```

so when we sinkDataPoint: 

```
(flags & Const.FLAG_FLOAT)  we get  0xb & 0x8 == 0x8  which is  != 0x0.
```
