### PR TITLE
Added option to timeout sockets server-side. (#304)

### DIFF
--- a/src/tsd/ConnectionManager.java
+++ b/src/tsd/ConnectionManager.java
@@ -24,15 +24,18 @@ import org.jboss.netty.channel.ChannelEvent;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ChannelStateEvent;
 import org.jboss.netty.channel.ExceptionEvent;
-import org.jboss.netty.channel.SimpleChannelHandler;
 import org.jboss.netty.channel.group.DefaultChannelGroup;
+import org.jboss.netty.handler.timeout.IdleState;
+import org.jboss.netty.handler.timeout.IdleStateAwareChannelHandler;
+import org.jboss.netty.handler.timeout.IdleStateEvent;
+import org.jboss.netty.handler.timeout.ReadTimeoutException;
 
 import net.opentsdb.stats.StatsCollector;
 
 /**
  * Keeps track of all existing connections.
  */
-final class ConnectionManager extends SimpleChannelHandler {
+final class ConnectionManager extends IdleStateAwareChannelHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConnectionManager.class);
 
@@ -116,4 +119,12 @@ final class ConnectionManager extends SimpleChannelHandler {
     e.getChannel().close();
   }
 
+  @Override
+  public void channelIdle(ChannelHandlerContext ctx, IdleStateEvent e) {
+    if (e.getState() == IdleState.ALL_IDLE) {
+      LOG.debug("Closed idle socket.");
+      e.getChannel().close();
+    }
+  }
+  
 }

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -389,6 +389,7 @@ public class Config {
     default_map.put("tsd.core.meta.enable_tsuid_incrementing", "false");
     default_map.put("tsd.core.meta.enable_tsuid_tracking", "false");
     default_map.put("tsd.core.plugin_path", "");
+    default_map.put("tsd.core.socket.timeout", "0");
     default_map.put("tsd.core.tree.enable_processing", "false");
     default_map.put("tsd.rtpublisher.enable", "false");
     default_map.put("tsd.rtpublisher.plugin", "");


### PR DESCRIPTION
By default, Netty sets socket timeouts to 0; this causes sockets to linger forever until they're explicitly closed. As seen in #304, it seems that sockets can be left in a weird state (TIMED_WAIT) when a TSD loses its connection to all of its region servers when `tsd.network.async_io = true` - my guess it has to be something to do with async I/O and re-using sockets `tsd.network.reuseaddress = true` causes some weirdness to occur in Netty.

This PR provides a workaround by providing a way to configure the socket timeout for Netty by using the IdleStateHandler:

http://docs.jboss.org/netty/3.2/api/org/jboss/netty/handler/timeout/IdleStateHandler.html

The `IdleStateHandler` watches the Netty channel and fires an `IdleStateEvent` when N number of seconds have passed without any reads/writes being done on the socket (effectively idle) - I've also updated `ConnectionManager` to inherit from `IdleStateAwareChannelHandler` and implements `channelIdle`.

By default, socket timeouts are left to infinite wait (a timeout of 0 prevents the `IdleState.ALL_IDLE` event from firing - this maintains the current functionality in 2.0) but you can configure them by setting the `tsd.core.socket.timeout` configuration property:

```
# timeout sockets in Netty when idle for 5 minutes 
tsd.core.socket.timeout = 300
```

This is what it looks like in the logs:

```
2014-08-08 14:27:53,118 INFO  [New I/O worker #1] HttpQuery: [id: 0xf086015a, /0:0:0:0:0:0:0:1:64884 => /0:0:0:0:0:0:0:1:4242] HTTP /stats done in 78ms
2014-08-08 14:32:53,095 DEBUG  [New I/O worker #1] ConnectionManager: Closed idle socket.
```

Using this, you can force to sockets to close if they're left open and idle for a long enough duration. This should mitigate the open sockets in #304 when using async I/O while giving the option to maintain the indefinite socket timeouts by default.
