### PR TITLE
Added details about values and timestamps into the Fsck command for duplicate values

### DIFF
--- a/src/tools/Fsck.java
+++ b/src/tools/Fsck.java
@@ -597,6 +597,8 @@ final class Fsck {
         buf.append("More than one column had a value for the same timestamp: ")
            .append("(")
            .append(time_map.getKey())
+           .append(" - ")
+           .append(new java.util.Date(time_map.getKey()))
            .append(")\n    row key: (")
            .append(UniqueId.uidToString(key))
            .append(")\n");
@@ -606,11 +608,19 @@ final class Fsck {
           buf.append("    ")
              .append("write time: (")
              .append(dp.kv.timestamp())
+             .append(" - ")
+             .append(new java.util.Date(dp.kv.timestamp()))
              .append(") ")
              .append(" compacted: (")
              .append(dp.compacted)
              .append(")  qualifier: ")
-             .append(Arrays.toString(dp.kv.qualifier()));
+             .append(Arrays.toString(dp.kv.qualifier()))
+             .append(" value: ")
+             .append(Internal.isFloat(dp.kv.qualifier()) ?
+                Internal.extractFloatingPointValue(
+                   dp.value(), 0, (byte)Internal.getFlagsFromQualifier(dp.kv.qualifier())) :
+                Internal.extractIntegerValue(
+                   dp.value(), 0, (byte)Internal.getFlagsFromQualifier(dp.kv.qualifier())));
           unique_columns.put(dp.kv.qualifier(), dp.kv.value());
           if (options.lastWriteWins()) { 
             if (index == time_map.getValue().size() - 1) {


### PR DESCRIPTION
Hi,

We get duplicate values in our OpenTSDB metrics from time to time. The current Fsck output for duplicate values is not very helpful for us because it does not show the duplicate values or human-readable timestamps. This makes it hard to understand why these duplicates are occurring.

I changed the Fsck output so that it also shows human-readable timestamps and the actual duplicate values.

Current OpenTSDB Fsck (only relevant part):
  
     2014-08-22 00:26:44,872 ERROR [main] Fsck: More than one column had a value for the same       timestamp: (1346846400000)
        row key: (00007050473EC000001202D70A)
        write time: (1408666697967)  compacted: (false)  qualifier: [0, 0]  <--- Keep oldest
        write time: (1408666939569)  compacted: (false)  qualifier: [0, 11]
    2014-08-22 00:26:44,873 WARN  [main] Fsck: One or more errors found in row that were not marked for     repair


Proposed change (only relevant part):
   
     2014-08-22 00:40:16,940 ERROR [main] Fsck: More than one column had a value for the same timestamp: (1346846400000 - Wed Sep 05 12:00:00 UTC 2012)
        row key: (00007050473EC000001202D70A)
        write time: (1408666697967 - Fri Aug 22 00:18:17 UTC 2014)  compacted: (false)  qualifier: [0, 0] value: 19.0  <--- Keep oldest
        write time: (1408666939569 - Fri Aug 22 00:22:19 UTC 2014)  compacted: (false)  qualifier: [0, 11] value: 19.700000762939453
    2014-08-22 00:40:16,940 WARN  [main] Fsck: One or more errors found in row that were not marked for repair

Feel free to comment on the code, I am not very familiar with the OpenTSDB codebase and mainly program in python. I am happy to put a little bit more time into this to get it merged.

Thanks,
Tomas



