### PR TITLE
Fix comment conf file - s/space/comma/

### DIFF
--- a/src/opentsdb.conf
+++ b/src/opentsdb.conf
@@ -55,6 +55,6 @@ tsd.http.cachedir =
 # Path under which the znode for the -ROOT- region is located, default is "/hbase"
 #tsd.storage.hbase.zk_basedir = /hbase
 
-# A space separated list of Zookeeper hosts to connect to, with or without 
+# A comma separated list of Zookeeper hosts to connect to, with or without 
 # port specifiers, default is "localhost"
 #tsd.storage.hbase.zk_quorum = localhost


### PR DESCRIPTION
Commit fixes comment in 'src/opentsdb.conf' which says list of ZK hosts is a
space separated list, but in reality it's a comma separated list.

See: http://opentsdb.net/docs/build/html/user_guide/configuration.html

Also, it would be great to fix the following at the link I've mentioned - ``192.168.1.1:2181, 192.168.1.2:2181'' << there is no white space, so don't put one there! It's rather confusing. But I don't know where the source of this documentation is.

Thanks.
