### PR TITLE
Fix #335 by pointing at tsdb.local in /usr/share/opentsdb/bin

### DIFF
--- a/src/core/Query.java
+++ b/src/core/Query.java
@@ -22,7 +22,7 @@ import com.stumbleupon.async.Deferred;
 import net.opentsdb.uid.NoSuchUniqueName;
 
 /**
- * A query to retreive data from the TSDB.
+ * A query to retrieve data from the TSDB.
  */
 public interface Query {
 
@@ -69,7 +69,7 @@ public interface Query {
 
   /**
   * Sets the time series to the query.
-  * @param metric The metric to retreive from the TSDB.
+  * @param metric The metric to retrieve from the TSDB.
   * @param tags The set of tags of interest.
   * @param function The aggregation function to use.
   * @param rate If true, the rate of the series will be used instead of the
@@ -86,7 +86,7 @@ public interface Query {
     
   /**
    * Sets the time series to the query.
-   * @param metric The metric to retreive from the TSDB.
+   * @param metric The metric to retrieve from the TSDB.
    * @param tags The set of tags of interest.
    * @param function The aggregation function to use.
    * @param rate If true, the rate of the series will be used instead of the

--- a/src/core/TsdbQuery.java
+++ b/src/core/TsdbQuery.java
@@ -333,7 +333,7 @@ final class TsdbQuery implements Query {
    * stored in the map has its timestamp zero'ed out.
    * @throws HBaseException if there was a problem communicating with HBase to
    * perform the search.
-   * @throws IllegalArgumentException if bad data was retreived from HBase.
+   * @throws IllegalArgumentException if bad data was retrieved from HBase.
    */
   private Deferred<TreeMap<byte[], Span>> findSpans() throws HBaseException {
     final short metric_width = tsdb.metrics.width();

--- a/tsdb.in
+++ b/tsdb.in
@@ -18,7 +18,7 @@ test -d "$pkgdatadir" || test -n "$abs_srcdir$abs_builddir" || {
 }
 
 if test -n "$pkgdatadir"; then
-  localdir="$pkgdatadir"
+  localdir="$pkgdatadir/bin"
   for jar in "$pkgdatadir"/*.jar; do
     CLASSPATH="$CLASSPATH:$jar"
   done


### PR DESCRIPTION
For distribution packages, `$localdir` points at `/usr/share/opentsdb`. It's counterintuitive and inconsistent with the source version behavior where `./tsdb` expects `tsdb.local` to be in the same directory (./build).

https://github.com/OpenTSDB/opentsdb/issues/335