### PR TITLE
Fix for repeated global annotation as reported in issue #377

### DIFF
--- a/src/meta/Annotation.java
+++ b/src/meta/Annotation.java
@@ -273,7 +273,7 @@ public final class Annotation implements Comparable<Annotation> {
           return Deferred.fromResult(null);
         }
         
-        Annotation note = JSON.parseToObject(row.get(0).value(), 
+        Annotation note = JSON.parseToObject(row.get(0).value(),
             Annotation.class);
         return Deferred.fromResult(note);
       }
@@ -356,7 +356,7 @@ public final class Annotation implements Comparable<Annotation> {
           for (KeyValue column : row) {
             if (column.qualifier().length == 3 && 
                 column.qualifier()[0] == PREFIX()) {
-              Annotation note = JSON.parseToObject(row.get(0).value(), 
+              Annotation note = JSON.parseToObject(column.value(),
                   Annotation.class);
               if (note.start_time < start_time || note.end_time > end_time) {
                 continue;

--- a/test/meta/TestAnnotation.java
+++ b/test/meta/TestAnnotation.java
@@ -153,6 +153,10 @@ public final class TestAnnotation {
         1328141000).joinUninterruptibly();
     assertNotNull(notes);
     assertEquals(2, notes.size());
+    Annotation note0 = notes.get(0);
+    Annotation note1 = notes.get(1);
+    assertEquals("Description", note0.getDescription());
+    assertEquals("Global 2", note1.getDescription());
   }
   
   @Test


### PR DESCRIPTION
As reported by @bbhati in #377 if there are N global annotations to be fetched, the content the first annotation is presented N times through the API endpoint. This trivial change corrects this undesired behavior and completes the existing test which covers the use case.
