### PR TITLE
Addressing #341 Redirecting logging to STDERR.

### DIFF
--- a/build-aux/deb/logback.xml
+++ b/build-aux/deb/logback.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <!--<jmxConfigurator/>-->
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>
+        System.err
+    </target>
     <encoder>
       <pattern>
         %d{ISO8601} %-5level [%thread] %logger{0}: %msg%n
@@ -38,7 +41,7 @@
   <logger name="org.hbase.async" level="INFO"/>
   <logger name="com.stumbleupon.async" level="INFO"/>
   <root level="INFO">
-    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="STDERR"/>
     <appender-ref ref="CYCLIC"/>
     <appender-ref ref="FILE"/>
   </root>

--- a/build-aux/rpm/logback.xml
+++ b/build-aux/rpm/logback.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <!--<jmxConfigurator/>-->
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>
+        System.err
+    </target>
     <encoder>
       <pattern>
         %d{ISO8601} %-5level [%thread] %logger{0}: %msg%n
@@ -38,7 +41,7 @@
   <logger name="org.hbase.async" level="INFO"/>
   <logger name="com.stumbleupon.async" level="INFO"/>
   <root level="INFO">
-    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="STDERR"/>
     <appender-ref ref="CYCLIC"/>
     <appender-ref ref="FILE"/>
   </root>

--- a/src/logback.xml
+++ b/src/logback.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <!--<jmxConfigurator/>-->
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>
+        System.err
+    </target>
     <encoder>
       <pattern>
         %d{ISO8601} %-5level [%thread] %logger{0}: %msg%n
@@ -16,7 +19,7 @@
   <logger name="org.hbase.async" level="info"/>
   <logger name="com.stumbleupon.async" level="info"/>
   <root level="info">
-    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="STDERR"/>
     <appender-ref ref="CYCLIC"/>
   </root>
 </configuration>


### PR DESCRIPTION
Logging to stdout may pollute output from `tsdb` resulting in inconvenient use, as pointed out by @dennismphil in https://github.com/OpenTSDB/opentsdb/issues/341. This change points the default logging destination at STDERR.

```
$ sudo -u opentsdb ./tsdb scan 2014/09/11-23:42:00 sum network.hosts --import > /tmp/import.txt
2014-09-13 00:55:13,329 INFO  [main] Config: Successfully loaded configuration file: /etc/opentsdb/opentsdb.conf
2014-09-13 00:55:13,505 INFO  [main] ZooKeeper: Client environment:zookeeper.version=3.3.6-1366786, built on 07/29/2012 06:22 GMT
2014-09-13 00:55:13,505 INFO  [main] ZooKeeper: Client environment:host.name=number5
2014-09-13 00:55:13,506 INFO  [main] ZooKeeper: Client environment:java.version=1.7.0_65
2014-09-13 00:55:13,506 INFO  [main] ZooKeeper: Client environment:java.vendor=Oracle Corporation
[...]
```
That way the result of the scan is ready for import, log messages don't have to be filtered out:
```
oozie@number5:/usr/share/opentsdb/bin$ head /tmp/import.txt 
network.hosts 1410498110 1 hostname=number5 host=number5
network.hosts 1410498375 1 hostname=number5 host=number5
network.hosts 1410498700 1 hostname=number5 host=number5
network.hosts 1410498973 1 hostname=number5 host=number5
network.hosts 1410499278 1 hostname=number5 host=number5
network.hosts 1410499581 1 hostname=number5 host=number5
network.hosts 1410499877 1 hostname=number5 host=number5
[...]
```