### PR TITLE
Addressing #268 - add `tsdb version` command. 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,11 +18,12 @@ ACLOCAL_AMFLAGS = -I build-aux
 all-am: jar staticroot
 
 package = net.opentsdb
+builddata_subpackage = tools
 spec_title = OpenTSDB
 spec_vendor = The OpenTSDB Authors
 jar := tsdb-$(PACKAGE_VERSION).jar
 plugin_test_jar := plugin_test.jar
-builddata_SRC := src/BuildData.java
+builddata_SRC := src/tools/BuildData.java
 BUILT_SOURCES = $(builddata_SRC)
 nodist_bin_SCRIPTS = tsdb
 dist_noinst_SCRIPTS = src/create_table.sh src/upgrade_1to2.sh src/mygnuplot.sh \
@@ -297,7 +298,7 @@ install-exec-hook:
 	rm -f tsdb.tmp
 
 $(builddata_SRC): .git/HEAD $(tsdb_SRC) $(top_srcdir)/build-aux/gen_build_data.sh
-	$(srcdir)/build-aux/gen_build_data.sh $(builddata_SRC) $(package) $(PACKAGE_VERSION)
+	$(srcdir)/build-aux/gen_build_data.sh $(builddata_SRC) $(package).$(builddata_subpackage) $(PACKAGE_VERSION)
 
 jar: $(jar) .javac-unittests-stamp .gwtc-stamp
 

--- a/build-aux/gen_build_data.sh
+++ b/build-aux/gen_build_data.sh
@@ -143,5 +143,10 @@ public final class $CLASS {
 
   // Can't instantiate.
   private $CLASS() {}
+
+  public static void main(String[] args) {
+    System.out.println(revisionString());
+    System.out.println(buildString());
+  }
 }
 EOF

--- a/pom.xml.in
+++ b/pom.xml.in
@@ -93,8 +93,8 @@
               <executable>build-aux/gen_build_data.sh</executable>
               <!-- optional -->
               <arguments>
-                <argument>target/generated-sources/net/opentsdb/BuildData.java</argument>
-                <argument>net.opentsdb</argument>
+                <argument>target/generated-sources/net/opentsdb/tools/BuildData.java</argument>
+                <argument>net.opentsdb.tools</argument>
                 <argument>BuildData</argument>
               </arguments>
             </configuration>

--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 
-import net.opentsdb.BuildData;
+import net.opentsdb.tools.BuildData;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.tsd.PipelineFactory;
 import net.opentsdb.utils.Config;

--- a/src/tsd/RpcHandler.java
+++ b/src/tsd/RpcHandler.java
@@ -33,7 +33,7 @@ import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
-import net.opentsdb.BuildData;
+import net.opentsdb.tools.BuildData;
 import net.opentsdb.core.Aggregators;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.stats.StatsCollector;

--- a/tsdb.in
+++ b/tsdb.in
@@ -62,7 +62,7 @@ CLASSPATH="${CLASSPATH#:}"
 
 usage() {
   echo >&2 "usage: $me <command> [args]"
-  echo 'Valid commands: fsck, import, mkmetric, query, tsd, scan, uid'
+  echo 'Valid commands: fsck, import, mkmetric, query, tsd, scan, search, uid, version'
   exit 1
 }
 
@@ -92,6 +92,9 @@ case $1 in
     ;;
   (uid)
     MAINCLASS=UidManager
+    ;;
+  (version)
+    MAINCLASS=BuildData
     ;;
   (*)
     echo >&2 "$me: error: unknown command '$1'"


### PR DESCRIPTION
This change addresses #268 comments by moving `BuildData.java` into src/tools and making it one of `tsdb`'s command classes. 
```
oozie@number5:/usr/share/opentsdb/bin$ ./tsdb version
net.opentsdb.tools 2.1.0 built at revision bbe7925 (MODIFIED)
Built on 2014/09/14 01:14:57 +0000 by oozie@anonymous:/home/oozie/src/opentsdb/build

oozie@number5:/tmp$ wget -qO- localhost:4242/version
net.opentsdb.tools 2.1.0 built at revision bbe7925 (MODIFIED)
Built on 2014/09/14 01:14:57 +0000 by oozie@anonymous:/home/oozie/src/opentsdb/build
```

BONUS: This change will simplify the eclipse setup procedure by taking out the "copy BuildData.java" bullet point.
http://opentsdb.net/docs/build/html/development/development.html