### PR TITLE
Adds HttpRpcPlugins that run on the main Netty loop.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -190,6 +190,7 @@ test_SRC := \
 	test/tsd/TestQueryRpc.java	\
 	test/tsd/TestRpcHandler.java	\
 	test/tsd/TestRpcPlugin.java	\
+	test/tsd/TestRpcPluginsManager.java	\
 	test/tsd/TestRTPublisher.java	\
 	test/tsd/TestSearchRpc.java	\
 	test/tsd/TestSuggestRpc.java	\

--- a/Makefile.am
+++ b/Makefile.am
@@ -89,6 +89,7 @@ tsdb_SRC := \
 	src/tree/Tree.java	\
 	src/tree/TreeBuilder.java	\
 	src/tree/TreeRule.java	\
+	src/tsd/AbstractHttpQuery.java	\
 	src/tsd/AnnotationRpc.java	\
 	src/tsd/BadRequestException.java	\
 	src/tsd/ConnectionManager.java	\
@@ -98,6 +99,8 @@ tsdb_SRC := \
 	src/tsd/HttpSerializer.java	\
 	src/tsd/HttpQuery.java	\
 	src/tsd/HttpRpc.java	\
+	src/tsd/HttpRpcPlugin.java	\
+	src/tsd/HttpRpcPluginQuery.java	\
 	src/tsd/LineBasedFrameDecoder.java	\
 	src/tsd/LogsRpc.java	\
 	src/tsd/PipelineFactory.java	\
@@ -105,6 +108,7 @@ tsdb_SRC := \
 	src/tsd/QueryRpc.java	\
 	src/tsd/RpcHandler.java	\
 	src/tsd/RpcPlugin.java	\
+	src/tsd/RpcPluginsManager.java	\
 	src/tsd/RTPublisher.java	\
 	src/tsd/SearchRpc.java	\
 	src/tsd/StaticFileRpc.java	\

--- a/Makefile.am
+++ b/Makefile.am
@@ -186,6 +186,7 @@ test_SRC := \
 	test/tsd/TestGraphHandler.java	\
 	test/tsd/TestHttpJsonSerializer.java	\
 	test/tsd/TestHttpQuery.java	\
+	test/tsd/TestHttpRpcPluginQuery.java	\
 	test/tsd/TestPutRpc.java	\
 	test/tsd/TestQueryRpc.java	\
 	test/tsd/TestRpcHandler.java	\
@@ -210,6 +211,7 @@ test_plugin_SRC := \
   test/plugin/DummyPluginB.java \
   test/search/DummySearchPlugin.java \
   test/tsd/DummyHttpSerializer.java \
+  test/tsd/DummyHttpRpcPlugin.java \
   test/tsd/DummyRpcPlugin.java \
   test/tsd/DummyRTPublisher.java
 
@@ -218,6 +220,7 @@ test_plugin_SVCS := \
   META-INF/services/net.opentsdb.plugin.DummyPlugin \
   META-INF/services/net.opentsdb.search.SearchPlugin \
   META-INF/services/net.opentsdb.tsd.HttpSerializer \
+  META-INF/services/net.opentsdb.tsd.HttpRpcPlugin \
   META-INF/services/net.opentsdb.tsd.RpcPlugin \
   META-INF/services/net.opentsdb.tsd.RTPublisher
   

--- a/Makefile.am
+++ b/Makefile.am
@@ -191,7 +191,7 @@ test_SRC := \
 	test/tsd/TestQueryRpc.java	\
 	test/tsd/TestRpcHandler.java	\
 	test/tsd/TestRpcPlugin.java	\
-	test/tsd/TestRpcPluginsManager.java	\
+	test/tsd/TestRpcManager.java	\
 	test/tsd/TestRTPublisher.java	\
 	test/tsd/TestSearchRpc.java	\
 	test/tsd/TestSuggestRpc.java	\

--- a/Makefile.am
+++ b/Makefile.am
@@ -108,7 +108,7 @@ tsdb_SRC := \
 	src/tsd/QueryRpc.java	\
 	src/tsd/RpcHandler.java	\
 	src/tsd/RpcPlugin.java	\
-	src/tsd/RpcPluginsManager.java	\
+	src/tsd/RpcManager.java	\
 	src/tsd/RTPublisher.java	\
 	src/tsd/SearchRpc.java	\
 	src/tsd/StaticFileRpc.java	\

--- a/pom.xml.in
+++ b/pom.xml.in
@@ -126,6 +126,9 @@
                 <argument>net/opentsdb/tsd/DummyHttpSerializer.class</argument>
                 <argument>-C</argument>
                 <argument>target/test-classes</argument>
+                <argument>net/opentsdb/tsd/DummyHttpRpcPlugin.class</argument>
+                <argument>-C</argument>
+                <argument>target/test-classes</argument>
                 <argument>net/opentsdb/tsd/DummyRpcPlugin.class</argument>
                 <argument>-C</argument>
                 <argument>target/test-classes</argument>
@@ -139,6 +142,9 @@
                 <argument>-C</argument>
                 <argument>test</argument>
                 <argument>META-INF/services/net.opentsdb.tsd.HttpSerializer</argument>
+                <argument>-C</argument>
+                <argument>test</argument>
+                <argument>META-INF/services/net.opentsdb.tsd.HttpRpcPlugin</argument>
                 <argument>-C</argument>
                 <argument>test</argument>
                 <argument>META-INF/services/net.opentsdb.tsd.RpcPlugin</argument>

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -36,7 +36,6 @@ import org.hbase.async.PutRequest;
 
 import net.opentsdb.tree.TreeBuilder;
 import net.opentsdb.tsd.RTPublisher;
-import net.opentsdb.tsd.RpcPlugin;
 import net.opentsdb.uid.NoSuchUniqueName;
 import net.opentsdb.uid.UniqueId;
 import net.opentsdb.uid.UniqueId.UniqueIdType;

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -107,9 +107,6 @@ public final class TSDB {
   /** Optional real time pulblisher plugin to use if configured */
   private RTPublisher rt_publisher = null;
   
-  /** List of activated RPC plugins */
-  private List<RpcPlugin> rpc_plugins = null;
-
   /**
    * Constructor
    * @param client An initialized HBase client object
@@ -230,32 +227,6 @@ public final class TSDB {
           + rt_publisher.version());
     } else {
       rt_publisher = null;
-    }
-    
-    if (init_rpcs && config.hasProperty("tsd.rpc.plugins")) {
-      final String[] plugins = config.getString("tsd.rpc.plugins").split(",");
-      for (final String plugin : plugins) {
-        final RpcPlugin rpc = PluginLoader.loadSpecificPlugin(plugin.trim(), 
-            RpcPlugin.class);
-        if (rpc == null) {
-          throw new IllegalArgumentException(
-              "Unable to locate RPC plugin: " + plugin.trim());
-        }
-        try {
-          rpc.initialize(this);
-        } catch (Exception e) {
-          throw new RuntimeException(
-              "Failed to initialize RPC plugin", e);
-        }
-        
-        if (rpc_plugins == null) {
-          rpc_plugins = new ArrayList<RpcPlugin>(1);
-        }
-        rpc_plugins.add(rpc);
-        LOG.info("Successfully initialized RPC plugin [" + 
-            rpc.getClass().getCanonicalName() + "] version: " 
-            + rpc.version());
-      }
     }
   }
   
@@ -455,30 +426,20 @@ public final class TSDB {
     // Collect Stats from Plugins
     if (rt_publisher != null) {
       try {
-	collector.addExtraTag("plugin", "publish");
+        collector.addExtraTag("plugin", "publish");
         rt_publisher.collectStats(collector);
       } finally {
-	collector.clearExtraTag("plugin");
+        collector.clearExtraTag("plugin");
       }                        
     }
     if (search != null) {
       try {
-	collector.addExtraTag("plugin", "search");
-	search.collectStats(collector);
+        collector.addExtraTag("plugin", "search");
+        search.collectStats(collector);
       } finally {
-	collector.clearExtraTag("plugin");
+        collector.clearExtraTag("plugin");
       }                        
     }
-    if (rpc_plugins != null) {
-      try {
-	collector.addExtraTag("plugin", "rpc");
-	for(RpcPlugin rpc: rpc_plugins) {
-		rpc.collectStats(collector);
-	}                                
-      } finally {
-	collector.clearExtraTag("plugin");
-      }                        
-    }        
   }
 
   /** Returns a latency histogram for Put RPCs used to store data points. */
@@ -799,14 +760,6 @@ public final class TSDB {
       LOG.info("Shutting down RT plugin: " + 
           rt_publisher.getClass().getCanonicalName());
       deferreds.add(rt_publisher.shutdown());
-    }
-    
-    if (rpc_plugins != null && !rpc_plugins.isEmpty()) {
-      for (final RpcPlugin rpc : rpc_plugins) {
-        LOG.info("Shutting down RPC plugin: " + 
-            rpc.getClass().getCanonicalName());
-        deferreds.add(rpc.shutdown());
-      }
     }
     
     // wait for plugins to shutdown before we close the client

--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 import net.opentsdb.BuildData;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.tsd.PipelineFactory;
-import net.opentsdb.tsd.RpcPluginsManager;
+import net.opentsdb.tsd.RpcManager;
 import net.opentsdb.utils.Config;
 
 /**
@@ -152,7 +152,7 @@ final class TSDMain {
       
       // This manager is capable of lazy init, but we force an init
       // here to fail fast.
-      final RpcPluginsManager manager = RpcPluginsManager.instance(tsdb);
+      final RpcManager manager = RpcManager.instance(tsdb);
 
       server.setPipelineFactory(new PipelineFactory(tsdb, manager));
       if (config.hasProperty("tsd.network.backlog")) {
@@ -196,10 +196,10 @@ final class TSDMain {
       }
       public void run() {
         try {
-          if (RpcPluginsManager.isInitialized()) {
+          if (RpcManager.isInitialized()) {
             // Check that its actually been initialized.  We don't want to
             // create a new instance only to shutdown!
-            RpcPluginsManager.instance(tsdb).shutdown().join();
+            RpcManager.instance(tsdb).shutdown().join();
           }
           if (tsdb != null) {
             tsdb.shutdown().join();

--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -18,17 +18,17 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.Executors;
 
+import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.socket.ServerSocketChannelFactory;
+import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 import org.jboss.netty.channel.socket.oio.OioServerSocketChannelFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.jboss.netty.bootstrap.ServerBootstrap;
-import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
-
 import net.opentsdb.BuildData;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.tsd.PipelineFactory;
+import net.opentsdb.tsd.RpcPluginsManager;
 import net.opentsdb.utils.Config;
 
 /**
@@ -52,7 +52,10 @@ final class TSDMain {
   private static final boolean DONT_CREATE = false;
   private static final boolean CREATE_IF_NEEDED = true;
   private static final boolean MUST_BE_WRITEABLE = true;
-
+  
+  private static TSDB tsdb = null;
+  private static RpcPluginsManager rpc_plugins_manager = null;
+  
   public static void main(String[] args) throws IOException {
     Logger log = LoggerFactory.getLogger(TSDMain.class);
     log.info("Starting.");
@@ -138,18 +141,20 @@ final class TSDMain {
           Executors.newCachedThreadPool(), Executors.newCachedThreadPool());
     }
     
-    TSDB tsdb = null;
     try {
       tsdb = new TSDB(config);
       tsdb.initializePlugins(true);
       
       // Make sure we don't even start if we can't find our tables.
       tsdb.checkNecessaryTablesExist().joinUninterruptibly();
-
-      registerShutdownHook(tsdb);
+      
+      registerShutdownHook();
       final ServerBootstrap server = new ServerBootstrap(factory);
+      
+      rpc_plugins_manager = new RpcPluginsManager();
+      rpc_plugins_manager.initialize(tsdb);
 
-      server.setPipelineFactory(new PipelineFactory(tsdb));
+      server.setPipelineFactory(new PipelineFactory(tsdb, rpc_plugins_manager));
       if (config.hasProperty("tsd.network.backlog")) {
         server.setOption("backlog", config.getInt("tsd.network.backlog")); 
       }
@@ -184,14 +189,19 @@ final class TSDMain {
     // The server is now running in separate threads, we can exit main.
   }
 
-  private static void registerShutdownHook(final TSDB tsdb) {
+  private static void registerShutdownHook() {
     final class TSDBShutdown extends Thread {
       public TSDBShutdown() {
         super("TSDBShutdown");
       }
       public void run() {
         try {
-          tsdb.shutdown().join();
+          if (rpc_plugins_manager != null) {
+            rpc_plugins_manager.shutdown().join();
+          }
+          if (tsdb != null) {
+            tsdb.shutdown().join();
+          }
         } catch (Exception e) {
           LoggerFactory.getLogger(TSDBShutdown.class)
             .error("Uncaught exception during shutdown", e);

--- a/src/tsd/AbstractHttpQuery.java
+++ b/src/tsd/AbstractHttpQuery.java
@@ -33,6 +33,8 @@ import org.jboss.netty.handler.codec.http.QueryStringDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.opentsdb.core.TSDB;
+
 /**
  * Abstract base class for HTTP queries.
  * 
@@ -60,13 +62,17 @@ public abstract class AbstractHttpQuery {
   private final DefaultHttpResponse response =
     new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
 
+  /** The {@code TSDB} instance we belong to */
+  protected final TSDB tsdb;
+  
   /**
    * Set up required internal state.  For subclasses.
    * 
    * @param request the incoming HTTP request
    * @param chan the {@link Channel} the request was received on
    */
-  protected AbstractHttpQuery(final HttpRequest request, final Channel chan) {
+  protected AbstractHttpQuery(final TSDB tsdb, final HttpRequest request, final Channel chan) {
+    this.tsdb = tsdb;
     this.request = request;
     this.chan = chan;
     this.method = request.getMethod();

--- a/src/tsd/AbstractHttpQuery.java
+++ b/src/tsd/AbstractHttpQuery.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2010-2012  The OpenTSDB Authors.
+// Copyright (C) 2010-2014  The OpenTSDB Authors.
 //
 // This program is free software: you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License as published by
@@ -17,6 +17,8 @@ import java.nio.charset.UnsupportedCharsetException;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.base.Objects;
+
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelFuture;
@@ -30,8 +32,6 @@ import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.jboss.netty.handler.codec.http.QueryStringDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Objects;
 
 /**
  * Abstract base class for HTTP queries.

--- a/src/tsd/AbstractHttpQuery.java
+++ b/src/tsd/AbstractHttpQuery.java
@@ -173,10 +173,34 @@ abstract class AbstractHttpQuery {
    * is to simply log the request info.  Can be overridden by subclasses.
    */
   public void done() {
-    if (LOG.isInfoEnabled()) {
-      final int processing_time = processingTimeMillis();
-      LOG.info(chan.toString() + " HTTP " + request.getUri() + " done in " + processing_time + "ms");
-    }
+    final int processing_time = processingTimeMillis();
+    logInfo("HTTP " + request.getUri() + " done in " + processing_time + "ms");
+  }
+  
+  /**
+   * Sends <code>500/Internal Server Error</code> to the client.
+   * @param cause The unexpected exception that caused this error.
+   */
+  public void internalError(final Exception cause) {
+    logError("Internal Server Error on " + request().getUri(), cause);
+    sendStatusOnly(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  /**
+   * Sends <code>400/Bad Request</code> status to the client.
+   * @param exception The exception that was thrown
+   */
+  public void badRequest(final BadRequestException exception) {
+    logWarn("Bad Request on " + request().getUri() + ": " + exception.getMessage());
+    sendStatusOnly(HttpResponseStatus.BAD_REQUEST);
+  }
+
+  /**
+   * Sends <code>404/Not Found</code> to the client.
+   */
+  public void notFound() {
+    logWarn("Not Found: " + request().getUri());
+    sendStatusOnly(HttpResponseStatus.NOT_FOUND);
   }
   
   /**
@@ -241,4 +265,31 @@ abstract class AbstractHttpQuery {
         .add("querystring", querystring)
         .toString();
   }
+  
+  // ---------------- //
+  // Logging helpers. //
+  // ---------------- //
+  
+  protected Logger logger() {
+    return LOG;
+  }
+
+  protected final void logInfo(final String msg) {
+    if (logger().isInfoEnabled()) {
+      logger().info(chan.toString() + ' ' + msg);
+    }
+  }
+
+  protected final void logWarn(final String msg) {
+    if (logger().isWarnEnabled()) {
+      logger().warn(chan.toString() + ' ' + msg);
+    }
+  }
+
+  protected final void logError(final String msg, final Exception e) {
+    if (logger().isErrorEnabled()) {
+      logger().error(chan.toString() + ' ' + msg, e);
+    }
+  }
+
 }

--- a/src/tsd/AbstractHttpQuery.java
+++ b/src/tsd/AbstractHttpQuery.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.base.Objects;
+import com.stumbleupon.async.Deferred;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
@@ -57,6 +58,10 @@ public abstract class AbstractHttpQuery {
 
   /** Parsed query string (lazily built on first access). */
   private Map<String, List<String>> querystring;
+  
+  /** Deferred result of this query, to allow asynchronous processing.
+   * (Optional.) */
+  protected final Deferred<Object> deferred = new Deferred<Object>();
   
   /** The response object we'll fill with data */
   private final DefaultHttpResponse response =

--- a/src/tsd/AbstractHttpQuery.java
+++ b/src/tsd/AbstractHttpQuery.java
@@ -129,6 +129,62 @@ public abstract class AbstractHttpQuery {
   }
   
   /**
+   * Returns the value of the given query string parameter.
+   * <p>
+   * If this parameter occurs multiple times in the URL, only the last value
+   * is returned and others are silently ignored.
+   * @param paramname Name of the query string parameter to get.
+   * @return The value of the parameter or {@code null} if this parameter
+   * wasn't passed in the URI.
+   */
+  public String getQueryStringParam(final String paramname) {
+    final List<String> params = getQueryString().get(paramname);
+    return params == null ? null : params.get(params.size() - 1);
+  }
+
+  /**
+   * Returns the non-empty value of the given required query string parameter.
+   * <p>
+   * If this parameter occurs multiple times in the URL, only the last value
+   * is returned and others are silently ignored.
+   * @param paramname Name of the query string parameter to get.
+   * @return The value of the parameter.
+   * @throws BadRequestException if this query string parameter wasn't passed
+   * or if its last occurrence had an empty value ({@code &amp;a=}).
+   */
+  public String getRequiredQueryStringParam(final String paramname)
+    throws BadRequestException {
+    final String value = getQueryStringParam(paramname);
+    if (value == null || value.isEmpty()) {
+      throw BadRequestException.missingParameter(paramname);
+    }
+    return value;
+  }
+
+  /**
+   * Returns whether or not the given query string parameter was passed.
+   * @param paramname Name of the query string parameter to get.
+   * @return {@code true} if the parameter
+   */
+  public boolean hasQueryStringParam(final String paramname) {
+    return getQueryString().get(paramname) != null;
+  }
+
+  /**
+   * Returns all the values of the given query string parameter.
+   * <p>
+   * In case this parameter occurs multiple times in the URL, this method is
+   * useful to get all the values.
+   * @param paramname Name of the query string parameter to get.
+   * @return The values of the parameter or {@code null} if this parameter
+   * wasn't passed in the URI.
+   */
+  public List<String> getQueryStringParams(final String paramname) {
+    return getQueryString().get(paramname);
+  }
+
+  
+  /**
    * Returns only the path component of the URI as a string
    * This call strips the protocol, host, port and query string parameters
    * leaving only the path e.g. "/path/starts/here"

--- a/src/tsd/AbstractHttpQuery.java
+++ b/src/tsd/AbstractHttpQuery.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Abstract base class for HTTP queries.
  * 
- * @since 2.1
+ * @since 2.2
  */
 public abstract class AbstractHttpQuery {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractHttpQuery.class);
@@ -60,6 +60,12 @@ public abstract class AbstractHttpQuery {
   private final DefaultHttpResponse response =
     new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
 
+  /**
+   * Set up required internal state.  For subclasses.
+   * 
+   * @param request the incoming HTTP request
+   * @param chan the {@link Channel} the request was received on
+   */
   protected AbstractHttpQuery(final HttpRequest request, final Channel chan) {
     this.request = request;
     this.chan = chan;
@@ -126,7 +132,6 @@ public abstract class AbstractHttpQuery {
    * parameters manually.
    * @return The path component of the URI
    * @throws NullPointerException if the URI is null
-   * @since 2.0
    */
   public String getQueryPath() {
     return new QueryStringDecoder(request.getUri()).getPath();
@@ -145,7 +150,6 @@ public abstract class AbstractHttpQuery {
    * @throws BadRequestException if the URI is empty or does not start with a
    * slash
    * @throws NullPointerException if the URI is null
-   * @since 2.0
    */
   public String[] explodePath() {
     final String path = getQueryPath();
@@ -167,7 +171,6 @@ public abstract class AbstractHttpQuery {
    * @return the base route
    * @throws BadRequestException if some necessary part of the query cannot
    * be parsed.
-   * @since 2.0
    */
   public abstract String getQueryBaseRoute();
   
@@ -176,7 +179,6 @@ public abstract class AbstractHttpQuery {
    * defaults to UTF-8
    * @return A Charset object
    * @throws UnsupportedCharsetException if the parsed character set is invalid
-   * @since 2.0
    */
   public Charset getCharset() {
     // RFC2616 3.7
@@ -190,7 +192,7 @@ public abstract class AbstractHttpQuery {
     return Charset.forName("UTF-8");
   }
   
-  /** @return True if the request has content, false if not @since 2.0 */
+  /** @return True if the request has content, false if not. */
   public boolean hasContent() {
     return this.request.getContent() != null &&
       this.request.getContent().readable();
@@ -201,7 +203,6 @@ public abstract class AbstractHttpQuery {
    * @return Decoded content or an empty string if the request did not include
    * content
    * @throws UnsupportedCharsetException if the parsed character set is invalid
-   * @since 2.0
    */
   public String getContent() {
     return this.request.getContent().toString(this.getCharset());
@@ -245,7 +246,6 @@ public abstract class AbstractHttpQuery {
   /**
    * Send just the status code without a body, used for 204 or 304
    * @param status The response code to reply with
-   * @since 2.0
    */
   public void sendStatusOnly(final HttpResponseStatus status) {
     if (!chan.isConnected()) {

--- a/src/tsd/BadRequestException.java
+++ b/src/tsd/BadRequestException.java
@@ -22,7 +22,7 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
  * optional detailed response. The default "message" field is still used for
  * short error descriptions, typically one sentence long.
  */
-final class BadRequestException extends RuntimeException {
+public final class BadRequestException extends RuntimeException {
 
   /** The HTTP status code to return to the user 
    * @since 2.0 */

--- a/src/tsd/ConnectionManager.java
+++ b/src/tsd/ConnectionManager.java
@@ -28,7 +28,6 @@ import org.jboss.netty.handler.codec.embedder.CodecEmbedderException;
 import org.jboss.netty.handler.timeout.IdleState;
 import org.jboss.netty.handler.timeout.IdleStateAwareChannelHandler;
 import org.jboss.netty.handler.timeout.IdleStateEvent;
-import org.jboss.netty.handler.timeout.ReadTimeoutException;
 
 import net.opentsdb.stats.StatsCollector;
 

--- a/src/tsd/HttpQuery.java
+++ b/src/tsd/HttpQuery.java
@@ -145,61 +145,6 @@ final class HttpQuery extends AbstractHttpQuery {
   }
 
   /**
-   * Returns the value of the given query string parameter.
-   * <p>
-   * If this parameter occurs multiple times in the URL, only the last value
-   * is returned and others are silently ignored.
-   * @param paramname Name of the query string parameter to get.
-   * @return The value of the parameter or {@code null} if this parameter
-   * wasn't passed in the URI.
-   */
-  public String getQueryStringParam(final String paramname) {
-    final List<String> params = getQueryString().get(paramname);
-    return params == null ? null : params.get(params.size() - 1);
-  }
-
-  /**
-   * Returns the non-empty value of the given required query string parameter.
-   * <p>
-   * If this parameter occurs multiple times in the URL, only the last value
-   * is returned and others are silently ignored.
-   * @param paramname Name of the query string parameter to get.
-   * @return The value of the parameter.
-   * @throws BadRequestException if this query string parameter wasn't passed
-   * or if its last occurrence had an empty value ({@code &amp;a=}).
-   */
-  public String getRequiredQueryStringParam(final String paramname)
-    throws BadRequestException {
-    final String value = getQueryStringParam(paramname);
-    if (value == null || value.isEmpty()) {
-      throw BadRequestException.missingParameter(paramname);
-    }
-    return value;
-  }
-
-  /**
-   * Returns whether or not the given query string parameter was passed.
-   * @param paramname Name of the query string parameter to get.
-   * @return {@code true} if the parameter
-   */
-  public boolean hasQueryStringParam(final String paramname) {
-    return getQueryString().get(paramname) != null;
-  }
-
-  /**
-   * Returns all the values of the given query string parameter.
-   * <p>
-   * In case this parameter occurs multiple times in the URL, this method is
-   * useful to get all the values.
-   * @param paramname Name of the query string parameter to get.
-   * @return The values of the parameter or {@code null} if this parameter
-   * wasn't passed in the URI.
-   */
-  public List<String> getQueryStringParams(final String paramname) {
-    return getQueryString().get(paramname);
-  }
-
-  /**
    * Helper that strips the api and optional version from the URI array since
    * api calls only care about what comes after.
    * E.g. if the URI is "/api/v1/uid/assign" this method will return the

--- a/src/tsd/HttpQuery.java
+++ b/src/tsd/HttpQuery.java
@@ -204,35 +204,6 @@ final class HttpQuery extends AbstractHttpQuery {
   }
 
   /**
-   * Returns the path component of the URI as an array of strings, split on the
-   * forward slash
-   * Similar to the {@link #getQueryPath} call, this returns only the path
-   * without the protocol, host, port or query string params. E.g.
-   * "/path/starts/here" will return an array of {"path", "starts", "here"}
-   * <p>
-   * Note that for maximum speed you may want to parse the query path manually.
-   * @return An array with 1 or more components, note the first item may be
-   * an empty string.
-   * @throws BadRequestException if the URI is empty or does not start with a
-   * slash
-   * @throws NullPointerException if the URI is null
-   * @since 2.0
-   */
-  public String[] explodePath() {
-    final String path = this.getQueryPath();
-    if (path.isEmpty()) {
-      throw new BadRequestException("Query path is empty");
-    }
-    if (path.charAt(0) != '/') {
-      throw new BadRequestException("Query path doesn't start with a slash");
-    }
-    // split may be a tad slower than other methods, but since the URIs are
-    // usually pretty short and not every request will make this call, we
-    // probably don't need any premature optimization
-    return path.substring(1).split("/");
-  }
-
-  /**
    * Helper that strips the api and optional version from the URI array since
    * api calls only care about what comes after.
    * E.g. if the URI is "/api/v1/uid/assign" this method will return the
@@ -277,8 +248,6 @@ final class HttpQuery extends AbstractHttpQuery {
   }
 
   /**
-   * Parses the query string to determine the base route for handing a query
-   * off to an RPC handler.
    * This method splits the query path component and returns a string suitable
    * for routing by {@link RpcHandler}. The resulting route is always lower case
    * and will consist of either an empty string, a deprecated API call or an
@@ -296,8 +265,9 @@ final class HttpQuery extends AbstractHttpQuery {
    * max or the version # can't be parsed
    * @since 2.0
    */
+  @Override
   public String getQueryBaseRoute() {
-    final String[] split = this.explodePath();
+    final String[] split = explodePath();
     if (split.length < 1) {
       return "";
     }

--- a/src/tsd/HttpQuery.java
+++ b/src/tsd/HttpQuery.java
@@ -89,9 +89,6 @@ final class HttpQuery extends AbstractHttpQuery {
   /** The serializer to use for parsing input and responding */
   private HttpSerializer serializer = null;
 
-  /** Deferred result of this query, to allow asynchronous processing.  */
-  private final Deferred<Object> deferred = new Deferred<Object>();
-
   /** Whether or not to show stack traces in the output */
   private final boolean show_stack_trace;
 

--- a/src/tsd/HttpQuery.java
+++ b/src/tsd/HttpQuery.java
@@ -92,9 +92,6 @@ final class HttpQuery extends AbstractHttpQuery {
   /** Deferred result of this query, to allow asynchronous processing.  */
   private final Deferred<Object> deferred = new Deferred<Object>();
 
-  /** The {@code TSDB} instance we belong to */
-  private final TSDB tsdb;
-
   /** Whether or not to show stack traces in the output */
   private final boolean show_stack_trace;
 
@@ -104,8 +101,7 @@ final class HttpQuery extends AbstractHttpQuery {
    * @param chan The channel on which the request was received.
    */
   public HttpQuery(final TSDB tsdb, final HttpRequest request, final Channel chan) {
-    super(request, chan);
-    this.tsdb = tsdb;
+    super(tsdb, request, chan);
     this.show_stack_trace =
       tsdb.getConfig().getBoolean("tsd.http.show_stack_trace");
     this.serializer = new HttpJsonSerializer(this);

--- a/src/tsd/HttpRpc.java
+++ b/src/tsd/HttpRpc.java
@@ -16,7 +16,9 @@ import java.io.IOException;
 
 import net.opentsdb.core.TSDB;
 
-/** Base interface for all HTTP query handlers. */
+/**
+ * Base interface for all built-in HTTP query handlers.
+ */
 interface HttpRpc {
 
   /**

--- a/src/tsd/HttpRpcPlugin.java
+++ b/src/tsd/HttpRpcPlugin.java
@@ -35,7 +35,7 @@ import net.opentsdb.stats.StatsCollector;
  *    and {@link collectStats} methods <strong>must be thread safe</strong> 
  *    with respect to the plugin's internal state and external resources.
  * </ul>
- * @since 2.1
+ * @since 2.2
  */
 public abstract class HttpRpcPlugin {
   /**

--- a/src/tsd/HttpRpcPlugin.java
+++ b/src/tsd/HttpRpcPlugin.java
@@ -88,7 +88,8 @@ public abstract class HttpRpcPlugin {
    * <strong>must not</strong> contain the system's plugin base path or the
    * plugin will fail to load. 
    * 
-   * <p>Here are some examples where <code>path --is available at--> server path</code>
+   * <p>Here are some examples where 
+   * <code>path --(is available at)--> server path</code>
    * <ul>
    *  <li><code>/myAwesomePlugin --> /plugin/myAwesomePlugin</code>
    *  <li><code>/myOtherPlugin/operation --> /plugin/myOtherPlugin/operation</code>

--- a/src/tsd/HttpRpcPlugin.java
+++ b/src/tsd/HttpRpcPlugin.java
@@ -1,0 +1,74 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2014  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.tsd;
+
+import java.io.IOException;
+
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.stats.StatsCollector;
+
+/**
+ * @since 2.1
+ */
+public abstract class HttpRpcPlugin {
+  /**
+   * Called by TSDB to initialize the plugin.
+   * <b>Note:</b> Implementations should throw exceptions if they can't start
+   * up properly. The TSD will then shutdown so the operator can fix the 
+   * problem. Please use IllegalArgumentException for configuration issues.
+   * @param tsdb The parent TSDB object
+   * @throws IllegalArgumentException if required configuration parameters are 
+   * missing
+   * @throws Exception
+   */
+  public abstract void initialize(TSDB tsdb);
+  
+  /**
+   * Called to gracefully shutdown the plugin.
+   * @return A deferred object that indicates the completion of the request.
+   * The {@link Object} has not special meaning and can be {@code null}
+   * (think of it as {@code Deferred<Void>}).
+   */
+  public abstract Deferred<Object> shutdown();
+  
+  /**
+   * Should return the version of this plugin in the format:
+   * MAJOR.MINOR.MAINT, e.g. "2.0.1". The MAJOR version should match the major
+   * version of OpenTSDB the plugin is meant to work with.
+   * @return A version string used to log the loaded version
+   */
+  public abstract String version();
+  
+  /**
+   * Called by the TSD when a request for statistics collection has come in. The
+   * implementation may provide one or more statistics. If no statistics are
+   * available for the implementation, simply stub the method.
+   * @param collector The collector used for emitting statistics
+   */
+  public abstract void collectStats(StatsCollector collector);
+  
+  /**
+   * @return
+   */
+  public abstract String getPath();
+
+  /**
+   * @param tsdb
+   * @param query
+   * @throws IOException
+   */
+  public abstract void execute(TSDB tsdb, HttpRpcPluginQuery query) throws IOException;
+
+}

--- a/src/tsd/HttpRpcPluginQuery.java
+++ b/src/tsd/HttpRpcPluginQuery.java
@@ -1,0 +1,32 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2014  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.tsd;
+
+import net.opentsdb.core.TSDB;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+
+/**
+ * @since 2.1
+ */
+public final class HttpRpcPluginQuery extends AbstractHttpQuery {
+  public HttpRpcPluginQuery(final TSDB tsdb, final HttpRequest request, final Channel chan) {
+    super(request, chan);
+  }
+
+  @Override
+  public String getQueryBaseRoute() {
+    return "";
+  }
+}

--- a/src/tsd/HttpRpcPluginQuery.java
+++ b/src/tsd/HttpRpcPluginQuery.java
@@ -21,7 +21,7 @@ import net.opentsdb.core.TSDB;
  * Query class for {@link HttpRpcPlugin}s.  Binds together a request, its 
  * owning channel, and reponse helpers.
  * 
- * @since 2.1
+ * @since 2.2
  */
 public final class HttpRpcPluginQuery extends AbstractHttpQuery {
   public HttpRpcPluginQuery(final TSDB tsdb, final HttpRequest request, final Channel chan) {

--- a/src/tsd/HttpRpcPluginQuery.java
+++ b/src/tsd/HttpRpcPluginQuery.java
@@ -25,7 +25,7 @@ import net.opentsdb.core.TSDB;
  */
 public final class HttpRpcPluginQuery extends AbstractHttpQuery {
   public HttpRpcPluginQuery(final TSDB tsdb, final HttpRequest request, final Channel chan) {
-    super(request, chan);
+    super(tsdb, request, chan);
   }
 
   /**

--- a/src/tsd/HttpRpcPluginQuery.java
+++ b/src/tsd/HttpRpcPluginQuery.java
@@ -12,12 +12,15 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.tsd;
 
-import net.opentsdb.core.TSDB;
-
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 
+import net.opentsdb.core.TSDB;
+
 /**
+ * Query class for {@link HttpRpcPlugin}s.  Binds together a request, its 
+ * owning channel, and reponse helpers.
+ * 
  * @since 2.1
  */
 public final class HttpRpcPluginQuery extends AbstractHttpQuery {
@@ -25,8 +28,26 @@ public final class HttpRpcPluginQuery extends AbstractHttpQuery {
     super(request, chan);
   }
 
+  /**
+   * Return the base route with no plugin prefix in it.  This is matched with
+   * values returned by {@link HttpRpcPlugin#getPath()}.
+   * @return the base route path (no query parameters, etc.)
+   */
   @Override
   public String getQueryBaseRoute() {
-    return "";
+    final String[] parts = explodePath();
+    if (parts.length < 2) { // Must be at least something like: /plugin/blah
+      throw new BadRequestException("Invalid plugin request path: " + getQueryPath());
+    }
+    // Lop off the first element (which is the "plugin" base path).
+    // The remaining elements are the base route.
+    final StringBuilder joined = new StringBuilder();
+    for (int i=1; i<parts.length; i++) {
+      if (i != 1) {
+        joined.append('/');
+      }
+      joined.append(parts[i]);
+    }
+    return joined.toString();
   }
 }

--- a/src/tsd/PipelineFactory.java
+++ b/src/tsd/PipelineFactory.java
@@ -57,11 +57,24 @@ public final class PipelineFactory implements ChannelPipelineFactory {
   
   /** The server side socket timeout. **/
   private final int socketTimeout;
+  
+  /**
+   * Constructor that initializes the RPC router and loads HTTP formatter 
+   * plugins. This constructor creates it's own {@link RpcPluginsManager}.
+   * @param tsdb The TSDB to use.
+   * @throws RuntimeException if there is an issue loading plugins
+   * @throws Exception if the HttpQuery handler is unable to load 
+   * serializers
+   */
+  public PipelineFactory(final TSDB tsdb) {
+    this(tsdb, RpcPluginsManager.instance(tsdb));
+  }
 
   /**
    * Constructor that initializes the RPC router and loads HTTP formatter 
-   * plugins
+   * plugins using an already-configured {@link RpcPluginsManager}.
    * @param tsdb The TSDB to use.
+   * @param manager instance of a ready-to-use {@link RpcPluginsManager}.
    * @throws RuntimeException if there is an issue loading plugins
    * @throws Exception if the HttpQuery handler is unable to load 
    * serializers

--- a/src/tsd/PipelineFactory.java
+++ b/src/tsd/PipelineFactory.java
@@ -60,7 +60,7 @@ public final class PipelineFactory implements ChannelPipelineFactory {
   
   /**
    * Constructor that initializes the RPC router and loads HTTP formatter 
-   * plugins. This constructor creates it's own {@link RpcManager}.
+   * plugins. This constructor creates its own {@link RpcManager}.
    * @param tsdb The TSDB to use.
    * @throws RuntimeException if there is an issue loading plugins
    * @throws Exception if the HttpQuery handler is unable to load 

--- a/src/tsd/PipelineFactory.java
+++ b/src/tsd/PipelineFactory.java
@@ -60,26 +60,26 @@ public final class PipelineFactory implements ChannelPipelineFactory {
   
   /**
    * Constructor that initializes the RPC router and loads HTTP formatter 
-   * plugins. This constructor creates it's own {@link RpcPluginsManager}.
+   * plugins. This constructor creates it's own {@link RpcManager}.
    * @param tsdb The TSDB to use.
    * @throws RuntimeException if there is an issue loading plugins
    * @throws Exception if the HttpQuery handler is unable to load 
    * serializers
    */
   public PipelineFactory(final TSDB tsdb) {
-    this(tsdb, RpcPluginsManager.instance(tsdb));
+    this(tsdb, RpcManager.instance(tsdb));
   }
 
   /**
    * Constructor that initializes the RPC router and loads HTTP formatter 
-   * plugins using an already-configured {@link RpcPluginsManager}.
+   * plugins using an already-configured {@link RpcManager}.
    * @param tsdb The TSDB to use.
-   * @param manager instance of a ready-to-use {@link RpcPluginsManager}.
+   * @param manager instance of a ready-to-use {@link RpcManager}.
    * @throws RuntimeException if there is an issue loading plugins
    * @throws Exception if the HttpQuery handler is unable to load 
    * serializers
    */
-  public PipelineFactory(final TSDB tsdb, final RpcPluginsManager manager) {
+  public PipelineFactory(final TSDB tsdb, final RpcManager manager) {
     this.tsdb = tsdb;
     this.socketTimeout = tsdb.getConfig().getInt("tsd.core.socket.timeout");
     this.timeoutHandler = new IdleStateHandler(this.timer, 0, 0, this.socketTimeout);

--- a/src/tsd/PipelineFactory.java
+++ b/src/tsd/PipelineFactory.java
@@ -66,11 +66,11 @@ public final class PipelineFactory implements ChannelPipelineFactory {
    * @throws Exception if the HttpQuery handler is unable to load 
    * serializers
    */
-  public PipelineFactory(final TSDB tsdb) {
+  public PipelineFactory(final TSDB tsdb, final RpcPluginsManager manager) {
     this.tsdb = tsdb;
     this.socketTimeout = tsdb.getConfig().getInt("tsd.core.socket.timeout");
     this.timeoutHandler = new IdleStateHandler(this.timer, 0, 0, this.socketTimeout);
-    this.rpchandler = new RpcHandler(tsdb);
+    this.rpchandler = new RpcHandler(tsdb, manager);
     try {
       HttpQuery.initializeSerializerMaps(tsdb);
     } catch (RuntimeException e) {

--- a/src/tsd/RpcHandler.java
+++ b/src/tsd/RpcHandler.java
@@ -166,7 +166,7 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
       throw new BadRequestException("Request URI is empty");
     } else if (uri.charAt(0) != '/') {
       throw new BadRequestException("Request URI doesn't start with a slash");
-    } else if (uri.startsWith("/plugin")) {
+    } else if (plugins_manager.isHttpRpcPluginPath(uri)) {
       http_plugin_rpcs_received.incrementAndGet();
       return new HttpRpcPluginQuery(tsdb, request, chan);
     } else {

--- a/src/tsd/RpcHandler.java
+++ b/src/tsd/RpcHandler.java
@@ -65,9 +65,22 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
   private final TSDB tsdb;
   
   /**
-   * Constructor that loads the CORS domain list and configures the route maps 
-   * for telnet and HTTP requests
+   * Constructor that loads the CORS domain list and prepares for
+   * handling requests. This constructor creates its own {@link RpcManager}.
    * @param tsdb The TSDB to use.
+   * @param manager instance of a ready-to-use {@link RpcManager}.
+   * @throws IllegalArgumentException if there was an error with the CORS domain
+   * list
+   */
+  public RpcHandler(final TSDB tsdb) {
+    this(tsdb, RpcManager.instance(tsdb));
+  }
+  
+  /**
+   * Constructor that loads the CORS domain list and prepares for handling 
+   * requests.
+   * @param tsdb The TSDB to use.
+   * @param manager instance of a ready-to-use {@link RpcManager}.
    * @throws IllegalArgumentException if there was an error with the CORS domain
    * list
    */
@@ -359,39 +372,17 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
   // Logging helpers. //
   // ---------------- //
 
-  //private static void logInfo(final HttpQuery query, final String msg) {
-  //  LOG.info(query.channel().toString() + ' ' + msg);
-  //}
-
   private static void logWarn(final AbstractHttpQuery query, final String msg) {
     LOG.warn(query.channel().toString() + ' ' + msg);
   }
-
-  //private void logWarn(final HttpQuery query, final String msg,
-  //                     final Exception e) {
-  //  LOG.warn(query.channel().toString() + ' ' + msg, e);
-  //}
 
   private void logError(final AbstractHttpQuery query, final String msg) {
     LOG.error(query.channel().toString() + ' ' + msg);
   }
 
-  //private static void logError(final HttpQuery query, final String msg,
-  //                             final Exception e) {
-  //  LOG.error(query.channel().toString() + ' ' + msg, e);
-  //}
-
-  //private void logInfo(final Channel chan, final String msg) {
-  //  LOG.info(chan.toString() + ' ' + msg);
-  //}
-
   private static void logWarn(final Channel chan, final String msg) {
     LOG.warn(chan.toString() + ' ' + msg);
   }
-
-  //private void logWarn(final Channel chan, final String msg, final Exception e) {
-  //  LOG.warn(chan.toString() + ' ' + msg, e);
-  //}
 
   private void logError(final Channel chan, final String msg) {
     LOG.error(chan.toString() + ' ' + msg);

--- a/src/tsd/RpcHandler.java
+++ b/src/tsd/RpcHandler.java
@@ -12,7 +12,6 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.tsd;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicLong;

--- a/src/tsd/RpcHandler.java
+++ b/src/tsd/RpcHandler.java
@@ -148,11 +148,12 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
   }
 
   /**
-   * Creates a query instance capable of handling the given request.
-   * @param tsdb
-   * @param request
-   * @param chan
-   * @return a sublcass of {@link AbstractHttpQuery}
+   * Using the request URI, creates a query instance capable of handling 
+   * the given request.
+   * @param tsdb the TSDB instance we are running within
+   * @param request the incoming HTTP request
+   * @param chan the {@link Channel} the request came in on.
+   * @return a subclass of {@link AbstractHttpQuery}
    * @throws BadRequestException if the request is invalid in a way that
    * can be detected early, here.
    */

--- a/src/tsd/RpcHandler.java
+++ b/src/tsd/RpcHandler.java
@@ -12,60 +12,59 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.tsd;
 
-import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.google.common.base.Strings;
 import com.google.common.net.HttpHeaders;
-import com.stumbleupon.async.Callback;
 import com.stumbleupon.async.Deferred;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ChannelFutureListener;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import net.opentsdb.BuildData;
-import net.opentsdb.core.Aggregators;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.stats.StatsCollector;
-import net.opentsdb.utils.JSON;
 
 /**
- * Stateless handler for RPCs (telnet-style or HTTP).
+ * Stateless handler for all RPCs: telnet-style, built-in or plugin
+ * HTTP.
  */
 final class RpcHandler extends SimpleChannelUpstreamHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(RpcHandler.class);
-
+  
   private static final AtomicLong telnet_rpcs_received = new AtomicLong();
   private static final AtomicLong http_rpcs_received = new AtomicLong();
+  private static final AtomicLong http_plugin_rpcs_received = new AtomicLong();
   private static final AtomicLong exceptions_caught = new AtomicLong();
 
-  /** Commands we can serve on the simple, telnet-style RPC interface. */
-  private final HashMap<String, TelnetRpc> telnet_commands;
   /** RPC executed when there's an unknown telnet-style command. */
   private final TelnetRpc unknown_cmd = new Unknown();
-  /** Commands we serve on the HTTP interface. */
-  private final HashMap<String, HttpRpc> http_commands;
   /** List of domains to allow access to HTTP. By default this will be empty and
    * all CORS headers will be ignored. */
   private final HashSet<String> cors_domains;
   /** List of headers allowed for access to HTTP. By default this will contain a
    * set of known-to-work headers */
   private final String cors_headers;
+  /** RPC plugins.  Contains the handlers we dispatch requests to. */
+  private final RpcPluginsManager plugins_manager;
 
   /** The TSDB to use. */
   private final TSDB tsdb;
-
+  
   /**
    * Constructor that loads the CORS domain list and configures the route maps 
    * for telnet and HTTP requests
@@ -73,8 +72,9 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
    * @throws IllegalArgumentException if there was an error with the CORS domain
    * list
    */
-  public RpcHandler(final TSDB tsdb) {
+  public RpcHandler(final TSDB tsdb, final RpcPluginsManager pluginsManager) {
     this.tsdb = tsdb;
+    this.plugins_manager = pluginsManager;
 
     final String cors = tsdb.getConfig().getString("tsd.http.request.cors_domains");
     final String mode = tsdb.getConfig().getString("tsd.mode");
@@ -107,64 +107,6 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
     } else {
       LOG.info("Loaded CORS headers (" + cors_headers + ")");
     }
-
-    telnet_commands = new HashMap<String, TelnetRpc>();
-    http_commands = new HashMap<String, HttpRpc>();
-    if (mode.equals("rw") || mode.equals("wo")) {
-      final PutDataPointRpc put = new PutDataPointRpc();
-      telnet_commands.put("put", put);
-      http_commands.put("api/put", put);
-    }
-
-    if (mode.equals("rw") || mode.equals("ro")) {
-      http_commands.put("", new HomePage());
-      final StaticFileRpc staticfile = new StaticFileRpc();
-      http_commands.put("favicon.ico", staticfile);
-      http_commands.put("s", staticfile);
-
-      final StatsRpc stats = new StatsRpc();
-      telnet_commands.put("stats", stats);
-      http_commands.put("stats", stats);
-      http_commands.put("api/stats", stats);
-
-      final DropCaches dropcaches = new DropCaches();
-      telnet_commands.put("dropcaches", dropcaches);
-      http_commands.put("dropcaches", dropcaches);
-      http_commands.put("api/dropcaches", dropcaches);
-
-      final ListAggregators aggregators = new ListAggregators();
-      http_commands.put("aggregators", aggregators);
-      http_commands.put("api/aggregators", aggregators);
-
-      final SuggestRpc suggest_rpc = new SuggestRpc();
-      http_commands.put("suggest", suggest_rpc);
-      http_commands.put("api/suggest", suggest_rpc);
-
-      http_commands.put("logs", new LogsRpc());
-      http_commands.put("q", new GraphHandler());
-      http_commands.put("api/serializers", new Serializers());
-      http_commands.put("api/uid", new UniqueIdRpc());
-      http_commands.put("api/query", new QueryRpc());
-      http_commands.put("api/tree", new TreeRpc());
-      http_commands.put("api/annotation", new AnnotationRpc());
-      http_commands.put("api/search", new SearchRpc());
-      http_commands.put("api/config", new ShowConfig());
-    }
-
-    if (tsdb.getConfig().getString("tsd.no_diediedie").equals("false")) {
-      final DieDieDie diediedie = new DieDieDie();
-      telnet_commands.put("diediedie", diediedie);
-      http_commands.put("diediedie", diediedie);
-    }
-    {
-      final Version version = new Version();
-      telnet_commands.put("version", version);
-      http_commands.put("version", version);
-      http_commands.put("api/version", version);
-    }
-
-    telnet_commands.put("exit", new Exit());
-    telnet_commands.put("help", new Help());
   }
 
   @Override
@@ -191,14 +133,14 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
       exceptions_caught.incrementAndGet();
     }
   }
-
+  
   /**
    * Finds the right handler for a telnet-style RPC and executes it.
    * @param chan The channel on which the RPC was received.
    * @param command The split telnet-style command.
    */
   private void handleTelnetRpc(final Channel chan, final String[] command) {
-    TelnetRpc rpc = telnet_commands.get(command[0]);
+    TelnetRpc rpc = plugins_manager.lookupTelnetRpc(command[0]);
     if (rpc == null) {
       rpc = unknown_cmd;
     }
@@ -207,78 +149,158 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
   }
 
   /**
-   * Finds the right handler for an HTTP query and executes it.
-   * Also handles simple and pre-flight CORS requests if configured, rejecting
-   * requests that do not match a domain in the list.
+   * Creates a query instance capable of handling the given request.
+   * @param tsdb
+   * @param request
+   * @param chan
+   * @return a sublcass of {@link AbstractHttpQuery}
+   * @throws BadRequestException if the request is invalid in a way that
+   * can be detected early, here.
+   */
+  private AbstractHttpQuery createQueryInstance(final TSDB tsdb,
+        final HttpRequest request,
+        final Channel chan) 
+            throws BadRequestException {
+    final String uri = request.getUri();
+    if (Strings.isNullOrEmpty(uri)) {
+      throw new BadRequestException("Request URI is empty");
+    } else if (uri.charAt(0) != '/') {
+      throw new BadRequestException("Request URI doesn't start with a slash");
+    } else if (uri.startsWith("/plugin")) {
+      http_plugin_rpcs_received.incrementAndGet();
+      return new HttpRpcPluginQuery(tsdb, request, chan);
+    } else {
+      http_rpcs_received.incrementAndGet();
+      HttpQuery builtinQuery = new HttpQuery(tsdb, request, chan);
+      return builtinQuery;
+    }
+  }
+  
+  /**
+   * Helper method to apply CORS configuration to a request, either a built-in
+   * RPC or a user plugin.
+   * @return <code>true</code> if a status reply was sent (in the the case of
+   * certain HTTP methods); <code>false</code> otherwise.
+   */
+  private boolean applyCorsConfig(final HttpRequest req, final AbstractHttpQuery query) 
+        throws BadRequestException {
+    final String domain = req.headers().get("Origin");
+    
+    // catch CORS requests and add the header or refuse them if the domain
+    // list has been configured
+    if (query.method() == HttpMethod.OPTIONS || 
+        (cors_domains != null && domain != null && !domain.isEmpty())) {          
+      if (cors_domains == null || domain == null || domain.isEmpty()) {
+        throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED, 
+            "Method not allowed", "The HTTP method [" + 
+            query.method().getName() + "] is not permitted");
+      }
+      
+      if (cors_domains.contains("*") || 
+          cors_domains.contains(domain.toUpperCase())) {
+
+        // when a domain has matched successfully, we need to add the header
+        query.response().headers().add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+            domain);
+        query.response().headers().add(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+            "GET, POST, PUT, DELETE");
+        query.response().headers().add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+            cors_headers);
+
+        // if the method requested was for OPTIONS then we'll return an OK
+        // here and no further processing is needed.
+        if (query.method() == HttpMethod.OPTIONS) {
+          query.sendStatusOnly(HttpResponseStatus.OK);
+          return true;
+        }
+      } else {
+        // You'd think that they would want the server to return a 403 if
+        // the Origin wasn't in the CORS domain list, but they want a 200
+        // without the allow origin header. We'll return an error in the
+        // body though.
+        throw new BadRequestException(HttpResponseStatus.OK, 
+            "CORS domain not allowed", "The domain [" + domain + 
+            "] is not permitted access");
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Finds the right handler for an HTTP query (either built-in or user plugin) 
+   * and executes it. Also handles simple and pre-flight CORS requests if 
+   * configured, rejecting requests that do not match a domain in the list.
    * @param chan The channel on which the query was received.
    * @param req The parsed HTTP request.
    */
   private void handleHttpQuery(final TSDB tsdb, final Channel chan, final HttpRequest req) {
-    http_rpcs_received.incrementAndGet();
-    final HttpQuery query = new HttpQuery(tsdb, req, chan);
-    if (!tsdb.getConfig().enable_chunked_requests() && req.isChunked()) {
-      logError(query, "Received an unsupported chunked request: "
-               + query.request());
-      query.badRequest("Chunked request not supported.");
-      return;
-    }
+    AbstractHttpQuery abstractQuery = null;
     try {
-      try {        
-        final String route = query.getQueryBaseRoute();
-        query.setSerializer();
-        
-        final String domain = req.headers().get("Origin");
-        
-        // catch CORS requests and add the header or refuse them if the domain
-        // list has been configured
-        if (query.method() == HttpMethod.OPTIONS || 
-            (cors_domains != null && domain != null && !domain.isEmpty())) {          
-          if (cors_domains == null || domain == null || domain.isEmpty()) {
-            throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED, 
-                "Method not allowed", "The HTTP method [" + 
-                query.method().getName() + "] is not permitted");
-          }
-          
-          if (cors_domains.contains("*") || 
-              cors_domains.contains(domain.toUpperCase())) {
-
-            // when a domain has matched successfully, we need to add the header
-            query.response().headers().add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
-                domain);
-            query.response().headers().add(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
-                "GET, POST, PUT, DELETE");
-            query.response().headers().add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
-                cors_headers);
-
-            // if the method requested was for OPTIONS then we'll return an OK
-            // here and no further processing is needed.
-            if (query.method() == HttpMethod.OPTIONS) {
-              query.sendStatusOnly(HttpResponseStatus.OK);
-              return;
-            }
-          } else {
-            // You'd think that they would want the server to return a 403 if
-            // the Origin wasn't in the CORS domain list, but they want a 200
-            // without the allow origin header. We'll return an error in the
-            // body though.
-            throw new BadRequestException(HttpResponseStatus.OK, 
-                "CORS domain not allowed", "The domain [" + domain + 
-                "] is not permitted access");
-          }
+      abstractQuery = createQueryInstance(tsdb, req, chan);
+      if (!tsdb.getConfig().enable_chunked_requests() && req.isChunked()) {
+        logError(abstractQuery, "Received an unsupported chunked request: "
+            + abstractQuery.request());
+        abstractQuery.badRequest(new BadRequestException("Chunked request not supported."));
+        return;
+      }
+      // NOTE: Some methods in HttpQuery have side-effects (getQueryBaseRoute and 
+      // setSerializer for instance) so invocation order is important here.
+      final String route = abstractQuery.getQueryBaseRoute();
+      if (abstractQuery.getClass().isAssignableFrom(HttpRpcPluginQuery.class)) {
+        if (applyCorsConfig(req, abstractQuery)) {
+          return;
         }
-        
-        final HttpRpc rpc = http_commands.get(route);
+        final HttpRpcPluginQuery pluginQuery = (HttpRpcPluginQuery) abstractQuery;
+        final HttpRpcPlugin rpc = plugins_manager.lookupHttpRpcPlugin(route);
         if (rpc != null) {
-          rpc.execute(tsdb, query);
+          rpc.execute(tsdb, pluginQuery);
         } else {
-          query.notFound();
+          pluginQuery.notFound();
         }
-      } catch (BadRequestException ex) {
-        query.badRequest(ex);
+      } else if (abstractQuery.getClass().isAssignableFrom(HttpQuery.class)) {
+        final HttpQuery builtinQuery = (HttpQuery) abstractQuery;
+        builtinQuery.setSerializer();
+        if (applyCorsConfig(req, abstractQuery)) {
+          return;
+        }
+        final HttpRpc rpc = plugins_manager.lookupHttpRpc(route);
+        if (rpc != null) {
+          rpc.execute(tsdb, builtinQuery);
+        } else {
+          builtinQuery.notFound();
+        }
+      } else {
+        throw new IllegalStateException("Unknown instance of AbstractHttpQuery: " 
+            + abstractQuery.getClass().getName());
+      }
+    } catch (BadRequestException ex) {
+      if (abstractQuery == null) {
+        LOG.warn("{} Unable to create query for {}. Reason: {}", chan, req, ex);
+        sendStatusAndClose(chan, HttpResponseStatus.BAD_REQUEST);
+      } else {
+        abstractQuery.badRequest(ex);
       }
     } catch (Exception ex) {
-      query.internalError(ex);
       exceptions_caught.incrementAndGet();
+      if (abstractQuery == null) {
+        LOG.warn("{} Unexpected error handling HTTP request {}. Reason: {} ", chan, req, ex);
+        sendStatusAndClose(chan, HttpResponseStatus.INTERNAL_SERVER_ERROR);
+      } else {
+        abstractQuery.internalError(ex);
+      }
+    }
+  }
+  
+  /**
+   * Helper method for sending a status-only HTTP response.  This is used in cases where 
+   * {@link #createQueryInstance(TSDB, HttpRequest, Channel)} failed to determine a query
+   * and we still want to return an error status to the client.
+   */
+  private void sendStatusAndClose(final Channel chan, final HttpResponseStatus status) {
+    if (chan.isConnected()) {
+      final DefaultHttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
+      final ChannelFuture future = chan.write(response);
+      future.addListener(ChannelFutureListener.CLOSE);
     }
   }
 
@@ -289,182 +311,11 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
   public static void collectStats(final StatsCollector collector) {
     collector.record("rpc.received", telnet_rpcs_received, "type=telnet");
     collector.record("rpc.received", http_rpcs_received, "type=http");
+    collector.record("rpc.received", http_plugin_rpcs_received, "type=http_plugin");
     collector.record("rpc.exceptions", exceptions_caught);
     HttpQuery.collectStats(collector);
     GraphHandler.collectStats(collector);
     PutDataPointRpc.collectStats(collector);
-  }
-
-  // ---------------------------- //
-  // Individual command handlers. //
-  // ---------------------------- //
-
-  /** The "diediedie" command and "/diediedie" endpoint. */
-  private final class DieDieDie implements TelnetRpc, HttpRpc {
-    public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
-                                    final String[] cmd) {
-      logWarn(chan, "shutdown requested");
-      chan.write("Cleaning up and exiting now.\n");
-      return doShutdown(tsdb, chan);
-    }
-
-    public void execute(final TSDB tsdb, final HttpQuery query) {
-      logWarn(query, "shutdown requested");
-      query.sendReply(HttpQuery.makePage("TSD Exiting", "You killed me",
-                                         "Cleaning up and exiting now."));
-      doShutdown(tsdb, query.channel());
-    }
-
-    private Deferred<Object> doShutdown(final TSDB tsdb, final Channel chan) {
-      ((GraphHandler) http_commands.get("q")).shutdown();
-      ConnectionManager.closeAllConnections();
-      // Netty gets stuck in an infinite loop if we shut it down from within a
-      // NIO thread.  So do this from a newly created thread.
-      final class ShutdownNetty extends Thread {
-        ShutdownNetty() {
-          super("ShutdownNetty");
-        }
-        public void run() {
-          chan.getFactory().releaseExternalResources();
-        }
-      }
-      new ShutdownNetty().start();  // Stop accepting new connections.
-
-      // Log any error that might occur during shutdown.
-      final class ShutdownTSDB implements Callback<Exception, Exception> {
-        public Exception call(final Exception arg) {
-          LOG.error("Unexpected exception while shutting down", arg);
-          return arg;
-        }
-        public String toString() {
-          return "shutdown callback";
-        }
-      }
-      return tsdb.shutdown().addErrback(new ShutdownTSDB());
-    }
-  }
-
-  /** The "exit" command. */
-  private static final class Exit implements TelnetRpc {
-    public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
-                                    final String[] cmd) {
-      chan.disconnect();
-      return Deferred.fromResult(null);
-    }
-  }
-
-  /** The "help" command. */
-  private final class Help implements TelnetRpc {
-    public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
-                                    final String[] cmd) {
-      final StringBuilder buf = new StringBuilder();
-      buf.append("available commands: ");
-      // TODO(tsuna): Maybe sort them?
-      for (final String command : telnet_commands.keySet()) {
-        buf.append(command).append(' ');
-      }
-      buf.append('\n');
-      chan.write(buf.toString());
-      return Deferred.fromResult(null);
-    }
-  }
-
-  /** The home page ("GET /"). */
-  private static final class HomePage implements HttpRpc {
-    public void execute(final TSDB tsdb, final HttpQuery query) 
-      throws IOException {
-      final StringBuilder buf = new StringBuilder(2048);
-      buf.append("<div id=queryuimain></div>"
-                 + "<noscript>You must have JavaScript enabled.</noscript>"
-                 + "<iframe src=javascript:'' id=__gwt_historyFrame tabIndex=-1"
-                 + " style=position:absolute;width:0;height:0;border:0>"
-                 + "</iframe>");
-      query.sendReply(HttpQuery.makePage(
-        "<script type=text/javascript language=javascript"
-        + " src=/s/queryui.nocache.js></script>",
-        "TSD", "Time Series Database", buf.toString()));
-    }
-  }
-
-  /** The "/aggregators" endpoint. */
-  private static final class ListAggregators implements HttpRpc {
-    public void execute(final TSDB tsdb, final HttpQuery query) 
-      throws IOException {
-      
-      // only accept GET/POST
-      if (query.method() != HttpMethod.GET && query.method() != HttpMethod.POST) {
-        throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED, 
-            "Method not allowed", "The HTTP method [" + query.method().getName() +
-            "] is not permitted for this endpoint");
-      }
-      
-      if (query.apiVersion() > 0) {
-        query.sendReply(
-            query.serializer().formatAggregatorsV1(Aggregators.set()));
-      } else {
-        query.sendReply(JSON.serializeToBytes(Aggregators.set()));
-      }
-    }
-  }
-
-  /** For unknown commands. */
-  private static final class Unknown implements TelnetRpc {
-    public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
-                                    final String[] cmd) {
-      logWarn(chan, "unknown command : " + Arrays.toString(cmd));
-      chan.write("unknown command: " + cmd[0] + ".  Try `help'.\n");
-      return Deferred.fromResult(null);
-    }
-  }
-
-  /** The "version" command. */
-  private static final class Version implements TelnetRpc, HttpRpc {
-    public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
-                                    final String[] cmd) {
-      if (chan.isConnected()) {
-        chan.write(BuildData.revisionString() + '\n'
-                   + BuildData.buildString() + '\n');
-      }
-      return Deferred.fromResult(null);
-    }
-
-    public void execute(final TSDB tsdb, final HttpQuery query) throws 
-      IOException {
-      
-      // only accept GET/POST
-      if (query.method() != HttpMethod.GET && query.method() != HttpMethod.POST) {
-        throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED, 
-            "Method not allowed", "The HTTP method [" + query.method().getName() +
-            "] is not permitted for this endpoint");
-      }
-      
-      final HashMap<String, String> version = new HashMap<String, String>();
-      version.put("version", BuildData.version);
-      version.put("short_revision", BuildData.short_revision);
-      version.put("full_revision", BuildData.full_revision);
-      version.put("timestamp", Long.toString(BuildData.timestamp));
-      version.put("repo_status", BuildData.repo_status.toString());
-      version.put("user", BuildData.user);
-      version.put("host", BuildData.host);
-      version.put("repo", BuildData.repo);
-      
-      if (query.apiVersion() > 0) {
-        query.sendReply(query.serializer().formatVersionV1(version));
-      } else {
-        final boolean json = query.request().getUri().endsWith("json");      
-        if (json) {
-          query.sendReply(JSON.serializeToBytes(version));
-        } else {
-          final String revision = BuildData.revisionString();
-          final String build = BuildData.buildString();
-          StringBuilder buf;
-          buf = new StringBuilder(2 // For the \n's
-                                  + revision.length() + build.length());
-          buf.append(revision).append('\n').append(build).append('\n');
-          query.sendReply(buf);
-        }
-      }
-    }
   }
 
   /**
@@ -489,94 +340,21 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
     }
     return dir;
   }
-
-  /** The "dropcaches" command. */
-  private static final class DropCaches implements TelnetRpc, HttpRpc {
+  
+  // ---------------------------- //
+  // Individual command handlers. //
+  // ---------------------------- //
+  
+  /** For unknown commands. */
+  private static final class Unknown implements TelnetRpc {
     public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
                                     final String[] cmd) {
-      dropCaches(tsdb, chan);
-      chan.write("Caches dropped.\n");
+      logWarn(chan, "unknown command : " + Arrays.toString(cmd));
+      chan.write("unknown command: " + cmd[0] + ".  Try `help'.\n");
       return Deferred.fromResult(null);
     }
-
-    public void execute(final TSDB tsdb, final HttpQuery query) 
-      throws IOException {
-      dropCaches(tsdb, query.channel());
-      
-      // only accept GET/POST
-      if (query.method() != HttpMethod.GET && query.method() != HttpMethod.POST) {
-        throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED, 
-            "Method not allowed", "The HTTP method [" + query.method().getName() +
-            "] is not permitted for this endpoint");
-      }
-      
-      if (query.apiVersion() > 0) {
-        final HashMap<String, String> response = new HashMap<String, String>();
-        response.put("status", "200");
-        response.put("message", "Caches dropped");
-        query.sendReply(query.serializer().formatDropCachesV1(response));
-      } else { // deprecated API
-        query.sendReply("Caches dropped.\n");
-      }
-    }
-
-    /** Drops in memory caches.  */
-    private void dropCaches(final TSDB tsdb, final Channel chan) {
-      LOG.warn(chan + " Dropping all in-memory caches.");
-      tsdb.dropCaches();
-    }
   }
 
-  /** The /api/formatters endpoint 
-   * @since 2.0 */
-  private static final class Serializers implements HttpRpc {
-    public void execute(final TSDB tsdb, final HttpQuery query) 
-      throws IOException {
-      // only accept GET/POST
-      if (query.method() != HttpMethod.GET && query.method() != HttpMethod.POST) {
-        throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED, 
-            "Method not allowed", "The HTTP method [" + query.method().getName() +
-            "] is not permitted for this endpoint");
-      }
-      
-      switch (query.apiVersion()) {
-        case 0:
-        case 1:
-          query.sendReply(query.serializer().formatSerializersV1());
-          break;
-        default: 
-          throw new BadRequestException(HttpResponseStatus.NOT_IMPLEMENTED, 
-              "Requested API version not implemented", "Version " + 
-              query.apiVersion() + " is not implemented");
-      }
-    }
-  }
-  
-  private static final class ShowConfig implements HttpRpc {
-
-    @Override
-    public void execute(TSDB tsdb, HttpQuery query) throws IOException {
-   // only accept GET/POST
-      if (query.method() != HttpMethod.GET && query.method() != HttpMethod.POST) {
-        throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED, 
-            "Method not allowed", "The HTTP method [" + query.method().getName() +
-            "] is not permitted for this endpoint");
-      }
-      
-      switch (query.apiVersion()) {
-        case 0:
-        case 1:
-          query.sendReply(query.serializer().formatConfigV1(tsdb.getConfig()));
-          break;
-        default: 
-          throw new BadRequestException(HttpResponseStatus.NOT_IMPLEMENTED, 
-              "Requested API version not implemented", "Version " + 
-              query.apiVersion() + " is not implemented");
-      }
-    }
-    
-  }
-  
   // ---------------- //
   // Logging helpers. //
   // ---------------- //
@@ -585,7 +363,7 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
   //  LOG.info(query.channel().toString() + ' ' + msg);
   //}
 
-  private static void logWarn(final HttpQuery query, final String msg) {
+  private static void logWarn(final AbstractHttpQuery query, final String msg) {
     LOG.warn(query.channel().toString() + ' ' + msg);
   }
 
@@ -594,7 +372,7 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
   //  LOG.warn(query.channel().toString() + ' ' + msg, e);
   //}
 
-  private void logError(final HttpQuery query, final String msg) {
+  private void logError(final AbstractHttpQuery query, final String msg) {
     LOG.error(query.channel().toString() + ' ' + msg);
   }
 

--- a/src/tsd/RpcManager.java
+++ b/src/tsd/RpcManager.java
@@ -62,17 +62,17 @@ import net.opentsdb.utils.PluginLoader;
  * 
  * // ... later, during shtudown ..
  * 
- * if (RpcPluginsManager.isInitialized()) {
+ * if (RpcManager.isInitialized()) {
  *   // Check that its actually been initialized.  We don't want to
  *   // create a new instance only to shutdown!
- *   RpcPluginsManager.instance(tsdb_instance).shutdown().join();
+ *   RpcManager.instance(tsdb_instance).shutdown().join();
  * }
  * </pre>
  * 
  * @since 2.2
  */
-public final class RpcPluginsManager {
-  private static final Logger LOG = LoggerFactory.getLogger(RpcPluginsManager.class);
+public final class RpcManager {
+  private static final Logger LOG = LoggerFactory.getLogger(RpcManager.class);
   
   @VisibleForTesting
   protected static final String PLUGIN_BASE_WEBPATH = "plugin";
@@ -89,7 +89,7 @@ public final class RpcPluginsManager {
       Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
   
   /** Reference to our singleton instance.  Set in {@link #initialize}. */
-  private static final AtomicReference<RpcPluginsManager> INSTANCE = Atomics.newReference();
+  private static final AtomicReference<RpcManager> INSTANCE = Atomics.newReference();
 
   /** Commands we can serve on the simple, telnet-style RPC interface. */
   private ImmutableMap<String, TelnetRpc> telnet_commands;
@@ -107,23 +107,23 @@ public final class RpcPluginsManager {
    * Constructor used by singleton factory method.
    * @param tsdb the owning TSDB instance.
    */
-  private RpcPluginsManager(final TSDB tsdb) {
+  private RpcManager(final TSDB tsdb) {
     this.tsdb = tsdb;
   }
   
   /**
    * Get or create the singleton instance of the manager, loading all the
    * plugins enabled in the given TSDB's {@link Config}.
-   * @return the shared instance of {@link RpcPluginsManager}. It's okay to
+   * @return the shared instance of {@link RpcManager}. It's okay to
    * hold this reference once obtained.
    */
-  public static synchronized RpcPluginsManager instance(final TSDB tsdb) {
-    final RpcPluginsManager existing = INSTANCE.get();
+  public static synchronized RpcManager instance(final TSDB tsdb) {
+    final RpcManager existing = INSTANCE.get();
     if (existing != null) {
       return existing;
     }
 
-    final RpcPluginsManager manager = new RpcPluginsManager(tsdb);
+    final RpcManager manager = new RpcManager(tsdb);
     final String mode = Strings.nullToEmpty(tsdb.getConfig().getString("tsd.mode"));
     
     // Load any plugins that are enabled via Config.  Fail if any plugin cannot be loaded.
@@ -401,10 +401,10 @@ public final class RpcPluginsManager {
   }
   
   /**
-   * Collect stats on the shared instance of {@link RpcPluginsManager}.
+   * Collect stats on the shared instance of {@link RpcManager}.
    */
   static void collectStats(final StatsCollector collector) {
-    final RpcPluginsManager manager = INSTANCE.get();
+    final RpcManager manager = INSTANCE.get();
     if (manager != null) {
       if (manager.rpc_plugins != null) {
         try {

--- a/src/tsd/RpcPluginsManager.java
+++ b/src/tsd/RpcPluginsManager.java
@@ -42,6 +42,7 @@ import net.opentsdb.BuildData;
 import net.opentsdb.core.Aggregators;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.stats.StatsCollector;
+import net.opentsdb.utils.Config;
 import net.opentsdb.utils.JSON;
 import net.opentsdb.utils.PluginLoader;
 
@@ -50,7 +51,7 @@ import net.opentsdb.utils.PluginLoader;
  * <code>RpcPlugin</code>s, and <code>HttpRpcPlugin</code>.  This is intended
  * to be a singleton.
  * 
- * @since 2.1
+ * @since 2.2
  */
 public final class RpcPluginsManager {
   private static final Logger LOG = LoggerFactory.getLogger(RpcPluginsManager.class);
@@ -84,6 +85,10 @@ public final class RpcPluginsManager {
   /** The TSDB that owns us. */
   private TSDB tsdb;
   
+  /**
+   * Create a new RPC plugins manager with no plugins initially registered.
+   * Users must call {@link #initialize(TSDB)} after construction.
+   */
   public RpcPluginsManager() {
     // Default values before initialize is called.
     telnet_commands = ImmutableMap.of();
@@ -93,7 +98,10 @@ public final class RpcPluginsManager {
   }
   
   /**
+   * Load plugins enabled in the given TSDB's {@link Config}.  This method should
+   * be called exactly once!  Subsequent invocations will throw an exception.
    * @param tsdb The parent TSDB object
+   * @throws IllegalStateException if the manager has already been initialized.
    */
   public void initialize(final TSDB tsdb) {
     if (!INSTANCE.compareAndSet(null, this)) {

--- a/src/tsd/RpcPluginsManager.java
+++ b/src/tsd/RpcPluginsManager.java
@@ -293,6 +293,8 @@ public final class RpcPluginsManager {
    * (think of it as {@code Deferred<Void>}).
    */
   public Deferred<ArrayList<Object>> shutdown() {
+    // Clear shared instance.
+    INSTANCE.set(null);
     final Collection<Deferred<Object>> deferreds = Lists.newArrayList();
     
     if (http_plugin_commands != null) {

--- a/src/tsd/RpcPluginsManager.java
+++ b/src/tsd/RpcPluginsManager.java
@@ -1,0 +1,476 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2014  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.tsd;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.opentsdb.BuildData;
+import net.opentsdb.core.Aggregators;
+import net.opentsdb.core.TSDB;
+import net.opentsdb.utils.JSON;
+import net.opentsdb.utils.PluginLoader;
+
+final class RpcPluginsManager {
+  private static final Logger LOG = LoggerFactory.getLogger(RpcPluginsManager.class);
+
+  /** Commands we can serve on the simple, telnet-style RPC interface. */
+  private ImmutableMap<String, TelnetRpc> telnet_commands;
+  /** Commands we serve on the HTTP interface. */
+  private ImmutableMap<String, HttpRpc> http_commands;
+  /** HTTP commands from user plugins. */
+  private ImmutableMap<String, HttpRpcPlugin> http_plugin_commands;
+  /** List of activated RPC plugins */
+  private ImmutableList<RpcPlugin> rpc_plugins = null;
+  
+  /** The TSDB that owns us. */
+  private TSDB tsdb;
+  
+  public RpcPluginsManager() {
+    // Default values before initialize is called.
+    telnet_commands = ImmutableMap.of();
+    http_commands = ImmutableMap.of();
+    http_plugin_commands = ImmutableMap.of();
+    rpc_plugins = ImmutableList.of();
+  }
+  
+  /**
+   * @param tsdb The parent TSDB object
+   */
+  public void initialize(final TSDB tsdb) {
+    this.tsdb = tsdb;
+    final String mode = tsdb.getConfig().getString("tsd.mode");
+    
+    if (tsdb.getConfig().hasProperty("tsd.rpc.plugins")) {
+      final String[] plugins = tsdb.getConfig().getString("tsd.rpc.plugins").split(",");
+      final ImmutableList.Builder<RpcPlugin> rpcBuilder = ImmutableList.builder();
+      initializeRpcPlugins(plugins, rpcBuilder);
+      rpc_plugins = rpcBuilder.build();
+    }
+    
+    final ImmutableMap.Builder<String, TelnetRpc> telnetBuilder = ImmutableMap.builder();
+    final ImmutableMap.Builder<String, HttpRpc> httpBuilder = ImmutableMap.builder();
+    initializeBuiltinRpcs(mode, telnetBuilder, httpBuilder);
+    telnet_commands = telnetBuilder.build();
+    http_commands = httpBuilder.build();
+    
+    if (tsdb.getConfig().hasProperty("tsd.httprpc.plugins")) {
+      final String[] plugins = tsdb.getConfig().getString("tsd.httprpc.plugins").split(",");
+      final ImmutableMap.Builder<String, HttpRpcPlugin> httpPluginsBuilder = ImmutableMap.builder();
+      initializeHttpRpcPlugins(mode, plugins, httpPluginsBuilder);
+      http_plugin_commands = httpPluginsBuilder.build();
+    }
+  }
+  
+  public TelnetRpc lookupTelnetRpc(final String command) {
+    return telnet_commands.get(command);
+  }
+  
+  public HttpRpc lookupHttpRpc(final String queryBaseRoute) {
+    return http_commands.get(queryBaseRoute);
+  }
+  
+  public HttpRpcPlugin lookupHttpRpcPlugin(final String queryBaseRoute) {
+    return http_plugin_commands.get(queryBaseRoute);
+  }
+  
+  private void initializeBuiltinRpcs(final String mode, 
+        final ImmutableMap.Builder<String, TelnetRpc> telnet,
+        final ImmutableMap.Builder<String, HttpRpc> http) {
+    if (mode.equals("rw") || mode.equals("wo")) {
+      final PutDataPointRpc put = new PutDataPointRpc();
+      telnet.put("put", put);
+      http.put("api/put", put);
+    }
+    
+    if (mode.equals("rw") || mode.equals("ro")) {
+      http.put("", new HomePage());
+      final StaticFileRpc staticfile = new StaticFileRpc();
+      http.put("favicon.ico", staticfile);
+      http.put("s", staticfile);
+
+      final StatsRpc stats = new StatsRpc();
+      telnet.put("stats", stats);
+      http.put("stats", stats);
+      http.put("api/stats", stats);
+
+      final DropCaches dropcaches = new DropCaches();
+      telnet.put("dropcaches", dropcaches);
+      http.put("dropcaches", dropcaches);
+      http.put("api/dropcaches", dropcaches);
+
+      final ListAggregators aggregators = new ListAggregators();
+      http.put("aggregators", aggregators);
+      http.put("api/aggregators", aggregators);
+
+      final SuggestRpc suggest_rpc = new SuggestRpc();
+      http.put("suggest", suggest_rpc);
+      http.put("api/suggest", suggest_rpc);
+
+      http.put("logs", new LogsRpc());
+      http.put("q", new GraphHandler());
+      http.put("api/serializers", new Serializers());
+      http.put("api/uid", new UniqueIdRpc());
+      http.put("api/query", new QueryRpc());
+      http.put("api/tree", new TreeRpc());
+      http.put("api/annotation", new AnnotationRpc());
+      http.put("api/search", new SearchRpc());
+      http.put("api/config", new ShowConfig());
+      
+      if (tsdb.getConfig().getString("tsd.no_diediedie").equals("false")) {
+        final DieDieDie diediedie = new DieDieDie();
+        telnet.put("diediedie", diediedie);
+        http.put("diediedie", diediedie);
+      }
+      {
+        final Version version = new Version();
+        telnet.put("version", version);
+        http.put("version", version);
+        http.put("api/version", version);
+      }
+
+      telnet.put("exit", new Exit());
+      telnet.put("help", new Help());
+    }
+  }
+  
+  private void initializeHttpRpcPlugins(final String mode,
+        final String[] pluginClassNames,
+        final ImmutableMap.Builder<String, HttpRpcPlugin> http) {
+    for (final String plugin : pluginClassNames) {
+      final HttpRpcPlugin rpc = createAndInitialize(plugin, HttpRpcPlugin.class);
+      LOG.info("Mounting {} at {}", rpc.getClass().getName(), rpc.getPath());
+      http.put(rpc.getPath(), rpc);
+    }
+  }
+  
+  private void initializeRpcPlugins(final String[] pluginClassNames, 
+        final ImmutableList.Builder<RpcPlugin> rpcs) {
+    for (final String plugin : pluginClassNames) {
+      final RpcPlugin rpc = createAndInitialize(plugin, RpcPlugin.class);
+      rpcs.add(rpc);
+    }
+  }
+  
+  /**
+   * Helper method to load and initialize a given plugin class. This uses reflection
+   * because plugins share no common interfaces. (They could though!)
+   * @param pluginClassName the class name of the plugin to load
+   * @param pluginClass class of the plugin
+   * @return loaded an initialized instance of {@code pluginClass}
+   */
+  private <T> T createAndInitialize(final String pluginClassName, final Class<T> pluginClass) {
+    final T instance = PluginLoader.loadSpecificPlugin(pluginClassName, pluginClass);
+    Preconditions.checkState(instance != null, 
+        "Unable to locate %s using name '%s", pluginClass, pluginClassName);
+    try {
+      final Method initMeth = instance.getClass().getMethod("initialize", TSDB.class);
+      initMeth.invoke(instance, tsdb);
+      final Method versionMeth = instance.getClass().getMethod("version");
+      String version = (String) versionMeth.invoke(instance);
+      LOG.info("Successfully initialized plugin [{}] version: {}",
+          instance.getClass().getCanonicalName(),
+          version);
+      return instance;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to initialize " + instance.getClass());
+    }
+  }
+  
+  /**
+   * Called to gracefully shutdown the plugin. Implementations should close 
+   * any IO they have open
+   * @return A deferred object that indicates the completion of the request.
+   * The {@link Object} has not special meaning and can be {@code null}
+   * (think of it as {@code Deferred<Void>}).
+   */
+  public Deferred<Object> shutdown() {
+    final Deferred<Object> deferred = new Deferred<Object>();
+    
+    if (http_plugin_commands != null) {
+      for (final Map.Entry<String, HttpRpcPlugin> entry : http_plugin_commands.entrySet()) {
+        deferred.chain(entry.getValue().shutdown());
+      }
+    }
+    
+    if (rpc_plugins != null) {
+      for (final RpcPlugin rpc : rpc_plugins) {
+        deferred.chain(rpc.shutdown());
+      }
+    }
+    
+    return deferred;
+  }
+  
+  // ---------------------------- //
+  // Individual command handlers. //
+  // ---------------------------- //
+
+  /** The "diediedie" command and "/diediedie" endpoint. */
+  private final class DieDieDie implements TelnetRpc, HttpRpc {
+    public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
+                                    final String[] cmd) {
+      LOG.warn("{} {}", chan, "shutdown requested");
+      chan.write("Cleaning up and exiting now.\n");
+      return doShutdown(tsdb, chan);
+    }
+
+    public void execute(final TSDB tsdb, final HttpQuery query) {
+      LOG.warn("{} {}", query, "shutdown requested");
+      query.sendReply(HttpQuery.makePage("TSD Exiting", "You killed me",
+                                         "Cleaning up and exiting now."));
+      doShutdown(tsdb, query.channel());
+    }
+
+    private Deferred<Object> doShutdown(final TSDB tsdb, final Channel chan) {
+      ((GraphHandler) http_commands.get("q")).shutdown();
+      ConnectionManager.closeAllConnections();
+      // Netty gets stuck in an infinite loop if we shut it down from within a
+      // NIO thread.  So do this from a newly created thread.
+      final class ShutdownNetty extends Thread {
+        ShutdownNetty() {
+          super("ShutdownNetty");
+        }
+        public void run() {
+          chan.getFactory().releaseExternalResources();
+        }
+      }
+      new ShutdownNetty().start();  // Stop accepting new connections.
+
+      // Log any error that might occur during shutdown.
+      final class ShutdownTSDB implements Callback<Exception, Exception> {
+        public Exception call(final Exception arg) {
+          LOG.error("Unexpected exception while shutting down", arg);
+          return arg;
+        }
+        public String toString() {
+          return "shutdown callback";
+        }
+      }
+      return tsdb.shutdown().addErrback(new ShutdownTSDB());
+    }
+  }
+
+  /** The "exit" command. */
+  private static final class Exit implements TelnetRpc {
+    public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
+                                    final String[] cmd) {
+      chan.disconnect();
+      return Deferred.fromResult(null);
+    }
+  }
+
+  /** The "help" command. */
+  private final class Help implements TelnetRpc {
+    public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
+                                    final String[] cmd) {
+      final StringBuilder buf = new StringBuilder();
+      buf.append("available commands: ");
+      // TODO(tsuna): Maybe sort them?
+      for (final String command : telnet_commands.keySet()) {
+        buf.append(command).append(' ');
+      }
+      buf.append('\n');
+      chan.write(buf.toString());
+      return Deferred.fromResult(null);
+    }
+  }
+
+  /** The home page ("GET /"). */
+  private static final class HomePage implements HttpRpc {
+    public void execute(final TSDB tsdb, final HttpQuery query) 
+      throws IOException {
+      final StringBuilder buf = new StringBuilder(2048);
+      buf.append("<div id=queryuimain></div>"
+                 + "<noscript>You must have JavaScript enabled.</noscript>"
+                 + "<iframe src=javascript:'' id=__gwt_historyFrame tabIndex=-1"
+                 + " style=position:absolute;width:0;height:0;border:0>"
+                 + "</iframe>");
+      query.sendReply(HttpQuery.makePage(
+        "<script type=text/javascript language=javascript"
+        + " src=/s/queryui.nocache.js></script>",
+        "TSD", "Time Series Database", buf.toString()));
+    }
+  }
+  
+  /** The "/aggregators" endpoint. */
+  private static final class ListAggregators implements HttpRpc {
+    public void execute(final TSDB tsdb, final HttpQuery query) 
+      throws IOException {
+      
+      // only accept GET/POST
+      if (query.method() != HttpMethod.GET && query.method() != HttpMethod.POST) {
+        throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED, 
+            "Method not allowed", "The HTTP method [" + query.method().getName() +
+            "] is not permitted for this endpoint");
+      }
+      
+      if (query.apiVersion() > 0) {
+        query.sendReply(
+            query.serializer().formatAggregatorsV1(Aggregators.set()));
+      } else {
+        query.sendReply(JSON.serializeToBytes(Aggregators.set()));
+      }
+    }
+  }
+
+  /** The "version" command. */
+  private static final class Version implements TelnetRpc, HttpRpc {
+    public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
+                                    final String[] cmd) {
+      if (chan.isConnected()) {
+        chan.write(BuildData.revisionString() + '\n'
+                   + BuildData.buildString() + '\n');
+      }
+      return Deferred.fromResult(null);
+    }
+
+    public void execute(final TSDB tsdb, final HttpQuery query) throws 
+      IOException {
+      
+      // only accept GET/POST
+      if (query.method() != HttpMethod.GET && query.method() != HttpMethod.POST) {
+        throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED, 
+            "Method not allowed", "The HTTP method [" + query.method().getName() +
+            "] is not permitted for this endpoint");
+      }
+      
+      final HashMap<String, String> version = new HashMap<String, String>();
+      version.put("version", BuildData.version);
+      version.put("short_revision", BuildData.short_revision);
+      version.put("full_revision", BuildData.full_revision);
+      version.put("timestamp", Long.toString(BuildData.timestamp));
+      version.put("repo_status", BuildData.repo_status.toString());
+      version.put("user", BuildData.user);
+      version.put("host", BuildData.host);
+      version.put("repo", BuildData.repo);
+      
+      if (query.apiVersion() > 0) {
+        query.sendReply(query.serializer().formatVersionV1(version));
+      } else {
+        final boolean json = query.request().getUri().endsWith("json");      
+        if (json) {
+          query.sendReply(JSON.serializeToBytes(version));
+        } else {
+          final String revision = BuildData.revisionString();
+          final String build = BuildData.buildString();
+          StringBuilder buf;
+          buf = new StringBuilder(2 // For the \n's
+                                  + revision.length() + build.length());
+          buf.append(revision).append('\n').append(build).append('\n');
+          query.sendReply(buf);
+        }
+      }
+    }
+  }
+  
+  /** The "dropcaches" command. */
+  private static final class DropCaches implements TelnetRpc, HttpRpc {
+    public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
+                                    final String[] cmd) {
+      dropCaches(tsdb, chan);
+      chan.write("Caches dropped.\n");
+      return Deferred.fromResult(null);
+    }
+
+    public void execute(final TSDB tsdb, final HttpQuery query) 
+      throws IOException {
+      dropCaches(tsdb, query.channel());
+      
+      // only accept GET/POST
+      if (query.method() != HttpMethod.GET && query.method() != HttpMethod.POST) {
+        throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED, 
+            "Method not allowed", "The HTTP method [" + query.method().getName() +
+            "] is not permitted for this endpoint");
+      }
+      
+      if (query.apiVersion() > 0) {
+        final HashMap<String, String> response = new HashMap<String, String>();
+        response.put("status", "200");
+        response.put("message", "Caches dropped");
+        query.sendReply(query.serializer().formatDropCachesV1(response));
+      } else { // deprecated API
+        query.sendReply("Caches dropped.\n");
+      }
+    }
+
+    /** Drops in memory caches.  */
+    private void dropCaches(final TSDB tsdb, final Channel chan) {
+      LOG.warn(chan + " Dropping all in-memory caches.");
+      tsdb.dropCaches();
+    }
+  }
+
+  /** The /api/formatters endpoint 
+   * @since 2.0 */
+  private static final class Serializers implements HttpRpc {
+    public void execute(final TSDB tsdb, final HttpQuery query) 
+      throws IOException {
+      // only accept GET/POST
+      if (query.method() != HttpMethod.GET && query.method() != HttpMethod.POST) {
+        throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED, 
+            "Method not allowed", "The HTTP method [" + query.method().getName() +
+            "] is not permitted for this endpoint");
+      }
+      
+      switch (query.apiVersion()) {
+        case 0:
+        case 1:
+          query.sendReply(query.serializer().formatSerializersV1());
+          break;
+        default: 
+          throw new BadRequestException(HttpResponseStatus.NOT_IMPLEMENTED, 
+              "Requested API version not implemented", "Version " + 
+              query.apiVersion() + " is not implemented");
+      }
+    }
+  }
+  
+  private static final class ShowConfig implements HttpRpc {
+    @Override
+    public void execute(TSDB tsdb, HttpQuery query) throws IOException {
+      // only accept GET/POST
+      if (query.method() != HttpMethod.GET && query.method() != HttpMethod.POST) {
+        throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED, 
+            "Method not allowed", "The HTTP method [" + query.method().getName() +
+            "] is not permitted for this endpoint");
+      }
+      
+      switch (query.apiVersion()) {
+        case 0:
+        case 1:
+          query.sendReply(query.serializer().formatConfigV1(tsdb.getConfig()));
+          break;
+        default: 
+          throw new BadRequestException(HttpResponseStatus.NOT_IMPLEMENTED, 
+              "Requested API version not implemented", "Version " + 
+              query.apiVersion() + " is not implemented");
+      }
+    }
+  }
+
+}

--- a/src/tsd/StatsRpc.java
+++ b/src/tsd/StatsRpc.java
@@ -89,7 +89,7 @@ public final class StatsRpc implements TelnetRpc, HttpRpc {
         canonical);
     ConnectionManager.collectStats(collector);
     RpcHandler.collectStats(collector);
-    RpcPluginsManager.collectStats(collector);
+    RpcManager.collectStats(collector);
     tsdb.collectStats(collector);
     query.sendReply(query.serializer().formatStatsV1(dps));
   }
@@ -104,7 +104,7 @@ public final class StatsRpc implements TelnetRpc, HttpRpc {
     collector.addHostTag(canonical);
     ConnectionManager.collectStats(collector);
     RpcHandler.collectStats(collector);
-    RpcPluginsManager.collectStats(collector);
+    RpcManager.collectStats(collector);
     tsdb.collectStats(collector);
   }
   

--- a/src/tsd/StatsRpc.java
+++ b/src/tsd/StatsRpc.java
@@ -89,6 +89,7 @@ public final class StatsRpc implements TelnetRpc, HttpRpc {
         canonical);
     ConnectionManager.collectStats(collector);
     RpcHandler.collectStats(collector);
+    RpcPluginsManager.collectStats(collector);
     tsdb.collectStats(collector);
     query.sendReply(query.serializer().formatStatsV1(dps));
   }
@@ -103,6 +104,7 @@ public final class StatsRpc implements TelnetRpc, HttpRpc {
     collector.addHostTag(canonical);
     ConnectionManager.collectStats(collector);
     RpcHandler.collectStats(collector);
+    RpcPluginsManager.collectStats(collector);
     tsdb.collectStats(collector);
   }
   

--- a/test/META-INF/services/net.opentsdb.tsd.HttpRpcPlugin
+++ b/test/META-INF/services/net.opentsdb.tsd.HttpRpcPlugin
@@ -1,0 +1,1 @@
+net.opentsdb.tsd.DummyHttpRpcPlugin

--- a/test/tsd/DummyHttpRpcPlugin.java
+++ b/test/tsd/DummyHttpRpcPlugin.java
@@ -1,0 +1,56 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2014  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.tsd;
+
+import java.io.IOException;
+
+import com.google.common.base.Preconditions;
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.stats.StatsCollector;
+
+/**
+ * This is a dummy HTTP RPC plugin implementation for unit test purposes.
+ * @since 2.1
+ */
+public class DummyHttpRpcPlugin extends HttpRpcPlugin {
+  @Override
+  public void initialize(TSDB tsdb) {
+    Preconditions.checkNotNull(tsdb);
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String version() {
+    return "2.0.0";
+  }
+
+  @Override
+  public void collectStats(StatsCollector collector) {
+    collector.record("http_rpcplugin.dummy.value", 1);
+  }
+
+  @Override
+  public String getPath() {
+    return "/dummy/test";
+  }
+
+  @Override
+  public void execute(TSDB tsdb, HttpRpcPluginQuery query) throws IOException {
+  }
+}

--- a/test/tsd/TestHttpRpcPluginQuery.java
+++ b/test/tsd/TestHttpRpcPluginQuery.java
@@ -1,0 +1,73 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2011-2014  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.tsd;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpVersion;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.utils.Config;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({TSDB.class, Config.class, HttpRpcPluginQuery.class})
+public final class TestHttpRpcPluginQuery {
+  private TSDB mockTsdb;
+  private Channel mockChannel;
+  
+  @Before
+  public void before() {
+    mockTsdb = mock(TSDB.class);
+    mockChannel = NettyMocks.fakeChannel();
+  }
+  
+  @Test
+  public void getQueryBaseRoute() {
+    assertEquals("test/this/path", makeQuery("/plugin/test/this/path").getQueryBaseRoute());
+    assertEquals("test", makeQuery("/plugin/test/").getQueryBaseRoute());
+    assertEquals("test", makeQuery("/plugin/test?some=else&this=that").getQueryBaseRoute());
+  }
+  
+  @Test(expected=BadRequestException.class)
+  public void getQueryBaseRouteNoSlash() {
+    makeQuery("plugin/test?some=else&this=that").getQueryBaseRoute();
+  }
+  
+  @Test(expected=BadRequestException.class)
+  public void getQueryBaseRouteNoPluginBase() {
+    makeQuery("/test?some=else&this=that").getQueryBaseRoute();
+  }
+  
+  @Test(expected=BadRequestException.class)
+  public void getQueryBaseRouteNoPath() {
+    makeQuery("/plugin?some=else&this=that").getQueryBaseRoute();
+  }
+  
+  private HttpRpcPluginQuery makeQuery(final String uriString) {
+    HttpRequest req = new DefaultHttpRequest(
+        HttpVersion.HTTP_1_1, 
+        HttpMethod.GET, 
+        uriString);
+    return new HttpRpcPluginQuery(mockTsdb, req, mockChannel);
+  }
+}

--- a/test/tsd/TestRpcHandler.java
+++ b/test/tsd/TestRpcHandler.java
@@ -61,7 +61,7 @@ import net.opentsdb.utils.Config;
   ChannelHandlerContext.class })
 public final class TestRpcHandler {
   private TSDB tsdb = null;
-  private RpcPluginsManager pluginsManager;
+  private RpcManager rpc_manager;
   private ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
   private HBaseClient client = mock(HBaseClient.class);
   private MessageEvent message = mock(MessageEvent.class);
@@ -72,24 +72,24 @@ public final class TestRpcHandler {
     PowerMockito.whenNew(HBaseClient.class)
       .withArguments(anyString(), anyString()).thenReturn(client);
     tsdb = new TSDB(config);
-    pluginsManager = RpcPluginsManager.instance(tsdb);
+    rpc_manager = RpcManager.instance(tsdb);
   }
   
   @After
   public void after() {
-    pluginsManager.shutdown();
+    rpc_manager.shutdown();
   }
   
   @Test
   public void ctorDefaults() {
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     assertNotNull(rpc);
   }
   
   @Test
   public void ctorCORSPublic() {
     tsdb.getConfig().overrideConfig("tsd.http.request.cors_domains", "*");
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     assertNotNull(rpc);
   }
   
@@ -97,7 +97,7 @@ public final class TestRpcHandler {
   public void ctorCORSSeparated() {
     tsdb.getConfig().overrideConfig("tsd.http.request.cors_domains", 
         "aurther.com,dent.net,beeblebrox.org");
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     assertNotNull(rpc);
   }
   
@@ -105,7 +105,7 @@ public final class TestRpcHandler {
   public void ctorCORSPublicAndDomains() {
     tsdb.getConfig().overrideConfig("tsd.http.request.cors_domains", 
         "*,aurther.com,dent.net,beeblebrox.org");
-    new RpcHandler(tsdb, pluginsManager);
+    new RpcHandler(tsdb, rpc_manager);
   }
   
   @Test
@@ -127,7 +127,7 @@ public final class TestRpcHandler {
       }
     );
     
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     rpc.messageReceived(ctx, message);
   }
   
@@ -152,7 +152,7 @@ public final class TestRpcHandler {
     );
     
     tsdb.getConfig().overrideConfig("tsd.http.request.cors_domains", "*");
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     rpc.messageReceived(ctx, message);
   }
   
@@ -178,7 +178,7 @@ public final class TestRpcHandler {
     
     tsdb.getConfig().overrideConfig("tsd.http.request.cors_domains", 
         "aurther.com,dent.net,42.com,beeblebrox.org");
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     rpc.messageReceived(ctx, message);
   }
   
@@ -203,7 +203,7 @@ public final class TestRpcHandler {
     
     tsdb.getConfig().overrideConfig("tsd.http.request.cors_domains", 
         "aurther.com,dent.net,beeblebrox.org");
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     rpc.messageReceived(ctx, message);
   }
   
@@ -225,7 +225,7 @@ public final class TestRpcHandler {
       }
     );
     
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     rpc.messageReceived(ctx, message);
   }
   
@@ -248,7 +248,7 @@ public final class TestRpcHandler {
       }
     );
     
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     rpc.messageReceived(ctx, message);
   }
   
@@ -273,7 +273,7 @@ public final class TestRpcHandler {
     );
     
     tsdb.getConfig().overrideConfig("tsd.http.request.cors_domains", "*");
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     rpc.messageReceived(ctx, message);
   }
   
@@ -299,7 +299,7 @@ public final class TestRpcHandler {
     
     tsdb.getConfig().overrideConfig("tsd.http.request.cors_domains", 
       "aurther.com,dent.net,42.com,beeblebrox.org");
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     rpc.messageReceived(ctx, message);
   }
   
@@ -324,13 +324,13 @@ public final class TestRpcHandler {
     
     tsdb.getConfig().overrideConfig("tsd.http.request.cors_domains", 
       "aurther.com,dent.net,beeblebrox.org");
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     rpc.messageReceived(ctx, message);
   }
   
   @Test
   public void createQueryInstanceForBuiltin() throws Exception {
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     final Channel mockChan = NettyMocks.fakeChannel();
     final Method meth = Whitebox.getMethod(RpcHandler.class, "createQueryInstance", 
         TSDB.class, HttpRequest.class, Channel.class);
@@ -361,7 +361,7 @@ public final class TestRpcHandler {
   
   @Test(expected=BadRequestException.class)
   public void createQueryInstanceEmptyRequestInvalid() throws Exception {
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     final Channel mockChan = NettyMocks.fakeChannel();
     final Method meth = Whitebox.getMethod(RpcHandler.class, "createQueryInstance", 
         TSDB.class, HttpRequest.class, Channel.class);
@@ -388,7 +388,7 @@ public final class TestRpcHandler {
       }
     );
     
-    final RpcHandler rpc = new RpcHandler(tsdb, pluginsManager);
+    final RpcHandler rpc = new RpcHandler(tsdb, rpc_manager);
     Whitebox.invokeMethod(rpc, "handleHttpQuery", tsdb, mockChan, req);
   }
   

--- a/test/tsd/TestRpcHandler.java
+++ b/test/tsd/TestRpcHandler.java
@@ -16,8 +16,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 

--- a/test/tsd/TestRpcHandler.java
+++ b/test/tsd/TestRpcHandler.java
@@ -72,8 +72,7 @@ public final class TestRpcHandler {
     PowerMockito.whenNew(HBaseClient.class)
       .withArguments(anyString(), anyString()).thenReturn(client);
     tsdb = new TSDB(config);
-    pluginsManager = new RpcPluginsManager();
-    pluginsManager.initialize(tsdb);
+    pluginsManager = RpcPluginsManager.instance(tsdb);
   }
   
   @After

--- a/test/tsd/TestRpcManager.java
+++ b/test/tsd/TestRpcManager.java
@@ -107,6 +107,7 @@ public class TestRpcManager {
     assertTrue(mgr_under_test.isHttpRpcPluginPath("plugin/my/http/plugin"));
     assertTrue(mgr_under_test.isHttpRpcPluginPath("/plugin/my?hey=hi&howdy=ho"));
     assertTrue(mgr_under_test.isHttpRpcPluginPath("plugin/my?hey=hi&howdy=ho"));
+    assertTrue(mgr_under_test.isHttpRpcPluginPath("plugin/my/?hey=hi&howdy=ho"));
   }
   
   @Test
@@ -116,6 +117,8 @@ public class TestRpcManager {
     assertFalse(mgr_under_test.isHttpRpcPluginPath("plugin/"));
     assertFalse(mgr_under_test.isHttpRpcPluginPath("plugin"));
     assertFalse(mgr_under_test.isHttpRpcPluginPath("/plugin"));
+    assertFalse(mgr_under_test.isHttpRpcPluginPath("/plugin?howdy=ho"));
+    assertFalse(mgr_under_test.isHttpRpcPluginPath("/plugin/?howdy=ho"));
     assertFalse(mgr_under_test.isHttpRpcPluginPath("api/query"));
   }
   

--- a/test/tsd/TestRpcManager.java
+++ b/test/tsd/TestRpcManager.java
@@ -37,7 +37,7 @@ import net.opentsdb.utils.PluginLoader;
   "com.sum.*", "org.xml.*"})
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ TSDB.class, Config.class, HBaseClient.class, RpcManager.class })
-public class TestRpcPluginsManager {
+public class TestRpcManager {
   private TSDB mock_tsdb_no_plugins;
   
   // Set in individual test methods; shutdown by after() if set.

--- a/test/tsd/TestRpcPluginsManager.java
+++ b/test/tsd/TestRpcPluginsManager.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
 import org.hbase.async.HBaseClient;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -36,6 +38,26 @@ import net.opentsdb.utils.PluginLoader;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ TSDB.class, Config.class, HBaseClient.class, RpcPluginsManager.class })
 public class TestRpcPluginsManager {
+  private TSDB mock_tsdb_no_plugins;
+  
+  // Set in individual test methods; shutdown by after() if set.
+  private RpcPluginsManager mgr_under_test;
+  
+  @Before
+  public void before() {
+    Config config = mock(Config.class);
+    TSDB tsdb = mock(TSDB.class);
+    when(tsdb.getConfig()).thenReturn(config);
+    mock_tsdb_no_plugins = tsdb;
+  }
+  
+  @After
+  public void after() throws Exception {
+    if (mgr_under_test != null) {
+      mgr_under_test.shutdown().join();
+    }
+  }
+  
   @Test
   public void loadHttpRpcPlugins() throws Exception {
     Config config = mock(Config.class);
@@ -48,13 +70,10 @@ public class TestRpcPluginsManager {
     when(tsdb.getConfig()).thenReturn(config);
     
     PluginLoader.loadJAR("plugin_test.jar");
-    RpcPluginsManager mgr = new RpcPluginsManager();
-    mgr.initialize(tsdb);
+    mgr_under_test = RpcPluginsManager.instance(tsdb);
     
-    HttpRpcPlugin plugin = mgr.lookupHttpRpcPlugin("dummy/test");
+    HttpRpcPlugin plugin = mgr_under_test.lookupHttpRpcPlugin("dummy/test");
     assertNotNull(plugin);
-    
-    mgr.shutdown().join();
   }
   
   @Test
@@ -76,108 +95,106 @@ public class TestRpcPluginsManager {
     when(tsdb.getConfig()).thenReturn(config);
     
     PluginLoader.loadJAR("plugin_test.jar");
-    RpcPluginsManager mgr = new RpcPluginsManager();
-    mgr.initialize(tsdb);
+    mgr_under_test= RpcPluginsManager.instance(tsdb);
     
-    assertFalse(mgr.getRpcPlugins().isEmpty());
-    
-    mgr.shutdown().join();
+    assertFalse(mgr_under_test.getRpcPlugins().isEmpty());
   }
   
   @Test
   public void isHttpRpcPluginPathValid() {
-    RpcPluginsManager mgr = new RpcPluginsManager();
-    assertTrue(mgr.isHttpRpcPluginPath("/plugin/my/http/plugin"));
-    assertTrue(mgr.isHttpRpcPluginPath("plugin/my/http/plugin"));
-    assertTrue(mgr.isHttpRpcPluginPath("/plugin/my?hey=hi&howdy=ho"));
-    assertTrue(mgr.isHttpRpcPluginPath("plugin/my?hey=hi&howdy=ho"));
+    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
+    assertTrue(mgr_under_test.isHttpRpcPluginPath("/plugin/my/http/plugin"));
+    assertTrue(mgr_under_test.isHttpRpcPluginPath("plugin/my/http/plugin"));
+    assertTrue(mgr_under_test.isHttpRpcPluginPath("/plugin/my?hey=hi&howdy=ho"));
+    assertTrue(mgr_under_test.isHttpRpcPluginPath("plugin/my?hey=hi&howdy=ho"));
   }
   
   @Test
   public void isHttpRpcPluginPathInvalid() {
-    RpcPluginsManager mgr = new RpcPluginsManager();
-    assertFalse(mgr.isHttpRpcPluginPath("/plugin/"));
-    assertFalse(mgr.isHttpRpcPluginPath("plugin/"));
-    assertFalse(mgr.isHttpRpcPluginPath("plugin"));
-    assertFalse(mgr.isHttpRpcPluginPath("/plugin"));
-    assertFalse(mgr.isHttpRpcPluginPath("api/query"));
+    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
+    assertFalse(mgr_under_test.isHttpRpcPluginPath("/plugin/"));
+    assertFalse(mgr_under_test.isHttpRpcPluginPath("plugin/"));
+    assertFalse(mgr_under_test.isHttpRpcPluginPath("plugin"));
+    assertFalse(mgr_under_test.isHttpRpcPluginPath("/plugin"));
+    assertFalse(mgr_under_test.isHttpRpcPluginPath("api/query"));
   }
   
   @Test
   public void validateHttpRpcPluginPathValid() {
-    RpcPluginsManager mgr = new RpcPluginsManager();
-    mgr.validateHttpRpcPluginPath("/my/test/path");
-    mgr.validateHttpRpcPluginPath("my/test/path");
-    mgr.validateHttpRpcPluginPath("my/test/path");
-    mgr.validateHttpRpcPluginPath("api/query");
+    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
+    mgr_under_test.validateHttpRpcPluginPath("/my/test/path");
+    mgr_under_test.validateHttpRpcPluginPath("my/test/path");
+    mgr_under_test.validateHttpRpcPluginPath("my/test/path");
+    mgr_under_test.validateHttpRpcPluginPath("api/query");
   }
   
   @Test
   public void validateHttpRpcPluginPathInvalid() {
-    RpcPluginsManager mgr = new RpcPluginsManager();
+    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
     try {
-      mgr.validateHttpRpcPluginPath("/plugin/my/test");
+      mgr_under_test.validateHttpRpcPluginPath("/plugin/my/test");
       assertTrue(false);
     } catch (IllegalArgumentException e) { }
     try {
-      mgr.validateHttpRpcPluginPath("plugin/my/test");
+      mgr_under_test.validateHttpRpcPluginPath("plugin/my/test");
       assertTrue(false);
     } catch (IllegalArgumentException e) { }
     try {
-      mgr.validateHttpRpcPluginPath("plugin/");
+      mgr_under_test.validateHttpRpcPluginPath("plugin/");
       assertTrue(false);
     } catch (IllegalArgumentException e) { }
     try {
-      mgr.validateHttpRpcPluginPath("/plugin/");
+      mgr_under_test.validateHttpRpcPluginPath("/plugin/");
       assertTrue(false);
     } catch (IllegalArgumentException e) { }
     try {
-      mgr.validateHttpRpcPluginPath("/plugin");
+      mgr_under_test.validateHttpRpcPluginPath("/plugin");
       assertTrue(false);
     } catch (IllegalArgumentException e) { }
     try {
-      mgr.validateHttpRpcPluginPath("plugin");
+      mgr_under_test.validateHttpRpcPluginPath("plugin");
       assertTrue(false);
     } catch (IllegalArgumentException e) { }
   }
   
   @Test
   public void canonicalizePluginPathsValid() throws Exception {
-    RpcPluginsManager mgr = new RpcPluginsManager();
+    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
     assertEquals("my/test/path",
-        mgr.canonicalizePluginPath("/my/test/path"));
+        mgr_under_test.canonicalizePluginPath("/my/test/path"));
     assertEquals("my/test/path", 
-        mgr.canonicalizePluginPath("/my/test/path/"));
+        mgr_under_test.canonicalizePluginPath("/my/test/path/"));
     assertEquals("my/test/path",
-        mgr.canonicalizePluginPath("my/test/path/"));
+        mgr_under_test.canonicalizePluginPath("my/test/path/"));
     assertEquals("my/test/path", 
-        mgr.canonicalizePluginPath("my/test/path"));
+        mgr_under_test.canonicalizePluginPath("my/test/path"));
     
     assertEquals("my", 
-        mgr.canonicalizePluginPath("/my/"));
+        mgr_under_test.canonicalizePluginPath("/my/"));
     assertEquals("my", 
-        mgr.canonicalizePluginPath("my/"));
+        mgr_under_test.canonicalizePluginPath("my/"));
     assertEquals("my", 
-        mgr.canonicalizePluginPath("my"));
+        mgr_under_test.canonicalizePluginPath("my"));
   }
   
   @Test(expected=IllegalArgumentException.class)
   public void canonicalizePluginPathIsRoot() {
+    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
     assertEquals(RpcPluginsManager.PLUGIN_BASE_WEBPATH + "/", 
-        new RpcPluginsManager().canonicalizePluginPath(""));
+        mgr_under_test.canonicalizePluginPath(""));
   }
   
   @Test
   public void validHttpPathEndToEnd() {
-    RpcPluginsManager mgr = new RpcPluginsManager();
-    mgr.validateHttpRpcPluginPath("myplugin");
-    assertEquals("myplugin", mgr.canonicalizePluginPath("myplugin"));
-    mgr.validateHttpRpcPluginPath("/myplugin");
-    assertEquals("myplugin", mgr.canonicalizePluginPath("/myplugin"));
+    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
+    mgr_under_test.validateHttpRpcPluginPath("myplugin");
+    assertEquals("myplugin", mgr_under_test.canonicalizePluginPath("myplugin"));
+    mgr_under_test.validateHttpRpcPluginPath("/myplugin");
+    assertEquals("myplugin", mgr_under_test.canonicalizePluginPath("/myplugin"));
     
-    mgr.validateHttpRpcPluginPath("myplugin/subcommand");
-    assertEquals("myplugin/subcommand", mgr.canonicalizePluginPath("myplugin/subcommand"));
-    mgr.validateHttpRpcPluginPath("/myplugin/subcommand");
-    assertEquals("myplugin/subcommand", mgr.canonicalizePluginPath("/myplugin/subcommand"));
+    mgr_under_test.validateHttpRpcPluginPath("myplugin/subcommand");
+    assertEquals("myplugin/subcommand", mgr_under_test.canonicalizePluginPath("myplugin/subcommand"));
+    mgr_under_test.validateHttpRpcPluginPath("/myplugin/subcommand");
+    assertEquals("myplugin/subcommand", mgr_under_test.canonicalizePluginPath("/myplugin/subcommand"));
   }
 }

--- a/test/tsd/TestRpcPluginsManager.java
+++ b/test/tsd/TestRpcPluginsManager.java
@@ -36,12 +36,12 @@ import net.opentsdb.utils.PluginLoader;
   "ch.qos.*", "org.slf4j.*",
   "com.sum.*", "org.xml.*"})
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ TSDB.class, Config.class, HBaseClient.class, RpcPluginsManager.class })
+@PrepareForTest({ TSDB.class, Config.class, HBaseClient.class, RpcManager.class })
 public class TestRpcPluginsManager {
   private TSDB mock_tsdb_no_plugins;
   
   // Set in individual test methods; shutdown by after() if set.
-  private RpcPluginsManager mgr_under_test;
+  private RpcManager mgr_under_test;
   
   @Before
   public void before() {
@@ -70,7 +70,7 @@ public class TestRpcPluginsManager {
     when(tsdb.getConfig()).thenReturn(config);
     
     PluginLoader.loadJAR("plugin_test.jar");
-    mgr_under_test = RpcPluginsManager.instance(tsdb);
+    mgr_under_test = RpcManager.instance(tsdb);
     
     HttpRpcPlugin plugin = mgr_under_test.lookupHttpRpcPlugin("dummy/test");
     assertNotNull(plugin);
@@ -95,14 +95,14 @@ public class TestRpcPluginsManager {
     when(tsdb.getConfig()).thenReturn(config);
     
     PluginLoader.loadJAR("plugin_test.jar");
-    mgr_under_test= RpcPluginsManager.instance(tsdb);
+    mgr_under_test= RpcManager.instance(tsdb);
     
     assertFalse(mgr_under_test.getRpcPlugins().isEmpty());
   }
   
   @Test
   public void isHttpRpcPluginPathValid() {
-    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
+    mgr_under_test = RpcManager.instance(mock_tsdb_no_plugins);
     assertTrue(mgr_under_test.isHttpRpcPluginPath("/plugin/my/http/plugin"));
     assertTrue(mgr_under_test.isHttpRpcPluginPath("plugin/my/http/plugin"));
     assertTrue(mgr_under_test.isHttpRpcPluginPath("/plugin/my?hey=hi&howdy=ho"));
@@ -111,7 +111,7 @@ public class TestRpcPluginsManager {
   
   @Test
   public void isHttpRpcPluginPathInvalid() {
-    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
+    mgr_under_test = RpcManager.instance(mock_tsdb_no_plugins);
     assertFalse(mgr_under_test.isHttpRpcPluginPath("/plugin/"));
     assertFalse(mgr_under_test.isHttpRpcPluginPath("plugin/"));
     assertFalse(mgr_under_test.isHttpRpcPluginPath("plugin"));
@@ -121,7 +121,7 @@ public class TestRpcPluginsManager {
   
   @Test
   public void validateHttpRpcPluginPathValid() {
-    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
+    mgr_under_test = RpcManager.instance(mock_tsdb_no_plugins);
     mgr_under_test.validateHttpRpcPluginPath("/my/test/path");
     mgr_under_test.validateHttpRpcPluginPath("my/test/path");
     mgr_under_test.validateHttpRpcPluginPath("my/test/path");
@@ -130,7 +130,7 @@ public class TestRpcPluginsManager {
   
   @Test
   public void validateHttpRpcPluginPathInvalid() {
-    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
+    mgr_under_test = RpcManager.instance(mock_tsdb_no_plugins);
     try {
       mgr_under_test.validateHttpRpcPluginPath("/plugin/my/test");
       assertTrue(false);
@@ -159,7 +159,7 @@ public class TestRpcPluginsManager {
   
   @Test
   public void canonicalizePluginPathsValid() throws Exception {
-    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
+    mgr_under_test = RpcManager.instance(mock_tsdb_no_plugins);
     assertEquals("my/test/path",
         mgr_under_test.canonicalizePluginPath("/my/test/path"));
     assertEquals("my/test/path", 
@@ -179,14 +179,14 @@ public class TestRpcPluginsManager {
   
   @Test(expected=IllegalArgumentException.class)
   public void canonicalizePluginPathIsRoot() {
-    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
-    assertEquals(RpcPluginsManager.PLUGIN_BASE_WEBPATH + "/", 
+    mgr_under_test = RpcManager.instance(mock_tsdb_no_plugins);
+    assertEquals(RpcManager.PLUGIN_BASE_WEBPATH + "/", 
         mgr_under_test.canonicalizePluginPath(""));
   }
   
   @Test
   public void validHttpPathEndToEnd() {
-    mgr_under_test = RpcPluginsManager.instance(mock_tsdb_no_plugins);
+    mgr_under_test = RpcManager.instance(mock_tsdb_no_plugins);
     mgr_under_test.validateHttpRpcPluginPath("myplugin");
     assertEquals("myplugin", mgr_under_test.canonicalizePluginPath("myplugin"));
     mgr_under_test.validateHttpRpcPluginPath("/myplugin");

--- a/test/tsd/TestRpcPluginsManager.java
+++ b/test/tsd/TestRpcPluginsManager.java
@@ -1,0 +1,131 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2014 The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.tsd;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.hbase.async.HBaseClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.utils.Config;
+
+@PowerMockIgnore({"javax.management.*", "javax.xml.*",
+  "ch.qos.*", "org.slf4j.*",
+  "com.sum.*", "org.xml.*"})
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ TSDB.class, Config.class, HBaseClient.class, RpcPluginsManager.class })
+public class TestRpcPluginsManager {
+  @Test
+  public void isHttpRpcPluginPathValid() {
+    RpcPluginsManager mgr = new RpcPluginsManager();
+    assertTrue(mgr.isHttpRpcPluginPath("/plugin/my/http/plugin"));
+    assertTrue(mgr.isHttpRpcPluginPath("plugin/my/http/plugin"));
+    assertTrue(mgr.isHttpRpcPluginPath("/plugin/my?hey=hi&howdy=ho"));
+    assertTrue(mgr.isHttpRpcPluginPath("plugin/my?hey=hi&howdy=ho"));
+  }
+  
+  @Test
+  public void isHttpRpcPluginPathInvalid() {
+    RpcPluginsManager mgr = new RpcPluginsManager();
+    assertFalse(mgr.isHttpRpcPluginPath("/plugin/"));
+    assertFalse(mgr.isHttpRpcPluginPath("plugin/"));
+    assertFalse(mgr.isHttpRpcPluginPath("plugin"));
+    assertFalse(mgr.isHttpRpcPluginPath("/plugin"));
+    assertFalse(mgr.isHttpRpcPluginPath("api/query"));
+  }
+  
+  @Test
+  public void validateHttpRpcPluginPathValid() {
+    RpcPluginsManager mgr = new RpcPluginsManager();
+    mgr.validateHttpRpcPluginPath("/my/test/path");
+    mgr.validateHttpRpcPluginPath("my/test/path");
+    mgr.validateHttpRpcPluginPath("my/test/path");
+    mgr.validateHttpRpcPluginPath("api/query");
+  }
+  
+  @Test
+  public void validateHttpRpcPluginPathInvalid() {
+    RpcPluginsManager mgr = new RpcPluginsManager();
+    try {
+      mgr.validateHttpRpcPluginPath("/plugin/my/test");
+      assertTrue(false);
+    } catch (IllegalArgumentException e) { }
+    try {
+      mgr.validateHttpRpcPluginPath("plugin/my/test");
+      assertTrue(false);
+    } catch (IllegalArgumentException e) { }
+    try {
+      mgr.validateHttpRpcPluginPath("plugin/");
+      assertTrue(false);
+    } catch (IllegalArgumentException e) { }
+    try {
+      mgr.validateHttpRpcPluginPath("/plugin/");
+      assertTrue(false);
+    } catch (IllegalArgumentException e) { }
+    try {
+      mgr.validateHttpRpcPluginPath("/plugin");
+      assertTrue(false);
+    } catch (IllegalArgumentException e) { }
+    try {
+      mgr.validateHttpRpcPluginPath("plugin");
+      assertTrue(false);
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void canonicalizePluginPathsValid() throws Exception {
+    RpcPluginsManager mgr = new RpcPluginsManager();
+    assertEquals(RpcPluginsManager.PLUGIN_BASE_WEBPATH + "/my/test/path",
+        mgr.canonicalizePluginPath("/my/test/path"));
+    assertEquals(RpcPluginsManager.PLUGIN_BASE_WEBPATH + "/my/test/path", 
+        mgr.canonicalizePluginPath("/my/test/path/"));
+    assertEquals(RpcPluginsManager.PLUGIN_BASE_WEBPATH + "/my/test/path",
+        mgr.canonicalizePluginPath("my/test/path/"));
+    assertEquals(RpcPluginsManager.PLUGIN_BASE_WEBPATH + "/my/test/path", 
+        mgr.canonicalizePluginPath("my/test/path"));
+    
+    assertEquals(RpcPluginsManager.PLUGIN_BASE_WEBPATH + "/my", 
+        mgr.canonicalizePluginPath("/my/"));
+    assertEquals(RpcPluginsManager.PLUGIN_BASE_WEBPATH + "/my", 
+        mgr.canonicalizePluginPath("my/"));
+    assertEquals(RpcPluginsManager.PLUGIN_BASE_WEBPATH + "/my", 
+        mgr.canonicalizePluginPath("my"));
+  }
+  
+  @Test(expected=IllegalArgumentException.class)
+  public void canonicalizePluginPathIsRoot() {
+    assertEquals(RpcPluginsManager.PLUGIN_BASE_WEBPATH + "/", 
+        new RpcPluginsManager().canonicalizePluginPath(""));
+  }
+  
+  @Test
+  public void validHttpPathEndToEnd() {
+    RpcPluginsManager mgr = new RpcPluginsManager();
+    mgr.validateHttpRpcPluginPath("myplugin");
+    assertEquals("plugin/myplugin", mgr.canonicalizePluginPath("myplugin"));
+    mgr.validateHttpRpcPluginPath("/myplugin");
+    assertEquals("plugin/myplugin", mgr.canonicalizePluginPath("/myplugin"));
+    
+    mgr.validateHttpRpcPluginPath("myplugin/subcommand");
+    assertEquals("plugin/myplugin/subcommand", mgr.canonicalizePluginPath("myplugin/subcommand"));
+    mgr.validateHttpRpcPluginPath("/myplugin/subcommand");
+    assertEquals("plugin/myplugin/subcommand", mgr.canonicalizePluginPath("/myplugin/subcommand"));
+  }
+}

--- a/test/utils/TestPluginLoader.java
+++ b/test/utils/TestPluginLoader.java
@@ -20,6 +20,7 @@ import java.io.FileNotFoundException;
 import java.util.List;
 
 import net.opentsdb.plugin.DummyPlugin;
+import net.opentsdb.tsd.HttpRpcPlugin;
 import net.opentsdb.utils.PluginLoader;
 
 import org.junit.Test;
@@ -107,6 +108,14 @@ public final class TestPluginLoader {
         DummyPlugin.class);
     assertNotNull(plugins);
     assertEquals(2, plugins.size());
+  }
+  
+  @Test
+  public void loadHttpRpcPlugin() throws Exception {
+    PluginLoader.loadJAR("plugin_test.jar");
+    HttpRpcPlugin plugin = PluginLoader.loadSpecificPlugin("net.opentsdb.tsd.DummyHttpRpcPlugin", HttpRpcPlugin.class);
+    assertNotNull(plugin);
+    assertEquals("/dummy/test", plugin.getPath());
   }
   
   @Test


### PR DESCRIPTION
Introduces a new plugin type:  `HttpRpcPlugin`.  These are first class entities like the pre-existing `RpcPlugin`s though they have a separate lifecycle.  Further, unlike RPC plugins, the HTTP variety run on the main Netty loop along with built-in `HttpRpc` commands.  HTTP RPC plugins automatically placed beneath the **/plugin** base web path to keep them totally separate from build-in, core `HttpRpc` commands.  Even though these two HTTP RPC commands types are separate, both are dispatched by `RpcHandler` so a certain amount of common configuration can be safely shared; the CORS settings in particular.

HTTP RPC plugins can be loaded using the new `tsd.http.rpc.plugins` configuration parameter.  This is a comma-separated list of class names that extend the base `HttpRpcPlugin` class.