### PR TITLE
Adds style options to select gnuplot data style

### DIFF
--- a/src/graph/Plot.java
+++ b/src/graph/Plot.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
@@ -253,6 +254,7 @@ public final class Plot {
         .append(Short.toString(height));
       final String smooth = params.remove("smooth");
       final String fgcolor = params.remove("fgcolor");
+      final String style = params.remove("style");
       String bgcolor = params.remove("bgcolor");
       if (fgcolor != null && bgcolor == null) {
         // We can't specify a fgcolor without specifying a bgcolor.
@@ -287,7 +289,8 @@ public final class Plot {
       final int nseries = datapoints.size();
       if (nseries > 0) {
         gp.write("set grid\n"
-                 + "set style data linespoints\n");
+                 + "set style data ");
+        gp.append(style != null? style : "linespoint").append("\n");
         if (!params.containsKey("key")) {
           gp.write("set key right box\n");
         }

--- a/src/tsd/GraphHandler.java
+++ b/src/tsd/GraphHandler.java
@@ -693,6 +693,9 @@ final class GraphHandler implements HttpRpc {
     if ((value = popParam(querystring, "smooth")) != null) {
       params.put("smooth", value);
     }
+    if ((value = popParam(querystring, "style")) != null) {
+      params.put("style", value);
+    }
     // This must remain after the previous `if' in order to properly override
     // any previous `key' parameter if a `nokey' parameter is given.
     if ((value = popParam(querystring, "nokey")) != null) {

--- a/src/tsd/client/QueryUi.java
+++ b/src/tsd/client/QueryUi.java
@@ -19,8 +19,14 @@ package tsd.client;
  */
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import net.opentsdb.graph.Plot;
 
 import com.google.gwt.core.client.EntryPoint;
 import com.google.gwt.dom.client.Style;
@@ -80,6 +86,7 @@ import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.InlineLabel;
 import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.RadioButton;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.TextBox;
@@ -91,6 +98,18 @@ import com.google.gwt.user.client.ui.Widget;
  * Manages the entire UI, forms to query the TSDB and other misc panels.
  */
 public class QueryUi implements EntryPoint, HistoryListener {
+
+  /** Map of available gnuplot data styles. */
+  public static Map<String, Integer> stylesMap = new HashMap<String, Integer>();
+  static {
+      Map<String, Integer> map = new HashMap<String, Integer>();
+      map.put("linespoint", 0);
+      map.put("points", 1);
+      map.put("circles", 3);
+      map.put("dots", 4);
+      stylesMap = Collections.unmodifiableMap(map);
+  }
+
   // Some URLs we use to fetch data from the TSD.
   private static final String AGGREGATORS_URL = "/aggregators";
   private static final String LOGS_URL = "/logs?json";
@@ -125,6 +144,7 @@ public class QueryUi implements EntryPoint, HistoryListener {
 
   // Styling options.
   private final CheckBox smooth = new CheckBox();
+  private final ListBox styles = new ListBox();
 
   /**
    * Handles every change to the query form and gets a new graph.
@@ -176,7 +196,7 @@ public class QueryUi implements EntryPoint, HistoryListener {
 
   /** List of known aggregation functions.  Fetched once from the server. */
   private final ArrayList<String> aggregators = new ArrayList<String>();
-
+  
   private final DecoratedTabPanel metrics = new DecoratedTabPanel();
 
   /** Panel to place generated graphs and a box for zoom highlighting. */
@@ -260,6 +280,7 @@ public class QueryUi implements EntryPoint, HistoryListener {
     keybox.addClickHandler(refreshgraph);
     nokey.addClickHandler(refreshgraph);
     smooth.addClickHandler(refreshgraph);
+    styles.addChangeHandler(refreshgraph);
 
     yrange.setValidationRegexp("^("                            // Nothing or
                                + "|\\[([-+.0-9eE]+|\\*)?"      // "[start
@@ -455,9 +476,14 @@ public class QueryUi implements EntryPoint, HistoryListener {
 
   /** Additional styling options.  */
   private Grid makeStylePanel() {
+    for (Entry<String, Integer> item : stylesMap.entrySet()) {
+      styles.insertItem(item.getKey(), item.getValue());
+    }
     final Grid grid = new Grid(5, 3);
     grid.setText(0, 1, "Smooth");
     grid.setWidget(0, 2, smooth);
+    grid.setText(1, 1, "Style");
+    grid.setWidget(1, 2, styles);
     return grid;
   }
 
@@ -812,6 +838,9 @@ public class QueryUi implements EntryPoint, HistoryListener {
     }
     nokey.setValue(qs.containsKey("nokey"));
     smooth.setValue(qs.containsKey("smooth"));
+    if (stylesMap.containsKey(qs.getFirst("style"))) {
+      styles.setSelectedIndex(stylesMap.get(qs.getFirst("style")));
+    }
   }
 
   private void refreshGraph() {
@@ -879,6 +908,7 @@ public class QueryUi implements EntryPoint, HistoryListener {
     if (smooth.getValue()) {
       url.append("&smooth=csplines");
     }
+    url.append("&style=").append(styles.getValue(styles.getSelectedIndex()));
     final String unencodedUri = url.toString();
     final String uri = URL.encode(unencodedUri);
     if (uri.equals(lastgraphuri)) {


### PR DESCRIPTION
When plotting dense points, lines between each datapoint can make the
output quite cumbersome. This adds the possibility to display only
points, and two additional styles as a bonus (dot and circle).

The HTTP API now handles the `&style` parameter as well to inject any
additional style.


![tsdb-styles-1](https://cloud.githubusercontent.com/assets/231014/4516008/85f7aa92-4bdc-11e4-9894-40a8e7e350ca.jpg)

![tsdb-styles-2](https://cloud.githubusercontent.com/assets/231014/4516010/8c00e20a-4bdc-11e4-8265-6d228a4c9f95.jpg)
