### PR TITLE
Added <pluginManagement> tag to pom.xml.in to fix eclipse maven errors.

### DIFF
--- a/pom.xml.in
+++ b/pom.xml.in
@@ -60,240 +60,241 @@
   <packaging>jar</packaging>
 
   <build>
-    <sourceDirectory>src-main</sourceDirectory>
-    <testSourceDirectory>src-test</testSourceDirectory>
+      <sourceDirectory>src-main</sourceDirectory>
+      <testSourceDirectory>src-test</testSourceDirectory>
+  	<pluginManagement>
+      <plugins>
 
-    <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.5.1</version>
+          <configuration>
+            <source>1.6</source>
+            <target>1.6</target>
+            <compilerArgument>-Xlint</compilerArgument>
+            <excludes>
+              <exclude>**/client/*.java</exclude>
+            </excludes>
+      		  <testExcludes>
+      		    <exclude>**/TestGraphHandler.java</exclude>
+      		  </testExcludes>
+          </configuration>
+        </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.5.1</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-          <compilerArgument>-Xlint</compilerArgument>
-          <excludes>
-            <exclude>**/client/*.java</exclude>
-          </excludes>
-		  <testExcludes>
-		    <exclude>**/TestGraphHandler.java</exclude>
-		  </testExcludes>
-        </configuration>
-      </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.2.1</version>
+          <executions>
+            <execution>
+              <id>generate-build-data</id>
+              <configuration>
+                <executable>build-aux/gen_build_data.sh</executable>
+                <!-- optional -->
+                <arguments>
+                  <argument>target/generated-sources/net/opentsdb/BuildData.java</argument>
+                  <argument>net.opentsdb</argument>
+                  <argument>BuildData</argument>
+                </arguments>
+              </configuration>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>exec</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>create-plugin-test-jar</id>
+              <!-- TODO: Put the jar in the target dir and fix surefire conf. -->
+              <configuration>
+                <executable>jar</executable>
+                <arguments>
+                  <argument>cvfm</argument>
+                  <argument>plugin_test.jar</argument>
+                  <argument>test/META-INF/MANIFEST.MF</argument>
+                  <argument>-C</argument>
+                  <argument>target/test-classes</argument>
+                  <argument>net/opentsdb/plugin/DummyPluginA.class</argument>
+                  <argument>-C</argument>
+                  <argument>target/test-classes</argument>
+                  <argument>net/opentsdb/plugin/DummyPluginB.class</argument>
+                  <argument>-C</argument>
+                  <argument>target/test-classes</argument>
+                  <argument>net/opentsdb/search/DummySearchPlugin.class</argument>
+                  <argument>-C</argument>
+                  <argument>target/test-classes</argument>
+                  <argument>net/opentsdb/tsd/DummyHttpSerializer.class</argument>
+                  <argument>-C</argument>
+                  <argument>target/test-classes</argument>
+                  <argument>net/opentsdb/tsd/DummyRpcPlugin.class</argument>
+                  <argument>-C</argument>
+                  <argument>target/test-classes</argument>
+                  <argument>net/opentsdb/tsd/DummyRTPublisher.class</argument>
+                  <argument>-C</argument>
+                  <argument>test</argument>
+                  <argument>META-INF/services/net.opentsdb.plugin.DummyPlugin</argument>
+                  <argument>-C</argument>
+                  <argument>test</argument>
+                  <argument>META-INF/services/net.opentsdb.search.SearchPlugin</argument>
+                  <argument>-C</argument>
+                  <argument>test</argument>
+                  <argument>META-INF/services/net.opentsdb.tsd.HttpSerializer</argument>
+                  <argument>-C</argument>
+                  <argument>test</argument>
+                  <argument>META-INF/services/net.opentsdb.tsd.RpcPlugin</argument>
+                  <argument>-C</argument>
+                  <argument>test</argument>
+                  <argument>META-INF/services/net.opentsdb.tsd.RTPublisher</argument>
+                </arguments>
+              </configuration>
+              <phase>test-compile</phase>
+              <goals>
+                <goal>exec</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
 
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2.1</version>
-        <executions>
-          <execution>
-            <id>generate-build-data</id>
-            <configuration>
-              <executable>build-aux/gen_build_data.sh</executable>
-              <!-- optional -->
-              <arguments>
-                <argument>target/generated-sources/net/opentsdb/BuildData.java</argument>
-                <argument>net.opentsdb</argument>
-                <argument>BuildData</argument>
-              </arguments>
-            </configuration>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>create-plugin-test-jar</id>
-            <!-- TODO: Put the jar in the target dir and fix surefire conf. -->
-            <configuration>
-              <executable>jar</executable>
-              <arguments>
-                <argument>cvfm</argument>
-                <argument>plugin_test.jar</argument>
-                <argument>test/META-INF/MANIFEST.MF</argument>
-                <argument>-C</argument>
-                <argument>target/test-classes</argument>
-                <argument>net/opentsdb/plugin/DummyPluginA.class</argument>
-                <argument>-C</argument>
-                <argument>target/test-classes</argument>
-                <argument>net/opentsdb/plugin/DummyPluginB.class</argument>
-                <argument>-C</argument>
-                <argument>target/test-classes</argument>
-                <argument>net/opentsdb/search/DummySearchPlugin.class</argument>
-                <argument>-C</argument>
-                <argument>target/test-classes</argument>
-                <argument>net/opentsdb/tsd/DummyHttpSerializer.class</argument>
-                <argument>-C</argument>
-                <argument>target/test-classes</argument>
-                <argument>net/opentsdb/tsd/DummyRpcPlugin.class</argument>
-                <argument>-C</argument>
-                <argument>target/test-classes</argument>
-                <argument>net/opentsdb/tsd/DummyRTPublisher.class</argument>
-                <argument>-C</argument>
-                <argument>test</argument>
-                <argument>META-INF/services/net.opentsdb.plugin.DummyPlugin</argument>
-                <argument>-C</argument>
-                <argument>test</argument>
-                <argument>META-INF/services/net.opentsdb.search.SearchPlugin</argument>
-                <argument>-C</argument>
-                <argument>test</argument>
-                <argument>META-INF/services/net.opentsdb.tsd.HttpSerializer</argument>
-                <argument>-C</argument>
-                <argument>test</argument>
-                <argument>META-INF/services/net.opentsdb.tsd.RpcPlugin</argument>
-                <argument>-C</argument>
-                <argument>test</argument>
-                <argument>META-INF/services/net.opentsdb.tsd.RTPublisher</argument>
-              </arguments>
-            </configuration>
-            <phase>test-compile</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>1.7</version>
+          <executions>
+            <execution>
+              <id>add-source</id>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>add-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>target/generated-sources</source>
+                </sources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
 
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.7</version>
-        <executions>
-          <execution>
-            <id>add-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>target/generated-sources</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+        <plugin>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.7</version>
+          <executions>
+            <execution>
+              <phase>process-resources</phase>
+              <configuration>
+                <target>
+                  <copy file="${basedir}/src/mygnuplot.sh" todir="${basedir}/target/classes"/>
+                  <chmod file="${basedir}/target/classes/mygnuplot.sh" perm="ugo+rx"/>
+                  <copy file="${basedir}/src/mygnuplot.bat" todir="${basedir}/target/classes"/>
+                  <chmod file="${basedir}/target/classes/mygnuplot.bat" perm="ugo+rx"/>
+                </target>
+              </configuration>
+              <goals>
+                <goal>run</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.16</version>
+          <configuration>
+            <argLine>-Xmx2048m -XX:MaxPermSize=256m</argLine>
+            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            <parallel>classes</parallel>
+            <threadCount>2</threadCount>
+            <reuseForks>false</reuseForks>
+          </configuration>
+        </plugin>
 
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
-        <executions>
-          <execution>
-            <phase>process-resources</phase>
-            <configuration>
-              <target>
-                <copy file="${basedir}/src/mygnuplot.sh" todir="${basedir}/target/classes"/>
-                <chmod file="${basedir}/target/classes/mygnuplot.sh" perm="ugo+rx"/>
-                <copy file="${basedir}/src/mygnuplot.bat" todir="${basedir}/target/classes"/>
-                <chmod file="${basedir}/target/classes/mygnuplot.bat" perm="ugo+rx"/>
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.16</version>
-        <configuration>
-          <argLine>-Xmx2048m -XX:MaxPermSize=256m</argLine>
-          <redirectTestOutputToFile>true</redirectTestOutputToFile>
-          <parallel>classes</parallel>
-          <threadCount>2</threadCount>
-          <reuseForks>false</reuseForks>
-        </configuration>
-      </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.4</version>
+          <configuration>
+            <excludes>
+            <exclude>queryui/**</exclude>
+            <exclude>WEB-INF/deploy/**</exclude>
+            <exclude>mygnuplot.sh</exclude>
+            </excludes>
+          </configuration>
+        </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
-        <configuration>
-          <excludes>
-          <exclude>queryui/**</exclude>
-          <exclude>WEB-INF/deploy/**</exclude>
-          <exclude>mygnuplot.sh</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>gwt-maven-plugin</artifactId>
+          <version>@GWT_VERSION@</version>
+          <executions>
+            <execution>
+              <configuration>
+                <enableAssertions>true</enableAssertions>
+                <module>tsd.QueryUi</module>
+              </configuration>
+              <phase>compile</phase>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
 
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
-        <version>@GWT_VERSION@</version>
-        <executions>
-          <execution>
-            <configuration>
-              <enableAssertions>true</enableAssertions>
-              <module>tsd.QueryUi</module>
-            </configuration>
-            <phase>compile</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.1.2</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>2.1.2</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.8.1</version>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <quiet>true</quiet>
+            <validateLinks>true</validateLinks>
+            <bottom>
+              Copyright &#169; {inceptionYear}-{currentYear},
+              ${project.organization.name}
+            </bottom>
+          </configuration>
+        </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.8.1</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <quiet>true</quiet>
-          <validateLinks>true</validateLinks>
-          <bottom>
-            Copyright &#169; {inceptionYear}-{currentYear},
-            ${project.organization.name}
-          </bottom>
-        </configuration>
-      </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.4</version>
+          <executions>
+           <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <keyname>tsunanet@gmail.com</keyname>
+          </configuration>
+        </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.4</version>
-        <executions>
-         <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <keyname>tsunanet@gmail.com</keyname>
-        </configuration>
-      </plugin>
-
-    </plugins>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <dependencies>
@@ -303,19 +304,19 @@
       <artifactId>guava</artifactId>
       <version>@GUAVA_VERSION@</version>
     </dependency>
-    
+
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <version>@JACKSON_VERSION@</version>
     </dependency>
-    
+
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>@JACKSON_VERSION@</version>
     </dependency>
-    
+
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>


### PR DESCRIPTION
Without this tag, Eclipse throws errors in the pom file like: `Plugin execution not covered by lifecycle configuration: org.apache.maven.plugins:maven-antrun-plugin:1.7:run (execution: default, phase: process-resources`