### PR TITLE
Updated I/O worker to handle IdleStateEvent after Netty upgrade. (#304)

### DIFF
--- a/src/tsd/ConnectionManager.java
+++ b/src/tsd/ConnectionManager.java
@@ -23,19 +23,16 @@ import org.jboss.netty.channel.ChannelEvent;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ChannelStateEvent;
 import org.jboss.netty.channel.ExceptionEvent;
+import org.jboss.netty.channel.SimpleChannelHandler;
 import org.jboss.netty.channel.group.DefaultChannelGroup;
 import org.jboss.netty.handler.codec.embedder.CodecEmbedderException;
-import org.jboss.netty.handler.timeout.IdleState;
-import org.jboss.netty.handler.timeout.IdleStateAwareChannelHandler;
-import org.jboss.netty.handler.timeout.IdleStateEvent;
-import org.jboss.netty.handler.timeout.ReadTimeoutException;
 
 import net.opentsdb.stats.StatsCollector;
 
 /**
  * Keeps track of all existing connections.
  */
-final class ConnectionManager extends IdleStateAwareChannelHandler {
+final class ConnectionManager extends SimpleChannelHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConnectionManager.class);
 
@@ -125,12 +122,4 @@ final class ConnectionManager extends IdleStateAwareChannelHandler {
     e.getChannel().close();
   }
 
-  @Override
-  public void channelIdle(ChannelHandlerContext ctx, IdleStateEvent e) {
-    if (e.getState() == IdleState.ALL_IDLE) {
-      LOG.debug("Closed idle socket.");
-      e.getChannel().close();
-    }
-  }
-  
 }

--- a/src/tsd/PipelineFactory.java
+++ b/src/tsd/PipelineFactory.java
@@ -85,7 +85,6 @@ public final class PipelineFactory implements ChannelPipelineFactory {
   public ChannelPipeline getPipeline() throws Exception {
    final ChannelPipeline pipeline = pipeline();
 
-    pipeline.addLast("timeout", this.timeoutHandler);
     pipeline.addLast("connmgr", connmgr);
     pipeline.addLast("detect", HTTP_OR_RPC);
     return pipeline;
@@ -126,6 +125,8 @@ public final class PipelineFactory implements ChannelPipelineFactory {
         pipeline.addLast("encoder", ENCODER);
         pipeline.addLast("decoder", DECODER);
       }
+
+      pipeline.addLast("timeout", timeoutHandler);
       pipeline.remove(this);
       pipeline.addLast("handler", rpchandler);
 

--- a/src/tsd/RpcHandler.java
+++ b/src/tsd/RpcHandler.java
@@ -28,10 +28,12 @@ import org.slf4j.LoggerFactory;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.MessageEvent;
-import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.timeout.IdleState;
+import org.jboss.netty.handler.timeout.IdleStateAwareChannelUpstreamHandler;
+import org.jboss.netty.handler.timeout.IdleStateEvent;
 
 import net.opentsdb.BuildData;
 import net.opentsdb.core.Aggregators;
@@ -42,7 +44,7 @@ import net.opentsdb.utils.JSON;
 /**
  * Stateless handler for RPCs (telnet-style or HTTP).
  */
-final class RpcHandler extends SimpleChannelUpstreamHandler {
+final class RpcHandler extends IdleStateAwareChannelUpstreamHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(RpcHandler.class);
 
@@ -575,6 +577,14 @@ final class RpcHandler extends SimpleChannelUpstreamHandler {
       }
     }
     
+  }
+
+  @Override
+  public void channelIdle(ChannelHandlerContext ctx, IdleStateEvent e) {
+    if (e.getState() == IdleState.ALL_IDLE) {
+      LOG.debug("Closed idle socket.");
+      e.getChannel().close();
+    }
   }
   
   // ---------------- //


### PR DESCRIPTION
Looks like for Netty 3.5.9 and later, the `IdleStateEvent` is now handed to the I/O worker thread. Was changed here [#641](https://github.com/netty/netty/issues/641) - this causes OpenTSDB to not close sockets after an idle period anymore since when I made the original change in #379 it was done on the Netty Timer Thread ([ConnectionManager](https://github.com/OpenTSDB/opentsdb/blob/next/src/tsd/ConnectionManager.java#L129) (this worked because I was using an older version of Netty at the time)

I've moved the handling of IdleEvents to `RpcHandler` where it should be now since we're on Netty 3.9.x.

Changes:
- Switched `ConnectionManager` back to `SimpleChannelHandler` since Timer Threads don't handle `IdleStateEvent` anymore
- Moved `IdleStateHandler` inside `ChannelPipeline` in the `PipelineFactory` class.
- `RpcHandler` now extends `IdleStateAwareChannelUpstreamHandler` and overrides `channelIdle` to handle idle sockets.

If you have DEBUG level logging on, you will see this if you have a timeout set:

```
2015-02-06 08:59:59,213 DEBUG  [New I/O worker #1] RpcHandler: Closed idle socket.
```