### PR TITLE
Remove compactionq flush call from tsdb flush

### DIFF
--- a/src/core/CompactionQueue.java
+++ b/src/core/CompactionQueue.java
@@ -189,7 +189,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
     if (nflushes == MAX_CONCURRENT_FLUSHES && maxflushes > 0) {
       // We're not done yet.  Once this group of flushes completes, we need
       // to kick off more.
-      tsdb.flush();  // Speed up this batch by telling the client to flush.
+      tsdb.getClient().flush();  // Speed up this batch by telling the client to flush.
       final int maxflushez = maxflushes;  // Make it final for closure.
       final class FlushMoreCB implements Callback<Deferred<ArrayList<Object>>,
                                                   ArrayList<Object>> {


### PR DESCRIPTION
Flushing compaction queue from tsdb flush, is creating an endless
chain of compaction queue flushes, as compaction queue flush
calls tsdb flush to flush HBaseClient.

Also we don't really need to call compaction queue flush from tsdb.flush(),
as compaction background thread flush anyways every FLUSH_INTERVAL seconds.