### PR TITLE
Reimplementation of sorted aggregators drop-down.

### DIFF
--- a/src/tsd/client/MetricForm.java
+++ b/src/tsd/client/MetricForm.java
@@ -14,8 +14,6 @@ package tsd.client;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-
 import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.event.dom.client.BlurHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -277,11 +275,11 @@ final class MetricForm extends HorizontalPanel implements Focusable {
   }
 
   public void setAggregators(final ArrayList<String> aggs) {
-    final String[] agg_rray = (String[])aggs.toArray();
-    Arrays.sort(agg_rray);
-    for (final String agg : agg_rray) {
-      aggregators.addItem(agg);
-      downsampler.addItem(agg);
+    Object[] aggsSortedArray = aggs.toArray();
+    Arrays.sort(aggsSortedArray);
+    for (final Object agg : aggsSortedArray) {
+      aggregators.addItem((String)agg);
+      downsampler.addItem((String)agg);
     }
     setSelectedItem(aggregators, "sum");
     setSelectedItem(downsampler, "avg");


### PR DESCRIPTION
This change reimplements the breaking https://github.com/OpenTSDB/opentsdb/commit/6dc59e30383d406213fdffc114d60da5592a20a5 change. See screenshots  for proof ot correctness.

Before (an actual before is a broken UI that doesn't load):
![before-aggregators](https://cloud.githubusercontent.com/assets/1587140/6224642/f22c87ac-b633-11e4-819e-7dbe0b64aae3.png)
After:
![after-aggregators](https://cloud.githubusercontent.com/assets/1587140/6224645/f5a64bde-b633-11e4-85cd-109b8147af9f.png)