### PR TITLE
Fsck: Refactor dedupe resolution logic and fix 3 accounting problems

### DIFF
--- a/src/tools/Fsck.java
+++ b/src/tools/Fsck.java
@@ -623,7 +623,6 @@ final class Fsck {
 
         unique_columns.put(dpToKeep.kv.qualifier(), dpToKeep.kv.value());
         valid_datapoints.getAndIncrement();
-        duplicates.getAndIncrement();
         has_uncorrected_value_error |= Internal.isFloat(dpToKeep.qualifier()) ?
             fsckFloat(dpToKeep) : fsckInteger(dpToKeep);
 

--- a/src/tools/Fsck.java
+++ b/src/tools/Fsck.java
@@ -83,7 +83,7 @@ final class Fsck {
   /** Options to use while iterating over rows */
   private final FsckOptions options;
   
-  /** Counters incremented during processing. They have to be atomic countsers
+  /** Counters incremented during processing. They have to be atomic counters
    * as we may be running multiple fsck threads. */
   final AtomicLong kvs_processed = new AtomicLong();
   final AtomicLong rows_processed = new AtomicLong();
@@ -592,7 +592,9 @@ final class Fsck {
         // or newest
         Collections.sort(time_map.getValue());       
         has_duplicates = true;
-        
+        // We want to keep either the first or the last incoming datapoint 
+        // and ignore delete the middle.
+
         final StringBuilder buf = new StringBuilder();
         buf.append("More than one column had a value for the same timestamp: ")
            .append("(")
@@ -600,66 +602,66 @@ final class Fsck {
            .append(")\n    row key: (")
            .append(UniqueId.uidToString(key))
            .append(")\n");
-        int index = 0;
-        DP last_dp = null;
-        for (DP dp : time_map.getValue()) {
-          buf.append("    ")
-             .append("write time: (")
-             .append(dp.kv.timestamp())
-             .append(") ")
-             .append(" compacted: (")
-             .append(dp.compacted)
-             .append(")  qualifier: ")
-             .append(Arrays.toString(dp.kv.qualifier()));
-          unique_columns.put(dp.kv.qualifier(), dp.kv.value());
-          if (options.lastWriteWins()) { 
-            if (index == time_map.getValue().size() - 1) {
-              buf.append("  <--- Keep latest");
-              valid_datapoints.getAndIncrement();
-              has_uncorrected_value_error |= Internal.isFloat(dp.qualifier()) ?
-                  fsckFloat(dp) : fsckInteger(dp);
-              if (Internal.inMilliseconds(dp.qualifier())) {
-                has_milliseconds = true;
-              } else {
-                has_seconds = true;
-              }
-            }
-            if (last_dp != null && options.fix() && options.resolveDupes()) {
-              if (!compact_row && options.fix() && options.resolveDupes() && 
-                  !last_dp.compacted) {
-                final DeleteRequest delete = new DeleteRequest(tsdb.dataTable(), 
-                    last_dp.kv.key(), last_dp.kv.family(), last_dp.qualifier());
-                tsdb.getClient().delete(delete);
-              }
-            }             
-          } else if (!options.lastWriteWins() && index == 0) {
-            buf.append("  <--- Keep oldest");
-            valid_datapoints.getAndIncrement();
-            has_uncorrected_value_error |= Internal.isFloat(dp.qualifier()) ?
-                fsckFloat(dp) : fsckInteger(dp);
-            if (Internal.inMilliseconds(dp.qualifier())) {
-              has_milliseconds = true;
-            } else {
-              has_seconds = true;
-            }
-          } else if (options.fix() && options.resolveDupes()) {
-            // don't want this dp
-            LOG.error("Delete: " + dp.kv);
-            if (!compact_row && options.fix() && options.resolveDupes() && 
-                !dp.compacted) {
-              final DeleteRequest delete = new DeleteRequest(tsdb.dataTable(), 
-                  dp.kv.key(), dp.kv.family(), dp.qualifier());
-              tsdb.getClient().delete(delete);
-            }
-          }
-          index++;
-          if (index < time_map.getValue().size()) {
-            buf.append("\n");
-          }
-          last_dp = dp;
-          duplicates.getAndIncrement();
+
+        int num_dupes = time_map.getValue().size();
+
+        final int deleteRangeStart;
+        final int deleteRangeStop;
+        final DP dpToKeep;
+        if (options.lastWriteWins()) {
+          // Save the latest datapoint from extinction.
+          deleteRangeStart = 0;
+          deleteRangeStop = num_dupes - 1;
+          dpToKeep = time_map.getValue().get(num_dupes - 1);
+        } else {
+          // Save the oldest datapoint from extinction.
+          deleteRangeStart = 1;
+          deleteRangeStop = num_dupes;
+          dpToKeep = time_map.getValue().get(0);
+          appendDatapointInfo(buf, dpToKeep, " <--- keep oldest").append("\n");
         }
-        LOG.error(buf.toString());
+
+        unique_columns.put(dpToKeep.kv.qualifier(), dpToKeep.kv.value());
+        valid_datapoints.getAndIncrement();
+        duplicates.getAndIncrement();
+        has_uncorrected_value_error |= Internal.isFloat(dpToKeep.qualifier()) ?
+            fsckFloat(dpToKeep) : fsckInteger(dpToKeep);
+
+        if (Internal.inMilliseconds(dpToKeep.qualifier())) {
+          has_milliseconds = true;
+        } else {
+          has_seconds = true;
+        }
+
+        for (int dpIndex = deleteRangeStart; dpIndex < deleteRangeStop; dpIndex++) {
+          duplicates.getAndIncrement();
+          DP dp = time_map.getValue().get(dpIndex);
+          buf.append("    ")
+          .append("write time: (")
+          .append(dp.kv.timestamp())
+          .append(") ")
+          .append(" compacted: (")
+          .append(dp.compacted)
+          .append(")  qualifier: ")
+          .append(Arrays.toString(dp.kv.qualifier()))
+          .append("\n");
+          unique_columns.put(dp.kv.qualifier(), dp.kv.value());
+          if (!compact_row && options.fix() && options.resolveDupes()) {
+            if (!dp.compacted) {
+              LOG.debug("REMOVING: " + dp.kv);
+              tsdb.getClient().delete(
+                new DeleteRequest(
+                  tsdb.dataTable(), dp.kv.key(), dp.kv.family(), dp.qualifier()
+                )
+              );
+              duplicates_fixed.getAndIncrement();
+            }
+          }
+        }
+        if (options.lastWriteWins()) {
+          appendDatapointInfo(buf, dpToKeep, " <--- keep latest").append("\n");
+        }
+        LOG.info(buf.toString());
       }
       
       // if an error was found in this row that was not marked for repair, then
@@ -944,7 +946,24 @@ final class Fsck {
       System.arraycopy(new_value, 0, compact_value, value_index, value_length);
       value_index += value_length;  
     }
-    
+    /**
+     * Appends a representation of a datapoint to a string buffer
+     * @param buf
+     * @param extraMessage
+     */
+    private StringBuilder appendDatapointInfo(StringBuilder buf, DP dp, String extraMessage) {
+      buf.append("    ")
+      .append("write time: (")
+      .append(dp.kv.timestamp())
+      .append(") ")
+      .append(" compacted: (")
+      .append(dp.compacted)
+      .append(")  qualifier: ")
+      .append(Arrays.toString(dp.kv.qualifier()))
+      .append(extraMessage);
+      return buf;
+    }
+
     /**
      * Resets the running compaction variables. This should be called AFTER a 
      * {@link fsckDataPoints()} has been run and before the next row of values

--- a/test/tools/TestFsck.java
+++ b/test/tools/TestFsck.java
@@ -3657,6 +3657,7 @@ public final class TestFsck {
     assertEquals(2, fsck.correctable());
     assertEquals(1, fsck.duplicates.get());
     assertEquals(1, fsck.bad_values.get());
+    assertEquals(0, fsck.totalFixed());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -3690,6 +3691,7 @@ public final class TestFsck {
     assertEquals(2, fsck.correctable());
     assertEquals(1, fsck.duplicates.get());
     assertEquals(1, fsck.bad_values.get());
+    assertEquals(2, fsck.totalFixed());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertNull(storage.getColumn(ROW, qual3));
@@ -3724,6 +3726,7 @@ public final class TestFsck {
     assertEquals(2, fsck.correctable());
     assertEquals(1, fsck.duplicates.get());
     assertEquals(1, fsck.bad_values.get());
+    assertEquals(2, fsck.totalFixed());
     assertArrayEquals(MockBase.concatByteArrays(val1, val4, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertNull(storage.getColumn(ROW, qual3));

--- a/test/tools/TestFsck.java
+++ b/test/tools/TestFsck.java
@@ -1898,6 +1898,7 @@ public final class TestFsck {
     assertEquals(2, fsck.duplicates.get());
     assertEquals(2, fsck.totalErrors());
     assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.totalFixed());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertNull(storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -1923,6 +1924,7 @@ public final class TestFsck {
     assertEquals(2, fsck.duplicates.get());
     assertEquals(2, fsck.totalErrors());
     assertEquals(2, fsck.correctable());
+    assertEquals(0, fsck.totalFixed());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -1950,6 +1952,7 @@ public final class TestFsck {
     assertEquals(2, fsck.duplicates.get());
     assertEquals(2, fsck.totalErrors());
     assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.totalFixed());
     assertNull(storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));

--- a/test/tools/TestFsck.java
+++ b/test/tools/TestFsck.java
@@ -1563,7 +1563,7 @@ public final class TestFsck {
   @Test
   public void integerVle1ByteNegativeFix() throws Exception {
     when(options.fix()).thenReturn(true);
-    
+
     final byte[] qual1 = { 0x00, 0x00 };
     final byte[] val1 = new byte[] { 1 };
     final byte[] qual2 = { 0x00, 0x27 };
@@ -1869,9 +1869,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -1895,9 +1895,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertEquals(1, fsck.totalFixed());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertNull(storage.getColumn(ROW, qual2));
@@ -1921,9 +1921,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertEquals(0, fsck.totalFixed());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
@@ -1949,9 +1949,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertEquals(1, fsck.totalFixed());
     assertNull(storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
@@ -1979,9 +1979,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(5, fsck.kvs_processed.get());
-    assertEquals(4, fsck.duplicates.get());
-    assertEquals(4, fsck.totalErrors());
-    assertEquals(4, fsck.correctable());
+    assertEquals(3, fsck.duplicates.get());
+    assertEquals(3, fsck.totalErrors());
+    assertEquals(3, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -2013,9 +2013,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(5, fsck.kvs_processed.get());
-    assertEquals(4, fsck.duplicates.get());
-    assertEquals(4, fsck.totalErrors());
-    assertEquals(4, fsck.correctable());
+    assertEquals(3, fsck.duplicates.get());
+    assertEquals(3, fsck.totalErrors());
+    assertEquals(3, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertNull(storage.getColumn(ROW, qual2));
     assertNull(storage.getColumn(ROW, qual3));
@@ -2046,9 +2046,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(5, fsck.kvs_processed.get());
-    assertEquals(4, fsck.duplicates.get());
-    assertEquals(4, fsck.totalErrors());
-    assertEquals(4, fsck.correctable());
+    assertEquals(3, fsck.duplicates.get());
+    assertEquals(3, fsck.totalErrors());
+    assertEquals(3, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -2081,9 +2081,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(5, fsck.kvs_processed.get());
-    assertEquals(4, fsck.duplicates.get());
-    assertEquals(4, fsck.totalErrors());
-    assertEquals(4, fsck.correctable());
+    assertEquals(3, fsck.duplicates.get());
+    assertEquals(3, fsck.totalErrors());
+    assertEquals(3, fsck.correctable());
     assertNull(storage.getColumn(ROW, qual1));
     assertNull(storage.getColumn(ROW, qual2));
     assertNull(storage.getColumn(ROW, qual3));
@@ -2106,9 +2106,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -2132,9 +2132,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertNull(storage.getColumn(ROW, qual3));
@@ -2157,9 +2157,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -2184,9 +2184,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertNull(storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -2213,9 +2213,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(5, fsck.kvs_processed.get());
-    assertEquals(3, fsck.duplicates.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
+    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -2247,9 +2247,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(5, fsck.kvs_processed.get());
-    assertEquals(3, fsck.duplicates.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
+    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertNull(storage.getColumn(ROW, qual3));
@@ -2280,9 +2280,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(5, fsck.kvs_processed.get());
-    assertEquals(3, fsck.duplicates.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
+    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -2315,9 +2315,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(5, fsck.kvs_processed.get());
-    assertEquals(3, fsck.duplicates.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
+    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertNull(storage.getColumn(ROW, qual2));
     assertNull(storage.getColumn(ROW, qual3));
@@ -2340,9 +2340,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -2366,9 +2366,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertNull(storage.getColumn(ROW, qual3));
@@ -2391,9 +2391,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -2418,9 +2418,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertNull(storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -2449,9 +2449,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertArrayEquals(MockBase.concatByteArrays(val3, val4, new byte[] { 0 }), 
@@ -2480,9 +2480,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertNull(storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertNull(storage.getColumn(ROW, MockBase.concatByteArrays(qual3, qual4)));
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val4, 
@@ -2512,9 +2512,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertArrayEquals(MockBase.concatByteArrays(val3, val4, new byte[] { 0 }), 
@@ -2545,9 +2545,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertNull(storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertNull(storage.getColumn(ROW, MockBase.concatByteArrays(qual3, qual4)));
     assertArrayEquals(MockBase.concatByteArrays(val1, val3, val4, 
@@ -2575,9 +2575,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertArrayEquals(MockBase.concatByteArrays(val3, val4, new byte[] { 0 }), 
@@ -2607,9 +2607,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertNull(storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertNull(storage.getColumn(ROW, MockBase.concatByteArrays(qual3, qual4)));
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val4, new byte[] { 0 }), 
@@ -2638,9 +2638,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertArrayEquals(MockBase.concatByteArrays(val3, val4, new byte[] { 0 }), 
@@ -2671,9 +2671,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertNull(storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertNull(storage.getColumn(ROW, MockBase.concatByteArrays(qual3, qual4)));
     assertArrayEquals(MockBase.concatByteArrays(val1, val3, val4, new byte[] { 0 }), 
@@ -2704,9 +2704,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(3, fsck.duplicates.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
+    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertArrayEquals(MockBase.concatByteArrays(val3, val4, new byte[] { 0 }), 
@@ -2740,9 +2740,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(3, fsck.duplicates.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
+    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val4, 
         new byte[] { 0 }), storage.getColumn(ROW, 
             MockBase.concatByteArrays(qual1, qual2, qual4)));
@@ -2777,9 +2777,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(3, fsck.duplicates.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
+    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertArrayEquals(MockBase.concatByteArrays(val3, val4, new byte[] { 0 }), 
@@ -2814,9 +2814,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(3, fsck.duplicates.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
+    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val5, val4, 
         new byte[] { 0 }), storage.getColumn(ROW, 
             MockBase.concatByteArrays(qual1, qual5, qual4)));
@@ -2842,9 +2842,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val3, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2, qual3)));
     assertArrayEquals(val4, storage.getColumn(ROW, qual4));
@@ -2870,9 +2870,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val3, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2, qual3)));
     assertNull(storage.getColumn(ROW, qual4));
@@ -2898,9 +2898,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val3, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2, qual3)));
     assertArrayEquals(val4, storage.getColumn(ROW, qual4));
@@ -2927,9 +2927,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val4, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2, qual4)));
     assertNull(storage.getColumn(ROW, qual3));
@@ -2953,9 +2953,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val3, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2, qual3)));
     assertArrayEquals(val4, storage.getColumn(ROW, qual4));
@@ -2982,9 +2982,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val3, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2, qual3)));
     assertNull(storage.getColumn(ROW, qual4));
@@ -3010,9 +3010,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val3, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2, qual3)));
     assertArrayEquals(val4, storage.getColumn(ROW, qual4));
@@ -3040,9 +3040,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val4, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2, qual4)));
     assertNull(storage.getColumn(ROW, qual4));
@@ -3065,9 +3065,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val3, new byte[] { 1 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2, qual3)));
     assertArrayEquals(val4, storage.getColumn(ROW, qual4));
@@ -3093,9 +3093,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val3, new byte[] {1 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2, qual3)));
     assertNull(storage.getColumn(ROW, qual4));
@@ -3119,9 +3119,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val3, new byte[] { 1 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2, qual3)));
     assertArrayEquals(val4, storage.getColumn(ROW, qual4));
@@ -3148,9 +3148,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(2, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val4, val3, new byte[] {1 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual4, qual3)));
     assertNull(storage.getColumn(ROW, qual4));
@@ -3184,9 +3184,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(3, fsck.duplicates.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
+    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertArrayEquals(MockBase.concatByteArrays(val3, val4, new byte[] { 0 }), 
@@ -3225,9 +3225,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(3, fsck.duplicates.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
+    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, val4, val6, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2, qual4, qual6)));
     assertNull(storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
@@ -3264,9 +3264,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(3, fsck.duplicates.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
+    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
     assertArrayEquals(MockBase.concatByteArrays(val3, val4, new byte[] { 0 }), 
@@ -3306,9 +3306,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(3, fsck.duplicates.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
+    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
     assertArrayEquals(MockBase.concatByteArrays(val1, val5, val4, val6, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual5, qual4, qual6)));
     assertNull(storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
@@ -3339,9 +3339,9 @@ public final class TestFsck {
     fsck.runFullTable();
     storage.dumpToSystemOut();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertArrayEquals(val1, storage.getColumn(ROW, qual1));
     assertArrayEquals(val2, storage.getColumn(ROW, qual2));
     assertArrayEquals(val3, storage.getColumn(ROW, qual3));
@@ -3366,9 +3366,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(2, fsck.duplicates.get());
-    assertEquals(2, fsck.totalErrors());
-    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
+    assertEquals(1, fsck.totalErrors());
+    assertEquals(1, fsck.correctable());
     assertNull(storage.getColumn(ROW, qual1));
     assertNull(storage.getColumn(ROW, qual2));
     assertNull(storage.getColumn(ROW, qual3));
@@ -3586,9 +3586,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
-    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
     assertEquals(1, fsck.bad_values.get());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
@@ -3619,9 +3619,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
-    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
     assertEquals(1, fsck.bad_values.get());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
@@ -3653,9 +3653,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
-    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
     assertEquals(1, fsck.bad_values.get());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
@@ -3686,9 +3686,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
-    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
     assertEquals(1, fsck.bad_values.get());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));
@@ -3720,9 +3720,9 @@ public final class TestFsck {
     final Fsck fsck = new Fsck(tsdb, options);
     fsck.runFullTable();
     assertEquals(3, fsck.kvs_processed.get());
-    assertEquals(3, fsck.totalErrors());
-    assertEquals(3, fsck.correctable());
-    assertEquals(2, fsck.duplicates.get());
+    assertEquals(2, fsck.totalErrors());
+    assertEquals(2, fsck.correctable());
+    assertEquals(1, fsck.duplicates.get());
     assertEquals(1, fsck.bad_values.get());
     assertArrayEquals(MockBase.concatByteArrays(val1, val4, new byte[] { 0 }), 
         storage.getColumn(ROW, MockBase.concatByteArrays(qual1, qual2)));


### PR DESCRIPTION
This change fixes two problems with accounting in fsck. Suppose you're dealing with duplicate datapoints:
```
oozie@number5:~$ cat dupe
put mymetric 1424417830 1 host=thursday
put mymetric 1424417830 2.0 host=thursday  
oozie@number5:~$ cat dupe | nc localhost 4242
```
a) fsck forgets to increment its fixed counter 
```
# /usr/share/opentsdb/bin/tsdb fsck 1 sum mymetric --fix-all
[...]
2015-02-20 01:35:40,107 INFO  [main] Fsck: Bytes Saved with VLE: 0
2015-02-20 01:35:40,107 INFO  [main] Fsck: Total Errors: 2
2015-02-20 01:35:40,107 INFO  [main] Fsck: Total Correctable Errors: 2
2015-02-20 01:35:40,107 INFO  [main] Fsck: Total Errors Fixed: 0        <--- Actually fixed, but counter not incremented 
2015-02-20 01:35:40,107 INFO  [main] Fsck: Completed fsck in [0] seconds
[...]
```
Added assertions for `totalFixed()` in some tests to cover this.

b) When two datapoints are recorded with the same timestamp, only one of them should be recorded as problematic - the other one is a legit data point and should not be counted as an error. Otherwise, there will be a discrepancy between Total Errors (2) and Errors Fixed (1). The new output sets both to 1, eliminating any confusion that could arise.
```
# /usr/share/opentsdb/bin/tsdb fsck 1 sum mymetric --fix-all
[...]
2015-02-20 01:40:44,899 INFO  [main] Fsck: Bytes Saved with VLE: 0
2015-02-20 01:40:44,899 INFO  [main] Fsck: Total Errors: 1
2015-02-20 01:40:44,900 INFO  [main] Fsck: Total Correctable Errors: 1
2015-02-20 01:40:44,900 INFO  [main] Fsck: Total Errors Fixed: 1
2015-02-20 01:40:44,900 INFO  [main] Fsck: Completed fsck in [0] seconds
[...]
```