### PR TITLE
Only remove config files if uninstalling last copy

### DIFF
--- a/opentsdb.spec.in
+++ b/opentsdb.spec.in
@@ -81,13 +81,18 @@ rm -rf %{buildroot}
 
 %post
 
-ln -s %{_datarootdir}/opentsdb/etc/opentsdb /etc/opentsdb
-ln -s %{_datarootdir}/opentsdb/etc/init.d/opentsdb /etc/init.d/opentsdb
+if [ $1 -eq 1 ]; then
+  # we're installing the first version of this package
+  ln -s %{_datarootdir}/opentsdb/etc/opentsdb /etc/opentsdb
+  ln -s %{_datarootdir}/opentsdb/etc/init.d/opentsdb /etc/init.d/opentsdb
+fi
 exit 0
 
 %postun
 
-rm -rf /etc/opentsdb
-rm -rf /etc/init.d/opentsdb
-
+if [ $1 -eq 0 ]; then
+  # we're removing last version of this package
+  rm -rf /etc/opentsdb
+  rm -rf /etc/init.d/opentsdb
+fi
 exit 0


### PR DESCRIPTION
The RPM post and postun scripts have weird behaviour when you're
upgrading. We should check the first argument to each script, to detect
if this is a fresh install, ugprade, or uninstall. See
http://www.rpm.org/max-rpm/s1-rpm-inside-scripts.html for an
explanation.