### PR TITLE
Fix for #412 insufficient tag validation + improved TestTSDB

### DIFF
--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -659,7 +659,6 @@ public final class TSDB {
           + " when trying to add value=" + Arrays.toString(value) + '/' + flags
           + " to metric=" + metric + ", tags=" + tags);
     }
-
     IncomingDataPoints.checkMetricAndTags(metric, tags);
     final byte[] row = IncomingDataPoints.rowKeyTemplate(this, metric, tags);
     final long base_time;

--- a/src/core/Tags.java
+++ b/src/core/Tags.java
@@ -401,6 +401,8 @@ public final class Tags {
   public static void validateString(final String what, final String s) {
     if (s == null) {
       throw new IllegalArgumentException("Invalid " + what + ": null");
+    } else if ("".equals(s)) {
+      throw new IllegalArgumentException("Invalid " + what + ": empty string");
     }
     final int n = s.length();
     for (int i = 0; i < n; i++) {


### PR DESCRIPTION
This change fixes the problem reported by @mburger in the related issue. Refactored TestTSDB to eliminate static mocks on `IncomingDataPoints.class` and enable more in-depth testing.
Before:
```
oozie@number5:~$ wget http://number5:4242/api/put --post-file=badpost
--2015-02-24 02:40:47--  http://number5:4242/api/put
Resolving number5 (number5)... 192.168.1.67
Connecting to number5 (number5)|192.168.1.67|:4242... connected.
HTTP request sent, awaiting response... 500 Internal Server Error
2015-02-24 02:40:48 ERROR 500: Internal Server Error.

oozie@number5:~$ 

02:40:48.295 ERROR [HttpQuery.logError] - [id: 0xadb5925a, /192.168.1.67:58344 => /192.168.1.67:4242] Internal Server Error on /api/put
java.lang.RuntimeException: Should never be here
        at net.opentsdb.uid.UniqueId.getOrCreateId(UniqueId.java:607) ~[tsdb-2.1.0RC1.jar:164b055]
        at net.opentsdb.core.Tags.resolveAllInternal(Tags.java:461) ~[tsdb-2.1.0RC1.jar:164b055]
[...]
```
After:
```
oozie@number5:~$ wget http://number5:4242/api/put --post-file=badpost
--2015-02-24 02:43:32--  http://number5:4242/api/put
Resolving number5 (number5)... 192.168.1.67
Connecting to number5 (number5)|192.168.1.67|:4242... connected.
HTTP request sent, awaiting response... 400 Bad Request
2015-02-24 02:43:33 ERROR 400: Bad Request.

oozie@number5:~$ 

02:43:33.580 WARN  [PutDataPointRpc.execute] - Invalid tag value: empty string: metric=bad_host_metric ts=1424660260 value=1111 host=
02:43:33.581 WARN  [HttpQuery.logWarn] - [id: 0x10e8d50b, /192.168.1.67:58378 => /192.168.1.67:4242] Bad Request on /api/put: One or more data points had errors

```