### PR TITLE
Fixing #408 a flaky test with ClassLoader voodoo.

### DIFF
--- a/test/tsd/TestGraphHandler.java
+++ b/test/tsd/TestGraphHandler.java
@@ -16,6 +16,7 @@ import java.io.File;
 
 import org.jboss.netty.channel.Channel;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import static org.junit.Assert.assertFalse;
@@ -39,6 +40,13 @@ import static org.powermock.api.mockito.PowerMockito.mock;
                   "com.sum.*", "org.xml.*"})
 @PrepareForTest({ GraphHandler.class, HttpQuery.class })
 public final class TestGraphHandler {
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    // This is pure voodoo. It ensures the GraphHelper is initialized on time
+    // for all other tests.
+    staleCacheFile(null, 0, 10, fakeFile("voodoo"));
+  }
 
   @Test  // If the file doesn't exist, we don't use it, obviously.
   public void staleCacheFileDoesntExist() throws Exception {


### PR DESCRIPTION
In comedy timing is everything.

To test this, make sure the moon is in full phase and run:
```
$ for i in $(seq 100); do make check test_SRC=test/tsd/TestGraphHandler.java | egrep "OK|FAILURES"; done | sort | uniq -c 
```
Before:
```
     21 FAILURES!!!
     79 OK (6 tests)
```
After:
```
    100 OK (6 tests)

```