### PR TITLE
Address #396 to alleviate the recurring cachedir removal problem

### DIFF
--- a/src/core/Const.java
+++ b/src/core/Const.java
@@ -74,4 +74,11 @@ public final class Const {
    * before losing precision.
    */
   public static final long MAX_INT_IN_DOUBLE = 0xFFE0000000000000L;
+
+  /**
+   * Mnemonics for Plot.checkDirectory()
+   */
+  public static final boolean DONT_CREATE = false;
+  public static final boolean CREATE_IF_NEEDED = true;
+  public static final boolean MUST_BE_WRITEABLE = true;
 }

--- a/src/core/Const.java
+++ b/src/core/Const.java
@@ -76,7 +76,7 @@ public final class Const {
   public static final long MAX_INT_IN_DOUBLE = 0xFFE0000000000000L;
 
   /**
-   * Mnemonics for Plot.checkDirectory()
+   * Mnemonics for FileSystem.checkDirectory()
    */
   public static final boolean DONT_CREATE = false;
   public static final boolean CREATE_IF_NEEDED = true;

--- a/src/graph/Plot.java
+++ b/src/graph/Plot.java
@@ -28,6 +28,7 @@ import net.opentsdb.core.Const;
 import net.opentsdb.core.DataPoint;
 import net.opentsdb.core.DataPoints;
 import net.opentsdb.meta.Annotation;
+import net.opentsdb.utils.FileSystem;
 
 /**
  * Produces files to generate graphs with Gnuplot.
@@ -196,7 +197,7 @@ public final class Plot {
     int npoints = 0;
     final int nseries = datapoints.size();
     final String datafiles[] = nseries > 0 ? new String[nseries] : null;
-    checkDirectory(new File(basepath).getParent(),
+    FileSystem.checkDirectory(new File(basepath).getParent(),
         Const.MUST_BE_WRITEABLE, Const.CREATE_IF_NEEDED);
     for (int i = 0; i < nseries; i++) {
       datafiles[i] = basepath + "_" + i + ".dat";
@@ -395,32 +396,6 @@ public final class Plot {
       return "%b %d";
     } else {
       return "%Y/%m/%d";
-    }
-  }
-
-  /**
-   * Verifies a directory and checks to see if it's writeable or not if
-   * configured
-   * @param dir The path to check on
-   * @param need_write Set to true if the path needs write access
-   * @param create Set to true if the directory should be created if it does not
-   *          exist
-   * @throws IllegalArgumentException if the path is empty, if it's not there
-   *           and told not to create it or if it needs write access and can't
-   *           be written to
-   */
-  public static void checkDirectory(final String dir,
-      final boolean need_write, final boolean create) {
-    if (dir.isEmpty())
-      throw new IllegalArgumentException("Directory path is empty");
-    final File f = new File(dir);
-    if (!f.exists() && !(create && f.mkdirs())) {
-      throw new IllegalArgumentException("No such directory [" + dir + "]");
-    } else if (!f.isDirectory()) {
-      throw new IllegalArgumentException("Not a directory [" + dir + "]");
-    } else if (need_write && !f.canWrite()) {
-      throw new IllegalArgumentException("Cannot write to directory [" + dir
-          + "]");
     }
   }
 }

--- a/src/graph/Plot.java
+++ b/src/graph/Plot.java
@@ -12,6 +12,7 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.graph;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -23,6 +24,7 @@ import java.util.TimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.opentsdb.core.Const;
 import net.opentsdb.core.DataPoint;
 import net.opentsdb.core.DataPoints;
 import net.opentsdb.meta.Annotation;
@@ -194,6 +196,8 @@ public final class Plot {
     int npoints = 0;
     final int nseries = datapoints.size();
     final String datafiles[] = nseries > 0 ? new String[nseries] : null;
+    checkDirectory(new File(basepath).getParent(),
+        Const.MUST_BE_WRITEABLE, Const.CREATE_IF_NEEDED);
     for (int i = 0; i < nseries; i++) {
       datafiles[i] = basepath + "_" + i + ".dat";
       final PrintWriter datafile = new PrintWriter(datafiles[i]);
@@ -393,5 +397,29 @@ public final class Plot {
       return "%Y/%m/%d";
     }
   }
-
+  /**
+   * Verifies a directory and checks to see if it's writeable or not if
+   * configured
+   * @param dir The path to check on
+   * @param need_write Set to true if the path needs write access
+   * @param create Set to true if the directory should be created if it does not
+   *          exist
+   * @throws IllegalArgumentException if the path is empty, if it's not there
+   *           and told not to create it or if it needs write access and can't
+   *           be written to
+   */
+  public static void checkDirectory(final String dir,
+      final boolean need_write, final boolean create) {
+    if (dir.isEmpty())
+      throw new IllegalArgumentException("Directory path is empty");
+    final File f = new File(dir);
+    if (!f.exists() && !(create && f.mkdirs())) {
+      throw new IllegalArgumentException("No such directory [" + dir + "]");
+    } else if (!f.isDirectory()) {
+      throw new IllegalArgumentException("Not a directory [" + dir + "]");
+    } else if (need_write && !f.canWrite()) {
+      throw new IllegalArgumentException("Cannot write to directory [" + dir
+          + "]");
+    }
+  }
 }

--- a/src/graph/Plot.java
+++ b/src/graph/Plot.java
@@ -397,6 +397,7 @@ public final class Plot {
       return "%Y/%m/%d";
     }
   }
+
   /**
    * Verifies a directory and checks to see if it's writeable or not if
    * configured

--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -22,7 +22,6 @@ import org.jboss.netty.channel.socket.ServerSocketChannelFactory;
 import org.jboss.netty.channel.socket.oio.OioServerSocketChannelFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 
@@ -31,6 +30,7 @@ import net.opentsdb.core.TSDB;
 import net.opentsdb.core.Const;
 import net.opentsdb.tsd.PipelineFactory;
 import net.opentsdb.utils.Config;
+import net.opentsdb.utils.FileSystem;
 import net.opentsdb.graph.Plot;
 /**
  * Main class of the TSD, the Time Series Daemon.
@@ -110,9 +110,9 @@ final class TSDMain {
 
     // validate the cache and staticroot directories
     try {
-      Plot.checkDirectory(config.getString("tsd.http.staticroot"), 
+      FileSystem.checkDirectory(config.getString("tsd.http.staticroot"), 
           !Const.MUST_BE_WRITEABLE, Const.DONT_CREATE);
-      Plot.checkDirectory(config.getString("tsd.http.cachedir"),
+      FileSystem.checkDirectory(config.getString("tsd.http.cachedir"),
           Const.MUST_BE_WRITEABLE, Const.CREATE_IF_NEEDED);
     } catch (IllegalArgumentException e) {
       usage(argp, e.getMessage(), 3);

--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -28,9 +28,10 @@ import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 
 import net.opentsdb.BuildData;
 import net.opentsdb.core.TSDB;
+import net.opentsdb.core.Const;
 import net.opentsdb.tsd.PipelineFactory;
 import net.opentsdb.utils.Config;
-
+import net.opentsdb.graph.Plot;
 /**
  * Main class of the TSD, the Time Series Daemon.
  */
@@ -49,9 +50,6 @@ final class TSDMain {
   }
 
   private static final short DEFAULT_FLUSH_INTERVAL = 1000;
-  private static final boolean DONT_CREATE = false;
-  private static final boolean CREATE_IF_NEEDED = true;
-  private static final boolean MUST_BE_WRITEABLE = true;
 
   public static void main(String[] args) throws IOException {
     Logger log = LoggerFactory.getLogger(TSDMain.class);
@@ -112,10 +110,10 @@ final class TSDMain {
 
     // validate the cache and staticroot directories
     try {
-      checkDirectory(config.getString("tsd.http.staticroot"), 
-          !MUST_BE_WRITEABLE, DONT_CREATE);
-      checkDirectory(config.getString("tsd.http.cachedir"),
-          MUST_BE_WRITEABLE, CREATE_IF_NEEDED);
+      Plot.checkDirectory(config.getString("tsd.http.staticroot"), 
+          !Const.MUST_BE_WRITEABLE, Const.DONT_CREATE);
+      Plot.checkDirectory(config.getString("tsd.http.cachedir"),
+          Const.MUST_BE_WRITEABLE, Const.CREATE_IF_NEEDED);
     } catch (IllegalArgumentException e) {
       usage(argp, e.getMessage(), 3);
     }
@@ -199,31 +197,5 @@ final class TSDMain {
       }
     }
     Runtime.getRuntime().addShutdownHook(new TSDBShutdown());
-  }
-
-  /**
-   * Verifies a directory and checks to see if it's writeable or not if
-   * configured
-   * @param dir The path to check on
-   * @param need_write Set to true if the path needs write access
-   * @param create Set to true if the directory should be created if it does not
-   *          exist
-   * @throws IllegalArgumentException if the path is empty, if it's not there
-   *           and told not to create it or if it needs write access and can't
-   *           be written to
-   */
-  private static void checkDirectory(final String dir,
-      final boolean need_write, final boolean create) {
-    if (dir.isEmpty())
-      throw new IllegalArgumentException("Directory path is empty");
-    final File f = new File(dir);
-    if (!f.exists() && !(create && f.mkdirs())) {
-      throw new IllegalArgumentException("No such directory [" + dir + "]");
-    } else if (!f.isDirectory()) {
-      throw new IllegalArgumentException("Not a directory [" + dir + "]");
-    } else if (need_write && !f.canWrite()) {
-      throw new IllegalArgumentException("Cannot write to directory [" + dir
-          + "]");
-    }
   }
 }

--- a/src/utils/FileSystem.java
+++ b/src/utils/FileSystem.java
@@ -1,0 +1,43 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2015  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.utils;
+
+import java.io.File;
+
+public class FileSystem {
+  /**
+   * Verifies a directory and checks to see if it's writeable or not if
+   * configured
+   * @param dir The path to check on
+   * @param need_write Set to true if the path needs write access
+   * @param create Set to true if the directory should be created if it does not
+   *          exist
+   * @throws IllegalArgumentException if the path is empty, if it's not there
+   *           and told not to create it or if it needs write access and can't
+   *           be written to
+   */
+  public static void checkDirectory(final String dir,
+      final boolean need_write, final boolean create) {
+    if (dir.isEmpty())
+      throw new IllegalArgumentException("Directory path is empty");
+    final File f = new File(dir);
+    if (!f.exists() && !(create && f.mkdirs())) {
+      throw new IllegalArgumentException("No such directory [" + dir + "]");
+    } else if (!f.isDirectory()) {
+      throw new IllegalArgumentException("Not a directory [" + dir + "]");
+    } else if (need_write && !f.canWrite()) {
+      throw new IllegalArgumentException("Cannot write to directory [" + dir
+          + "]");
+    }
+  }
+}

--- a/test/graph/TestPlot.java
+++ b/test/graph/TestPlot.java
@@ -1,0 +1,97 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2011-2012  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.graph;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PrintWriter.class, File.class, Plot.class})
+public final class TestPlot {
+
+  Plot plot;
+  File mockFile;
+  @Before
+  public void setUp() throws Exception {
+    plot = new Plot(0, 1234567890, null);
+    Map<String, String> params = new HashMap<String, String>();
+    plot.setParams(params);
+    
+    PrintWriter mockWriter = PowerMockito.mock(PrintWriter.class);
+    PowerMockito.whenNew(PrintWriter.class)
+      .withAnyArguments()
+      .thenReturn(mockWriter);
+    
+    // Mock the builder pattern for PrintWriter instances.
+    PowerMockito.when(mockWriter, "append", Mockito.anyString()).thenReturn(mockWriter);
+    PowerMockito.when(mockWriter, "append", Mockito.anyChar()).thenReturn(mockWriter);
+  
+    mockFile = PowerMockito.mock(File.class);
+    PowerMockito.whenNew(File.class).withAnyArguments().thenReturn(mockFile);
+    PowerMockito.when(mockFile, "getParent").thenReturn("/temp/opentsdb");
+    PowerMockito.when(mockFile, "exists").thenReturn(true);
+    PowerMockito.when(mockFile, "isDirectory").thenReturn(true);
+    PowerMockito.when(mockFile, "canWrite").thenReturn(true);
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void checkDirectoryEmptyString() throws Exception {
+    Plot.checkDirectory("", true, false);
+  }
+
+  @Test
+  public void dumpToFilesDirectoryExistsIsWritable() throws Exception {
+    plot.dumpToFiles("/temp/opentsdb/s0M3haSh");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void dumpToFilesDirectoryExistsNotWritable() throws Exception {
+    PowerMockito.when(mockFile, "canWrite").thenReturn(false);
+    plot.dumpToFiles("/temp/opentsdb/s0M3haSh");
+  }
+
+  @Test
+  public void dumpToFilesCreateNonexistentDirectory() throws Exception {
+    PowerMockito.when(mockFile, "exists").thenReturn(false);
+    PowerMockito.when(mockFile, "mkdirs").thenReturn(true);
+    plot.dumpToFiles("/temp/opentsdb/s0M3haSh");
+    verify(mockFile, times(1)).mkdirs();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void dumpToFilesCreateNonexistentDirectoryFail() throws Exception {
+    PowerMockito.when(mockFile, "exists").thenReturn(false);
+    PowerMockito.when(mockFile, "mkdirs").thenReturn(false);
+    plot.dumpToFiles("/temp/opentsdb/s0M3haSh");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void dumpToFilesNotADirectory() throws Exception {
+    PowerMockito.when(mockFile, "exists").thenReturn(true);
+    PowerMockito.when(mockFile, "isDirectory").thenReturn(false);
+    plot.dumpToFiles("/temp/opentsdb/s0M3haSh");
+  }
+}

--- a/test/graph/TestPlot.java
+++ b/test/graph/TestPlot.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2011-2012  The OpenTSDB Authors.
+// Copyright (C) 2011-2015  The OpenTSDB Authors.
 //
 // This program is free software: you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License as published by

--- a/test/graph/TestPlot.java
+++ b/test/graph/TestPlot.java
@@ -17,6 +17,8 @@ import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
 
+import net.opentsdb.utils.FileSystem;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +31,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({PrintWriter.class, File.class, Plot.class})
+@PrepareForTest({PrintWriter.class, File.class, FileSystem.class, Plot.class})
 public final class TestPlot {
 
   Plot plot;
@@ -55,11 +57,6 @@ public final class TestPlot {
     PowerMockito.when(mockFile, "exists").thenReturn(true);
     PowerMockito.when(mockFile, "isDirectory").thenReturn(true);
     PowerMockito.when(mockFile, "canWrite").thenReturn(true);
-  }
-
-  @Test (expected = IllegalArgumentException.class)
-  public void checkDirectoryEmptyString() throws Exception {
-    Plot.checkDirectory("", true, false);
   }
 
   @Test

--- a/test/utils/TestFileSystem.java
+++ b/test/utils/TestFileSystem.java
@@ -1,0 +1,46 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2013-2014  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.utils;
+
+import java.io.File;
+
+import net.opentsdb.utils.FileSystem;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({File.class, FileSystem.class})
+public final class TestFileSystem {
+
+  File mockFile;
+  
+  @Before
+  public void setUp() throws Exception {  
+    mockFile = PowerMockito.mock(File.class);
+    PowerMockito.whenNew(File.class).withAnyArguments().thenReturn(mockFile);
+    PowerMockito.when(mockFile, "getParent").thenReturn("/temp/opentsdb");
+    PowerMockito.when(mockFile, "exists").thenReturn(true);
+    PowerMockito.when(mockFile, "isDirectory").thenReturn(true);
+    PowerMockito.when(mockFile, "canWrite").thenReturn(true);
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void checkDirectoryEmptyString() throws Exception {
+    FileSystem.checkDirectory("", true, false);
+  }
+}


### PR DESCRIPTION
To reproduce:
* pull up a graph in TSD,
* `rm -fr /tmp/opentsdb`
* go back to the browser, press `F5`

With this change, the graph will load after `F5` is pressed.