### PR TITLE
Added examples for retrying to write a datapoint in the errback

### DIFF
--- a/src/examples/RetryAddPointExample.java
+++ b/src/examples/RetryAddPointExample.java
@@ -1,0 +1,82 @@
+package net.opentsdb.examples;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.core.WritableDataPoints;
+import net.opentsdb.utils.Config;
+
+import com.stumbleupon.async.Deferred;
+
+public class RetryAddPointExample {
+	private static String pathToConfigFile;
+
+	public static void processArgs(String[] args) {
+		/*
+		 * Set these as arguments so you don't have to keep path information in source files
+		 */
+		if (args.length == 0) {
+			System.err
+					.println("First (and only) argument must be the full path to the opentsdb.conf file. (e.g. /User/thisUser/opentsdb/src/opentsdb.conf");
+			System.exit(1);
+		} else {
+			pathToConfigFile = args[0];
+		}
+	}
+
+	public static void main(String[] args) throws Exception {
+
+		processArgs(args);
+
+		/*
+		 * Create a config object with a path to the file for parsing. Or
+		 * manually override settings. e.g.
+		 * config.overrideConfig("tsd.storage.hbase.zk_quorum", "localhost");
+		 */
+		Config config = new Config(pathToConfigFile);
+		final TSDB tsdb = new TSDB(config);
+
+		// Declare new metric
+		String metricName = "dummyFromjavaAPI";
+
+		long initValue = 314159;
+		Map<String, String> tags = new HashMap<String, String>(1);
+		tags.put("dummy-key", "dummy-val1");
+
+		TimeSeriesManager tsm = new TimeSeriesManager(tsdb, false, (short) 50);
+
+		// Start timer
+		long startTime1 = System.currentTimeMillis();
+
+		int m = 10;
+		int n = 1000;
+
+		ArrayList<Deferred<Object>> deferreds = new ArrayList<Deferred<Object>>(n * m);
+		for (int j = 0; j < m; j++) {
+			System.out.println("Saving set: " + j);
+			for (int i = 0; i < n; i++) {
+				long timestamp = System.currentTimeMillis();
+				Deferred<Object> deferred = tsm.addPoint(metricName, tags, timestamp, initValue + i);
+				deferreds.add(deferred);
+			}
+		}
+		
+		System.out.println("Waiting for deferred result to return...");
+		if (deferreds.size() > 1) {
+			Deferred.groupInOrder(deferreds).join();
+		} else {
+			deferreds.get(0).join();
+		}
+
+		// End timer.
+		long elapsedTime1 = System.currentTimeMillis() - startTime1;
+		System.out.println("\nAdding " + n * m + " points took: " + elapsedTime1 + " milliseconds.\n");
+
+		// Gracefully shutdown connection to TSDB
+		tsdb.shutdown();
+
+	}
+
+}

--- a/src/examples/RetryErrBack.java
+++ b/src/examples/RetryErrBack.java
@@ -1,0 +1,63 @@
+package net.opentsdb.examples;
+
+import java.io.IOException;
+
+import net.opentsdb.core.WritableDataPoints;
+
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+
+/**
+ * An ErrBack specifically made for the case when we want to retry an addPoint() call when an Exception is returned to
+ * the Deferred result.  This implementation requires a maxNumRetries input.  If the call to addPoint fails after this 
+ * many attempts, we will give up, finally returning an IOException.  This is likely to happen when the connection to 
+ * HBase is lost. 
+ *
+ */
+public class RetryErrBack implements Callback<Deferred<Object>, Exception> {
+
+	private final WritableDataPoints wdp;
+	private final long timestamp;
+	private final long value;
+	private final int maxNumRetries;
+	private int numRetries;
+	
+	
+	
+	/**
+	 * @param wdp
+	 * @param timestamp
+	 * @param value
+	 * @param maxNumRetries
+	 * @param numRetries
+	 */
+	public RetryErrBack(WritableDataPoints wdp, long timestamp, long value, int maxNumRetries, int numRetries) {
+		this.wdp = wdp;
+		this.timestamp = timestamp;
+		this.value = value;
+		this.maxNumRetries = maxNumRetries;
+		this.numRetries = numRetries;
+	}
+
+
+
+	@Override
+	public Deferred<Object> call(Exception e) throws Exception {
+		Deferred<Object> def;
+		if (numRetries < maxNumRetries) {
+			System.err.println("Retrying addPoint because Deferred returned an exception!!");
+			numRetries++;
+			try {
+				Thread.sleep(1 * 1000); // in millis
+			} catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+			}
+			def = wdp.addPoint(timestamp, value);
+			def.addErrback(new RetryErrBack(wdp, timestamp, value, maxNumRetries, numRetries));
+		} else {
+			def = Deferred.fromError(new IOException("addPoint for datum: timestamp=" + timestamp + ", value=" + value 
+					+ " failed after " + maxNumRetries + " attempts."));
+		}
+		return def;
+	}
+}

--- a/src/examples/TimeSeriesManager.java
+++ b/src/examples/TimeSeriesManager.java
@@ -1,0 +1,121 @@
+package net.opentsdb.examples;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.core.WritableDataPoints;
+
+
+/**
+ * A class to manage writing multiple data points to one or more timeseries.  This is specifically for the case when
+ * we may try to write two data to the same timeseries at the same time (in ms).  Rather than writing over the first
+ * point though, what we'd like is to "bump" the second point later (in time) by 1 ms.  That way, it will be as close
+ * as possible to its correct time, but we won't lose the point that was written first.
+ * More explicitly, if we recieve two data, d1, and d2 both at time=t1.  Then d1 will be written to t1 and d2 will be 
+ * written to t1+1, where t1 is given in milliseconds.  
+ *
+ */
+public class TimeSeriesManager {
+
+	private final TSDB tsdb;
+	private final boolean batchImport;
+	private final short bufferingTime;
+	private HashMap<String, WritableDataPoints> wdpPool;
+	
+
+	/**
+	 * 
+	 * @param tsdb TSDB object
+	 * @param batchImport Whether to set batchImport on our instantiation of WritableDataPoints 
+	 * @param bufferingTime What buffering time to use if batchImport is true.
+	 */
+	public TimeSeriesManager(TSDB tsdb, boolean batchImport, short bufferingTime) {
+		this.tsdb = tsdb;
+		this.batchImport = batchImport;
+		this.bufferingTime = bufferingTime;
+		this.wdpPool = new HashMap<String, WritableDataPoints>();
+	}
+
+	/**
+	 * Add a point to the input metric for the input tags.  Metric + tags define the timeseries.
+	 * Internally, this will first check to see if we already have an instance of WritableDataPoints for the desired
+	 * timeseries.  If so it will reuse it, otherwise it will create a new one and cache it for later use.  
+	 * @param metricName
+	 * @param tags
+	 * @param timestamp
+	 * @param value
+	 * @return
+	 * @throws InterruptedException
+	 * @throws Exception
+	 */
+	public Deferred<Object> addPoint(String metricName, Map<String, String> tags, long timestamp, long value) {
+		String id = makeId(metricName, tags);
+		WritableDataPoints wdp;
+		if (wdpPool.containsKey(id) ) {
+			wdp = wdpPool.get(id);
+		} else {
+			wdp = tsdb.newDataPoints();
+			wdp.setBatchImport(batchImport);
+			wdp.setBufferingTime(bufferingTime);
+			wdp.setSeries(metricName, tags);
+			wdpPool.put(id, wdp);
+		}
+		
+		return retryAddPointUntilSuccess(wdp, timestamp, value);
+	}
+
+	/**
+	 * Will try to write the point at the input timestamp.  However, if an IllegalArgumentException is thrown, as will
+	 * be the case when there already was a data point written to that timeseries at that specific time, this will add
+	 * 1 to the time and try again until it succeeds. 
+	 * @param wdp
+	 * @param timestamp
+	 * @param value
+	 * @return
+	 * @throws InterruptedException
+	 * @throws Exception
+	 */
+	private Deferred<Object> retryAddPointUntilSuccess(final WritableDataPoints wdp, final long timestamp, 
+			final long value) {
+		Deferred<Object> deferred = null;
+		
+		boolean accepted = false;
+		for (long t = timestamp; !accepted ; t++) {
+			try {
+				deferred = wdp.addPoint(t, value);
+				
+				deferred.addErrback(new RetryErrBack(wdp, timestamp, value, 10, 0));
+				
+				deferred.addCallback(new Callback<Object, Object>() {
+						public Object call(Object results) {
+							if (results == null) {
+								// log success to debug
+							} else {
+								if (results.toString().equals("MultiActionSuccess")) {
+									// log to debug
+								} else {
+									// log to error
+									System.err.println(">>>>>>>>>>>" + results.getClass() + ">>>>>>>>>>>");
+								}
+							}
+							return null;
+						}
+				});
+				accepted = true;
+				
+			} catch (IllegalArgumentException iae) {
+//				System.err.println("Tried to write on the same ms. Bumping to 1 ms later.");
+			}
+		}
+		return deferred;
+	}
+	
+	private String makeId(String metricName, Map<String, String> tags) {
+		return metricName + tags.toString();
+	}
+
+}


### PR DESCRIPTION
- Main method in RetryAddPointExample.java
- The purpose of this example is to show how to retry writing a data
point when an exception is returned in its Deferred result.