### PR TITLE
Address #460 by handling counter rollovers automatically

### DIFF
--- a/src/core/RateOptions.java
+++ b/src/core/RateOptions.java
@@ -23,7 +23,6 @@ package net.opentsdb.core;
  * @since 2.0
  */
 public class RateOptions {
-  public static final long DEFAULT_RESET_VALUE = 0;
 
   /**
    * If true, then when calculating a rate of change assume that the metric
@@ -51,25 +50,15 @@ public class RateOptions {
    */
   public RateOptions() {
     this.counter = false;
-    this.counter_max = Long.MAX_VALUE;
-    this.reset_value = DEFAULT_RESET_VALUE;
   }
   
   /**
    * Ctor
    * @param counter If true, indicates that the rate calculation should assume
    * that the underlying data is from a counter
-   * @param counter_max Specifies the maximum value for the counter before it
-   * will roll over and restart at 0
-   * @param reset_value Specifies the largest rate change that is considered
-   * acceptable, if a rate change is seen larger than this value then the
-   * counter is assumed to have been reset
    */
-  public RateOptions(final boolean counter, final long counter_max,
-      final long reset_value) {
+  public RateOptions(final boolean counter) {
     this.counter = counter;
-    this.counter_max = counter_max;
-    this.reset_value = reset_value;
   }
   
   /** @return Whether or not the counter flag is set */

--- a/src/core/RateSpan.java
+++ b/src/core/RateSpan.java
@@ -175,7 +175,7 @@ public class RateSpan implements SeekableView {
         while(source.hasNext()) {
           moveToNextDatapoint();
           difference = getValueDifference();
-          if (difference > 0) {
+          if (difference >= 0) {
             break;
           }
         }

--- a/src/core/SpanGroup.java
+++ b/src/core/SpanGroup.java
@@ -114,9 +114,8 @@ final class SpanGroup implements DataPoints {
             final boolean rate,
             final Aggregator aggregator,
             final long interval, final Aggregator downsampler) {
-    this(tsdb, start_time, end_time, spans, rate, new RateOptions(false,
-        Long.MAX_VALUE, RateOptions.DEFAULT_RESET_VALUE), aggregator, interval,
-        downsampler);
+    this(tsdb, start_time, end_time, spans, rate, new RateOptions(false),
+        aggregator, interval, downsampler);
   }
 
   /**

--- a/src/tools/CliQuery.java
+++ b/src/tools/CliQuery.java
@@ -199,22 +199,12 @@ final class CliQuery {
     while (i < args.length) {
       final Aggregator agg = Aggregators.get(args[i++]);
       final boolean rate = args[i].equals("rate");
-      RateOptions rate_options = new RateOptions(false, Long.MAX_VALUE,
-          RateOptions.DEFAULT_RESET_VALUE);
+      RateOptions rate_options = new RateOptions(false);
       if (rate) {
         i++;
         
-        long counterMax = Long.MAX_VALUE;
-        long resetValue = RateOptions.DEFAULT_RESET_VALUE;
         if (args[i].startsWith("counter")) {
-          String[] parts = Tags.splitString(args[i], ',');
-          if (parts.length >= 2 && parts[1].length() > 0) {
-            counterMax = Long.parseLong(parts[1]);
-          }
-          if (parts.length >= 3 && parts[2].length() > 0) {
-            resetValue = Long.parseLong(parts[2]);
-          }
-          rate_options = new RateOptions(true, counterMax, resetValue);
+          rate_options = new RateOptions(true);
           i++;
         }
       }

--- a/src/tsd/QueryRpc.java
+++ b/src/tsd/QueryRpc.java
@@ -505,8 +505,7 @@ final class QueryRpc implements HttpRpc {
    static final public RateOptions parseRateOptions(final boolean rate,
        final String spec) {
      if (!rate || spec.length() == 4) {
-       return new RateOptions(false, Long.MAX_VALUE,
-           RateOptions.DEFAULT_RESET_VALUE);
+       return new RateOptions(false);
      }
 
      if (spec.length() < 6) {
@@ -524,22 +523,7 @@ final class QueryRpc implements HttpRpc {
      }
 
      final boolean counter = "counter".equals(parts[0]);
-     try {
-       final long max = (parts.length >= 2 && parts[1].length() > 0 ? Long
-           .parseLong(parts[1]) : Long.MAX_VALUE);
-       try {
-         final long reset = (parts.length >= 3 && parts[2].length() > 0 ? Long
-             .parseLong(parts[2]) : RateOptions.DEFAULT_RESET_VALUE);
-         return new RateOptions(counter, max, reset);
-       } catch (NumberFormatException e) {
-         throw new BadRequestException(
-             "Reset value of counter was not a number, received '" + parts[2]
-                 + "'");
-       }
-     } catch (NumberFormatException e) {
-       throw new BadRequestException(
-           "Max value of counter was not a number, received '" + parts[1] + "'");
-     }
+     return new RateOptions(counter);
    }
 
   /**

--- a/src/tsd/client/MetricForm.java
+++ b/src/tsd/client/MetricForm.java
@@ -52,8 +52,6 @@ final class MetricForm extends HorizontalPanel implements Focusable {
   private final ValidatedTextBox interval = new ValidatedTextBox();
   private final CheckBox rate = new CheckBox("Rate");
   private final CheckBox rate_counter = new CheckBox("Rate Ctr");
-  private final TextBox counter_max = new TextBox();
-  private final TextBox counter_reset_value = new TextBox();
   private final CheckBox x1y2 = new CheckBox("Right Axis");
   private final ListBox aggregators = new ListBox();
   private final ValidatedTextBox metric = new ValidatedTextBox();
@@ -68,10 +66,6 @@ final class MetricForm extends HorizontalPanel implements Focusable {
     interval.addKeyPressHandler(handler);
     rate.addClickHandler(handler);
     rate_counter.addClickHandler(handler);
-    counter_max.addBlurHandler(handler);
-    counter_max.addKeyPressHandler(handler);
-    counter_reset_value.addBlurHandler(handler);
-    counter_reset_value.addKeyPressHandler(handler);
     x1y2.addClickHandler(handler);
     aggregators.addChangeHandler(handler);
     metric.addBlurHandler(handler);
@@ -168,11 +162,6 @@ final class MetricForm extends HorizontalPanel implements Focusable {
     LocalRateOptions rate_options = parseRateOptions(rate, parts[i]);
     this.rate_counter.setValue(rate_options.is_counter, false);
     final long rate_counter_max = rate_options.counter_max;
-    this.counter_max.setValue(
-        rate_counter_max == Long.MAX_VALUE ? "" : Long.toString(rate_counter_max), 
-        false);
-    this.counter_reset_value
-        .setValue(Long.toString(rate_options.reset_value), false);
     if (rate) {
       i--;
     }
@@ -239,20 +228,6 @@ final class MetricForm extends HorizontalPanel implements Focusable {
       }
       {
         final HorizontalPanel hbox = new HorizontalPanel();
-        final InlineLabel l = new InlineLabel("Rate Ctr Max:");
-        hbox.add(l);
-        hbox.add(counter_max);
-        vbox.add(hbox);
-      }
-      {
-        final HorizontalPanel hbox = new HorizontalPanel();
-        final InlineLabel l = new InlineLabel("Rate Ctr Reset:");
-        hbox.add(l);
-        hbox.add(counter_reset_value);
-        vbox.add(hbox);
-      }
-      {
-        final HorizontalPanel hbox = new HorizontalPanel();
         final InlineLabel l = new InlineLabel();
         l.setText("Aggregator:");
         hbox.add(l);
@@ -300,15 +275,6 @@ final class MetricForm extends HorizontalPanel implements Focusable {
       url.append(":rate");
       if (rate_counter.getValue()) {
         url.append('{').append("counter");
-        final String max = counter_max.getValue().trim();
-        final String reset = counter_reset_value.getValue().trim();
-        if (max.length() > 0 && reset.length() > 0) {
-          url.append(',').append(max).append(',').append(reset);
-        } else if (max.length() > 0 && reset.length() == 0) {
-          url.append(',').append(max);
-        } else if (max.length() == 0 && reset.length() > 0){
-          url.append(",,").append(reset);
-        }
         url.append('}');
       }
     }

--- a/test/core/TestRateSpan.java
+++ b/test/core/TestRateSpan.java
@@ -75,6 +75,17 @@ public class TestRateSpan {
     MutableDataPoint.ofDoubleValue(1426385514000L, 9)
   };
 
+  private static final DataPoint[] COUNTER_DATA_POINTS_NO_INCREASE = new DataPoint[] {
+    MutableDataPoint.ofDoubleValue(1426385507000L, 5),
+    MutableDataPoint.ofDoubleValue(1426385508000L, 5),
+    MutableDataPoint.ofDoubleValue(1426385509000L, 5),
+    MutableDataPoint.ofDoubleValue(1426385510000L, 0),
+    MutableDataPoint.ofDoubleValue(1426385511000L, 0),
+    MutableDataPoint.ofDoubleValue(1426385512000L, 0),
+    MutableDataPoint.ofDoubleValue(1426385513000L, 0),
+    MutableDataPoint.ofDoubleValue(1426385514000L, 0)
+  };
+
   private SeekableView source;
   private RateOptions options;
 
@@ -214,7 +225,7 @@ public class TestRateSpan {
     options = new RateOptions(true);
     RateSpan rate_span = new RateSpan(source, options);
     int count = 0;
-    rate_span.next(); // Skip first datapoint.
+    rate_span.next(); // Throw away the initial datapoint.
     while(rate_span.hasNext()) {
       DataPoint rateDp = rate_span.next();
       assertEquals(1, rateDp.doubleValue(), 0);
@@ -229,7 +240,7 @@ public class TestRateSpan {
     options = new RateOptions(false);
     RateSpan rate_span = new RateSpan(source, options);
     int count = 0;
-    rate_span.next(); // Throw away first datapoint.
+    rate_span.next(); // Throw away the initial datapoint.
     double[] values = new double[7];
     while(rate_span.hasNext()) {
       DataPoint rateDp = rate_span.next();
@@ -245,7 +256,7 @@ public class TestRateSpan {
     options = new RateOptions(true);
     RateSpan rate_span = new RateSpan(source, options);
     int count = 0;
-    rate_span.next(); // Throw away first datapoint.
+    rate_span.next(); // Throw away the initial datapoint.
     double[] values = new double[6];
     while(rate_span.hasNext()) {
       DataPoint rateDp = rate_span.next();
@@ -253,6 +264,22 @@ public class TestRateSpan {
     }
     assertEquals(6, count);
     assertTrue(Arrays.equals(new double[]{2,2,2,2,2,2}, values));
+  }
+
+  @Test
+  public void CounterResetSkipLowQualityDatapointNoIncrease() {
+    source = SeekableViewsForTest.fromArray(COUNTER_DATA_POINTS_NO_INCREASE);
+    options = new RateOptions(true);
+    RateSpan rate_span = new RateSpan(source, options);
+    int count = 0;
+    rate_span.next(); // Throw away the initial datapoint.
+    double[] values = new double[6];
+    while(rate_span.hasNext()) {
+      DataPoint rateDp = rate_span.next();
+      values[count++] = rateDp.doubleValue();
+    }
+    assertEquals(6, count);
+    assertTrue(Arrays.equals(new double[]{0,0,0,0,0,0}, values));
   }
 
 }

--- a/test/core/TestTsdbQuery.java
+++ b/test/core/TestTsdbQuery.java
@@ -1229,7 +1229,7 @@ public final class TestTsdbQuery {
       .joinUninterruptibly();
     tsdb.addPoint("sys.cpu.user", timestamp += 30, 5, tags).joinUninterruptibly();
     
-    RateOptions ro = new RateOptions(true, Long.MAX_VALUE, 0);
+    RateOptions ro = new RateOptions(true);
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries("sys.cpu.user", tags, Aggregators.SUM, true, ro);
@@ -1238,7 +1238,7 @@ public final class TestTsdbQuery {
     for (DataPoint dp : dps[0]) {
       assertEquals(1.0, dp.doubleValue(), 0.001);
     }
-    assertEquals(2, dps[0].size());
+    assertEquals(1, dps[0].size());
   }
   
   @Test
@@ -1251,7 +1251,7 @@ public final class TestTsdbQuery {
     tsdb.addPoint("sys.cpu.user", timestamp += 30, 60, tags).joinUninterruptibly();
     tsdb.addPoint("sys.cpu.user", timestamp += 30, 90, tags).joinUninterruptibly();
     
-    RateOptions ro = new RateOptions(true, Long.MAX_VALUE, 0);
+    RateOptions ro = new RateOptions(true);
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries("sys.cpu.user", tags, Aggregators.SUM, true, ro);
@@ -1260,49 +1260,6 @@ public final class TestTsdbQuery {
     for (DataPoint dp : dps[0]) {
       assertEquals(1.0, dp.doubleValue(), 0.001);
     }
-    assertEquals(2, dps[0].size());
-  }
-  
-  @Test
-  public void runRateCounterMaxSet() throws Exception {
-    setQueryStorage();
-    HashMap<String, String> tags = new HashMap<String, String>(1);
-    tags.put("host", "web01");
-    long timestamp = 1356998400;
-    tsdb.addPoint("sys.cpu.user", timestamp += 30, 45, tags).joinUninterruptibly();
-    tsdb.addPoint("sys.cpu.user", timestamp += 30, 75, tags).joinUninterruptibly();
-    tsdb.addPoint("sys.cpu.user", timestamp += 30, 5, tags).joinUninterruptibly();
-    
-    RateOptions ro = new RateOptions(true, 100, 0);
-    query.setStartTime(1356998400);
-    query.setEndTime(1357041600);
-    query.setTimeSeries("sys.cpu.user", tags, Aggregators.SUM, true, ro);
-    final DataPoints[] dps = query.run();
-
-    for (DataPoint dp : dps[0]) {
-      assertEquals(1.0, dp.doubleValue(), 0.001);
-    }
-    assertEquals(2, dps[0].size());
-  }
-  
-  @Test
-  public void runRateCounterAnomally() throws Exception {
-    setQueryStorage();
-    HashMap<String, String> tags = new HashMap<String, String>(1);
-    tags.put("host", "web01");
-    long timestamp = 1356998400;
-    tsdb.addPoint("sys.cpu.user", timestamp += 30, 45, tags).joinUninterruptibly();
-    tsdb.addPoint("sys.cpu.user", timestamp += 30, 75, tags).joinUninterruptibly();
-    tsdb.addPoint("sys.cpu.user", timestamp += 30, 25, tags).joinUninterruptibly();
-    
-    RateOptions ro = new RateOptions(true, 10000, 35);
-    query.setStartTime(1356998400);
-    query.setEndTime(1357041600);
-    query.setTimeSeries("sys.cpu.user", tags, Aggregators.SUM, true, ro);
-    final DataPoints[] dps = query.run();
-
-    assertEquals(1.0, dps[0].doubleValue(0), 0.001);
-    assertEquals(0, dps[0].doubleValue(1), 0.001);
     assertEquals(2, dps[0].size());
   }
 


### PR DESCRIPTION
![rate_counter](https://cloud.githubusercontent.com/assets/1587140/6654490/ff284192-ca85-11e4-9cdd-c8a7ee4d781a.png)

This change detects resets of strictly increasing counters and skips the low-quality data point rather than fudging it with constant values. The change also gets rid of two redundant fields in the UI that consumed a lot of real estate and provided dubious value.