### PR TITLE
Log illegal put arguments at DEBUG level.

### DIFF
--- a/src/core/IncomingDataPoints.java
+++ b/src/core/IncomingDataPoints.java
@@ -93,7 +93,7 @@ final class IncomingDataPoints implements WritableDataPoints {
    */
   static void checkMetricAndTags(final String metric, final Map<String, String> tags) {
     if (tags.size() <= 0) {
-      throw new IllegalArgumentException("Need at least one tags (metric="
+      throw new IllegalArgumentException("Need at least one tag (metric="
           + metric + ", tags=" + tags + ')');
     } else if (tags.size() > Const.MAX_NUM_TAGS) {
       throw new IllegalArgumentException("Too many tags: " + tags.size()

--- a/src/tsd/PutDataPointRpc.java
+++ b/src/tsd/PutDataPointRpc.java
@@ -70,8 +70,11 @@ final class PutDataPointRpc implements TelnetRpc, HttpRpc {
       errmsg = "put: unknown metric: " + x.getMessage() + '\n';
       unknown_metrics.incrementAndGet();
     }
-    if (errmsg != null && chan.isConnected()) {
-      chan.write(errmsg);
+    if (errmsg != null) {
+      LOG.debug(errmsg);
+      if (chan.isConnected()) {
+        chan.write(errmsg);
+      }
     }
     return Deferred.fromResult(null);
   }


### PR DESCRIPTION
The TSD already returns an illegal argument message to the client, 
```
$ nc number5 4242
put mymetric 1427014820 1 host=thursday a=a b=b c=c d=d e=e f=f g=g i=i
put: illegal argument: Too many tags: 9 maximum allowed: 8, tags: {f=f, g=g, d=d, e=e, host=thursday, b=b, c=c, a=a, i=i}
```
but when a collector framework does not surface the problem, it can be hard to realize otherwise, as reported in #437. Adding the error message at a DEBUG level to make troubleshooting of missing metrics easier.
```
02:34:12.886 DEBUG [PutDataPointRpc.execute] - put: illegal argument: Too many tags: 9 maximum allowed: 8, tags: {f=f, g=g, d=d, e=e, host=thursday, b=b, c=c, a=a, i=i}
```