### PR TITLE
Fix .rpm build with -'s in version (ie; -SNAPSHOT)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -653,8 +653,8 @@ pom.xml: pom.xml.in Makefile
 TIMESTAMP := $(shell date +"%Y%m%d%H%M%S")
 RPM_REVISION := 1
 RPM_TARGET := noarch
-RPM := opentsdb-$(PACKAGE_VERSION)-$(RPM_REVISION).$(RPM_TARGET).rpm
-RPM_SNAPSHOT := opentsdb-$(PACKAGE_VERSION)-$(RPM_REVISION)-$(TIMESTAMP)-"`whoami`".$(RPM_TARGET).rpm
+RPM := opentsdb-$(subst -,_,$(PACKAGE_VERSION))-$(RPM_REVISION).$(RPM_TARGET).rpm
+RPM_SNAPSHOT := opentsdb-$(subst -,_,$(PACKAGE_VERSION))-$(RPM_REVISION)-$(TIMESTAMP)-"`whoami`".$(RPM_TARGET).rpm
 SOURCE_TARBALL := opentsdb-$(PACKAGE_VERSION).tar.gz
 rpm: $(RPM)
 

--- a/opentsdb.spec.in
+++ b/opentsdb.spec.in
@@ -4,7 +4,7 @@
 %define _sourcedir %(echo $PWD)
 
 Name:		@PACKAGE@
-Version:	@VERSION@
+Version:	%(echo @VERSION@ | sed 's/-/_/g')
 Release:	1
 Summary:	A scalable, distributed Time Series Database
 Packager:	@PACKAGE_BUGREPORT@
@@ -45,7 +45,7 @@ seconds). OpenTSDB will never delete or downsample data and can easily store
 billions of data points.
 
 %prep
-%setup -q
+%setup -q -n @PACKAGE@-@VERSION@
 
 
 %build


### PR DESCRIPTION
rpmbuild doesn't like -'s in the package Version (dpkg seems less fussy).
To stay strictly-semver, we replace any -'s with _'s.

Alternatively, we could use ~'s in the AC_INIT.  More discussion here: mojombo/semver#145