### PR TITLE
Fix #452 Protect the UI from getting stuck when no tags are returned.

### DIFF
--- a/src/tsd/client/QueryUi.java
+++ b/src/tsd/client/QueryUi.java
@@ -956,9 +956,11 @@ public class QueryUi implements EntryPoint, HistoryListener {
             }
             final MetricForm metric = (MetricForm) widget;
             final JSONArray tags = etags.get(i).isArray();
-            final int ntags = tags.size();
-            for (int j = 0; j < ntags; j++) {
-              metric.autoSuggestTag(tags.get(j).isString().stringValue());
+            // Skip if no tags were associated with the query.
+            if (null != tags) {
+              for (int j = 0; j < tags.size(); j++) {
+                metric.autoSuggestTag(tags.get(j).isString().stringValue());
+              }
             }
           }
         }


### PR DESCRIPTION
When one of the queries returns no datapoints, the suggested tags for it are empty and therefore not set (they remain null). QueryUI code assumes that they will always be at least a 0-element array, which is not true.

1. To reproduce, take a standard tsd metric and graph it.
2. Clone this metric and under host tag enter "eth0", which is a legit tag-value pair, but will likely return 0 data points.
3. Try to change the time range on the ui - the UI should be stuck at this point.

An example bad query: http://j.mp/19f04EE - just replace the host:port with your TSD's address.

With this change, the UI isn't getting stuck in such situations.