### PR TITLE
Fix startup on boot via init script (RPM)

### DIFF
--- a/build-aux/rpm/init.d/opentsdb
+++ b/build-aux/rpm/init.d/opentsdb
@@ -28,18 +28,14 @@
 # Source init functions
 . /etc/init.d/functions
 
-# Set this so that you can run as many opentsdb instances you want as long as
-# the name of this script is changed (or a symlink is used)
-NAME=`basename $0`
-
 # Maximum number of open files
 MAX_OPEN_FILES=65535
 
 # Default program options
+NAME=opentsdb
 PROG=/usr/bin/tsdb
 HOSTNAME=$(hostname --fqdn)
 USER=root
-CONFIG=/etc/opentsdb/${NAME}.conf
 
 # Default directories
 LOG_DIR=/var/log/opentsdb
@@ -48,12 +44,13 @@ PID_DIR=/var/run/opentsdb
 
 # Global and Local sysconfig files
 [ -e /etc/sysconfig/opentsdb ] && . /etc/sysconfig/opentsdb
-[ -e /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+[ "`basename $0`" != "$NAME" ] && [ -e /etc/sysconfig/`basename $0` ] && . /etc/sysconfig/`basename $0`
 
 # Set file names
 LOG_FILE=$LOG_DIR/$NAME-$HOSTNAME-
 LOCK_FILE=$LOCK_DIR/$NAME
 PID_FILE=$PID_DIR/$NAME.pid
+CONFIG=/etc/opentsdb/${NAME}.conf
 
 # Create dirs if they don't exist
 [ -e $LOG_DIR ] || (mkdir -p $LOG_DIR && chown $USER: $LOG_DIR)


### PR DESCRIPTION
NAME=`basename $0` only works if you're starting opentsdb by hand.
On boot `basename $0` actually ends up being "S80opentsdb" (since it's run from the /etc/rcX.d symlinks rather than /etc/init.d) - the init script can't find /etc/opentsdb/S80opentsdb.conf, writes its logs to S80opentsdb-xxx etc.

Instead we can default to a static 'opentsdb' for NAME, and let it be overridden in a /etc/sysconfig/`basename $0` if you want to run multiple instances.