### PR TITLE
Handle double precision floating point via the API -- refs #473

### DIFF
--- a/src/core/Tags.java
+++ b/src/core/Tags.java
@@ -637,4 +637,19 @@ public final class Tags {
     return true;
   }
 
+  /**
+   * Returns true if the given string can fit into a float.
+   * @param value The String holding the float value.
+   * @return true if the value can fit into a float, false otherwise.
+   * @throws NumberFormatException if the value is not numeric.
+   * @since 2.0.2
+   */
+  public static boolean fitsInFloat(final String value) {
+    final float f = Float.parseFloat(value);
+    final String converted = Float.toString(f);
+
+    // this will be false if there was a loss of precision.
+    return value.equals(converted);
+  }
+
 }

--- a/src/tsd/PutDataPointRpc.java
+++ b/src/tsd/PutDataPointRpc.java
@@ -145,9 +145,12 @@ final class PutDataPointRpc implements TelnetRpc, HttpRpc {
         if (Tags.looksLikeInteger(dp.getValue())) {
           tsdb.addPoint(dp.getMetric(), dp.getTimestamp(), 
               Tags.parseLong(dp.getValue()), dp.getTags());
-        } else {
+        } else if (Tags.fitsInFloat(dp.getValue())) {
           tsdb.addPoint(dp.getMetric(), dp.getTimestamp(), 
               Float.parseFloat(dp.getValue()), dp.getTags());
+        } else {
+          tsdb.addPoint(dp.getMetric(), dp.getTimestamp(),
+              Double.parseDouble(dp.getValue()), dp.getTags());
         }
         success++;
       } catch (NumberFormatException x) {
@@ -252,8 +255,10 @@ final class PutDataPointRpc implements TelnetRpc, HttpRpc {
     }
     if (Tags.looksLikeInteger(value)) {
       return tsdb.addPoint(metric, timestamp, Tags.parseLong(value), tags);
-    } else {  // floating point value
-      return tsdb.addPoint(metric, timestamp, Float.parseFloat(value), tags);
+    } else if (Tags.fitsInFloat(value)) {  // floating point value
+       return tsdb.addPoint(metric, timestamp, Float.parseFloat(value), tags);
+    } else {  // double point value
+      return tsdb.addPoint(metric, timestamp, Double.parseDouble(value), tags);
     }
   }
 

--- a/test/core/TestTags.java
+++ b/test/core/TestTags.java
@@ -533,7 +533,6 @@ public final class TestTags {
       assertEquals(false, Tags.fitsInFloat("1.2abc34"));
   }
 
-
   @Test
   public void resolveIdsAsync() throws Exception {
     setupStorage();

--- a/test/core/TestTags.java
+++ b/test/core/TestTags.java
@@ -504,6 +504,37 @@ public final class TestTags {
   }
 
   @Test
+  public void looksLikeIntegerSimple() {
+      assertEquals(true, Tags.looksLikeInteger("123"));
+  }
+
+  @Test
+  public void looksLikeIntegerFloat() {
+      assertEquals(false, Tags.looksLikeInteger("12.3"));
+  }
+
+  @Test
+  public void looksLikeIntegerExponent() {
+      assertEquals(false, Tags.looksLikeInteger("1e10"));
+  }
+
+  @Test
+  public void fitsInFloatSimple() {
+      assertEquals(true, Tags.fitsInFloat("12.3"));
+  }
+
+  @Test
+  public void fitsInFloatDoublePrecision() {
+      assertEquals(false, Tags.fitsInFloat("1.234556789123456"));
+  }
+
+  @Test(expected=NumberFormatException.class)
+  public void fitsInFloatMalformed() {
+      assertEquals(false, Tags.fitsInFloat("1.2abc34"));
+  }
+
+
+  @Test
   public void resolveIdsAsync() throws Exception {
     setupStorage();
     setupResolveIds();

--- a/test/tsd/TestPutRpc.java
+++ b/test/tsd/TestPutRpc.java
@@ -183,6 +183,26 @@ public final class TestPutRpc {
     put.execute(tsdb, query);
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
   }
+
+  @Test
+  public void putDoublePrecisionFloatingPoint() throws Exception {
+    HttpQuery query = NettyMocks.postQuery(tsdb, "/api/put",
+        "{\"metric\":\"sys.cpu.nice\",\"timestamp\":1365465600,\"value\""
+        +":123456.123456789,\"tags\":{\"host\":\"web01\"}}");
+    PutDataPointRpc put = new PutDataPointRpc();
+    put.execute(tsdb, query);
+    assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
+  }
+
+  @Test
+  public void putNegativeDoublePrecisionFloatingPoint() throws Exception {
+    HttpQuery query = NettyMocks.postQuery(tsdb, "/api/put",
+        "{\"metric\":\"sys.cpu.nice\",\"timestamp\":1365465600,\"value\""
+        +":-123456.123456789,\"tags\":{\"host\":\"web01\"}}");
+    PutDataPointRpc put = new PutDataPointRpc();
+    put.execute(tsdb, query);
+    assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
+  }
   
   @Test
   public void putSEBig() throws Exception {


### PR DESCRIPTION
Add a `fitsInFloat` function similar to `looksLikeInteger` to determine whether a floating point value should be stored in a Float or a Double. Add a few tests.

There is also a call to `looksLikeInteger` in [src/tools/TextImport.java](https://github.com/OpenTSDB/opentsdb/blob/master/src/tools/TextImporter.java#L151), but I'm not sure what to do here. It doesn't seem like there is a way to add doubles in the `WritableDataPoints` interface.

It seemed like a pretty easy change so I'm wondering: is there a reason this wasn't implemented sooner? Am I missing something?