### PR TITLE
Trim blanks from boolean property values of config file for proper value...

### DIFF
--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -223,7 +223,20 @@ public class Config {
    * @throws NullPointerException if the property did not exist
    */
   public final int getInt(final String property) {
-    return Integer.parseInt(properties.get(property));
+    return Integer.parseInt(sanitize(properties.get(property)));
+  }
+
+  /**
+   * Returns the given string trimed or null if is null 
+   * @param string The string be trimmed of 
+   * @return The string trimed or null
+  */  
+  private final String sanitize(final String string) {
+    if (string == null) {
+      return null;
+    }
+
+    return string.trim();
   }
 
   /**
@@ -234,7 +247,7 @@ public class Config {
    * @throws NullPointerException if the property did not exist
    */
   public final short getShort(final String property) {
-    return Short.parseShort(properties.get(property));
+    return Short.parseShort(sanitize(properties.get(property)));
   }
 
   /**
@@ -245,7 +258,7 @@ public class Config {
    * @throws NullPointerException if the property did not exist
    */
   public final long getLong(final String property) {
-    return Long.parseLong(properties.get(property));
+    return Long.parseLong(sanitize(properties.get(property)));
   }
 
   /**
@@ -256,7 +269,7 @@ public class Config {
    * @throws NullPointerException if the property did not exist
    */
   public final float getFloat(final String property) {
-    return Float.parseFloat(properties.get(property));
+    return Float.parseFloat(sanitize(properties.get(property)));
   }
 
   /**
@@ -267,7 +280,7 @@ public class Config {
    * @throws NullPointerException if the property did not exist
    */
   public final double getDouble(final String property) {
-    return Double.parseDouble(properties.get(property));
+    return Double.parseDouble(sanitize(properties.get(property)));
   }
 
   /**
@@ -283,7 +296,7 @@ public class Config {
    * @throws NullPointerException if the property was not found
    */
   public final boolean getBoolean(final String property) {
-    final String val = properties.get(property).toUpperCase();
+    final String val = properties.get(property).trim().toUpperCase();
     if (val.equals("1"))
       return true;
     if (val.equals("TRUE"))

--- a/test/utils/TestConfig.java
+++ b/test/utils/TestConfig.java
@@ -143,6 +143,15 @@ public final class TestConfig {
   }
 
   @Test
+  public void getIntWithSpaces() throws Exception {
+    final Config config = new Config(false);
+    config.overrideConfig("tsd.int", 
+        " " + Integer.toString(Integer.MAX_VALUE) + " ");
+    assertEquals(Integer.MAX_VALUE, 
+        config.getInt("tsd.int"));
+  }
+
+  @Test
   public void getIntNegative() throws Exception {
     final Config config = new Config(false);
     config.overrideConfig("tsd.int", 
@@ -177,6 +186,15 @@ public final class TestConfig {
     final Config config = new Config(false);
     config.overrideConfig("tsd.short", 
         Short.toString(Short.MAX_VALUE));
+    assertEquals(Short.MAX_VALUE, 
+        config.getShort("tsd.short"));
+  }
+
+  @Test
+  public void getShortWithSpaces() throws Exception {
+    final Config config = new Config(false);
+    config.overrideConfig("tsd.short", 
+        " " + Short.toString(Short.MAX_VALUE) + " ");
     assertEquals(Short.MAX_VALUE, 
         config.getShort("tsd.short"));
   }
@@ -219,6 +237,13 @@ public final class TestConfig {
   }
 
   @Test
+  public void getLongWithSpaces() throws Exception {
+    final Config config = new Config(false);
+    config.overrideConfig("tsd.long", " " + Long.toString(Long.MAX_VALUE) + " ");
+    assertEquals(Long.MAX_VALUE, config.getLong("tsd.long"));
+  }
+
+  @Test
   public void getLongNegative() throws Exception {
     final Config config = new Config(false);
     config.overrideConfig("tsd.long", Long.toString(Long.MIN_VALUE));
@@ -250,6 +275,14 @@ public final class TestConfig {
   public void getFloat() throws Exception {
     final Config config = new Config(false);
     config.overrideConfig("tsd.float", Float.toString(Float.MAX_VALUE));
+    assertEquals(Float.MAX_VALUE, 
+        config.getFloat("tsd.float"), 0.000001);
+  }
+
+  @Test
+  public void getFloatWithSpaces() throws Exception {
+    final Config config = new Config(false);
+    config.overrideConfig("tsd.float", " " + Float.toString(Float.MAX_VALUE) + " ");
     assertEquals(Float.MAX_VALUE, 
         config.getFloat("tsd.float"), 0.000001);
   }
@@ -318,6 +351,14 @@ public final class TestConfig {
   public void getDouble() throws Exception {
     final Config config = new Config(false);
     config.overrideConfig("tsd.double", Double.toString(Double.MAX_VALUE));
+    assertEquals(Double.MAX_VALUE, 
+        config.getDouble("tsd.double"), 0.000001);
+  }
+
+  @Test
+  public void getDoubleWithSpaces() throws Exception {
+    final Config config = new Config(false);
+    config.overrideConfig("tsd.double", " " + Double.toString(Double.MAX_VALUE) + " ");
     assertEquals(Double.MAX_VALUE, 
         config.getDouble("tsd.double"), 0.000001);
   }
@@ -398,6 +439,13 @@ public final class TestConfig {
   }
 
   @Test
+  public void getBool1WithSpaces() throws Exception {
+    final Config config = new Config(false);
+    config.overrideConfig("tsd.bool", " 1  ");
+    assertTrue(config.getBoolean("tsd.bool"));
+  }
+
+  @Test
   public void getBoolTrueCaseInsensitive() throws Exception {
     final Config config = new Config(false);
     config.overrideConfig("tsd.bool", "TrUe");
@@ -405,9 +453,23 @@ public final class TestConfig {
   }
 
   @Test
+  public void getBoolTrueWithSpaces() throws Exception {
+    final Config config = new Config(false);
+    config.overrideConfig("tsd.bool", "TrUe ");
+    assertTrue(config.getBoolean("tsd.bool"));
+  }
+
+  @Test
   public void getBoolYes() throws Exception {
     final Config config = new Config(false);
     config.overrideConfig("tsd.bool", "yes");
+    assertTrue(config.getBoolean("tsd.bool"));
+  }
+
+  @Test
+  public void getBoolYesWithSpaces() throws Exception {
+    final Config config = new Config(false);
+    config.overrideConfig("tsd.bool", " yes  ");
     assertTrue(config.getBoolean("tsd.bool"));
   }
 


### PR DESCRIPTION
This fix a a problem with the parsing of boolean values if they have spaces. If the property value have additional spaces, the value does not get parsed correctly.