### PR TITLE
Fix missing info from /api/uid/tsmeta - refs #498

### DIFF
--- a/src/meta/TSMeta.java
+++ b/src/meta/TSMeta.java
@@ -406,20 +406,20 @@ public final class TSMeta {
       throw new IllegalArgumentException("Empty column value");
     }
 
-    final TSMeta parsedMeta = JSON.parseToObject(column.value(), TSMeta.class);
+    final TSMeta parsed_meta = JSON.parseToObject(column.value(), TSMeta.class);
     
     // fix in case the tsuid is missing
-    if (parsedMeta.tsuid == null || parsedMeta.tsuid.isEmpty()) {
-      parsedMeta.tsuid = UniqueId.uidToString(column.key());
+    if (parsed_meta.tsuid == null || parsed_meta.tsuid.isEmpty()) {
+      parsed_meta.tsuid = UniqueId.uidToString(column.key());
     }
 
-    Deferred<TSMeta> meta = getFromStorage(tsdb, UniqueId.stringToUid(parsedMeta.tsuid));
+    Deferred<TSMeta> meta = getFromStorage(tsdb, UniqueId.stringToUid(parsed_meta.tsuid));
     
     if (!load_uidmetas) {
       return meta;
     }
     
-    return meta.addCallbackDeferring(new LoadUIDs(tsdb, parsedMeta.tsuid));
+    return meta.addCallbackDeferring(new LoadUIDs(tsdb, parsed_meta.tsuid));
   }
   
   /**

--- a/test/meta/TestTSMeta.java
+++ b/test/meta/TestTSMeta.java
@@ -128,6 +128,15 @@ public final class TestTSMeta {
         NAME_FAMILY,
         "ts_ctr".getBytes(MockBase.ASCII()),
         Bytes.fromLong(1L));
+
+    storage.addColumn(new byte[] { 0, 0, 1, 0, 0, 1, 0, 0, 2 },
+        NAME_FAMILY,
+        "ts_meta".getBytes(MockBase.ASCII()),
+        ("{\"tsuid\":\"000001000001000002\",\"" +
+        "description\":\"Description\",\"notes\":\"Notes\",\"created\":1328140800," +
+        "\"custom\":null,\"units\":\"\",\"retention\":42,\"max\":1.0,\"min\":" +
+        "\"NaN\",\"displayName\":\"Display\",\"dataType\":\"Data\"}")
+        .getBytes(MockBase.ASCII()));
   }
   
   @Test


### PR DESCRIPTION
Unfortunately this breaks the [parseFromColumnWithUIDMetaNSU](https://github.com/OpenTSDB/opentsdb/blob/next/test/meta/TestTSMeta.java#L400) test as the `NoSuchUniqueId` exception is not raised anymore since `LoadUIDs.call` [returns early](https://github.com/OpenTSDB/opentsdb/blob/next/src/meta/TSMeta.java#L837) due to `meta` being `null`. I didn't know how to fix the test, whether to keep it as-is and try to raise the same exception again, or change it to make the tsuid `000001000001000002` a valid TSUID missing a UID meta object.

What's the best approach?