### PR TITLE
Relax the pgrep regex to correctly find and kill the java process.

### DIFF
--- a/build-aux/rpm/init.d/opentsdb
+++ b/build-aux/rpm/init.d/opentsdb
@@ -139,7 +139,7 @@ rh_status_q() {
 }
 
 findproc() {
-    pgrep -f "^java .* net.opentsdb.tools.TSDMain .*${NAME}"
+    pgrep -f "java .* net.opentsdb.tools.TSDMain .*${NAME}"
 }
 
 case "$1" in


### PR DESCRIPTION
On RPM based systems, when TSD runs on `java` found in the path, the process name is simply "java", so `ps aux|grep opentsdb` looks something like that:
```
opentsdb      157272 19.8  0.0 19816804 94612 pts/0  Sl   21:40   0:01 java -DLOG_FILE_PREFIX=...
```
When TSD is pointed at a specific java version, e.g. through the `JAVA=` variable, the name of the java process includes full path, `ps aux|grep opentsdb` and looks something like this:
```
opentsdb      166305 25.2  0.0 19816804 94332 pts/0  Sl   21:56   0:01 /usr/local/jdk-8u20-64/bin/java -DLOG_FILE_PREFIX=
```
Now, the `findproc()` function in `/etc/init.d/opentsdb` which is used for identifying the running TSD process and storing it in a pid file, assumes only the former case (i.e no full path) and is defined as follows:
```
findproc() {
    pgrep -f "^java .* net.opentsdb.tools.TSDMain .*${NAME}"
}
```
As a frustrating side effect for the latter case, it's impossible to restart the service with the `init.d` script. 
```
# pgrep -f /usr/local/jdk-8u20-64/bin/java
170513
# /etc/init.d/opentsdb restart
Stopping opentsdb:                                         [FAILED]
Starting opentsdb:                                         [  OK  ]
# service opentsdb restart
Stopping opentsdb:                                         [FAILED]
Starting opentsdb:                                         [  OK  ]
# pgrep -f /usr/local/jdk-8u20-64/bin/java
170513
#
```
This change relaxes the regex to cover both cases.