### PR TITLE
Server should just exit whenever there is some unrecognized option

### DIFF
--- a/src/tools/CliOptions.java
+++ b/src/tools/CliOptions.java
@@ -77,7 +77,7 @@ final class CliOptions {
       args = argp.parse(args);
     } catch (IllegalArgumentException e) {
       System.err.println("Invalid usage.  " + e.getMessage());
-      return null;
+      System.exit(2);
     }
     honorVerboseFlag(argp);
     return args;


### PR DESCRIPTION
Currently, server just throws out and error message and continues. Generally its ok but sometimes for eg. in this case

$ ./tsdb tsd --port=4242 --staticroot=/app/data.1/opentsdb-2.1.0/build/staticroot --cachedir=/app/data.1/opentsdb-2.1.0/build/cachedir  --auto-metric=true --conf=/etc/opentsdb.conf  --zkquorum=192.168.101.1:2181

There is a wrong option used named "conf" instead of "config". During starting server will just throw an error "Invalid usage.  Unrecognized option --conf=/etc/opentsdb.conf" and will parse all the options before --conf and will not parse option those after that (--zkquorum in current case).

One who started the program expects that it should talk to zookeeper on 192.168.101.1 but logs shows it is trying to localhost(default config) zookeeper.

So hence, in order to prevent such scenarios, server should just exit whenever there is some unrecognized option used.


