### PR TITLE
Updates 'search/lookup' to obey limit

### DIFF
--- a/src/search/TimeSeriesLookup.java
+++ b/src/search/TimeSeriesLookup.java
@@ -110,6 +110,7 @@ public class TimeSeriesLookup {
    */
   public List<byte[]> lookup() {
     LOG.info(query.toString());
+    boolean limit_reached = false;
     final StringBuilder tagv_filter = new StringBuilder();
     final Scanner scanner = getScanner(tagv_filter);
     final List<byte[]> tsuids = new ArrayList<byte[]>();
@@ -166,8 +167,16 @@ public class TimeSeriesLookup {
             }
             buf.setLength(0);   // reset the buffer so we can re-use it
           } else {
-            tsuids.add(tsuid);
+            if(tsuids.size() < query.getLimit()) {
+              tsuids.add(tsuid);
+            } else {
+              limit_reached = true;
+              break;
+            }
           }
+        }
+        if(limit_reached) {
+          break;
         }
       }
     } catch (Exception e) {

--- a/src/tsd/SearchRpc.java
+++ b/src/tsd/SearchRpc.java
@@ -109,6 +109,15 @@ final class SearchRpc implements HttpRpc {
       } catch (IllegalArgumentException e) {
         throw new BadRequestException("Unable to parse query", e);
       }
+      if (query.hasQueryStringParam("limit")) {
+        final String limit = query.getQueryStringParam("limit");
+        try {
+          search_query.setLimit(Integer.parseInt(limit));
+        } catch (NumberFormatException e) {
+          throw new BadRequestException(
+                  "Unable to convert 'limit' to a valid number");
+        }
+      }
       return search_query;
     }
     


### PR DESCRIPTION
This commit updates the ['search/lookup' HTTP API endpoint](http://opentsdb.net/docs/build/html/api_http/search/lookup.html) to obey the SearchQuery limit property. Now, a request can contain an optional 'limit' parameter which sets an upper bound on the number of results returned.

The default value remains 25, but is now actually enforced.

Context: https://github.com/grafana/grafana/issues/1250#issuecomment-109185678