### PR TITLE
[check_tsd] Explicitly check for w/c is None

### DIFF
--- a/tools/check_tsd
+++ b/tools/check_tsd
@@ -91,9 +91,9 @@ def main(argv):
     elif options.ignore_recent < 0:
         parser.error('--ignore-recent must be positive.')
 
-    if not options.critical:
+    if options.critical is None:
         options.critical = options.warning
-    elif not options.warning:
+    elif options.warning is None:
         options.warning = options.critical
 
     # argument construction


### PR DESCRIPTION
In its current form, if you want to warn between 0 and `x` and go
critical after `x` (i.e. `-w 0 -c 10`) the script will set `options.warning`
to `x` as `not 0` or `not 0.0` will evaluate to true. This changes it so that
`None` is explicitly checked for, thus if you pass `-w 0 -c 10` then
`options.warning` will remain `0` and `options.critical` will still be 10