### PR TITLE
Allow overriding the maximum number of tags via config

### DIFF
--- a/src/core/Const.java
+++ b/src/core/Const.java
@@ -19,8 +19,26 @@ public final class Const {
   public static final short TIMESTAMP_BYTES = 4;
 
   /** Maximum number of tags allowed per data point.  */
-  public static final short MAX_NUM_TAGS = 8;
-  // 8 is an aggressive limit on purpose.  Can always be increased later.
+  private static short MAX_NUM_TAGS = 8;
+  public static short MAX_NUM_TAGS() {
+    return MAX_NUM_TAGS;
+  }
+
+  /**
+   * -------------- WARNING ----------------
+   * Package private method to override the maximum number of tags.
+   * 8 is an aggressive limit on purpose to avoid performance issues.
+   * @param tags The number of tags to allow
+   * @throws IllegalArgumentException if the number of tags is less
+   * than 1 (OpenTSDB requires at least one tag per metric).
+   */
+  static void setMaxNumTags(final short tags) {
+    if (tags < 1) {
+      throw new IllegalArgumentException("tsd.storage.max_tags must be greater than 0");
+    }
+    MAX_NUM_TAGS = tags;
+  }
+
 
   /** Number of LSBs in time_deltas reserved for flags.  */
   public static final short FLAG_BITS = 4;

--- a/src/core/IncomingDataPoints.java
+++ b/src/core/IncomingDataPoints.java
@@ -100,9 +100,9 @@ final class IncomingDataPoints implements WritableDataPoints {
     if (tags.size() <= 0) {
       throw new IllegalArgumentException("Need at least one tag (metric="
           + metric + ", tags=" + tags + ')');
-    } else if (tags.size() > Const.MAX_NUM_TAGS) {
+    } else if (tags.size() > Const.MAX_NUM_TAGS()) {
       throw new IllegalArgumentException("Too many tags: " + tags.size()
-          + " maximum allowed: " + Const.MAX_NUM_TAGS + ", tags: " + tags);
+          + " maximum allowed: " + Const.MAX_NUM_TAGS() + ", tags: " + tags);
     }
 
     Tags.validateString("metric name", metric);

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -164,6 +164,9 @@ public final class TSDB {
     if (config.hasProperty("tsd.storage.uid.width.tagv")) {
       TAG_VALUE_WIDTH = config.getShort("tsd.storage.uid.width.tagv");
     }
+    if (config.hasProperty("tsd.storage.max_tags")) {
+      Const.setMaxNumTags(config.getShort("tsd.storage.max_tags"));
+    }
     if (config.hasProperty("tsd.storage.salt.buckets")) {
       Const.setSaltBuckets(config.getInt("tsd.storage.salt.buckets"));
     }

--- a/test/core/TestTSDB.java
+++ b/test/core/TestTSDB.java
@@ -94,7 +94,20 @@ public final class TestTSDB extends BaseTsdbTest {
     config.overrideConfig("tsd.storage.uid.width.tagv", "3");
     new TSDB(client, config);
   }
-  
+
+  @Test
+  public void ctorOverrideMaxNumTags() throws Exception {
+    assertEquals(8, Const.MAX_NUM_TAGS());
+
+    config.overrideConfig("tsd.storage.max_tags", "12");
+    new TSDB(client, config);
+    assertEquals(12, Const.MAX_NUM_TAGS());
+
+    // IMPORTANT Restore
+    config.overrideConfig("tsd.storage.max_tags", "8");
+    new TSDB(client, config);
+  }
+
   @Test
   public void ctorOverrideSalt() throws Exception {
     assertEquals(20, Const.SALT_BUCKETS());
@@ -111,7 +124,7 @@ public final class TestTSDB extends BaseTsdbTest {
     config.overrideConfig("tsd.storage.salt.width", "0");
     new TSDB(client, config);
   }
-  
+
   @Test
   public void initializePluginsDefaults() {
     // no configured plugin path, plugins disabled, no exceptions


### PR DESCRIPTION
Continues to default to 8.

Since precedent has been set for making footgun configs with UID widths and salting, having this configurable would also avoid some custom patching :)

Couple of questions...
* Is the config name (`tsd.storage.max_tags`) OK?
* Would you prefer me to switch any other code using Const.MAX_NUM_TAGS to the Const.MAX_NUM_TAGS() i added for the tests?

Cheers,
-kieren