### PR TITLE
enable /api/uid/rename endpoint

### DIFF
--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -1115,6 +1115,52 @@ public final class TSDB {
     }
   }
   
+  /**
+   * Attempts to rename a UID from existing name to the given name
+   * Used by the UniqueIdRpc call to rename name of existing metrics, tagks or
+   * tagvs. The name must pass validation. If the UID doesn't exist, the method
+   * will throw an error. Chained IllegalArgumentException is directly exposed
+   * to caller. If the rename was successful, this method returns.
+   * @param type The type of uid to rename, one of metric, tagk and tagv
+   * @param oldname The existing name of the uid object
+   * @param newname The new name to be used on the uid object
+   * @throws IllegalArgumentException if error happened
+   * @since 2.2
+   */
+  public void renameUid(final String type, final String oldname,
+      final String newname) {
+    Tags.validateString(type, oldname);
+    Tags.validateString(type, newname);
+    if (type.toLowerCase().equals("metric")) {
+      try {
+        this.metrics.getId(oldname);
+        this.metrics.rename(oldname, newname);
+      } catch (NoSuchUniqueName nsue) {
+        throw new IllegalArgumentException("Name(\"" + oldname +
+            "\") does not exist");
+      }
+    } else if (type.toLowerCase().equals("tagk")) {
+      try {
+        this.tag_names.getId(oldname);
+        this.tag_names.rename(oldname, newname);
+      } catch (NoSuchUniqueName nsue) {
+        throw new IllegalArgumentException("Name(\"" + oldname +
+            "\") does not exist");
+      }
+    } else if (type.toLowerCase().equals("tagv")) {
+      try {
+        this.tag_values.getId(oldname);
+        this.tag_values.rename(oldname, newname);
+      } catch (NoSuchUniqueName nsue) {
+        throw new IllegalArgumentException("Name(\"" + oldname +
+            "\") does not exist");
+      }
+    } else {
+      LOG.warn("Unknown type name: " + type);
+      throw new IllegalArgumentException("Unknown type name");
+    }
+  }
+
   /** @return the name of the UID table as a byte array for client requests */
   public byte[] uidTable() {
     return this.uidtable;

--- a/src/tsd/HttpJsonSerializer.java
+++ b/src/tsd/HttpJsonSerializer.java
@@ -193,6 +193,26 @@ class HttpJsonSerializer extends HttpSerializer {
   }
   
   /**
+   * Parses metric, tagk or tagv, and name to rename UID
+   * @return as hash map of type and name
+   * @throws JSONException if parsing failed
+   * @throws BadRequestException if the content was missing or parsing failed
+   */
+  public HashMap<String, String> parseUidRenameV1() {
+    final String json = query.getContent();
+    if (json == null || json.isEmpty()) {
+      throw new BadRequestException(HttpResponseStatus.BAD_REQUEST,
+          "Missing message content",
+          "Supply valid JSON formatted data in the body of your request");
+    }
+    try {
+      return JSON.parseToObject(json, TR_HASH_MAP);
+    } catch (IllegalArgumentException iae) {
+      throw new BadRequestException("Unable to parse the given JSON", iae);
+    }
+  }
+
+  /**
    * Parses a timeseries data query
    * @return A TSQuery with data ready to validate
    * @throws JSONException if parsing failed
@@ -533,6 +553,15 @@ class HttpJsonSerializer extends HttpSerializer {
     return this.serializeJSON(response);
   }
   
+  /**
+   * Format a response from the Uid Rename RPC
+   * @param response A map of result and error of the rename
+   * @return A JSON structure
+   * @throws JSONException if serialization failed
+   */
+  public ChannelBuffer formatUidRenameV1(final Map<String, String> response) {
+    return this.serializeJSON(response);
+  }
   /**
    * Format the results from a timeseries data query
    * @param data_query The TSQuery object used to fetch the results

--- a/src/tsd/HttpSerializer.java
+++ b/src/tsd/HttpSerializer.java
@@ -199,6 +199,18 @@ public abstract class HttpSerializer {
   }
   
   /**
+   * Parses metrics, tagk or tagvs type and name to rename UID
+   * @return as hash map of type and name
+   * @throws BadRequestException if the plugin has not implemented this method
+   */
+  public HashMap<String, String> parseUidRenameV1() {
+    throw new BadRequestException(HttpResponseStatus.NOT_IMPLEMENTED,
+        "The requested API endpoint has not been implemented",
+        this.getClass().getCanonicalName() +
+        " has not implemented parseUidRenameV1");
+  }
+
+  /**
    * Parses a SearchQuery request
    * @return The parsed search query
    * @throws BadRequestException if the plugin has not implemented this method
@@ -443,6 +455,19 @@ public abstract class HttpSerializer {
         " has not implemented formatUidAssignV1");
   }
   
+  /**
+   * Format a response from the Uid Rename RPC
+   * @param response A map of result and reason for error of the rename
+   * @return A ChannelBuffer object to pass on to the caller
+   * @throws BadRequestException if the plugin has not implemented this method
+   */
+  public ChannelBuffer formatUidRenameV1(final Map<String, String> response) {
+    throw new BadRequestException(HttpResponseStatus.NOT_IMPLEMENTED,
+        "The requested API endpoint has not been implemented",
+        this.getClass().getCanonicalName() +
+        " has not implemented formatUidRenameV1");
+  }
+
   /**
    * Format the results from a timeseries data query
    * @param query The TSQuery object used to fetch the results

--- a/src/tsd/UniqueIdRpc.java
+++ b/src/tsd/UniqueIdRpc.java
@@ -62,6 +62,9 @@ final class UniqueIdRpc implements HttpRpc {
     } else if (endpoint.toLowerCase().equals("tsmeta")) {
       this.handleTSMeta(tsdb, query);
       return;
+    } else if (endpoint.toLowerCase().equals("rename")) {
+      this.handleRename(tsdb, query);
+      return;
     } else {
       throw new BadRequestException(HttpResponseStatus.NOT_IMPLEMENTED, 
           "Other UID endpoints have not been implemented yet");
@@ -477,6 +480,70 @@ final class UniqueIdRpc implements HttpRpc {
     return meta;
   }
   
+  /**
+   * Rename UID to a new name of the given metric, tagk or tagv names
+   * <p>
+   * This handler supports GET and POST whereby the GET command can parse query
+   * strings with the {@code type} and {@code name} as their parameters.
+   * <p>
+   * @param tsdb The TSDB from the RPC router
+   * @param query The query for this request
+   */
+  private void handleRename(final TSDB tsdb, final HttpQuery query) {
+    // only accept GET and POST
+    if (query.method() != HttpMethod.GET && query.method() != HttpMethod.POST) {
+      throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED,
+          "Method not allowed", "The HTTP method[" + query.method().getName() +
+          "] is not permitted for this endpoint");
+    }
+
+    final HashMap<String, String> source;
+    if (query.method() == HttpMethod.POST) {
+      source = query.serializer().parseUidRenameV1();
+    } else {
+      source = new HashMap<String, String>(3);
+      final String[] types = {"metric", "tagk", "tagv", "name"};
+      for (int i = 0; i < types.length; i++) {
+        final String value = query.getQueryStringParam(types[i]);
+        if (value!= null && !value.isEmpty()) {
+          source.put(types[i], value);
+        }
+      }
+    }
+    String type = null;
+    String oldname = null;
+    String newname = null;
+    for (Map.Entry<String, String> entry : source.entrySet()) {
+      if (entry.getKey().equals("name")) {
+        newname = entry.getValue();
+      } else {
+        type = entry.getKey();
+        oldname = entry.getValue();
+      }
+    }
+
+    // we need a type/value and new name
+    if (type == null || oldname == null || newname == null) {
+      throw new BadRequestException("Missing necessary values to rename UID");
+    }
+
+    HashMap<String, String> response = new HashMap<String, String>(2);
+    try {
+      tsdb.renameUid(type, oldname, newname);
+      response.put("result", "true");
+    } catch (IllegalArgumentException e) {
+      response.put("result", "false");
+      response.put("error", e.getMessage());
+    }
+
+    if (!response.containsKey("error")) {
+      query.sendReply(query.serializer().formatUidRenameV1(response));
+    } else {
+      query.sendReply(HttpResponseStatus.BAD_REQUEST,
+          query.serializer().formatUidRenameV1(response));
+    }
+  }
+
   /**
    * Used with verb overrides to parse out values from a query string
    * @param query The query to parse

--- a/test/core/TestTSDB.java
+++ b/test/core/TestTSDB.java
@@ -401,6 +401,52 @@ public final class TestTSDB extends BaseTsdbTest {
     tsdb.assignUid("metric", "Not!A:Valid@Name");
   }
   
+  @Test (expected = IllegalArgumentException.class)
+  public void renameUidInvalidNewname() {
+    tsdb.renameUid("metric", "existing", null);
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void renameUidNonexistentMetric() {
+    when(metrics.getId("sys.cpu.1")).thenThrow(
+        new NoSuchUniqueName("metric", "sys.cpu.1"));
+    tsdb.renameUid("metric", "sys.cpu.1", "sys.cpu.2");
+  }
+
+  @Test
+  public void renameUidMetric() {
+    tsdb.renameUid("metric", "sys.cpu.1", "sys.cpu.2");
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void renameUidNonexistentTagk() {
+    when(tag_names.getId("datacenter")).thenThrow(
+        new NoSuchUniqueName("tagk", "datacenter"));
+    tsdb.renameUid("tagk", "datacenter", "datacluster");
+  }
+
+  @Test
+  public void renameUidTagk() {
+    tsdb.renameUid("tagk", "datacenter", "datacluster");
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void renameUidNonexistentTagv() {
+    when(tag_values.getId("localhost")).thenThrow(
+        new NoSuchUniqueName("tagv", "localhost"));
+    tsdb.renameUid("tagv", "localhost", "127.0.0.1");
+  }
+
+  @Test
+  public void renameUidTagv() {
+    tsdb.renameUid("tagv", "localhost", "127.0.0.1");
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void renameUidBadType() {
+    tsdb.renameUid("wrongtype", METRIC_STRING, METRIC_STRING);
+  }
+
   @Test
   public void uidTable() {
     assertNotNull(tsdb.uidTable());

--- a/test/tsd/TestHttpJsonSerializer.java
+++ b/test/tsd/TestHttpJsonSerializer.java
@@ -164,6 +164,37 @@ public final class TestHttpJsonSerializer {
   }
   
   @Test
+  public void parseUidRenameV1() throws Exception {
+    HttpQuery query = NettyMocks.postQuery(tsdb, "",
+        "{\"metric\":\"sys.cpu.1\",\"name\":\"sys.cpu.2\"}", "");
+    HttpJsonSerializer serdes = new HttpJsonSerializer(query);
+    HashMap<String, String> map = serdes.parseUidRenameV1();
+    assertNotNull(map);
+    assertEquals("sys.cpu.1", map.get("metric"));
+  }
+
+  @Test (expected = BadRequestException.class)
+  public void parseUidRenameV1NoContent() throws Exception {
+    HttpQuery query = NettyMocks.postQuery(tsdb, "", null, "");
+    HttpJsonSerializer serdes = new HttpJsonSerializer(query);
+    serdes.parseUidRenameV1();
+  }
+
+  @Test (expected = BadRequestException.class)
+  public void parseUidRenameV1EmptyContent() throws Exception {
+    HttpQuery query = NettyMocks.postQuery(tsdb, "", "", "");
+    HttpJsonSerializer serdes = new HttpJsonSerializer(query);
+    serdes.parseUidRenameV1();
+  }
+
+  @Test (expected = BadRequestException.class)
+  public void parseUidRenameV1NotJSON() throws Exception {
+    HttpQuery query = NettyMocks.postQuery(tsdb, "", "NOT JSON", "");
+    HttpJsonSerializer serdes = new HttpJsonSerializer(query);
+    serdes.parseUidRenameV1();
+  }
+
+  @Test
   public void formatSuggestV1() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "");
     HttpJsonSerializer serdes = new HttpJsonSerializer(query);
@@ -194,6 +225,38 @@ public final class TestHttpJsonSerializer {
     serdes.formatSuggestV1(null);
   }
   
+  @Test
+  public void formatUidRenameV1Success() throws Exception {
+    HttpQuery query = NettyMocks.getQuery(tsdb, "");
+    HttpJsonSerializer serdes = new HttpJsonSerializer(query);
+    final HashMap<String, String> map = new HashMap<String, String>(2);
+    map.put("result", "true");
+    ChannelBuffer cb = serdes.formatUidRenameV1(map);
+    assertNotNull(cb);
+    assertEquals("{\"result\":\"true\"}",
+        cb.toString(Charset.forName("UTF-8")));
+  }
+
+  @Test
+  public void formatUidRenameV1Failed() throws Exception {
+    HttpQuery query = NettyMocks.getQuery(tsdb, "");
+    HttpJsonSerializer serdes = new HttpJsonSerializer(query);
+    final HashMap<String, String> map = new HashMap<String, String>(2);
+    map.put("result", "false");
+    map.put("error", "known");
+    ChannelBuffer cb = serdes.formatUidRenameV1(map);
+    assertNotNull(cb);
+    assertEquals("{\"error\":\"known\",\"result\":\"false\"}",
+        cb.toString(Charset.forName("UTF-8")));
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void formatUidRenameV1Null() throws Exception {
+    HttpQuery query = NettyMocks.getQuery(tsdb, "");
+    HttpJsonSerializer serdes = new HttpJsonSerializer(query);
+    serdes.formatUidRenameV1(null);
+  }
+
   @Test
   public void formatSerializersV1() throws Exception {
     HttpQuery.initializeSerializerMaps(tsdb);


### PR DESCRIPTION
This exposes the UID rename as an api endpoint.

This comes handy when we need to rename the tag value. Currently only one rename at one api request.

./build.sh check passed 106 of total 107 tests, with the only failure being the fully commented test/tsd/TestGraphHandler.java.