### PR TITLE
Fix up Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -389,8 +389,8 @@ install-data-local: staticroot install-data-lib install-data-tools \
     install-data-bin install-data-etc
 	@$(NORMAL_INSTALL)
 	test -z "$(staticdir)" || $(mkdir_p) "$(DESTDIR)$(staticdir)"
-	@set -e; pwd; ls -lFh; cd "$(DEV_TSD_STATICROOT)"; \
-          list=`find -L . ! -type d`; for p in $$list; do \
+	@set -e; pwd; ls -lFh; (cd "$(DEV_TSD_STATICROOT)"; \
+          list=`find -L . ! -type d`); for p in $$list; do \
           p=$${p#./}; \
 	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
           dstdir=`dirname "$(DESTDIR)$(staticdir)/$$p"`; \


### PR DESCRIPTION
MAC OSX 10.10.5 (14F27)
automake (GNU automake) 1.15

I want to install opentsdb to a custom directory, say `install`.
`./build.sh ; ./configure --prefix=`pwd`/install; make; make install`  failed with output below.

/bin/sh: ./build-aux/install-sh: No such file or directory
make[2]: *** [install-data-local] Error 1
make[1]: *** [install-am] Error 2

Because `cd "$(DEV_TSD_STATICROOT)"` has change current directory. The commit can fix it.