### PR TITLE
Fuzzy row filter optimization for the first N consecutive tags

### DIFF
--- a/src/core/TsdbQuery.java
+++ b/src/core/TsdbQuery.java
@@ -32,6 +32,9 @@ import org.hbase.async.HBaseException;
 import org.hbase.async.KeyValue;
 import org.hbase.async.Scanner;
 import org.hbase.async.Bytes.ByteMap;
+import org.hbase.async.FuzzyRowFilter;
+import org.hbase.async.FilterList;
+import org.hbase.async.ScanFilter;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.stumbleupon.async.Callback;
@@ -40,6 +43,7 @@ import com.stumbleupon.async.DeferredGroupException;
 
 import net.opentsdb.query.QueryUtil;
 import net.opentsdb.query.filter.TagVFilter;
+import net.opentsdb.query.filter.TagVLiteralOrFilter;
 import net.opentsdb.stats.Histogram;
 import net.opentsdb.uid.NoSuchUniqueId;
 import net.opentsdb.uid.NoSuchUniqueName;
@@ -68,6 +72,13 @@ final class TsdbQuery implements Query {
    * We use this one because it preserves every possible byte unchanged.
    */
   private static final Charset CHARSET = Charset.forName("ISO-8859-1");
+
+  /**
+   * UID of the tagk that can only appear at the front of a sorted list of
+   * tagk/v pairs. We know that the value is 1 since each UID is issued by an
+   * atomic increment operation.
+   */
+  private static final long FIRST_UID = 1;
 
   /** The TSDB we belong to. */
   private final TSDB tsdb;
@@ -949,9 +960,12 @@ final class TsdbQuery implements Query {
   }
 
   /**
-   * Sets the server-side regexp filter on the scanner.
+   * Sets the server-side regexp filter and optional fuzzy row filter on the
+   * scanner.
    * In order to find the rows with the relevant tags, we use a
    * server-side filter that matches a regular expression on the row key.
+   * When the query has filters for the first N consecutive tags,
+   * we can use fuzzy row filter to skip-scan the rows.
    * @param scanner The scanner on which to add the filter.
    */
   private void createAndSetFilter(final Scanner scanner) {
@@ -961,6 +975,54 @@ final class TsdbQuery implements Query {
     scanner.setKeyRegexp(regex, CHARSET);
     if (LOG.isDebugEnabled()) {
       LOG.debug("Scanner regex: " + QueryUtil.byteRegexToString(regex));
+    }
+    if (filters.isEmpty()) {
+      return;
+    }
+
+    // Start building row key pattern and fuzzy mask for fuzzy row filter
+    byte[] rowkey = scanner.getCurrentKey();
+    byte[] fuzzy_mask = new byte[rowkey.length];
+    Arrays.fill(fuzzy_mask, (byte) 1);
+
+    // Let's see if we can also extend the start key with tag literals
+    byte[] start_key = rowkey;
+    boolean append_to_start_key = true;
+
+    long tagk_uid = FIRST_UID;
+    for (TagVFilter filter : filters) {
+      if (UniqueId.uidToLong(filter.getTagkBytes(), TSDB.tagk_width()) == tagk_uid) {
+        byte[] tag_mask = new byte[TSDB.tagk_width() + TSDB.tagv_width()];
+        if (filter instanceof TagVLiteralOrFilter && filter.getTagVUids().size() == 1) {
+          rowkey = com.google.common.primitives.Bytes.concat(
+              rowkey, filter.getTagkBytes(), filter.getTagVUids().get(0));
+        } else {
+          // We can no longer append tagk/v pairs to start key of the scanner
+          append_to_start_key = false;
+          rowkey = com.google.common.primitives.Bytes.concat(rowkey, tag_mask);
+          Arrays.fill(tag_mask, (byte) 1);
+        }
+        // Update start key
+        if (append_to_start_key) {
+          start_key = rowkey;
+        }
+        fuzzy_mask = com.google.common.primitives.Bytes.concat(fuzzy_mask, tag_mask);
+        tagk_uid++;
+        continue;
+      }
+      break;
+    }
+
+    // Apply extended start key and fuzzy row filter only when fuzzy mask has fixed parts
+    if (tagk_uid > FIRST_UID && com.google.common.primitives.Bytes.indexOf(fuzzy_mask, (byte) 0) > -1) {
+      scanner.setStartKey(start_key);
+
+      List<ScanFilter> scanFilters = new ArrayList<ScanFilter>(2);
+      scanFilters.add(
+          new FuzzyRowFilter(
+              new FuzzyRowFilter.FuzzyFilterPair(rowkey, fuzzy_mask)));
+      scanFilters.add(scanner.getFilter());
+      scanner.setFilter(new FilterList(scanFilters));
     }
   }
   

--- a/test/storage/MockBase.java
+++ b/test/storage/MockBase.java
@@ -1382,7 +1382,14 @@ public final class MockBase {
           return null;
         }      
       }).when(mock_scanner).setStartKey((byte[])any());
-      
+
+      doAnswer(new Answer<Object>() {
+        @Override
+        public Object answer(InvocationOnMock invocation) throws Throwable {
+          return start;
+        }
+      }).when(mock_scanner).getCurrentKey();
+
       doAnswer(new Answer<Object>() {
         @Override
         public Object answer(InvocationOnMock invocation) throws Throwable {


### PR DESCRIPTION
Hi, we're trying to build a monitoring system for our 50K+ servers using OpenTSDB.

In doing so, we have created a host dashboard page that shows a couple tens of charts for a single host during the specified time span. The page has to issue a query like follows for each metric that it displays.

```
opentsdb:4242/api/query?start=24h-ago&m=max:sys.cpu.idle%7Bhost=HOSTNAME%7D"
```

However, we noticed a significant slowdown in response time as we put more data into HBase and the cardinality of tags increases. The exact problem described in the link below.

http://opentsdb.net/docs/build/html/user_guide/writing.html#time-series-cardinality

We currently have around 8000 distinct host tags and when we open the aforementioned dashboard page, we see that the regionservers are spending all their CPU resources filtering the irrelevant rows using Regex filer while the page is rendering. The cardinality of host tags is expected to grow beyond 50K, and the page will simply be unusable in the end (it is already partly so unfortunately).

Luckily in our case, *tagk* for "host" was uid `001` and I realized we could append the filtering condition to the start key and apply fuzzy row filter to skip-scan the rows since the `001` tag can only appear at the front of the list of key-value pairs in the rowkey. (`???? ??? 001 foo`)

With the patch we are observing **over 30X improvement in the response time** and we expect the margin of improvement will further grow as the cardinality of the tag increases.

The attached patch is a generalization of the idea that sets up fuzzy row filter for the first N consecutive tags. So even if the filtering is not on `001`, but on `002`, it applies if we change the query to `001=*,002=foo`. However, we can't expect performance improvement if the preceding tag has higher cardinality because in that case fuzzy row filter will not be able to skip many rows. For your information, a quick test showed that the performance overhead of ineffective fuzzy row filter is negligible.

It's understandable if you don't want to accept the patch since the benefit is limited to specific use cases and it may not be straightforward for the users that they should *intentionally* assign the first UIDs to their most used tags with their cardinalities in mind (e.g. `curl http://opentsdb:4242/api/uid/assign?tagk=host`). Nevertheless, I really hope it's merged so we don't have to maintain our own fork.

So what do you think? Please let me know if there's anything wrong with the patch or with our approach in building the system. Test cases are currently missing, if you want I can try to add some.
