### PR TITLE
Increase max number of rows to be returned per Scanner round trip

### DIFF
--- a/src/query/QueryUtil.java
+++ b/src/query/QueryUtil.java
@@ -202,6 +202,7 @@ public class QueryUtil {
     System.arraycopy(metric, 0, end_row, Const.SALT_WIDTH(), metric_width);
     
     final Scanner scanner = tsdb.getClient().newScanner(table);
+    scanner.setMaxNumRows(tsdb.getConfig().getHbaseClient_maxNumRows());
     scanner.setStartKey(start_row);
     scanner.setStopKey(end_row);
     scanner.setFamily(family);

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -102,6 +102,9 @@ public class Config {
   
   /** tsd.core.tree.enable_processing */
   private boolean enable_tree_processing = false;
+
+  /** tsd.storage.hbaseclient.maxNumRows */
+  private int hbaseclient_maxNumRows = 128;
   
   /**
    * The list of properties configured to their defaults or modified by users
@@ -218,6 +221,11 @@ public class Config {
   /** @return whether or not to record a 1 for every TSUID */
   public boolean enable_tsuid_tracking() {
     return enable_tsuid_tracking;
+  }
+
+  /** @return maximum number of rows to be fetched per round trip while scanning HBase */
+  public int getHbaseClient_maxNumRows() {
+    return hbaseclient_maxNumRows;
   }
   
   /** @return whether or not chunked requests are supported */
@@ -498,6 +506,7 @@ public class Config {
     default_map.put("tsd.search.enable", "false");
     default_map.put("tsd.search.plugin", "");
     default_map.put("tsd.stats.canonical", "false");
+    default_map.put("tsd.storage.hbaseclient.maxNumRows", "768");
     default_map.put("tsd.storage.fix_duplicates", "false");
     default_map.put("tsd.storage.flush_interval", "1000");
     default_map.put("tsd.storage.hbase.data_table", "tsdb");
@@ -635,6 +644,8 @@ public class Config {
     }
     enable_tree_processing = this.getBoolean("tsd.core.tree.enable_processing");
     fix_duplicates = this.getBoolean("tsd.storage.fix_duplicates");
+    hbaseclient_maxNumRows = this.getInt("tsd.storage.hbaseclient.maxNumRows");
+
   }
   
   /**


### PR DESCRIPTION
We found that increasing this value improved our query time for many of our larger metrics (those with many tag values for a tag, or many tags).