### PR TITLE
Write branch info for Version API

### DIFF
--- a/build-aux/gen_build_data.sh
+++ b/build-aux/gen_build_data.sh
@@ -39,6 +39,7 @@ eval "$sh"  # Sets the timestamp and date variables.
 user=`whoami`
 host=`hostname`
 repo=`pwd`
+branch=`git branch | grep -h '\*.*' | awk '{print $2}'`
 
 sh=`git rev-list --pretty=format:%h HEAD --max-count=1 \
     | sed '1s/commit /full_rev=/;2s/^/short_rev=/'`
@@ -92,6 +93,8 @@ public final class $CLASS {
   public static final String host = "$host";
   /** Path to the repository in which this package was built. */
   public static final String repo = "$repo";
+  /** Git branch */
+  public static final String branch = "$branch";
 
   /** Human readable string describing the revision of this package. */
   public static final String revisionString() {

--- a/src/tsd/RpcManager.java
+++ b/src/tsd/RpcManager.java
@@ -623,7 +623,8 @@ public final class RpcManager {
       version.put("user", BuildData.user);
       version.put("host", BuildData.host);
       version.put("repo", BuildData.repo);
-      
+      version.put("branch", BuildData.branch);
+
       if (query.apiVersion() > 0) {
         query.sendReply(query.serializer().formatVersionV1(version));
       } else {


### PR DESCRIPTION
Added the branch data to the version info, useful when running in-house development branches or perhaps alternate branches in production even.