### PR TITLE
QueryUi: URL.decode() url/query string before use

### DIFF
--- a/src/tsd/client/QueryUi.java
+++ b/src/tsd/client/QueryUi.java
@@ -780,7 +780,7 @@ public class QueryUi implements EntryPoint, HistoryListener {
   }
 
   private void refreshFromQueryString() {
-    final QueryString qs = getQueryString(History.getToken());
+    final QueryString qs = getQueryString(URL.decode(History.getToken()));
 
     maybeSetTextbox(qs, "start", start_datebox.getTextBox());
     maybeSetTextbox(qs, "end", end_datebox.getTextBox());
@@ -961,7 +961,7 @@ public class QueryUi implements EntryPoint, HistoryListener {
           if (autoreload.getValue()) {
             history += "&autoreload=" + autoreoload_interval.getText();
           }
-          if (!history.equals(History.getToken())) {
+          if (!history.equals(URL.decode(History.getToken()))) {
             History.newItem(history, false);
           }
 


### PR DESCRIPTION
Some browsers (aka firefox) like to encode { and } as %7B and %7D.  This
causes problem when parsing the query string since its using { and } to
figure out the metric and tags.  Without this the UI thows an error like
the following:

Request failed: Bad Request: No such name for 'metrics': 'server.nic.usage.mbit%7Bhost=host1%7D'