### PR TITLE
alignTimestamp() according to the TimeZone if setted.

### DIFF
--- a/src/core/Downsampler.java
+++ b/src/core/Downsampler.java
@@ -13,6 +13,7 @@
 package net.opentsdb.core;
 
 import java.util.NoSuchElementException;
+import java.util.TimeZone;
 
 
 /**
@@ -193,7 +194,8 @@ public class Downsampler implements SeekableView, DataPoint {
 
     /** Returns timestamp aligned by interval. */
     private long alignTimestamp(long timestamp) {
-      return timestamp - (timestamp % interval_ms);
+      long tzOffset = TimeZone.getDefault().getRawOffset();
+      return timestamp - ((timestamp + tzOffset) % interval_ms);
     }
 
     // ---------------------- //


### PR DESCRIPTION
alignTimestamp() according to the TimeZone if setted. Or you cannot get the right result if you want to see datapoint aligned to a non-UTC timezone.

for example:
the query like:

    $ tsdb query 1445529600 1445788800 zimsum downsample 86400000 zimsum my.mtrc 
you'll get:

    ……
    my.mtrc 1445558400000 2570882.000000 {}
    my.mtrc 1445644800000 2591490.000000 {}
    my.mtrc 1445731200000 2879812.000000 {}
    ……
**1445558400000** is  **2015-10-23 00:00:00 UTC** 

but if your timezone is GMT+8， the actual result you want is:

    ……
    my.mtrc 1445529600000 2515360.000000 {}
    my.mtrc 1445616000000 2663943.000000 {}
    my.mtrc 1445702400000 2888318.000000 {}
    ……
**1445529600000** is  **2015-10-23 00:00:00 GMT+8** 