### PR TITLE
make OOM handler be able to handle multiple instances of opentsdb server

### DIFF
--- a/tools/opentsdb_restart.py
+++ b/tools/opentsdb_restart.py
@@ -8,8 +8,11 @@ This is known to work with python2.6 and above.
 import os
 import subprocess
 
+service_name = "opentsdb"
+if 'NAME' in os.environ:
+    service_name = os.environ['NAME']
 
-subprocess.call(["service", "opentsdb", "stop"])
+subprocess.call(["service", service_name, "stop"])
 # Close any file handles we inherited from our parent JVM. We need
 # to do this before restarting so that the socket isn't held open.
 openfiles = [int(f) for f in os.listdir("/proc/self/fd")]
@@ -17,4 +20,4 @@ openfiles = [int(f) for f in os.listdir("/proc/self/fd")]
 # that there is less chance of errors with those standard streams.
 # Other files start at fd 3.
 os.closerange(3, max(openfiles))
-subprocess.call(["service", "opentsdb", "start"])
+subprocess.call(["service", service_name, "start"])


### PR DESCRIPTION
The "/etc/init.d/opentsdb" can be made multiple symlinks to launch multiple opentsdb instances, such as:
```bash
$ ls -l /etc/init.d/opentsdb* /etc/opentsdb/opentsdb* /etc/sysconfig/opentsdb*
lrwxrwxrwx 1 root root   39 Oct 27 13:46 /etc/init.d/opentsdb -> /usr/share/opentsdb/etc/init.d/opentsdb
lrwxrwxrwx 1 root root    8 Sep  8 16:25 /etc/init.d/opentsdb-monitoring -> opentsdb
lrwxrwxrwx 1 root root    8 Sep  8 16:25 /etc/init.d/opentsdb-search -> opentsdb
-rw-r--r-- 1 root root 2101 Oct 27 13:41 /etc/opentsdb/opentsdb.conf
-rw-r--r-- 1 root root 2878 Oct 27 04:01 /etc/opentsdb/opentsdb-monitoring.conf
-rw-r--r-- 1 root root 2862 Oct 27 04:01 /etc/opentsdb/opentsdb-search.conf
-rw-r--r-- 1 root root  187 Oct 27 13:43 /etc/sysconfig/opentsdb-monitoring
-rw-r--r-- 1 root root  183 Oct 27 13:44 /etc/sysconfig/opentsdb-search
```

But the script specified by "-XX:OnOutOfMemoryError=/usr/share/opentsdb/tools/opentsdb_restart.py" can only handle service "opentsdb",  this little patch enhances it to support multiple instances of opentsdb server.