### PR TITLE
s/space/comma/ in instruction for specifying ZooKeeper quorum

### DIFF
--- a/build-aux/deb/opentsdb.conf
+++ b/build-aux/deb/opentsdb.conf
@@ -58,6 +58,6 @@ tsd.core.plugin_path = /usr/share/opentsdb/plugins
 # Path under which the znode for the -ROOT- region is located, default is "/hbase"
 #tsd.storage.hbase.zk_basedir = /hbase
 
-# A space separated list of Zookeeper hosts to connect to, with or without 
+# A comma separated list of Zookeeper hosts to connect to, with or without 
 # port specifiers, default is "localhost"
 #tsd.storage.hbase.zk_quorum = localhost

--- a/build-aux/rpm/opentsdb.conf
+++ b/build-aux/rpm/opentsdb.conf
@@ -58,6 +58,6 @@ tsd.core.plugin_path = /usr/share/opentsdb/plugins
 # Path under which the znode for the -ROOT- region is located, default is "/hbase"
 #tsd.storage.hbase.zk_basedir = /hbase
 
-# A space separated list of Zookeeper hosts to connect to, with or without
+# A comma separated list of Zookeeper hosts to connect to, with or without
 # port specifiers, default is "localhost"
 #tsd.storage.hbase.zk_quorum = localhost


### PR DESCRIPTION
Fix for issue https://github.com/OpenTSDB/opentsdb/issues/571

I grep the source folder, so we can be sure that all config files are updated.