### PR TITLE
fix stuck metasync when salting is enabled

### DIFF
--- a/src/core/BatchedDataPoints.java
+++ b/src/core/BatchedDataPoints.java
@@ -304,7 +304,7 @@ final class BatchedDataPoints implements WritableDataPoints {
     if (row_key == null) {
       throw new IllegalStateException("Instance was not properly constructed!");
     }
-    final byte[] id = Arrays.copyOfRange(row_key, 0, 
+    final byte[] id = Arrays.copyOfRange(row_key, Const.SALT_WIDTH(),
         tsdb.metrics.width() + Const.SALT_WIDTH());
     return tsdb.metrics.getNameAsync(id);
   }

--- a/src/search/TimeSeriesLookup.java
+++ b/src/search/TimeSeriesLookup.java
@@ -403,7 +403,7 @@ public class TimeSeriesLookup {
         key = metric_uid;
       } else {
         key = new byte[Const.SALT_WIDTH() + TSDB.metrics_width()];
-        key[0] = (byte)salt;
+        System.arraycopy(RowKey.getSaltBytes(salt), 0, key, 0, Const.SALT_WIDTH());
         System.arraycopy(metric_uid, 0, key, Const.SALT_WIDTH(), metric_uid.length);
       }
       scanner.setStartKey(key);
@@ -416,7 +416,7 @@ public class TimeSeriesLookup {
           key = UniqueId.longToUID(uid, TSDB.metrics_width());
         } else {
           key = new byte[Const.SALT_WIDTH() + TSDB.metrics_width()];
-          key[0] = (byte)salt;
+          System.arraycopy(RowKey.getSaltBytes(salt), 0, key, 0, Const.SALT_WIDTH());
           System.arraycopy(UniqueId.longToUID(uid, TSDB.metrics_width()), 0, 
               key, Const.SALT_WIDTH(), metric_uid.length);
         }

--- a/src/tools/MetaSync.java
+++ b/src/tools/MetaSync.java
@@ -392,7 +392,7 @@ final class MetaSync extends Thread {
           
           // now process the UID metric meta data
           final byte[] metric_uid_bytes = 
-            Arrays.copyOfRange(tsuid, 0, Const.SALT_WIDTH() + TSDB.metrics_width()); 
+            Arrays.copyOfRange(tsuid, 0, TSDB.metrics_width());
           final String metric_uid = UniqueId.uidToString(metric_uid_bytes);
           Long last_get = metric_uids.get(metric_uid);
           


### PR DESCRIPTION
MetaScanner extracts (salt_width + metric_width) bytes from tsuid
to metric uid, this triggers IllegalArgumentException in
UniqueId.getNameAsync(id), then MetaScanner.call() won't never
call result.callback(null), and result.joinUninterruptibly() in
MetaSync.run() never returns.

BTW, I checked all usages of Const.SALT_WIDTH() and fixed some
other similar wrong calculations.