### PR TITLE
Apply regex based whitelists to new uid auto-creation

### DIFF
--- a/src/opentsdb.conf
+++ b/src/opentsdb.conf
@@ -38,6 +38,18 @@ tsd.http.cachedir =
 # is False
 #tsd.core.auto_create_metrics = false
 
+# Comma-Delimited list of regex patterns to match against new metric names, default
+# is .*, examples might be ^awesome\..*$,^regexfoo[0-9].*$
+#tsd.core.auto_create_metrics_patterns = .*
+
+# Comma-Delimited list of regex patterns to match against new tagk names, default
+# is .*, examples might be ^awesome\..*$,^regexfoo[0-9].*$
+#tsd.core.auto_create_tagk_patterns = .*
+
+# Comma-Delimited list of regex patterns to match against new tagv names, default
+# is .*, examples might be ^awesome\..*$,^regexfoo[0-9].*$
+#tsd.core.auto_create_tagv_patterns = .*
+
 # --------- STORAGE ----------
 # Whether or not to enable data compaction in HBase, default is True
 #tsd.storage.enable_compaction = true

--- a/src/tools/CliOptions.java
+++ b/src/tools/CliOptions.java
@@ -120,6 +120,9 @@ final class CliOptions {
       // map the overrides
       if (entry.getKey().toLowerCase().equals("--auto-metric")) {
         config.overrideConfig("tsd.core.auto_create_metrics", "true");
+      } else if (entry.getKey().toLowerCase().equals("--auto-metric-pattern")) {
+        config.overrideConfig("tsd.core.auto_create_metrics_patterns",
+            entry.getValue());
       } else if (entry.getKey().toLowerCase().equals("--table")) {
         config.overrideConfig("tsd.storage.hbase.data_table", entry.getValue());
       } else if (entry.getKey().toLowerCase().equals("--uidtable")) {

--- a/src/uid/UniqueId.java
+++ b/src/uid/UniqueId.java
@@ -20,6 +20,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 
 import javax.xml.bind.DatatypeConverter;
 
@@ -631,6 +632,10 @@ public final class UniqueId implements UniqueIdInterface {
     try {
       return getIdAsync(name).joinUninterruptibly();
     } catch (NoSuchUniqueName e) {
+      if (!checkNameIsValid(name)) {
+        LOG.info("UID cannot be assigned, name is not acceptable: " + name);
+        throw new RuntimeException("UID cannot be assigned, name is not acceptable: " + name);
+      }
       Deferred<byte[]> assignment = null;
       boolean pending = false;
       synchronized (pending_assignments) {
@@ -675,6 +680,47 @@ public final class UniqueId implements UniqueIdInterface {
       return uid;
     } catch (Exception e) {
       throw new RuntimeException("Should never be here", e);
+    }
+  }
+
+  /**
+   * Checks to see if the provided string matches the acceptable
+   * patterns from the configuration.
+   * <p>
+   *
+   * @param name The name to compare to the acceptable name regexes
+   * @return
+     */
+  public Boolean checkNameIsValid(final String name) throws RuntimeException {
+    final List<Pattern> rxs = new ArrayList();
+    try {
+      String uid_patterns;
+      switch (type) {
+        case METRIC: uid_patterns = tsdb.getConfig().auto_metric_patterns();
+          break;
+        case TAGK: uid_patterns = tsdb.getConfig().auto_tagk_patterns();
+          break;
+        case TAGV: uid_patterns = tsdb.getConfig().auto_tagv_patterns();
+          break;
+        default:
+          throw new RuntimeException("Should never be here");
+      }
+      String[] patterns = uid_patterns.split(",");
+
+      for (String pattern : patterns) {
+        rxs.add(Pattern.compile(pattern));
+      }
+
+      for (Pattern rx : rxs) {
+        if (rx.matcher(name).matches()) {
+          LOG.debug("Accepted name for UID: " + name + " based on '" + rx.toString() + "'");
+          return true;
+        }
+      }
+      LOG.debug("Rejected name for UID: " + name);
+      return false;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to check name (" + name + ") against patterns.", e);
     }
   }
 

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -69,7 +69,17 @@ public class Config {
   
   /** tsd.core.auto_create_tagv */
   private boolean auto_tagv = true;
-  
+
+  /** tsd.core.auto_create_metrics_patterns */
+  private String auto_metric_patterns = ".*";
+
+  /** tsd.core.auto_create_tagk_patterns */
+  private String auto_tagk_patterns = ".*";
+
+  /** tsd.core.auto_create_tagv_patterns */
+  private String auto_tagv_patterns = ".*";
+
+
   /** tsd.storage.enable_compaction */
   private boolean enable_compactions = true;
   
@@ -179,7 +189,22 @@ public class Config {
   public boolean auto_tagv() {
     return auto_tagv;
   }
-  
+
+  /** @return the auto_metric value */
+  public String auto_metric_patterns() {
+    return auto_metric_patterns;
+  }
+
+  /** @return the auto_tagk value */
+  public String auto_tagk_patterns() {
+    return auto_tagk_patterns;
+  }
+
+  /** @return the auto_tagv value */
+  public String auto_tagv_patterns() {
+    return auto_tagv_patterns;
+  }
+
   /** @param auto_metric whether or not to auto create metrics */
   public void setAutoMetric(boolean auto_metric) {
     this.auto_metric = auto_metric;
@@ -487,6 +512,9 @@ public class Config {
     default_map.put("tsd.core.auto_create_metrics", "false");
     default_map.put("tsd.core.auto_create_tagks", "true");
     default_map.put("tsd.core.auto_create_tagvs", "true");
+    default_map.put("tsd.core.auto_create_metrics_patterns", ".*");
+    default_map.put("tsd.core.auto_create_tagk_patterns", ".*");
+    default_map.put("tsd.core.auto_create_tagv_patterns", ".*");
     default_map.put("tsd.core.meta.enable_realtime_ts", "false");
     default_map.put("tsd.core.meta.enable_realtime_uid", "false");
     default_map.put("tsd.core.meta.enable_tsuid_incrementing", "false");
@@ -629,6 +657,9 @@ public class Config {
     auto_metric = this.getBoolean("tsd.core.auto_create_metrics");
     auto_tagk = this.getBoolean("tsd.core.auto_create_tagks");
     auto_tagv = this.getBoolean("tsd.core.auto_create_tagvs");
+    auto_metric_patterns = this.getString("tsdb.core.auto_create_metrics_patterns");
+    auto_tagk_patterns = this.getString("tsdb.core.auto_create_tagk_patterns");
+    auto_tagv_patterns = this.getString("tsdb.core.auto_create_tagv_patterns");
     enable_compactions = this.getBoolean("tsd.storage.enable_compaction");
     enable_appends = this.getBoolean("tsd.storage.enable_appends");
     repair_appends = this.getBoolean("tsd.storage.repair_appends");


### PR DESCRIPTION
I did some very basic testing in our environment.

## A good metric name:

2015-11-17 16:10:45,055 DEBUG [OpenTSDB I/O Worker #1] UniqueId: Accepted name for UID: testing.metrics.foo based on 'test..*'
2015-11-17 16:10:45,056 INFO [OpenTSDB I/O Worker #1] UniqueId: Creating an ID for kind='metrics' name='testing.metrics.foo'

## A bad metric name:

2015-11-17 16:10:59,250 DEBUG [OpenTSDB I/O Worker #2] UniqueId: Rejected name for UID: tbadmetrics.foo
2015-11-17 16:10:59,250 INFO [OpenTSDB I/O Worker #2] UniqueId: UID cannot be assigned, name is not acceptable: tbadmetrics.foo
2015-11-17 16:10:59,255 ERROR [OpenTSDB I/O Worker #2] RpcHandler: [id: 0xe1397817, /50.116.203.7:59102 => /50.116.203.7:4244] Unexpected exception caught while serving [null, tbadmetrics.foo, 1447798259, 0, domain=test]
java.lang.RuntimeException: UID cannot be assigned, name is not acceptable: tbadmetrics.foo