### PR TITLE
Assign explicit string values to UniqueId enum

### DIFF
--- a/src/tools/UidManager.java
+++ b/src/tools/UidManager.java
@@ -361,7 +361,7 @@ final class UidManager {
                             final short idwidth,
                             final String[] args) {
     boolean randomize = false;
-    if (UniqueIdType.valueOf(args[1]) == UniqueIdType.METRIC) {
+    if (UniqueIdType.METRIC.equalsName(args[1])) {
       randomize = tsdb.getConfig().getBoolean("tsd.core.uid.random_metrics");
     }
     final UniqueId uid = new UniqueId(tsdb.getClient(), table, args[1], 

--- a/src/uid/UniqueId.java
+++ b/src/uid/UniqueId.java
@@ -57,9 +57,23 @@ public final class UniqueId implements UniqueIdInterface {
 
   /** Enumerator for different types of UIDS @since 2.0 */
   public enum UniqueIdType {
-    METRIC,
-    TAGK,
-    TAGV
+    METRIC("metrics"),
+    TAGK("tagk"),
+    TAGV("tagv");
+
+    private final String name;
+
+    private UniqueIdType(String s) {
+        name = s;
+    }
+
+    public boolean equalsName(String otherType) {
+        return (otherType == null) ? false : name.equals(otherType);
+    }
+
+    public String toString() {
+       return this.name;
+    }
   }
   
   /** Charset used to convert Strings to byte arrays and back. */


### PR DESCRIPTION
This pull request fixes issue #629 by assigning explicit string values to UniqueId enum matching the TSDB class constants and implementing a equalsName method on the Enum to compare it with a string.