### PR TITLE
Silence stray logging output in TSMeta.call()

### DIFF
--- a/src/meta/TSMeta.java
+++ b/src/meta/TSMeta.java
@@ -525,7 +525,7 @@ public final class TSMeta {
       @Override
       public Deferred<Long> call(final Long incremented_value) 
         throws Exception {
-LOG.info("Value: " + incremented_value);
+        LOG.debug("Value: " + incremented_value);
         if (incremented_value > 1) {
           // TODO - maybe update the search index every X number of increments?
           // Otherwise the search engine would only get last_updated/count 


### PR DESCRIPTION
This line was added in ab276c823ee082bc216951e371062d1d019652d6 and based on indentation is likely an accidental commit.  It causes continuous spamming in our logs after upgrade.  Changing log level to "debug" to quiet it down.