### PR TITLE
Limit  the total connections tsd can serve

### DIFF
--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -125,6 +125,12 @@ final class TSDMain {
     }
 
     final ServerSocketChannelFactory factory;
+    int connectionsLimit = 0;
+    try {
+      connectionsLimit = config.getInt("tsd.connections.limit");
+    } catch (NumberFormatException nfe) {
+      usage(argp, "Invalid connections limit", 1);
+    }
     if (config.getBoolean("tsd.network.async_io")) {
       int workers = Runtime.getRuntime().availableProcessors() * 2;
       if (config.hasProperty("tsd.network.worker_threads")) {
@@ -163,7 +169,7 @@ final class TSDMain {
       // here to fail fast.
       final RpcManager manager = RpcManager.instance(tsdb);
 
-      server.setPipelineFactory(new PipelineFactory(tsdb, manager));
+      server.setPipelineFactory(new PipelineFactory(tsdb, manager, connectionsLimit));
       if (config.hasProperty("tsd.network.backlog")) {
         server.setOption("backlog", config.getInt("tsd.network.backlog")); 
       }

--- a/src/tsd/PipelineFactory.java
+++ b/src/tsd/PipelineFactory.java
@@ -47,7 +47,7 @@ public final class PipelineFactory implements ChannelPipelineFactory {
 
   // Those are sharable but maintain some state, so a single instance per
   // PipelineFactory is needed.
-  private final ConnectionManager connmgr = new ConnectionManager();
+  private final ConnectionManager connmgr;
   private final DetectHttpOrRpc HTTP_OR_RPC = new DetectHttpOrRpc();
   private final Timer timer;
   private final ChannelHandler timeoutHandler;
@@ -70,7 +70,7 @@ public final class PipelineFactory implements ChannelPipelineFactory {
    * serializers
    */
   public PipelineFactory(final TSDB tsdb) {
-    this(tsdb, RpcManager.instance(tsdb));
+    this(tsdb, RpcManager.instance(tsdb), 0);
   }
 
   /**
@@ -82,12 +82,13 @@ public final class PipelineFactory implements ChannelPipelineFactory {
    * @throws Exception if the HttpQuery handler is unable to load 
    * serializers
    */
-  public PipelineFactory(final TSDB tsdb, final RpcManager manager) {
+  public PipelineFactory(final TSDB tsdb, final RpcManager manager, final int connectionsLimit) {
     this.tsdb = tsdb;
     this.socketTimeout = tsdb.getConfig().getInt("tsd.core.socket.timeout");
     timer = tsdb.getTimer();
     this.timeoutHandler = new IdleStateHandler(timer, 0, 0, this.socketTimeout);
     this.rpchandler = new RpcHandler(tsdb, manager);
+    this.connmgr = new ConnectionManager(connectionsLimit);
     try {
       HttpQuery.initializeSerializerMaps(tsdb);
     } catch (RuntimeException e) {
@@ -153,4 +154,3 @@ public final class PipelineFactory implements ChannelPipelineFactory {
   }
   
 }
- 

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -523,6 +523,7 @@ public class Config {
       + "Content-Type, Accept, Origin, User-Agent, DNT, Cache-Control, "
       + "X-Mx-ReqToken, Keep-Alive, X-Requested-With, If-Modified-Since");
     default_map.put("tsd.query.timeout", "0");
+    default_map.put("tsd.connections.limit", "0");
 
     for (Map.Entry<String, String> entry : default_map.entrySet()) {
       if (!properties.containsKey(entry.getKey()))


### PR DESCRIPTION
As https://github.com/OpenTSDB/opentsdb/issues/616 metioned, when tsd is not able to keep pace with comming requests, total connections limit refusing new connections, help tsd not crash. And tsd may return ok with outside improvement.