### PR TITLE
"tsdb fsck --fix-all" wrongly clears data points when salting enabled

### DIFF
--- a/src/tools/Fsck.java
+++ b/src/tools/Fsck.java
@@ -114,11 +114,11 @@ final class Fsck {
   final AtomicLong vle_fixed = new AtomicLong();
   
   /** Length of the metric + timestamp for key validation */
-  private static int key_prefix_length = Const.SALT_WIDTH() + 
+  private int key_prefix_length = Const.SALT_WIDTH() +
       TSDB.metrics_width() + Const.TIMESTAMP_BYTES;
   
   /** Length of a tagk + tagv pair for key validation */
-  private static int key_tags_length = TSDB.tagk_width() + TSDB.tagv_width();
+  private int key_tags_length = TSDB.tagk_width() + TSDB.tagv_width();
   
   /** How often to report progress */
   private static long report_rows = 10000;


### PR DESCRIPTION
Const.SALT_WIDTH() is actually not constant value, it mustn't be called on class initialization.