### PR TITLE
- Update asynccassandra to fix build

### DIFF
--- a/third_party/asynccassandra/asynccassandra-0.0.1-20151102.192826-2-jar-with-dependencies.jar.md5
+++ b/third_party/asynccassandra/asynccassandra-0.0.1-20151102.192826-2-jar-with-dependencies.jar.md5
@@ -1,1 +1,0 @@
-cce1a4b5736fcdcc3ced33982c3069d1

--- a/third_party/asynccassandra/asynccassandra-0.0.1-20151104.191228-3-jar-with-dependencies.jar.md5
+++ b/third_party/asynccassandra/asynccassandra-0.0.1-20151104.191228-3-jar-with-dependencies.jar.md5
@@ -1,0 +1,1 @@
+0dd29195cdb9ca4467d0fc32bfffb98c

--- a/third_party/asynccassandra/include.mk
+++ b/third_party/asynccassandra/include.mk
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-ASYNCCASSANDRA_VERSION := 0.0.1-20151102.192826-2
+ASYNCCASSANDRA_VERSION := 0.0.1-20151104.191228-3
 ASYNCCASSANDRA := third_party/asynccassandra/asynccassandra-$(ASYNCCASSANDRA_VERSION)-jar-with-dependencies.jar
 ASYNCCASSANDRA_BASE_URL := https://oss.sonatype.org/content/repositories/snapshots/net/opentsdb/asynccassandra/0.0.1-SNAPSHOT/
 


### PR DESCRIPTION
asynccassandra-0.0.1-SNAPSHOT is outdated.
Fix build for build-cassandra.sh. BTW, 'build-cassandra.sh pom.xml' is still broken.