### PR TITLE
Align downsampling intervals to the Gregorian calendar.

### DIFF
--- a/src/core/Downsampler.java
+++ b/src/core/Downsampler.java
@@ -12,13 +12,28 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
+import static net.opentsdb.utils.DateTime.toEndOfDay;
+import static net.opentsdb.utils.DateTime.toEndOfMonth;
+import static net.opentsdb.utils.DateTime.toEndOfWeek;
+import static net.opentsdb.utils.DateTime.toEndOfYear;
+import static net.opentsdb.utils.DateTime.toStartOfDay;
+import static net.opentsdb.utils.DateTime.toStartOfMonth;
+import static net.opentsdb.utils.DateTime.toStartOfWeek;
+import static net.opentsdb.utils.DateTime.toStartOfYear;
+
 import java.util.NoSuchElementException;
+import java.util.TimeZone;
 
 /**
  * Iterator that downsamples data points using an {@link Aggregator}.
  */
 public class Downsampler implements SeekableView, DataPoint {
 
+  static final long ONE_WEEK_INTERVAL = 604800000L;
+  static final long ONE_MONTH_INTERVAL = 2592000000L;
+  static final long ONE_YEAR_INTERVAL = 31536000000L;
+  static final long ONE_DAY_INTERVAL = 86400000L;
+  
   /** Function to use for downsampling. */
   protected final Aggregator downsampler;
   /** Iterator to iterate the values of the current interval. */
@@ -29,7 +44,7 @@ public class Downsampler implements SeekableView, DataPoint {
   protected double value;
   
   /**
-   * Ctor.
+   * Ctor (for backward compatibility).
    * @param source The iterator to access the underlying data.
    * @param interval_ms The interval in milli seconds wanted between each data
    * point.
@@ -38,10 +53,26 @@ public class Downsampler implements SeekableView, DataPoint {
   Downsampler(final SeekableView source,
               final long interval_ms,
               final Aggregator downsampler) {
-    this.values_in_interval = new ValuesInInterval(source, interval_ms);
-    this.downsampler = downsampler;
+    this(source, interval_ms, downsampler, null, false);
   }
 
+  /**
+   * Ctor.
+   * @param source The iterator to access the underlying data.
+   * @param interval_ms The interval in milli seconds wanted between each data
+   * point.
+   * @param downsampler The downsampling function to use.
+   * @param timezone The timezone to use for aligning intervals based on the calendar.
+   * @param use_calendar A flag denoting whether or not to align intervals based on the calendar.
+   */
+  Downsampler(final SeekableView source, 
+              final long interval_ms, 
+              final Aggregator downsampler,
+              final TimeZone timezone,
+              final boolean use_calendar) {
+    this.values_in_interval = new ValuesInInterval(source, interval_ms, timezone, use_calendar);
+    this.downsampler = downsampler;
+  }
   // ------------------ //
   // Iterator interface //
   // ------------------ //
@@ -133,6 +164,10 @@ public class Downsampler implements SeekableView, DataPoint {
     private boolean has_next_value_from_source = false;
     /** The last data point extracted from the source. */
     private DataPoint next_dp = null;
+    /** The timezone to use for aligning intervals based on the calendar */
+    private final TimeZone timezone;
+    /** A flag denoting whether or not to align intervals based on the calendar */
+    private final boolean use_calendar;
 
     /** True if it is initialized for iterating intervals. */
     private boolean initialized = false;
@@ -142,10 +177,13 @@ public class Downsampler implements SeekableView, DataPoint {
      * @param source The iterator to access the underlying data.
      * @param interval_ms Downsampling interval.
      */
-    ValuesInInterval(final SeekableView source, final long interval_ms) {
+    ValuesInInterval(final SeekableView source, final long interval_ms, 
+                     final TimeZone timezone, boolean use_calendar) {
       this.source = source;
       this.interval_ms = interval_ms;
       this.timestamp_end_interval = interval_ms;
+      this.timezone = timezone != null ? timezone : TimeZone.getDefault();
+      this.use_calendar = use_calendar;
     }
 
     /** Initializes to iterate intervals. */
@@ -177,8 +215,14 @@ public class Downsampler implements SeekableView, DataPoint {
     private void resetEndOfInterval() {
       if (has_next_value_from_source) {
         // Sets the end of the interval of the timestamp.
-        timestamp_end_interval = alignTimestamp(next_dp.timestamp()) + 
+        
+        if (use_calendar && isCalendarInterval()) {
+          timestamp_end_interval =  toEndOfInterval(next_dp.timestamp());
+        }  else {
+          // default timestamp normalization (tsdb v2.1.0)
+           timestamp_end_interval = alignTimestamp(next_dp.timestamp()) + 
             interval_ms;
+        }
       }
     }
 
@@ -193,8 +237,14 @@ public class Downsampler implements SeekableView, DataPoint {
       // To make sure that the interval of the given timestamp is fully filled,
       // rounds up the seeking timestamp to the smallest timestamp that is
       // a multiple of the interval and is greater than or equal to the given
-      // timestamp..
-      source.seek(alignTimestamp(timestamp + interval_ms - 1));
+      // timestamp.
+      if (use_calendar && isCalendarInterval()) {
+        source.seek(alignTimestamp(timestamp + toEndOfInterval(timestamp)
+            - toStartOfInterval(timestamp)));
+      }  else {
+        source.seek(alignTimestamp(timestamp + interval_ms - 1));
+      }
+      
       initialized = false;
     }
 
@@ -203,13 +253,111 @@ public class Downsampler implements SeekableView, DataPoint {
       // NOTE: It is well-known practice taking the start time of
       // a downsample interval as a representative timestamp of it. It also
       // provides the correct context for seek.
-      return alignTimestamp(timestamp_end_interval - interval_ms);
+      if (use_calendar && isCalendarInterval()) {
+        return toStartOfInterval(timestamp_end_interval);
+      }  else {
+        return alignTimestamp(timestamp_end_interval - interval_ms);
+      }
     }
 
     /** Returns timestamp aligned by interval. */
     protected long alignTimestamp(final long timestamp) {
-      return timestamp - (timestamp % interval_ms);
+      if (use_calendar && isCalendarInterval()) {
+        return toStartOfInterval(timestamp);
+      }  else {
+        return timestamp - (timestamp % interval_ms);
+      }
     }
+    
+    /** Returns a flag denoting whether the interval can
+     *  be aligned to the calendar */
+    private boolean isCalendarInterval () {
+      if (interval_ms != 0 && 
+         (interval_ms % ONE_YEAR_INTERVAL == 0 ||
+          interval_ms % ONE_MONTH_INTERVAL == 0 ||
+          interval_ms % ONE_WEEK_INTERVAL == 0 ||
+          interval_ms % ONE_DAY_INTERVAL == 0)) {
+        return true;
+      }
+      return false;
+    }
+    
+    /** Returns a timestamp corresponding to the start of the interval
+     *  in which the specified timestamp occurs, aligned to the calendar
+     *  based on the timezone. */
+    private long toStartOfInterval(long timestamp) {
+      if (interval_ms % ONE_YEAR_INTERVAL == 0) {
+        final long multiplier = interval_ms / ONE_YEAR_INTERVAL;
+        long result = timestamp;
+        for (long i = 0; i < multiplier; i++) {
+          result = toStartOfYear(result, timezone) - 1;
+        }
+        return result + 1;
+      } else if (interval_ms % ONE_MONTH_INTERVAL == 0) {
+        final long multiplier = interval_ms / ONE_MONTH_INTERVAL;
+        long result = timestamp;
+        for (long i = 0; i < multiplier; i++) {
+          result = toStartOfMonth(result, timezone) - 1;
+        }
+        return result + 1;
+      } else if (interval_ms % ONE_WEEK_INTERVAL == 0) {
+        final long multiplier = interval_ms / ONE_WEEK_INTERVAL;
+        long result = timestamp;
+        for (long i = 0; i < multiplier; i++) {
+          result = toStartOfWeek(result, timezone) - 1;
+        }
+        return result + 1;
+      } else if (interval_ms % ONE_DAY_INTERVAL == 0) {
+        final long multiplier = interval_ms / ONE_DAY_INTERVAL;
+        long result = timestamp;
+        for (long i = 0; i < multiplier; i++) {
+          result = toStartOfDay(result, timezone) - 1;
+        }
+        return result + 1;
+      } else {
+        throw new IllegalArgumentException(interval_ms + " does not correspond to a "
+            + "an interval that can be aligned to the calendar.");
+      }
+    }
+
+    /** Returns a timestamp corresponding to the end of the interval
+     *  in which the specified timestamp occurs, aligned to the calendar
+     *  based on the timezone. */
+    private long toEndOfInterval(long timestamp) {
+      if (interval_ms % ONE_YEAR_INTERVAL == 0) {
+        final long multiplier = interval_ms / ONE_YEAR_INTERVAL;
+        long result = timestamp;
+        for (long i = 0; i < multiplier; i++) {
+          result = toEndOfYear(result, timezone) + 1;
+        }
+        return result - 1;
+      } else if (interval_ms % ONE_MONTH_INTERVAL == 0) {
+        final long multiplier = interval_ms / ONE_MONTH_INTERVAL;
+        long result = timestamp;
+        for (long i = 0; i < multiplier; i++) {
+          result = toEndOfMonth(result, timezone) + 1;
+        }
+        return result - 1;
+      } else if (interval_ms % ONE_WEEK_INTERVAL == 0) {
+        final long multiplier = interval_ms / ONE_WEEK_INTERVAL;
+        long result = timestamp;
+        for (long i = 0; i < multiplier; i++) {
+          result = toEndOfWeek(result, timezone) + 1;
+        }
+        return result - 1;
+      } else if (interval_ms % ONE_DAY_INTERVAL == 0) {
+        final long multiplier = interval_ms / ONE_DAY_INTERVAL;
+        long result = timestamp;
+        for (long i = 0; i < multiplier; i++) {
+          result = toEndOfDay(result, timezone) + 1;
+        }
+        return result - 1;
+      } else {
+        throw new IllegalArgumentException(interval_ms + " does not correspond to a "
+            + "an interval that can be aligned to the calendar.");
+      }
+    }
+     
 
     // ---------------------- //
     // Doubles interface //

--- a/src/core/FillingDownsampler.java
+++ b/src/core/FillingDownsampler.java
@@ -13,6 +13,7 @@
 package net.opentsdb.core;
 
 import java.util.NoSuchElementException;
+import java.util.TimeZone;
 
 /**
  * A specialized downsampler that returns special values, based on the fill
@@ -30,7 +31,7 @@ public class FillingDownsampler extends Downsampler {
   protected final FillPolicy fill_policy;
 
   /** 
-   * Create a new nulling downsampler.
+   * Ctor (preserved for backward compatibility).
    * @param source The iterator to access the underlying data.
    * @param start_time The time in milliseconds at which the data begins.
    * @param end_time The time in milliseconds at which the data ends.
@@ -44,8 +45,30 @@ public class FillingDownsampler extends Downsampler {
   FillingDownsampler(final SeekableView source, final long start_time,
       final long end_time, final long interval_ms,
       final Aggregator downsampler, final FillPolicy fill_policy) {
+    this(source, start_time, end_time, interval_ms, downsampler, fill_policy, null, false);
+  }
+  
+  
+  /** 
+   * Create a new nulling downsampler.
+   * @param source The iterator to access the underlying data.
+   * @param start_time The time in milliseconds at which the data begins.
+   * @param end_time The time in milliseconds at which the data ends.
+   * @param interval_ms The interval in milli seconds wanted between each data
+   * point.
+   * @param downsampler The downsampling function to use.
+   * @param fill_policy Policy specifying whether to interpolate or to fill
+   * missing intervals with special values.
+   * @param timezone The timezone to use for aligning intervals based on the calendar.
+   * @throws IllegalArgumentException if fill_policy is interpolation.
+   */
+  FillingDownsampler(final SeekableView source, final long start_time,
+      final long end_time, final long interval_ms,
+      final Aggregator downsampler, final FillPolicy fill_policy,
+      final TimeZone timezone,
+      final boolean use_calendar) {
     // Lean on the superclass implementation.
-    super(source, interval_ms, downsampler);
+    super(source, interval_ms, downsampler, timezone, use_calendar);
 
     // Ensure we aren't given a bogus fill policy.
     if (FillPolicy.NONE == fill_policy) {

--- a/src/core/Query.java
+++ b/src/core/Query.java
@@ -66,7 +66,25 @@ public interface Query {
    * @return A strictly positive integer.
    */
   long getEndTime();
-
+  
+  /** 
+   * Sets the timezone to use for aligning intervals based on the calendar.
+   * @param timezone the timezone to use
+   */
+  void setTimezone(String timezone);
+  
+  /** @return the timezone to use for aligning intervals based on the calendar. */
+  String getTimezone();
+  
+  /** 
+   * Sets a flag denoting whether or not to align intervals based on the calendar.
+   * @param use_calendar true, if the intervals should be aligned based on the calendar; false, otherwise
+   */
+  void setUseCalendar(boolean use_calendar);
+  
+  /** @return A flag denoting whether or not to align intervals based on the calendar. */
+  boolean getUseCalendar();
+  
   /**
    * Sets whether or not the data queried will be deleted.
    * @param delete True if data should be deleted, false otherwise.

--- a/src/core/TSQuery.java
+++ b/src/core/TSQuery.java
@@ -95,6 +95,9 @@ public final class TSQuery {
   
   /** The query status for tracking over all performance of this query */
   private QueryStats query_stats;
+
+  /** A flag denoting whether or not to align intervals based on the calendar */
+  private boolean use_calendar;
   
   /**
    * Default constructor necessary for POJO de/serialization
@@ -303,6 +306,11 @@ public final class TSQuery {
     return timezone;
   }
 
+  /** @return the flag denoting whether intervals should be aligned based on the calendar */
+  public boolean getUseCalendar() {
+    return use_calendar;
+  }
+  
   /** @return a map of serializer options */
   public Map<String, ArrayList<String>> getOptions() {
     return options;
@@ -386,6 +394,11 @@ public final class TSQuery {
   /** @param timezone an optional timezone for date parsing */
   public void setTimezone(String timezone) {
     this.timezone = timezone;
+  }
+
+  /** @param use_calendar a flag denoting whether or not to align intervals based on the calendar */
+  public void setUseCalendar(boolean use_calendar) {
+    this.use_calendar = use_calendar;
   }
 
   /** @param options a map of options to pass on to the serializer */

--- a/src/tsd/QueryRpc.java
+++ b/src/tsd/QueryRpc.java
@@ -473,6 +473,23 @@ final class QueryRpc implements HttpRpc {
         data_query.setShowSummary(true);
     }
     
+    if (query.hasQueryStringParam("tz")) {
+      data_query.setTimezone(query.getQueryStringParam("tz"));
+    }
+    
+    if (query.hasQueryStringParam("use_calendar")) {
+      final String val = query.getQueryStringParam("use_calendar").trim().toUpperCase();
+      final boolean use_calendar;
+      if (val.equals("TRUE")) {
+        use_calendar = true;
+      } else {
+        use_calendar = false;
+      }
+      data_query.setUseCalendar(use_calendar);
+    } else {
+      data_query.setUseCalendar(tsdb.getConfig().use_calendar());
+    }
+
     // handle tsuid queries first
     if (query.hasQueryStringParam("tsuid")) {
       final List<String> tsuids = query.getQueryStringParams("tsuid");     

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -103,6 +103,9 @@ public class Config {
   /** tsd.core.tree.enable_processing */
   private boolean enable_tree_processing = false;
   
+  /** tsd.query.downsample.use_calendar */
+  private boolean use_calendar = false;
+
   /**
    * The list of properties configured to their defaults or modified by users
    */
@@ -245,6 +248,12 @@ public class Config {
     return enable_tree_processing;
   }
   
+  /** @return whether or not to align to the Gregorian calendar when downsampling a 
+   * daily, weekly, monthly, or yearly interval */
+  public boolean use_calendar() {
+    return use_calendar;
+  }
+
   /**
    * Allows for modifying properties after creation or loading.
    * 
@@ -523,6 +532,7 @@ public class Config {
       + "Content-Type, Accept, Origin, User-Agent, DNT, Cache-Control, "
       + "X-Mx-ReqToken, Keep-Alive, X-Requested-With, If-Modified-Since");
     default_map.put("tsd.query.timeout", "0");
+    default_map.put("tsd.query.downsample.use_calendar", "false");
 
     for (Map.Entry<String, String> entry : default_map.entrySet()) {
       if (!properties.containsKey(entry.getKey()))
@@ -635,6 +645,7 @@ public class Config {
     }
     enable_tree_processing = this.getBoolean("tsd.core.tree.enable_processing");
     fix_duplicates = this.getBoolean("tsd.storage.fix_duplicates");
+    use_calendar = this.getBoolean("tsd.query.downsample.use_calendar");
   }
   
   /**

--- a/src/utils/DateTime.java
+++ b/src/utils/DateTime.java
@@ -14,6 +14,7 @@ package net.opentsdb.utils;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.TimeZone;
 
@@ -267,5 +268,175 @@ public class DateTime {
   public static long currentTimeMillis() {
     return System.currentTimeMillis();
   }
+  
+  /**
+   * Returns a timestamp corresponding the beginning of the year in which the specified
+   * timestamp occurs.  This operation is performed based on the specified time zone.
+   * @param timestamp the epoch time
+   * @param time_zone the time zone used to determine the beginning of the year
+   * @return the epoch time corresponding to the beginning of the year
+   */
+  public static long toStartOfYear(final long timestamp, final TimeZone time_zone) {
+    final Calendar c = getStartOfYear(timestamp, time_zone);
+    return c.getTimeInMillis();
+  }
 
+  /**
+   * Returns a timestamp corresponding the end of the year in which the specified
+   * timestamp occurs.  This operation is performed based on the specified time zone.
+   * @param timestamp the epoch time
+   * @param time_zone the time zone used to determine the end of the year
+   * @return the epoch time corresponding to the end of the year
+   */
+  public static long toEndOfYear(final long timestamp, final TimeZone time_zone) {
+    final Calendar c = getStartOfYear(timestamp, time_zone);
+    c.add(Calendar.YEAR, 1);
+    return c.getTimeInMillis() - 1;
+  }
+
+  /**
+   * Returns a timestamp corresponding the beginning of the month in which the specified
+   * timestamp occurs.  This operation is performed based on the specified time zone.
+   * @param timestamp the epoch time
+   * @param time_zone the time zone used to determine the beginning of the month
+   * @return the epoch time corresponding to the beginning of the month
+   */
+  public static long toStartOfMonth(final long timestamp, final TimeZone time_zone) {
+    final Calendar c = getStartOfMonth(timestamp, time_zone);
+    return c.getTimeInMillis();
+  }
+  
+  /**
+   * Returns a timestamp corresponding the end of the month in which the specified
+   * timestamp occurs.  This operation is performed based on the specified time zone.
+   * @param timestamp the epoch time
+   * @param time_zone the time zone used to determine the end of the month
+   * @return the epoch time corresponding to the end of the month
+   */
+  public static long toEndOfMonth(final long timestamp, final TimeZone time_zone) {
+    final Calendar c = getStartOfMonth(timestamp, time_zone);
+    c.add(Calendar.MONTH, 1);
+    return c.getTimeInMillis() - 1;
+  }
+
+  /**
+   * Returns a timestamp corresponding the beginning of the week in which the specified
+   * timestamp occurs.  This operation is performed based on the specified time zone.
+   * @param timestamp the epoch time
+   * @param time_zone the time zone used to determine the beginning of the week
+   * @return the epoch time corresponding to the beginning of the week
+   */
+  public static long toStartOfWeek(final long timestamp, final TimeZone time_zone) {
+    final Calendar c = getStartOfWeek(timestamp, time_zone);
+    return c.getTimeInMillis();
+  }
+
+  /**
+   * Returns a timestamp corresponding the end of the week in which the specified
+   * timestamp occurs.  This operation is performed based on the specified time zone.
+   * @param timestamp the epoch time
+   * @param time_zone the time zone used to determine the end of the week
+   * @return the epoch time corresponding to the end of the week
+   */
+  public static long toEndOfWeek(final long timestamp, final TimeZone time_zone) {
+    final Calendar c = getStartOfWeek(timestamp, time_zone);
+    c.add(Calendar.DATE, 7);
+    return c.getTimeInMillis() - 1;
+  }
+
+  /**
+   * Returns a timestamp corresponding the beginning of the day in which the specified
+   * timestamp occurs.  This operation is performed based on the specified time zone.
+   * @param timestamp the epoch time
+   * @param time_zone the time zone used to determine the beginning of the day
+   * @return the epoch time corresponding to the beginning of the day
+   */
+  public static long toStartOfDay(final long timestamp, final TimeZone time_zone) {
+    final Calendar c = getStartOfDay(timestamp, time_zone);
+    return c.getTimeInMillis();
+  }
+  
+  /**
+   * Returns a timestamp corresponding the end of the day in which the specified
+   * timestamp occurs.  This operation is performed based on the specified time zone.
+   * @param timestamp the epoch time
+   * @param time_zone the time zone used to determine the end of the day
+   * @return the epoch time corresponding to the end of the day
+   */
+  public static long toEndOfDay(final long timestamp, final TimeZone time_zone) {
+    final Calendar c = getStartOfDay(timestamp, time_zone);
+    c.add(Calendar.DATE, 1);
+    return c.getTimeInMillis() - 1;
+  }
+
+  /**
+   * Returns a Calendar object corresponding the beginning of the year in which the specified
+   * timestamp occurs.  This operation is performed based on the specified time zone.
+   * @param timestamp the epoch time
+   * @param time_zone the time zone used to determine the beginning of the year
+   * @return a Calendar object corresponding to the beginning of the year
+   */
+  private static Calendar getStartOfYear(final long timestamp, final TimeZone time_zone) {
+    final Calendar c = Calendar.getInstance(time_zone);
+    c.setTimeInMillis(timestamp);
+    c.set(Calendar.DAY_OF_YEAR, 1);
+    c.set(Calendar.HOUR_OF_DAY, 0);
+    c.set(Calendar.MINUTE, 0);
+    c.set(Calendar.SECOND, 0);
+    c.set(Calendar.MILLISECOND, 0);
+    return c;
+  }
+
+  /**
+   * Returns a Calendar object corresponding the beginning of the month in which the specified
+   * timestamp occurs.  This operation is performed based on the specified time zone.
+   * @param timestamp the epoch time
+   * @param time_zone the time zone used to determine the beginning of the month
+   * @return a Calendar object corresponding to the beginning of the month
+   */
+  private static Calendar getStartOfMonth(final long timestamp, final TimeZone time_zone) {
+    final Calendar c = Calendar.getInstance(time_zone);
+    c.setTimeInMillis(timestamp);
+    c.set(Calendar.DAY_OF_MONTH, 1);
+    c.set(Calendar.HOUR_OF_DAY, 0);
+    c.set(Calendar.MINUTE, 0);
+    c.set(Calendar.SECOND, 0);
+    c.set(Calendar.MILLISECOND, 0);
+    return c;
+  }
+
+  /**
+   * Returns a Calendar object corresponding the beginning of the week in which the specified
+   * timestamp occurs.  This operation is performed based on the specified time zone.
+   * @param timestamp the epoch time
+   * @param time_zone the time zone used to determine the beginning of the week
+   * @return a Calendar object corresponding to the beginning of the week
+   */
+  private static Calendar getStartOfWeek(final long timestamp, final TimeZone time_zone) {
+    final Calendar c = Calendar.getInstance(time_zone);
+    c.setTimeInMillis(timestamp);
+    c.set(Calendar.DAY_OF_WEEK, 1); // 1-sun, 2-mon.
+    c.set(Calendar.HOUR_OF_DAY, 0);
+    c.set(Calendar.MINUTE, 0);
+    c.set(Calendar.SECOND, 0);
+    c.set(Calendar.MILLISECOND, 0);
+    return c;
+  }
+
+  /**
+   * Returns a Calendar object corresponding the beginning of the day in which the specified
+   * timestamp occurs.  This operation is performed based on the specified time zone.
+   * @param timestamp the epoch time
+   * @param time_zone the time zone used to determine the beginning of the day
+   * @return a Calendar object corresponding to the beginning of the day
+   */
+  private static Calendar getStartOfDay(final long timestamp, final TimeZone time_zone) {
+    final Calendar c = Calendar.getInstance(time_zone);
+    c.setTimeInMillis(timestamp);
+    c.set(Calendar.HOUR_OF_DAY, 0);
+    c.set(Calendar.MINUTE, 0);
+    c.set(Calendar.SECOND, 0);
+    c.set(Calendar.MILLISECOND, 0);
+    return c;
+  }
 }

--- a/test/core/TestDownsampler.java
+++ b/test/core/TestDownsampler.java
@@ -13,6 +13,10 @@
 package net.opentsdb.core;
 
 
+import static net.opentsdb.core.Downsampler.ONE_DAY_INTERVAL;
+import static net.opentsdb.core.Downsampler.ONE_MONTH_INTERVAL;
+import static net.opentsdb.core.Downsampler.ONE_WEEK_INTERVAL;
+import static net.opentsdb.core.Downsampler.ONE_YEAR_INTERVAL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -20,14 +24,16 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+import java.util.Calendar;
 import java.util.List;
-
-import com.google.common.collect.Lists;
+import java.util.TimeZone;
 
 import net.opentsdb.utils.DateTime;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import com.google.common.collect.Lists;
 
 
 /** Tests {@link Downsampler}. */
@@ -54,6 +60,9 @@ public class TestDownsampler {
       (int)DateTime.parseDuration("10s");
   private static final Aggregator AVG = Aggregators.get("avg");
   private static final Aggregator SUM = Aggregators.get("sum");
+  private static final TimeZone UTC_TIME_ZONE = DateTime.timezones.get("UTC");
+  private static final TimeZone EST_TIME_ZONE = DateTime.timezones.get("EST");
+
 
   private SeekableView source;
   private Downsampler downsampler;
@@ -161,6 +170,411 @@ public class TestDownsampler {
     assertEquals(48, values.get(3), 0.0000001);
     assertEquals(BASE_TIME + 45000L, timestamps_in_millis.get(3).longValue());
   }
+  
+  @Test
+  public void testDownsampler_1day() {
+    final DataPoint [] data_points = new DataPoint[4];
+    long timestamp = DateTime.toStartOfDay(BASE_TIME, UTC_TIME_ZONE);
+    for (int i = 0; i < data_points.length; i++) {
+      long value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+  
+      i += 1;
+      long startOfNextInterval = DateTime.toEndOfDay(timestamp, UTC_TIME_ZONE) + 1;
+      timestamp = timestamp + (startOfNextInterval - timestamp) / 2;
+      value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+      timestamp = startOfNextInterval;
+    }
+    
+    source = spy(SeekableViewsForTest.fromArray(data_points));
+    
+    downsampler = new Downsampler(source, ONE_DAY_INTERVAL, SUM);
+    verify(source, never()).next();
+    List<Double> values = Lists.newArrayList();
+    List<Long> timestamps_in_millis = Lists.newArrayList();
+    while (downsampler.hasNext()) {
+      DataPoint dp = downsampler.next();
+      assertFalse(dp.isInteger());
+      values.add(dp.doubleValue());
+      timestamps_in_millis.add(dp.timestamp());
+    }
+    
+    assertEquals(2, values.size());
+    timestamp = DateTime.toStartOfDay(BASE_TIME, UTC_TIME_ZONE);
+    for (int i = 0, j = 0; i < values.size(); i++) {
+      assertEquals((1 << j++) + (1 << j++), values.get(i), 0.0000001);
+      assertEquals(timestamp, timestamps_in_millis.get(i).longValue());
+      timestamp = DateTime.toEndOfDay(timestamp, UTC_TIME_ZONE) + 1;
+    }
+  }
+
+  @Test
+  public void testDownsampler_1day_timezone() {
+    final DataPoint [] data_points = new DataPoint[4];
+    long timestamp = DateTime.toStartOfDay(BASE_TIME, UTC_TIME_ZONE) - EST_TIME_ZONE.getOffset(BASE_TIME);
+    for (int i = 0; i < data_points.length; i++) {
+      long value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+  
+      i += 1;
+      long startOfNextInterval = DateTime.toEndOfDay(timestamp, EST_TIME_ZONE) + 1;
+      timestamp = timestamp + (startOfNextInterval - timestamp) / 2;
+      value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+      timestamp = startOfNextInterval;
+    }
+    
+    source = spy(SeekableViewsForTest.fromArray(data_points));
+    
+    downsampler = new Downsampler(source, ONE_DAY_INTERVAL, SUM, EST_TIME_ZONE, true);
+    verify(source, never()).next();
+    List<Double> values = Lists.newArrayList();
+    List<Long> timestamps_in_millis = Lists.newArrayList();
+    while (downsampler.hasNext()) {
+      DataPoint dp = downsampler.next();
+      assertFalse(dp.isInteger());
+      values.add(dp.doubleValue());
+      timestamps_in_millis.add(dp.timestamp());
+    }
+    
+    assertEquals(2, values.size());
+    timestamp = DateTime.toStartOfDay(BASE_TIME, UTC_TIME_ZONE) - EST_TIME_ZONE.getOffset(BASE_TIME);
+    for (int i = 0, j = 0; i < values.size(); i++) {
+      assertEquals((1 << j++) + (1 << j++), values.get(i), 0.0000001);
+      assertEquals(timestamp, timestamps_in_millis.get(i).longValue());
+      timestamp = DateTime.toEndOfDay(timestamp, EST_TIME_ZONE) + 1;
+    }
+  }
+  
+  
+  @Test
+  public void testDownsampler_1week() {
+    final DataPoint [] data_points = new DataPoint[4];
+    long timestamp = DateTime.toStartOfWeek(BASE_TIME, UTC_TIME_ZONE);
+    for (int i = 0; i < data_points.length; i++) {
+      long value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+  
+      i += 1;
+      long startOfNextInterval = DateTime.toEndOfWeek(timestamp, UTC_TIME_ZONE) + 1;
+      timestamp = timestamp + (startOfNextInterval - timestamp) / 2;
+      value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+      timestamp = startOfNextInterval;
+    }
+    
+    source = spy(SeekableViewsForTest.fromArray(data_points));
+    
+    downsampler = new Downsampler(source, ONE_WEEK_INTERVAL, SUM, UTC_TIME_ZONE, true);
+    verify(source, never()).next();
+    List<Double> values = Lists.newArrayList();
+    List<Long> timestamps_in_millis = Lists.newArrayList();
+    while (downsampler.hasNext()) {
+      DataPoint dp = downsampler.next();
+      assertFalse(dp.isInteger());
+      values.add(dp.doubleValue());
+      timestamps_in_millis.add(dp.timestamp());
+    }
+    
+    assertEquals(2, values.size());
+    timestamp = DateTime.toStartOfWeek(BASE_TIME, UTC_TIME_ZONE);
+    for (int i = 0, j = 0; i < values.size(); i++) {
+      assertEquals((1 << j++) + (1 << j++), values.get(i), 0.0000001);
+      assertEquals(timestamp, timestamps_in_millis.get(i).longValue());
+      timestamp = DateTime.toEndOfWeek(timestamp, UTC_TIME_ZONE) + 1;
+    }
+  }
+
+  @Test
+  public void testDownsampler_1week_timezone() {
+    final DataPoint [] data_points = new DataPoint[4];
+    long timestamp = DateTime.toStartOfWeek(BASE_TIME, UTC_TIME_ZONE) - EST_TIME_ZONE.getOffset(BASE_TIME);
+    for (int i = 0; i < data_points.length; i++) {
+      long value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+  
+      i += 1;
+      long startOfNextInterval = DateTime.toEndOfWeek(timestamp, EST_TIME_ZONE) + 1;
+      timestamp = timestamp + (startOfNextInterval - timestamp) / 2;
+      value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+      timestamp = startOfNextInterval;
+    }
+    
+    source = spy(SeekableViewsForTest.fromArray(data_points));
+    
+    downsampler = new Downsampler(source, ONE_WEEK_INTERVAL, SUM, EST_TIME_ZONE, true);
+    verify(source, never()).next();
+    List<Double> values = Lists.newArrayList();
+    List<Long> timestamps_in_millis = Lists.newArrayList();
+    while (downsampler.hasNext()) {
+      DataPoint dp = downsampler.next();
+      assertFalse(dp.isInteger());
+      values.add(dp.doubleValue());
+      timestamps_in_millis.add(dp.timestamp());
+    }
+    
+    assertEquals(2, values.size());
+    timestamp = DateTime.toStartOfWeek(BASE_TIME, UTC_TIME_ZONE) - EST_TIME_ZONE.getOffset(BASE_TIME);
+    for (int i = 0, j = 0; i < values.size(); i++) {
+      assertEquals((1 << j++) + (1 << j++), values.get(i), 0.0000001);
+      assertEquals(timestamp, timestamps_in_millis.get(i).longValue());
+      timestamp = DateTime.toEndOfWeek(timestamp, EST_TIME_ZONE) + 1;
+    }
+  }
+
+  @Test
+  public void testDownsampler_1month() {
+    final DataPoint [] data_points = new DataPoint[24];
+    long timestamp = DateTime.toStartOfMonth(BASE_TIME, UTC_TIME_ZONE);
+    for (int i = 0; i < data_points.length; i++) {
+      long value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+
+      i += 1;
+      long startOfNextInterval = DateTime.toEndOfMonth(timestamp, UTC_TIME_ZONE) + 1;
+      timestamp = timestamp + (startOfNextInterval - timestamp) / 2;
+      value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+      timestamp = startOfNextInterval;
+    }
+    
+    source = spy(SeekableViewsForTest.fromArray(data_points));
+    
+    downsampler = new Downsampler(source, ONE_MONTH_INTERVAL, SUM, UTC_TIME_ZONE, true);
+    verify(source, never()).next();
+    List<Double> values = Lists.newArrayList();
+    List<Long> timestamps_in_millis = Lists.newArrayList();
+    while (downsampler.hasNext()) {
+      DataPoint dp = downsampler.next();
+      assertFalse(dp.isInteger());
+      values.add(dp.doubleValue());
+      timestamps_in_millis.add(dp.timestamp());
+    }
+    
+    assertEquals(12, values.size());
+    timestamp = DateTime.toStartOfMonth(BASE_TIME, UTC_TIME_ZONE);
+    for (int i = 0, j = 0; i < values.size(); i++) {
+      assertEquals((1 << j++) + (1 << j++), values.get(i), 0.0000001);
+      assertEquals(timestamp, timestamps_in_millis.get(i).longValue());
+      timestamp = DateTime.toEndOfMonth(timestamp, UTC_TIME_ZONE) + 1;
+    }
+  }
+  
+  @Test
+  public void testDownsampler_1month_alt() {
+    /*
+    1380600000 -> 2013-10-01T04:00:00Z
+    1383278400 -> 2013-11-01T04:00:00Z
+    1385874000 -> 2013-12-01T05:00:00Z
+    1388552400 -> 2014-01-01T05:00:00Z
+    1391230800 -> 2014-02-01T05:00:00Z
+    1393650000 -> 2014-03-01T05:00:00Z
+    1396324800 -> 2014-04-01T04:00:00Z
+    1398916800 -> 2014-05-01T04:00:00Z
+    1401595200 -> 2014-06-01T04:00:00Z
+    1404187200 -> 2014-07-01T04:00:00Z
+    1406865600 -> 2014-08-01T04:00:00Z
+    1409544000 -> 2014-09-01T04:00:00Z
+    */
+
+    int value = 1;
+    final DataPoint [] data_points = new DataPoint[] {
+      MutableDataPoint.ofLongValue(1380600000000L, value), 
+      MutableDataPoint.ofLongValue(1383278400000L, value), 
+      MutableDataPoint.ofLongValue(1385874000000L, value), 
+      MutableDataPoint.ofLongValue(1388552400000L, value), 
+      MutableDataPoint.ofLongValue(1391230800000L, value), 
+      MutableDataPoint.ofLongValue(1393650000000L, value), 
+      MutableDataPoint.ofLongValue(1396324800000L, value), 
+      MutableDataPoint.ofLongValue(1398916800000L, value), 
+      MutableDataPoint.ofLongValue(1401595200000L, value), 
+      MutableDataPoint.ofLongValue(1404187200000L, value), 
+      MutableDataPoint.ofLongValue(1406865600000L, value), 
+      MutableDataPoint.ofLongValue(1409544000000L, value), 
+    };
+    
+    source = spy(SeekableViewsForTest.fromArray(data_points));
+    
+    downsampler = new Downsampler(source, ONE_MONTH_INTERVAL, SUM, UTC_TIME_ZONE, true);
+    verify(source, never()).next();
+    List<Double> values = Lists.newArrayList();
+    List<Long> timestamps_in_millis = Lists.newArrayList();
+    while (downsampler.hasNext()) {
+      DataPoint dp = downsampler.next();
+      assertFalse(dp.isInteger());
+      values.add(dp.doubleValue());
+      timestamps_in_millis.add(dp.timestamp());
+    }
+    
+    assertEquals(12, values.size());
+    long timestamp = DateTime.toStartOfMonth(data_points[0].timestamp(), UTC_TIME_ZONE);
+    for (int i = 0; i < values.size(); i++) {
+      assertEquals(1, values.get(i), 0.0000001);
+      assertEquals(timestamp, timestamps_in_millis.get(i).longValue());
+      timestamp = DateTime.toEndOfMonth(timestamp, UTC_TIME_ZONE) + 1;
+    }
+  }
+ 
+
+  @Test
+  public void testDownsampler_2months() {
+    final DataPoint [] data_points = new DataPoint[24];
+    long timestamp = DateTime.toStartOfMonth(BASE_TIME, UTC_TIME_ZONE);
+    for (int i = 0; i < data_points.length; i++) {
+      long value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+
+      i += 1;
+      long startOfNextInterval = DateTime.toEndOfMonth(timestamp, UTC_TIME_ZONE) + 1;
+      timestamp = timestamp + (startOfNextInterval - timestamp) / 2;
+      value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+      timestamp = startOfNextInterval;
+    }
+    
+    source = spy(SeekableViewsForTest.fromArray(data_points));
+    
+    downsampler = new Downsampler(source, 2 * ONE_MONTH_INTERVAL, SUM, UTC_TIME_ZONE, true);
+    verify(source, never()).next();
+    List<Double> values = Lists.newArrayList();
+    List<Long> timestamps_in_millis = Lists.newArrayList();
+    while (downsampler.hasNext()) {
+      DataPoint dp = downsampler.next();
+      assertFalse(dp.isInteger());
+      values.add(dp.doubleValue());
+      timestamps_in_millis.add(dp.timestamp());
+    }
+    
+    assertEquals(6, values.size());
+    timestamp = DateTime.toStartOfMonth(BASE_TIME, UTC_TIME_ZONE);
+    for (int i = 0, j = 0; i < values.size(); i++) {
+      long value = 0;
+      for (int k = 0; k < 4; k++) {
+        value += (1 << j++);
+      }
+      assertEquals(value, values.get(i), 0.0000001);
+      assertEquals(timestamp, timestamps_in_millis.get(i).longValue());
+      timestamp = DateTime.toEndOfMonth(timestamp, UTC_TIME_ZONE) + 1;
+      timestamp = DateTime.toEndOfMonth(timestamp, UTC_TIME_ZONE) + 1;
+    }
+  }
+
+  @Test
+  public void testDownsampler_1month_timezone() {
+    final DataPoint [] data_points = new DataPoint[24];
+    long timestamp = DateTime.toStartOfMonth(BASE_TIME, UTC_TIME_ZONE) - EST_TIME_ZONE.getOffset(BASE_TIME);
+    for (int i = 0; i < data_points.length; i++) {
+      long value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+
+      i += 1;
+      long startOfNextInterval = DateTime.toEndOfMonth(timestamp, EST_TIME_ZONE) + 1;
+      timestamp = timestamp + (startOfNextInterval - timestamp) / 2;
+      value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+      timestamp = startOfNextInterval;
+    }
+    
+    source = spy(SeekableViewsForTest.fromArray(data_points));
+    
+    downsampler = new Downsampler(source, ONE_MONTH_INTERVAL, SUM, EST_TIME_ZONE, true);
+    verify(source, never()).next();
+    List<Double> values = Lists.newArrayList();
+    List<Long> timestamps_in_millis = Lists.newArrayList();
+    while (downsampler.hasNext()) {
+      DataPoint dp = downsampler.next();
+      assertFalse(dp.isInteger());
+      values.add(dp.doubleValue());
+      timestamps_in_millis.add(dp.timestamp());
+    }
+    
+    assertEquals(12, values.size());
+    timestamp = DateTime.toStartOfMonth(BASE_TIME, UTC_TIME_ZONE) - EST_TIME_ZONE.getOffset(BASE_TIME);
+    for (int i = 0, j = 0; i < values.size(); i++) {
+      assertEquals((1 << j++) + (1 << j++), values.get(i), 0.0000001);
+      assertEquals(timestamp, timestamps_in_millis.get(i).longValue());
+      timestamp = DateTime.toEndOfMonth(timestamp, EST_TIME_ZONE) + 1;
+    }
+  }
+
+  @Test
+  public void testDownsampler_1year() {
+    final DataPoint [] data_points = new DataPoint[4];
+    long timestamp = DateTime.toStartOfYear(BASE_TIME, UTC_TIME_ZONE);
+    for (int i = 0; i < data_points.length; i++) {
+      long value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+
+      i += 1;
+      long startOfNextInterval = DateTime.toEndOfYear(timestamp, UTC_TIME_ZONE) + 1;
+      timestamp = timestamp + (startOfNextInterval - timestamp) / 2;
+      value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+      timestamp = startOfNextInterval;
+    }
+    
+    source = spy(SeekableViewsForTest.fromArray(data_points));
+    
+    downsampler = new Downsampler(source, ONE_YEAR_INTERVAL, SUM, UTC_TIME_ZONE, true);
+    verify(source, never()).next();
+    List<Double> values = Lists.newArrayList();
+    List<Long> timestamps_in_millis = Lists.newArrayList();
+    while (downsampler.hasNext()) {
+      DataPoint dp = downsampler.next();
+      assertFalse(dp.isInteger());
+      values.add(dp.doubleValue());
+      timestamps_in_millis.add(dp.timestamp());
+    }
+    
+    assertEquals(2, values.size());
+    timestamp = DateTime.toStartOfYear(BASE_TIME, UTC_TIME_ZONE);
+    for (int i = 0, j = 0; i < values.size(); i++) {
+      assertEquals((1 << j++) + (1 << j++), values.get(i), 0.0000001);
+      assertEquals(timestamp, timestamps_in_millis.get(i).longValue());
+      timestamp = DateTime.toEndOfYear(timestamp, UTC_TIME_ZONE) + 1;
+    }
+  }
+
+  @Test
+  public void testDownsampler_1year_timezone() {
+    final DataPoint [] data_points = new DataPoint[4];
+    long timestamp = DateTime.toStartOfYear(BASE_TIME, UTC_TIME_ZONE) - EST_TIME_ZONE.getOffset(BASE_TIME);
+    for (int i = 0; i < data_points.length; i++) {
+      long value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+
+      i += 1;
+      long startOfNextInterval = DateTime.toEndOfYear(timestamp, EST_TIME_ZONE) + 1;
+      timestamp = timestamp + (startOfNextInterval - timestamp) / 2;
+      value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+      timestamp = startOfNextInterval;
+    }
+    
+    source = spy(SeekableViewsForTest.fromArray(data_points));
+    
+    downsampler = new Downsampler(source, ONE_YEAR_INTERVAL, SUM, EST_TIME_ZONE, true);
+    verify(source, never()).next();
+    List<Double> values = Lists.newArrayList();
+    List<Long> timestamps_in_millis = Lists.newArrayList();
+    while (downsampler.hasNext()) {
+      DataPoint dp = downsampler.next();
+      assertFalse(dp.isInteger());
+      values.add(dp.doubleValue());
+      timestamps_in_millis.add(dp.timestamp());
+    }
+    
+    assertEquals(2, values.size());
+    timestamp = DateTime.toStartOfYear(BASE_TIME, UTC_TIME_ZONE) - EST_TIME_ZONE.getOffset(BASE_TIME);
+    for (int i = 0, j = 0; i < values.size(); i++) {
+      assertEquals((1 << j++) + (1 << j++), values.get(i), 0.0000001);
+      assertEquals(timestamp, timestamps_in_millis.get(i).longValue());
+      timestamp = DateTime.toEndOfYear(timestamp, EST_TIME_ZONE) + 1;
+    }
+  }
+  
 
   @Test(expected = UnsupportedOperationException.class)
   public void testRemove() {
@@ -190,6 +604,69 @@ public class TestDownsampler {
     assertEquals(BASE_TIME + 8600000L, timestamps_in_millis.get(2).longValue());
   }
 
+  @Test
+  public void testSeek_useCalendar() {
+    final DataPoint [] data_points = new DataPoint[4];
+    long timestamp = DateTime.toStartOfYear(BASE_TIME, UTC_TIME_ZONE);
+    final Calendar c = Calendar.getInstance(UTC_TIME_ZONE);
+    c.setTimeInMillis(timestamp);
+    for (int i = 0; i < data_points.length; i++) {
+      long value = 1 << i;
+      data_points[i] = MutableDataPoint.ofLongValue(timestamp, value);
+
+      timestamp = DateTime.toEndOfYear(timestamp, UTC_TIME_ZONE) + 1;
+    }
+    
+    source = spy(SeekableViewsForTest.fromArray(data_points));
+    
+    c.add(Calendar.YEAR, 2);
+    downsampler = new Downsampler(source, ONE_YEAR_INTERVAL, SUM, UTC_TIME_ZONE, true);
+    downsampler.seek(c.getTimeInMillis());
+    verify(source, never()).next();
+    List<Double> values = Lists.newArrayList();
+    List<Long> timestamps_in_millis = Lists.newArrayList();
+    while (downsampler.hasNext()) {
+      DataPoint dp = downsampler.next();
+      assertFalse(dp.isInteger());
+      values.add(dp.doubleValue());
+      timestamps_in_millis.add(dp.timestamp());
+    }
+    
+    assertEquals(2, values.size());
+    timestamp = DateTime.toStartOfYear(c.getTimeInMillis(), UTC_TIME_ZONE);
+    for (int i = 2; i < values.size(); i++) {
+      System.out.println(timestamps_in_millis.get(i).longValue());
+      assertEquals(1 << i, values.get(i), 0.0000001);
+      assertEquals(timestamp, timestamps_in_millis.get(i).longValue());
+      timestamp = DateTime.toEndOfYear(timestamp, UTC_TIME_ZONE) + 1;
+    }
+    
+    source = spy(SeekableViewsForTest.fromArray(data_points));
+
+    c.add(Calendar.MILLISECOND, 1);
+    downsampler = new Downsampler(source, ONE_YEAR_INTERVAL, SUM, UTC_TIME_ZONE, true);
+    downsampler.seek(c.getTimeInMillis());
+    verify(source, never()).next();
+    values = Lists.newArrayList();
+    timestamps_in_millis = Lists.newArrayList();
+    while (downsampler.hasNext()) {
+      DataPoint dp = downsampler.next();
+      assertFalse(dp.isInteger());
+      values.add(dp.doubleValue());
+      timestamps_in_millis.add(dp.timestamp());
+    }
+    
+    assertEquals(1, values.size());
+    timestamp = DateTime.toStartOfYear(c.getTimeInMillis(), UTC_TIME_ZONE);
+    for (int i = 3; i < values.size(); i++) {
+      System.out.println(timestamps_in_millis.get(i).longValue());
+      assertEquals(1 << i, values.get(i), 0.0000001);
+      assertEquals(timestamp, timestamps_in_millis.get(i).longValue());
+      timestamp = DateTime.toEndOfYear(timestamp, UTC_TIME_ZONE) + 1;
+    }
+    
+  }
+  
   @Test
   public void testSeek_skipPartialInterval() {
     downsampler = new Downsampler(source, THOUSAND_SEC_INTERVAL, AVG);

--- a/test/utils/TestDateTime.java
+++ b/test/utils/TestDateTime.java
@@ -33,6 +33,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest({ DateTime.class, System.class })
 public final class TestDateTime {
 
+  private static final TimeZone UTC_TIME_ZONE = DateTime.timezones.get("UTC");
+  
   @Before
   public void before() {
     PowerMockito.mockStatic(System.class);
@@ -370,6 +372,50 @@ public final class TestDateTime {
     PowerMockito.mockStatic(System.class);
     when(System.currentTimeMillis()).thenReturn(1388534400000L);
     assertEquals(1388534400000L, DateTime.currentTimeMillis());
+  }
+
+  @Test
+  public void toStartOfMonthBoundaryChecks() {
+    // test start and end with timestamp corresponding to 2013-10-01T00:00:00Z
+    assertEquals(1380585600000L, DateTime.toStartOfMonth(1380585600000L, UTC_TIME_ZONE));
+    assertEquals(1383263999999L, DateTime.toEndOfMonth(1380585600000L, UTC_TIME_ZONE));
+
+    // test start and end with timestamp corresponding to 2013-10-31T23:59:59Z
+    assertEquals(1380585600000L, DateTime.toStartOfMonth(1383263999999L, UTC_TIME_ZONE));
+    assertEquals(1383263999999L, DateTime.toEndOfMonth(1383263999999L, UTC_TIME_ZONE));
+  }
+
+  @Test
+  public void toStartOfWeekBoundaryChecks() {
+    // test start and end with timestamp corresponding to 2015-12-061T00:00:00Z, which is a Sunday
+    assertEquals(1449360000000L, DateTime.toStartOfWeek(1449360000000L, UTC_TIME_ZONE));
+    assertEquals(1449964799999L, DateTime.toEndOfWeek(1449360000000L, UTC_TIME_ZONE));
+
+    // test start and end with timestamp corresponding to 2015-12-12T23:59:59Z
+    assertEquals(1449360000000L, DateTime.toStartOfWeek(1449964799999L, UTC_TIME_ZONE));
+    assertEquals(1449964799999L, DateTime.toEndOfWeek(1449964799999L, UTC_TIME_ZONE));
+  }
+
+  @Test
+  public void toStartOfYearBoundaryChecks() {
+    // test start and end with timestamp corresponding to 2015-01-01T00:00:00Z
+    assertEquals(1420070400000L, DateTime.toStartOfYear(1420070400000L, UTC_TIME_ZONE));
+    assertEquals(1451606399999L, DateTime.toEndOfYear(1420070400000L, UTC_TIME_ZONE));
+
+    // test start and end with timestamp corresponding to 2015-12-31T23:59:59Z
+    assertEquals(1420070400000L, DateTime.toStartOfYear(1451606399999L, UTC_TIME_ZONE));
+    assertEquals(1451606399999L, DateTime.toEndOfYear(1451606399999L, UTC_TIME_ZONE));
+  }
+
+  @Test
+  public void toStartOfDayBoundaryChecks() {
+    // test start and end with timestamp corresponding to 2015-01-01T00:00:00Z
+    assertEquals(1420070400000L, DateTime.toStartOfDay(1420070400000L, UTC_TIME_ZONE));
+    assertEquals(1420156799999L, DateTime.toEndOfDay(1420070400000L, UTC_TIME_ZONE));
+
+    // test start and end with timestamp corresponding to 2015-01-01T23:59:59Z
+    assertEquals(1420070400000L, DateTime.toStartOfDay(1420156799999L, UTC_TIME_ZONE));
+    assertEquals(1420156799999L, DateTime.toEndOfDay(1420156799999L, UTC_TIME_ZONE));
   }
 
 }


### PR DESCRIPTION
This feature builds on the skeleton provided by @moarcaccio in
Pull Request #548, adding in all of the functionality requested by
@manolama in his Pull Request comments, and resolving a number of
defects which rendered the Pull Request unusable. After waiting
several months for @moarcaccio to complete the proposed
feature, we decided to move forward with our own Pull Request.

This feature supports the alignment of downsampling intervals to the
Gregorian calendar based on four different time categories:

- **DAILY:** The start time of each interval is computed as the start of the
  day in which the first data point occurs, based on a specified time zone
  (or the default JVM time zone, if no time zone has been specified).
  The end time of each interval is computed as the end of the day in which
  the first data point occurs.  For instance, if the specified time zone
  is UTC, and the timestamp of the first data point is 2016-01-05T05:32:00Z,
  then start of the interval will be computed as 2016-01-05T00:00:00.000Z,
  while the end of the interval will be computed as 2016-01-05T23:59:59.999Z.

- **WEEKLY:** The start time of each interval is computed as the start of the
  week in which the first data point occurs, based on a specified time zone
  (or the default JVM time zone, if no time zone has been specified).
  The end time of each interval is computed as the end of the week in which
  the first data point occurs.  Weeks are considered to begin on Sundays (in
  the future, it might be a good idea to allow for variations based on a
  configuration setting). For instance, if the specified time zone is UTC,
  and the timestamp of the first data point is 2016-01-05T05:32:00Z, then
  start of the interval will be computed as 2016-01-03T00:00:00.000Z,
  while the end of the interval will be computed as 2016-01-09T23:59:59.999Z.

- **MONTHLY:** The start time of each interval is computed as the start of the
  month in which the first data point occurs, based on a specified time zone
  (or the default JVM time zone, if no time zone has been specified).
  The end time of each interval is computed as the end of the month in which
  the first data point occurs.  For instance, if the specified time zone
  is UTC, and the timestamp of the first data point is 2016-01-05T05:32:00Z,
  then start of the interval will be computed as 2016-01-01T00:00:00.000Z,
  while the end of the interval will be computed as 2016-01-31T23:59:59.999Z.

- **YEARLY:** The start time of each interval is computed as the start of the
  year in which the first data point occurs, based on a specified time zone
  (or the default JVM time zone, if no time zone has been specified).
  The end time of each interval is computed as the end of the year in which
  the first data point occurs.  For instance, if the specified time zone
  is UTC, and the timestamp of the first data point is 2016-01-05T05:32:00Z,
  then start of the interval will be computed as 2016-01-01T00:00:00.000Z,
  while the end of the interval will be computed as 2016-12-31T23:59:59.999Z.

This feature also allows for the **alignment of intervals that are multiples
of one year, one month, one week, or one day**.  In cases where a given
interval is a multiple of more than one time category, the larger time
category will be used. For instance, an interval of 24 months will be
interpreted as an interval of two years, and will be aligned to the calendar
accordingly. As such, if the specified time zone is UTC,
and the timestamp of the first data point is 2016-03-05T05:32:00Z, then
the start of the interval will be computed as 2016-01-01T00:00:00.000Z,
while the end of the interval will be computed as 2017-12-31T23:59:59.999Z.
This is in keeping with the principle of least astonishment.

To specify the time zone for a given HTTP query, include a **query string
parameter named "tz"** with a value equal to a JVM time zone id (e.g. "UTC").
If a time zone is not included in the query string, the default JVM time zone will
be used.

To specify that a given HTTP query should use the calendar alignment feature
for downsampling, include a **query string parameter named "use_calendar"** with
a value of "true". You can stipulate that all HTTP queries should use the
calendar alignment feature by including a **"tsd.query.downsample.use_calendar"
configuration setting** within the opentsdb.conf file and by setting its value
to "true" (the default value is "false").  The value of this config file setting can be
overridden on a per-query basis by including the "use_calendar" parameter in
the query string as specified above.