### PR TITLE
Changing sysconfigdir with prefix in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -293,7 +293,7 @@ printdeps:
 # This is kind of a hack, but I couldn't find a better way to adjust the paths
 # in the script before it gets installed...
 install-exec-hook:
-	script=tsdb; pkgdatadir='$(pkgdatadir)'; configdir='$(sysconfigdir)/etc/opentsdb'; \
+	script=tsdb; pkgdatadir='$(pkgdatadir)'; configdir='$(prefix)/etc/opentsdb'; \
           abs_srcdir=''; abs_builddir=''; $(edit_tsdb_script)
 	cat tsdb.tmp >"$(DESTDIR)$(bindir)/tsdb"
 	rm -f tsdb.tmp


### PR DESCRIPTION
configure includes a sysconfdir option that is not present in Makefile.am (a sysconfigdir option is present, instead). This leads to tsdb using always a /etc/opentsdb config path that in FreeBSD (and in other systems al well, probably) is not the right one.