### PR TITLE
V2.1.0 hbase counters

### DIFF
--- a/src/core/ByteBufferList.java
+++ b/src/core/ByteBufferList.java
@@ -57,6 +57,15 @@ final class ByteBufferList {
     segments.add(new BufferSegment(buf, offset, len));
     total_length += len;
   }
+  
+  public BufferSegment removeLastSegment() {
+	  if (segments.isEmpty()) {
+		  return null;
+	  }
+	  BufferSegment seg = segments.remove(segments.size() - 1);
+	  total_length -= seg.len;
+	  return seg;
+  }
 
   /**
    * Get the most recently added segment.

--- a/src/core/ColumnDatapointIterator.java
+++ b/src/core/ColumnDatapointIterator.java
@@ -115,6 +115,12 @@ final class ColumnDatapointIterator implements Comparable<ColumnDatapointIterato
     compQualifier.add(qualifier, qualifier_offset, current_qual_length);
     compValue.add(value, value_offset, current_val_length);
   }
+  
+
+  public void writeToBuffers(byte[] new_qualifier, byte[] new_val, ByteBufferList compacted_qual, ByteBufferList compacted_val) {
+	  compacted_qual.add(new_qualifier, 0, new_qualifier.length);
+	  compacted_val.add(new_val, 0, new_val.length);  	
+  }
 
   /**
    * @return the length of the qualifier for the current datapoint.
@@ -161,6 +167,14 @@ final class ColumnDatapointIterator implements Comparable<ColumnDatapointIterato
     current_val_length = Internal.getValueLengthFromQualifier(qualifier, qualifier_offset);
     return true;
   }
+  
+  public short getFlagsFromQualifier() {
+	  return Internal.getFlagsFromQualifier(qualifier, qualifier_offset);
+  }
+  
+  public long getColumnTimestamp() {
+	  return column_timestamp;
+  }
 
   // order in ascending order by timestamp, descending order by row timestamp (so we find the
   // entry we are going to keep first, and don't have to copy over it)
@@ -179,4 +193,5 @@ final class ColumnDatapointIterator implements Comparable<ColumnDatapointIterato
     return "q=" + Arrays.toString(qualifier) + " [ofs=" + qualifier_offset + "], v="
         + Arrays.toString(value) + " [ofs=" + value_offset + "], ts=" + current_timestamp_offset;
   }
+  
 }

--- a/src/core/CompactionQueue.java
+++ b/src/core/CompactionQueue.java
@@ -429,6 +429,25 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
       }
       return tot_values;
     }
+    
+    private byte[] fromLong(long value) {
+    	final byte[] v;
+        
+        if (tsdb.config.use_hbase_counters()) {
+        	v = Bytes.fromLong(value);
+        }  
+        else if (Byte.MIN_VALUE <= value && value <= Byte.MAX_VALUE) {
+          v = new byte[] { (byte) value };
+        } else if (Short.MIN_VALUE <= value && value <= Short.MAX_VALUE) {
+          v = Bytes.fromShort((short) value);
+        } else if (Integer.MIN_VALUE <= value && value <= Integer.MAX_VALUE) {
+          v = Bytes.fromInt((int) value);
+        } else {
+          v = Bytes.fromLong(value);
+        }
+        
+        return v;
+    }
 
     /**
      * Process datapoints from the heap in order, merging into a sorted list.  Handles duplicates
@@ -448,7 +467,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
           final byte[] discardedVal = col.getCopyOfCurrentValue();
           if (!Arrays.equals(existingVal, discardedVal)) {
             duplicates_different.incrementAndGet();
-            if (!tsdb.config.fix_duplicates()) {
+            if (!tsdb.config.fix_duplicates() && !tsdb.config.sum_duplicates()) {
               throw new IllegalDataException("Duplicate timestamp for key="
                   + Arrays.toString(row.get(0).key()) + ", ms_offset=" + ts + ", older="
                   + Arrays.toString(existingVal) + ", newer=" + Arrays.toString(discardedVal)
@@ -459,6 +478,55 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
                 + Arrays.toString(discardedVal));
           } else {
             duplicates_same.incrementAndGet();
+          }
+          
+          if (tsdb.config.sum_duplicates()) {
+        	  short current_flags = Internal.getFlagsFromQualifier(compacted_qual.getLastSegment());
+        	  short discarded_flags = col.getFlagsFromQualifier();
+        	          	  
+        	  boolean is_current_long = ((current_flags & Const.FLAG_FLOAT) == 0x0);
+        	  boolean is_discarded_long = ((discarded_flags & Const.FLAG_FLOAT) == 0x0);
+        	  
+        	  /* the current value flags determine the type of the output (long or double) */
+        	  
+        	  double current_val = 0.0;
+        	  double discarded_val = 0.0;        	  
+        	  
+        	  if (is_current_long) {
+        		  current_val =  Internal.extractIntegerValue(existingVal, 0, (byte)current_flags);
+        	  } else {
+        		  current_val = Internal.extractFloatingPointValue(existingVal, 0, (byte) current_flags);
+        	  }
+        	  
+        	  if (is_discarded_long) {
+        		  discarded_val = Internal.extractIntegerValue(discardedVal, 0, (byte)discarded_flags);
+        	  } else {
+        		  discarded_val = Internal.extractFloatingPointValue(discardedVal, 0, (byte) current_flags);
+        	  }
+    		  
+    		  current_val += discarded_val;
+    		  byte[] new_val = null;
+    		  current_flags = 0;
+    		  
+    		  if (is_current_long) {
+    			  new_val = fromLong((long) current_val);
+    			  current_flags = (short) (new_val.length - 1);
+    		  } else {
+    			  new_val = Bytes.fromLong(Double.doubleToRawLongBits(current_val));
+    			  current_flags = Const.FLAG_FLOAT | 0x7;
+    		  }
+    		  
+    		  final byte[] new_qualifier = Internal.buildQualifier(col.getColumnTimestamp(), current_flags);
+    		  
+    		  /* now remove the last value & qualifier (existing one) and write the updated value and qualifier */
+    		  
+    		  prevTs = ts;
+    		  compacted_val.removeLastSegment();
+    		  compacted_qual.removeLastSegment();
+			  col.writeToBuffers(new_qualifier, new_val, compacted_qual, compacted_val);
+			  ms_in_row |= col.isMilliseconds();
+		      s_in_row |= !col.isMilliseconds();        		          	  
+        	  
           }
         } else {
           prevTs = ts;

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -823,7 +823,7 @@ public final class TSDB {
       }
     }
     
-    TsdbQuery.thread_pool.shutdown();
+    // TsdbQuery.thread_pool.shutdown();
     
     // wait for plugins to shutdown before we close the client
     return deferreds.size() > 0

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -24,6 +24,7 @@ import com.stumbleupon.async.DeferredGroupException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.hbase.async.AtomicIncrementRequest;
 import org.hbase.async.Bytes;
 import org.hbase.async.Bytes.ByteMap;
 import org.hbase.async.ClientStats;
@@ -555,12 +556,16 @@ public final class TSDB {
    * @throws HBaseException (deferred) if there was a problem while persisting
    * data.
    */
-  public Deferred<Object> addPoint(final String metric,
+  public Deferred addPoint(final String metric,
                                    final long timestamp,
                                    final long value,
                                    final Map<String, String> tags) {
     final byte[] v;
-    if (Byte.MIN_VALUE <= value && value <= Byte.MAX_VALUE) {
+    
+    if (config.use_hbase_counters()) {
+    	v = Bytes.fromLong(value);
+    }  
+    else if (Byte.MIN_VALUE <= value && value <= Byte.MAX_VALUE) {
       v = new byte[] { (byte) value };
     } else if (Short.MIN_VALUE <= value && value <= Short.MAX_VALUE) {
       v = Bytes.fromShort((short) value);
@@ -572,7 +577,7 @@ public final class TSDB {
     final short flags = (short) (v.length - 1);  // Just the length.
     return addPointInternal(metric, timestamp, v, tags, flags);
   }
-
+  
   /**
    * Adds a double precision floating-point value data point in the TSDB.
    * @param metric A non-empty string.
@@ -595,7 +600,7 @@ public final class TSDB {
    * data.
    * @since 1.2
    */
-  public Deferred<Object> addPoint(final String metric,
+  public Deferred addPoint(final String metric,
                                    final long timestamp,
                                    final double value,
                                    final Map<String, String> tags) {
@@ -631,7 +636,7 @@ public final class TSDB {
    * @throws HBaseException (deferred) if there was a problem while persisting
    * data.
    */
-  public Deferred<Object> addPoint(final String metric,
+  public Deferred addPoint(final String metric,
                                    final long timestamp,
                                    final float value,
                                    final Map<String, String> tags) {
@@ -645,8 +650,8 @@ public final class TSDB {
                             Bytes.fromInt(Float.floatToRawIntBits(value)),
                             tags, flags);
   }
-
-  private Deferred<Object> addPointInternal(final String metric,
+    
+  private Deferred addPointInternal(final String metric,
                                             final long timestamp,
                                             final byte[] value,
                                             final Map<String, String> tags,
@@ -674,11 +679,21 @@ public final class TSDB {
     
     Bytes.setInt(row, (int) base_time, metrics.width());
     scheduleForCompaction(row, (int) base_time);
-    final PutRequest point = new PutRequest(table, row, FAMILY, qualifier, value);
     
-    // TODO(tsuna): Add a callback to time the latency of HBase and store the
-    // timing in a moving Histogram (once we have a class for this).
-    Deferred<Object> result = client.put(point);
+    boolean isLong = ((flags & Const.FLAG_FLOAT) == 0x0);
+    Deferred<? extends Object> result = null;
+    
+    if (isLong && config.use_hbase_counters()) {
+    	    	
+    	AtomicIncrementRequest counterRequest = new AtomicIncrementRequest(table, row, FAMILY, qualifier, Bytes.getLong(value));
+    	result = client.atomicIncrement(counterRequest);
+    } else {
+    	final PutRequest point = new PutRequest(table, row, FAMILY, qualifier, value);
+    	// TODO(tsuna): Add a callback to time the latency of HBase and store the
+        // timing in a moving Histogram (once we have a class for this).
+        result = client.put(point);
+    }
+            
     if (!config.enable_realtime_ts() && !config.enable_tsuid_incrementing() && 
         !config.enable_tsuid_tracking() && rt_publisher == null) {
       return result;
@@ -807,6 +822,8 @@ public final class TSDB {
         deferreds.add(rpc.shutdown());
       }
     }
+    
+    TsdbQuery.thread_pool.shutdown();
     
     // wait for plugins to shutdown before we close the client
     return deferreds.size() > 0

--- a/src/core/WritableDataPoints.java
+++ b/src/core/WritableDataPoints.java
@@ -57,7 +57,7 @@ public interface WritableDataPoints extends DataPoints {
    * @throws HBaseException (deferred) if there was a problem while persisting
    * data.
    */
-  Deferred<Object> addPoint(long timestamp, long value);
+  Deferred addPoint(long timestamp, long value);
 
   /**
    * Appends a {@code float} data point to this sequence.
@@ -78,7 +78,7 @@ public interface WritableDataPoints extends DataPoints {
    * @throws HBaseException (deferred) if there was a problem while persisting
    * data.
    */
-  Deferred<Object> addPoint(long timestamp, float value);
+  Deferred addPoint(long timestamp, float value);
 
   /**
    * Specifies for how long to buffer edits, in milliseconds.

--- a/src/tools/TextImporter.java
+++ b/src/tools/TextImporter.java
@@ -147,7 +147,7 @@ final class TextImporter {
           }
         }
         final WritableDataPoints dp = getDataPoints(tsdb, metric, tags);
-        Deferred<Object> d;
+        Deferred d;
         if (Tags.looksLikeInteger(value)) {
           d = dp.addPoint(timestamp, Tags.parseLong(value));
         } else {  // floating point value

--- a/src/tools/TextImporter.java
+++ b/src/tools/TextImporter.java
@@ -147,7 +147,7 @@ final class TextImporter {
           }
         }
         final WritableDataPoints dp = getDataPoints(tsdb, metric, tags);
-        Deferred d;
+        Deferred<? extends Object> d;
         if (Tags.looksLikeInteger(value)) {
           d = dp.addPoint(timestamp, Tags.parseLong(value));
         } else {  // floating point value

--- a/src/tools/TextImporter.java
+++ b/src/tools/TextImporter.java
@@ -147,7 +147,7 @@ final class TextImporter {
           }
         }
         final WritableDataPoints dp = getDataPoints(tsdb, metric, tags);
-        Deferred d;
+        Deferred<Object> d;
         if (Tags.looksLikeInteger(value)) {
           d = dp.addPoint(timestamp, Tags.parseLong(value));
         } else {  // floating point value

--- a/src/tsd/PutDataPointRpc.java
+++ b/src/tsd/PutDataPointRpc.java
@@ -42,7 +42,7 @@ final class PutDataPointRpc implements TelnetRpc, HttpRpc {
   private static final AtomicLong illegal_arguments = new AtomicLong();
   private static final AtomicLong unknown_metrics = new AtomicLong();
 
-  public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
+  public Deferred execute(final TSDB tsdb, final Channel chan,
                                   final String[] cmd) {
     requests.incrementAndGet();
     String errmsg = null;
@@ -220,7 +220,7 @@ final class PutDataPointRpc implements TelnetRpc, HttpRpc {
    * @throws IllegalArgumentException if any other argument is invalid.
    * @throws NoSuchUniqueName if the metric isn't registered.
    */
-  private Deferred<Object> importDataPoint(final TSDB tsdb, final String[] words) {
+  private Deferred importDataPoint(final TSDB tsdb, final String[] words) {
     words[0] = null; // Ditch the "put".
     if (words.length < 5) {  // Need at least: metric timestamp value tag
       //               ^ 5 and not 4 because words[0] is "put".

--- a/src/tsd/TelnetRpc.java
+++ b/src/tsd/TelnetRpc.java
@@ -28,6 +28,6 @@ interface TelnetRpc {
    * @param command The command received, split.
    * @return A deferred result.
    */
-  Deferred<Object> execute(TSDB tsdb, Channel chan, String[] command);
+  Deferred execute(TSDB tsdb, Channel chan, String[] command);
 
 }

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -72,6 +72,9 @@ public class Config {
   
   /** tsd.storage.enable_compaction */
   private boolean enable_compactions = true;
+  
+  /** tsd.storage.hbase.use_hbase_counters */
+  private boolean use_hbase_counters = false;
 
   /** tsd.core.meta.enable_realtime_ts */
   private boolean enable_realtime_ts = false;
@@ -90,6 +93,9 @@ public class Config {
 
   /** tsd.storage.fix_duplicates */
   private boolean fix_duplicates = false;
+  
+  /** tsd.storage.sum_duplicates */
+  private boolean sum_duplicates = false;
 
   /** tsd.http.request.max_chunk */
   private int max_chunked_requests = 4096; 
@@ -176,6 +182,14 @@ public class Config {
   /** @return the enable_compaction value */
   public boolean enable_compactions() {
     return enable_compactions;
+  }
+  
+  public boolean use_hbase_counters() {
+	  return use_hbase_counters;
+  }
+  
+  public boolean sum_duplicates() {
+	  return sum_duplicates;
   }
   
   /** @return whether or not to record new TSMeta objects in real time */
@@ -463,6 +477,8 @@ public class Config {
     default_map.put("tsd.storage.hbase.zk_quorum", "localhost");
     default_map.put("tsd.storage.hbase.zk_basedir", "/hbase");
     default_map.put("tsd.storage.enable_compaction", "true");
+    default_map.put("tsd.storage.hbase.use_hbase_counters", "false");
+    default_map.put("tsd.storage.sum_duplicates", "false");    
     default_map.put("tsd.http.show_stack_trace", "true");
     default_map.put("tsd.http.request.enable_chunked", "false");
     default_map.put("tsd.http.request.max_chunk", "4096");
@@ -567,7 +583,9 @@ public class Config {
     auto_metric = this.getBoolean("tsd.core.auto_create_metrics");
     auto_tagk = this.getBoolean("tsd.core.auto_create_tagks");
     auto_tagv = this.getBoolean("tsd.core.auto_create_tagvs");
-    enable_compactions = this.getBoolean("tsd.storage.enable_compaction");
+    enable_compactions = this.getBoolean("tsd.storage.enable_compaction");    
+    use_hbase_counters = this.getBoolean("tsd.storage.hbase.use_hbase_counters");
+    sum_duplicates = this.getBoolean("tsd.storage.sum_duplicates");
     enable_chunked_requests = this.getBoolean("tsd.http.request.enable_chunked");
     enable_realtime_ts = this.getBoolean("tsd.core.meta.enable_realtime_ts");
     enable_realtime_uid = this.getBoolean("tsd.core.meta.enable_realtime_uid");


### PR DESCRIPTION
1. added support for using hbase counters as the underlying implementation of opentsdb
2. added support for summing up detected duplicate counters (instead of discarding them)