### PR TITLE
Allow parent-child branches have the same display name

### DIFF
--- a/test/tree/TestTreeBuilder.java
+++ b/test/tree/TestTreeBuilder.java
@@ -123,7 +123,7 @@ public final class TestTreeBuilder {
     root.setDisplayName("ROOT");
     root_path.put(0, "ROOT");
     root.prependParentPath(root_path);
-    storage.addColumn(root.compileBranchId(), 
+    storage.addColumn(root.compiledBranchId(),
         "branch".getBytes(MockBase.ASCII()), 
         (byte[])toStorageJson.invoke(root));
   }
@@ -628,7 +628,7 @@ public final class TestTreeBuilder {
   public void processTimeseriesMetaFormatBadType() throws Exception {
     tree.getRules().get(3).get(0).setDisplayFormat("Wrong: {tag_name}");
     treebuilder.processTimeseriesMeta(meta, false).joinUninterruptibly();
-    assertEquals(5, storage.numRows());
+    assertEquals(7, storage.numRows());
     final Branch branch = JSON.parseToObject(
         storage.getColumn(Branch.stringToId(
           "00010001A2460001CB54247F7202C3165573"), 
@@ -640,7 +640,7 @@ public final class TestTreeBuilder {
   public void processTimeseriesMetaFormatOverride() throws Exception {
     tree.getRules().get(3).get(0).setDisplayFormat("OVERRIDE");
     treebuilder.processTimeseriesMeta(meta, false).joinUninterruptibly();
-    assertEquals(5, storage.numRows());
+    assertEquals(7, storage.numRows());
     final Branch branch = JSON.parseToObject(
         storage.getColumn(Branch.stringToId(
           "00010001A2460001CB54247F72024E3D0BCC"), 

--- a/test/tsd/TestTreeRpc.java
+++ b/test/tsd/TestTreeRpc.java
@@ -1152,7 +1152,7 @@ public final class TestTreeRpc {
     root.setDisplayName("ROOT");
     root_path.put(0, "ROOT");
     root.prependParentPath(root_path);
-    storage.addColumn(root.compileBranchId(), Tree.TREE_FAMILY(),
+    storage.addColumn(root.compiledBranchId(), Tree.TREE_FAMILY(),
         "branch".getBytes(MockBase.ASCII()), 
         (byte[])branchToStorageJson.invoke(root));
     
@@ -1279,18 +1279,18 @@ public final class TestTreeRpc {
     path.put(2, "cpu");
     branch.prependParentPath(path);
     branch.setDisplayName("cpu");
-    storage.addColumn(branch.compileBranchId(), Tree.TREE_FAMILY(),
+    storage.addColumn(branch.compiledBranchId(), Tree.TREE_FAMILY(),
         "branch".getBytes(MockBase.ASCII()), 
         (byte[])branchToStorageJson.invoke(branch));
     
     Leaf leaf = new Leaf("user", "000001000001000001");
     qualifier = leaf.columnQualifier();
-    storage.addColumn(branch.compileBranchId(), Tree.TREE_FAMILY(),
+    storage.addColumn(branch.compiledBranchId(), Tree.TREE_FAMILY(),
         qualifier, (byte[])LeaftoStorageJson.invoke(leaf));
     
     leaf = new Leaf("nice", "000002000002000002");
     qualifier = leaf.columnQualifier();
-    storage.addColumn(branch.compileBranchId(), Tree.TREE_FAMILY(),
+    storage.addColumn(branch.compiledBranchId(), Tree.TREE_FAMILY(),
         qualifier, (byte[])LeaftoStorageJson.invoke(leaf));
     
     // child branch
@@ -1298,13 +1298,13 @@ public final class TestTreeRpc {
     path.put(3, "mboard");
     branch.prependParentPath(path);
     branch.setDisplayName("mboard");
-    storage.addColumn(branch.compileBranchId(), Tree.TREE_FAMILY(),
+    storage.addColumn(branch.compiledBranchId(), Tree.TREE_FAMILY(),
         "branch".getBytes(MockBase.ASCII()), 
         (byte[])branchToStorageJson.invoke(branch));
     
     leaf = new Leaf("Asus", "000003000003000003");
     qualifier = leaf.columnQualifier();
-    storage.addColumn(branch.compileBranchId(), Tree.TREE_FAMILY(),
+    storage.addColumn(branch.compiledBranchId(), Tree.TREE_FAMILY(),
         qualifier, (byte[])LeaftoStorageJson.invoke(leaf));
   }
   


### PR DESCRIPTION
Currently, a sequence of branches in parent-child relationship having the same display name are squashed into one branch, e.g. a.b.b.c.c.d is squashed into a.b.c.d. While reading code I haven't noticed any design reason for doing this. It would make more sense to preserve original metric name structure in a tree, in general. E.g. in my case some metrics can have consecutive repeated parts in metric name. Putting squashed branch B's children into B's parent children set is not convenient from browsing perspective.