### PR TITLE
Apply regex based whitelists to new uid auto-creation

### DIFF
--- a/src/opentsdb.conf
+++ b/src/opentsdb.conf
@@ -38,6 +38,22 @@ tsd.http.cachedir =
 # is False
 #tsd.core.auto_create_metrics = false
 
+# Whether or no to evaluate new metric/tagk/tagv items against a whitelist, default
+# is False
+# tsd.core.auto_create_whitelist = false
+
+# Comma-Delimited list of regex patterns to match against new metric names, default
+# is .*, examples might be ^awesome\..*$,^regexfoo[0-9].*$
+#tsd.core.auto_create_metrics_patterns = .*
+
+# Comma-Delimited list of regex patterns to match against new tagk names, default
+# is .*, examples might be ^awesome\..*$,^regexfoo[0-9].*$
+#tsd.core.auto_create_tagk_patterns = .*
+
+# Comma-Delimited list of regex patterns to match against new tagv names, default
+# is .*, examples might be ^awesome\..*$,^regexfoo[0-9].*$
+#tsd.core.auto_create_tagv_patterns = .*
+
 # --------- STORAGE ----------
 # Whether or not to enable data compaction in HBase, default is True
 #tsd.storage.enable_compaction = true

--- a/src/tools/CliOptions.java
+++ b/src/tools/CliOptions.java
@@ -120,6 +120,17 @@ final class CliOptions {
       // map the overrides
       if (entry.getKey().toLowerCase().equals("--auto-metric")) {
         config.overrideConfig("tsd.core.auto_create_metrics", "true");
+      } else if (entry.getKey().toLowerCase().equals("--auto-metric-whitelist")) {
+        config.overrideConfig("tsd.core.auto_create_whitelist", "true");
+      } else if (entry.getKey().toLowerCase().equals("--auto-metric-pattern")) {
+        config.overrideConfig("tsd.core.auto_create_metrics_patterns",
+                entry.getValue());
+      } else if (entry.getKey().toLowerCase().equals("--auto-tagk-pattern")) {
+        config.overrideConfig("tsd.core.auto_create_tagk_patterns",
+                entry.getValue());
+      } else if (entry.getKey().toLowerCase().equals("--auto-tagv-pattern")) {
+        config.overrideConfig("tsd.core.auto_create_tagv_patterns",
+                entry.getValue());
       } else if (entry.getKey().toLowerCase().equals("--table")) {
         config.overrideConfig("tsd.storage.hbase.data_table", entry.getValue());
       } else if (entry.getKey().toLowerCase().equals("--uidtable")) {

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -69,7 +69,20 @@ public class Config {
   
   /** tsd.core.auto_create_tagv */
   private boolean auto_tagv = true;
-  
+
+  /** tsd.core.auto_create_whitelist */
+  private boolean auto_whitelist = false;
+
+  /** tsd.core.auto_create_metrics_patterns */
+  private String auto_metric_patterns = ".*";
+
+  /** tsd.core.auto_create_tagk_patterns */
+  private String auto_tagk_patterns = ".*";
+
+  /** tsd.core.auto_create_tagv_patterns */
+  private String auto_tagv_patterns = ".*";
+
+
   /** tsd.storage.enable_compaction */
   private boolean enable_compactions = true;
   
@@ -179,7 +192,25 @@ public class Config {
   public boolean auto_tagv() {
     return auto_tagv;
   }
-  
+
+  /** @return the auto_whitelist value */
+  public boolean auto_whitelist() { return auto_whitelist; }
+
+  /** @return the auto_metric value */
+  public String auto_metric_patterns() {
+    return auto_metric_patterns;
+  }
+
+  /** @return the auto_tagk value */
+  public String auto_tagk_patterns() {
+    return auto_tagk_patterns;
+  }
+
+  /** @return the auto_tagv value */
+  public String auto_tagv_patterns() {
+    return auto_tagv_patterns;
+  }
+
   /** @param auto_metric whether or not to auto create metrics */
   public void setAutoMetric(boolean auto_metric) {
     this.auto_metric = auto_metric;
@@ -487,6 +518,10 @@ public class Config {
     default_map.put("tsd.core.auto_create_metrics", "false");
     default_map.put("tsd.core.auto_create_tagks", "true");
     default_map.put("tsd.core.auto_create_tagvs", "true");
+    default_map.put("tsd.core.auto_create_whitelist", "false");
+    default_map.put("tsd.core.auto_create_metrics_patterns", ".*");
+    default_map.put("tsd.core.auto_create_tagk_patterns", ".*");
+    default_map.put("tsd.core.auto_create_tagv_patterns", ".*");
     default_map.put("tsd.core.connections.limit", "0");
     default_map.put("tsd.core.meta.enable_realtime_ts", "false");
     default_map.put("tsd.core.meta.enable_realtime_uid", "false");
@@ -634,6 +669,10 @@ public class Config {
     auto_metric = this.getBoolean("tsd.core.auto_create_metrics");
     auto_tagk = this.getBoolean("tsd.core.auto_create_tagks");
     auto_tagv = this.getBoolean("tsd.core.auto_create_tagvs");
+    auto_whitelist = this.getBoolean("tsd.core.auto_create_whitelist");
+    auto_metric_patterns = this.getString("tsdb.core.auto_create_metrics_patterns");
+    auto_tagk_patterns = this.getString("tsdb.core.auto_create_tagk_patterns");
+    auto_tagv_patterns = this.getString("tsdb.core.auto_create_tagv_patterns");
     enable_compactions = this.getBoolean("tsd.storage.enable_compaction");
     enable_appends = this.getBoolean("tsd.storage.enable_appends");
     repair_appends = this.getBoolean("tsd.storage.repair_appends");


### PR DESCRIPTION
I did some very basic testing in our environment.

## A good metric name:
```
2015-11-17 16:10:45,055 DEBUG [OpenTSDB I/O Worker #1] UniqueId: Accepted name for UID: testing.metrics.foo based on 'test..*'
2015-11-17 16:10:45,056 INFO [OpenTSDB I/O Worker #1] UniqueId: Creating an ID for kind='metrics' name='testing.metrics.foo'
```
## A bad metric name:
```
2015-11-17 16:10:59,250 DEBUG [OpenTSDB I/O Worker #2] UniqueId: Rejected name for UID: tbadmetrics.foo
2015-11-17 16:10:59,250 INFO [OpenTSDB I/O Worker #2] UniqueId: UID cannot be assigned, name is not acceptable because it fails to match the whitelist: tbadmetrics.foo
2015-11-17 16:10:59,255 ERROR [OpenTSDB I/O Worker #2] RpcHandler: [id: 0xe1397817, /50.116.203.7:59102 => /50.116.203.7:4244] Unexpected exception caught while serving [null, tbadmetrics.foo, 1447798259, 0, domain=test]
java.lang.RuntimeException: UID cannot be assigned, name is not acceptable because it fails to match the whitelist: tbadmetrics.foo```