### PR TITLE
Added read-only CLI flag

### DIFF
--- a/src/tools/CliOptions.java
+++ b/src/tools/CliOptions.java
@@ -140,6 +140,8 @@ final class CliOptions {
         config.overrideConfig("tsd.core.flushinterval", entry.getValue());
       } else if (entry.getKey().toLowerCase().equals("--backlog")) {
         config.overrideConfig("tsd.network.backlog", entry.getValue());
+      } else if (entry.getKey().toLowerCase().equals("--read-only")) {
+        config.overrideConfig("tsd.mode", "ro");
       } else if (entry.getKey().toLowerCase().equals("--bind")) {
         config.overrideConfig("tsd.network.bind", entry.getValue());
       } else if (entry.getKey().toLowerCase().equals("--async-io")) {

--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -80,6 +80,8 @@ final class TSDMain {
                    "Number for async io workers (default: cpu * 2).");
     argp.addOption("--async-io", "true|false",
                    "Use async NIO (default true) or traditional blocking io");
+    argp.addOption("--read-only", "true|false",
+                   "Set tsd.mode to ro (default false)");
     argp.addOption("--backlog", "NUM",
                    "Size of connection attempt queue (default: 3072 or kernel"
                    + " somaxconn.");


### PR DESCRIPTION
We run OpenTSDB in containers where the configuration is read from the host. The OpenTSDB on the host is rw mode but we want to enfore ro mode within the container.

This adds a command line flag to override what is in the configuation.