### PR TITLE
Http latency stats plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -363,6 +363,7 @@ test_plugin_SRC := \
   test/plugin/DummyPluginA.java \
   test/plugin/DummyPluginB.java \
   test/search/DummySearchPlugin.java \
+  test/stats/DummyLatencyStatsPlugin.java \
   test/tsd/DummyHttpSerializer.java \
   test/tsd/DummyHttpRpcPlugin.java \
   test/tsd/DummyRpcPlugin.java \

--- a/Makefile.am
+++ b/Makefile.am
@@ -120,6 +120,8 @@ tsdb_SRC := \
 	src/search/SearchQuery.java	\
 	src/search/TimeSeriesLookup.java	\
 	src/stats/Histogram.java	\
+	src/stats/LatencyStats.java	\
+	src/stats/LatencyStatsPlugin.java	\
 	src/stats/StatsCollector.java	\
 	src/stats/QueryStats.java	\
 	src/tools/ArgP.java	\

--- a/pom.xml.in
+++ b/pom.xml.in
@@ -123,6 +123,9 @@
                 <argument>net/opentsdb/search/DummySearchPlugin.class</argument>
                 <argument>-C</argument>
                 <argument>target/test-classes</argument>
+                <argument>net/opentsdb/stats/DummyLatencyStatsPlugin.class</argument>
+                <argument>-C</argument>
+                <argument>target/test-classes</argument>
                 <argument>net/opentsdb/tsd/DummyHttpSerializer.class</argument>
                 <argument>-C</argument>
                 <argument>target/test-classes</argument>

--- a/pom.xml.in
+++ b/pom.xml.in
@@ -147,7 +147,7 @@
                 <argument>META-INF/services/net.opentsdb.search.SearchPlugin</argument>
                 <argument>-C</argument>
                 <argument>test</argument>
-                <argument>META-INF/services/net.opentsdb.stats.DummyLatencyStatsPlugin</argument>
+                <argument>META-INF/services/net.opentsdb.stats.LatencyStatsPlugin</argument>
                 <argument>-C</argument>
                 <argument>test</argument>
                 <argument>META-INF/services/net.opentsdb.tsd.HttpSerializer</argument>

--- a/pom.xml.in
+++ b/pom.xml.in
@@ -147,6 +147,9 @@
                 <argument>META-INF/services/net.opentsdb.search.SearchPlugin</argument>
                 <argument>-C</argument>
                 <argument>test</argument>
+                <argument>META-INF/services/net.opentsdb.stats.DummyLatencyStatsPlugin</argument>
+                <argument>-C</argument>
+                <argument>test</argument>
                 <argument>META-INF/services/net.opentsdb.tsd.HttpSerializer</argument>
                 <argument>-C</argument>
                 <argument>test</argument>

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -238,8 +238,8 @@ public final class TSDB {
     ExpressionFactory.addTSDBFunctions(this);
     
 
-    putlatency = LatencyStats.getInstance(config, "hbase_put");
-    scanlatency = LatencyStats.getInstance(config, "hbase_scan");
+    putlatency = LatencyStats.getInstance(config, "hbase_put", "hbase.latency", "method=put");
+    scanlatency = LatencyStats.getInstance(config, "hbase_scan", "hbase.latency", "method=scan");
 
     LOG.debug(config.dumpConfiguration());
   }
@@ -603,7 +603,7 @@ public final class TSDB {
 
     collector.addExtraTag("class", "IncomingDataPoints");
     try {
-      putlatency.collectStats(collector, "hbase.latency", "method=put");
+      putlatency.collectStats(collector);
     } finally {
       collector.clearExtraTag("class");
     }
@@ -617,7 +617,7 @@ public final class TSDB {
 
     collector.addExtraTag("class", "TsdbQuery");
     try {
-      scanlatency.collectStats(collector, "hbase.latency", "method=scan");
+      scanlatency.collectStats(collector);
     } finally {
       collector.clearExtraTag("class");
     }

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -61,10 +61,11 @@ import net.opentsdb.query.expression.ExpressionFactory;
 import net.opentsdb.query.filter.TagVFilter;
 import net.opentsdb.search.SearchPlugin;
 import net.opentsdb.search.SearchQuery;
-import net.opentsdb.tools.StartupPlugin;
-import net.opentsdb.stats.Histogram;
+import net.opentsdb.stats.LatencyStats;
+import net.opentsdb.stats.LatencyStatsPlugin;
 import net.opentsdb.stats.QueryStats;
 import net.opentsdb.stats.StatsCollector;
+import net.opentsdb.tools.StartupPlugin;
 
 /**
  * Thread-safe implementation of the TSDB client.
@@ -138,6 +139,16 @@ public final class TSDB {
   private static final AtomicLong datapoints_added = new AtomicLong();
 
   /**
+   * Keep track of the latency (in ms) we perceive sending edits to HBase.
+   */
+  private LatencyStatsPlugin putlatency;
+
+  /**
+   * Keep track of the latency (in ms) we perceive doing scans HBase.
+   */
+  private LatencyStatsPlugin scanlatency;
+
+    /**
    * Constructor
    * @param client An initialized HBase client object
    * @param config An initialized configuration object
@@ -226,6 +237,10 @@ public final class TSDB {
     // load up the functions that require the TSDB object
     ExpressionFactory.addTSDBFunctions(this);
     
+
+    putlatency = LatencyStats.getInstance(config, "hbase_put");
+    scanlatency = LatencyStats.getInstance(config, "hbase_scan");
+
     LOG.debug(config.dumpConfiguration());
   }
   
@@ -588,7 +603,7 @@ public final class TSDB {
 
     collector.addExtraTag("class", "IncomingDataPoints");
     try {
-      collector.record("hbase.latency", IncomingDataPoints.putlatency, "method=put");
+      putlatency.collectStats(collector, "hbase.latency", "method=put");
     } finally {
       collector.clearExtraTag("class");
     }
@@ -602,7 +617,7 @@ public final class TSDB {
 
     collector.addExtraTag("class", "TsdbQuery");
     try {
-      collector.record("hbase.latency", TsdbQuery.scanlatency, "method=scan");
+      scanlatency.collectStats(collector, "hbase.latency", "method=scan");
     } finally {
       collector.clearExtraTag("class");
     }
@@ -670,13 +685,13 @@ public final class TSDB {
   }
 
   /** Returns a latency histogram for Put RPCs used to store data points. */
-  public Histogram getPutLatencyHistogram() {
-    return IncomingDataPoints.putlatency;
+  public LatencyStatsPlugin getPutLatencyStats() {
+    return putlatency;
   }
 
-  /** Returns a latency histogram for Scan RPCs used to fetch data points.  */
-  public Histogram getScanLatencyHistogram() {
-    return TsdbQuery.scanlatency;
+  /** Returns a latency histogram for Put RPCs used to store data points. */
+  public LatencyStatsPlugin getScanLatencyStats() {
+    return putlatency;
   }
 
   /**
@@ -712,7 +727,7 @@ public final class TSDB {
    * Returns a new {@link Query} instance suitable for this TSDB.
    */
   public Query newQuery() {
-    return new TsdbQuery(this);
+    return new TsdbQuery(this, scanlatency);
   }
 
   /**
@@ -722,7 +737,7 @@ public final class TSDB {
    * instead.
    */
   public WritableDataPoints newDataPoints() {
-    return new IncomingDataPoints(this);
+    return new IncomingDataPoints(this, putlatency);
   }
 
   /**

--- a/src/stats/Histogram.java
+++ b/src/stats/Histogram.java
@@ -64,6 +64,8 @@ public final class Histogram extends LatencyStatsPlugin {
 
   /** Buckets where we actually store the values. */
   private final int[] buckets;
+  private String metricName;
+  private String xtratag;
 
 
   /**
@@ -115,8 +117,10 @@ public final class Histogram extends LatencyStatsPlugin {
   }
 
     @Override
-    public void initialize(Config config) {
-        // do nothing
+    public void initialize(Config config, String metricName, String xtratag) {
+      // save info for future writes
+      this.metricName = metricName;
+      this.xtratag = xtratag;
     }
 
     @Override
@@ -135,7 +139,7 @@ public final class Histogram extends LatencyStatsPlugin {
     }
 
     @Override
-    public void collectStats(StatsCollector collector, String metricName, String xtratag) {
+    public void collectStats(StatsCollector collector) {
         collector.record(metricName + "_50pct", percentile(50), xtratag);
         collector.record(metricName + "_75pct", percentile(75), xtratag);
         collector.record(metricName + "_90pct", percentile(90), xtratag);

--- a/src/stats/LatencyStats.java
+++ b/src/stats/LatencyStats.java
@@ -1,0 +1,103 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2015  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.stats;
+
+import com.stumbleupon.async.Deferred;
+import net.opentsdb.utils.Config;
+import net.opentsdb.utils.PluginLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages latency stats plugins for given measurement points. Supports differing plugin by measurement point as well as
+ * specifying a global default via config. If no config exists then this will return an {@link Histogram}. Ensures each 
+ * returned instance is a singleton.
+ */
+public class LatencyStats {
+
+  /** Logging */
+  private static final Logger LOG = LoggerFactory.getLogger(LatencyStats.class);
+
+  /** Created instances */
+  private static ConcurrentHashMap<String, LatencyStatsPlugin> instances = new ConcurrentHashMap<String, LatencyStatsPlugin>();
+
+  /**
+   * Get the latency stats plugin for a given measurement point.
+   * @param config The configuration for this TSDB instance
+   * @param name The named measurement point
+   */
+  public static LatencyStatsPlugin getInstance(Config config, String name) {
+    // simple existence check
+    if (instances.containsKey(name)) {
+      return instances.get(name);
+    }
+    
+    // need to create one..
+    String specificConfigKey = "tsd.latency_stats.plugin." + name;
+    String defaultConfigKey = "tsd.latency_stats.plugin";
+    
+    String configKey = null;
+    boolean pluginConfigured = false;
+    if (config.hasProperty(specificConfigKey)) {
+      configKey = specificConfigKey;
+      pluginConfigured = true;
+    }
+    else if (config.hasProperty(defaultConfigKey)) {
+      configKey = defaultConfigKey;
+      pluginConfigured = true;
+    }
+    
+    LatencyStatsPlugin ret;
+    if (pluginConfigured) {
+      ret = PluginLoader.loadSpecificPlugin(
+              config.getString(configKey), LatencyStatsPlugin.class);
+      if (ret == null) {
+        throw new IllegalArgumentException(
+                "Unable to locate latency stats plugin: " + config.getString(configKey));
+      }
+      try {
+        ret.initialize(config);
+      } catch (Exception e) {
+        throw new RuntimeException(
+                "Failed to initialize latency stats plugin", e);
+      }
+      LOG.info("Successfully initialized latency stats plugin - instance for " + name + " [" +
+              ret.getClass().getCanonicalName() + "] version: "
+              + ret.version());
+    } else {
+      ret = new Histogram(16000, (short) 2, 100);
+    }
+    
+    if (instances.putIfAbsent(name, ret) == null) {
+      ret.start();
+    };
+    return instances.get(name);
+  }
+
+  public static Deferred<ArrayList<Object>> shutdownAll() {
+    List<Deferred<Object>> multi = new ArrayList<Deferred<Object>>(instances.size());
+    for (LatencyStatsPlugin p : instances.values()) {
+      multi.add(p.shutdown());
+    }
+    return Deferred.group(multi);
+  }
+
+
+  static void clear() {
+    instances.clear();
+  }
+}

--- a/src/stats/LatencyStatsPlugin.java
+++ b/src/stats/LatencyStatsPlugin.java
@@ -31,10 +31,12 @@ public abstract class LatencyStatsPlugin {
    * problem. Please use IllegalArgumentException for configuration issues.
    *
    * @param config The TSDB configuration
+   * @param metricName The name of the metric to emit aggregations to
+   * @param xtratag    Extra tags to use when emitting aggregations
    * @throws IllegalArgumentException if required configuration parameters are
    *                                  missing
    */
-  public abstract void initialize(final Config config);
+  public abstract void initialize(final Config config, String metricName, String xtratag);
 
   /**
    * Called when this plugin is live. Calls to {@link #add(int)} will not be made
@@ -66,10 +68,8 @@ public abstract class LatencyStatsPlugin {
    * measurements it has been collecting
    *
    * @param collector  The collector used for emitting statistics
-   * @param metricName The name of the metric to emit aggregations to (should not be used for internal plugin metrics)
-   * @param xtratag    Extra tags to use when emitting aggregations (should not be used for internal plugin metrics)
    */
-  public abstract void collectStats(final StatsCollector collector, String metricName, String xtratag);
+  public abstract void collectStats(final StatsCollector collector);
 
   /**
    * Adds a value to be measured.

--- a/src/stats/LatencyStatsPlugin.java
+++ b/src/stats/LatencyStatsPlugin.java
@@ -1,0 +1,81 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2015  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.stats;
+
+import com.stumbleupon.async.Deferred;
+import net.opentsdb.utils.Config;
+
+/**
+ * Used to calculate latency stats for a given operation. May work synchronously by collecting measurements and
+ * recording directly into a {@link StatsCollector} or may emit events to an external system which writes back
+ * via TSDB write channels (e.g. Telnet or HTTP).
+ */
+public abstract class LatencyStatsPlugin {
+
+  /**
+   * Called by TSDB to initialize the plugin
+   * Implementations are responsible for setting up any IO they need as well
+   * as starting any required background threads.
+   * <b>Note:</b> Implementations should throw exceptions if they can't start
+   * up properly. The TSD will then shutdown so the operator can fix the
+   * problem. Please use IllegalArgumentException for configuration issues.
+   *
+   * @param config The TSDB configuration
+   * @throws IllegalArgumentException if required configuration parameters are
+   *                                  missing
+   */
+  public abstract void initialize(final Config config);
+
+  /**
+   * Called when this plugin is live. Calls to {@link #add(int)} will not be made
+   * before this method is called. Under race conditions it's possible this method will never
+   * be called on a given instance of this class.
+   */
+  public abstract void start();
+
+  /**
+   * Called when the TSD is shutting down to gracefully flush any buffers or
+   * close open connections.
+   */
+  public abstract Deferred<Object> shutdown();
+
+  /**
+   * Should return the version of this plugin in the format:
+   * MAJOR.MINOR.MAINT, e.g. 2.0.1. The MAJOR version should match the major
+   * version of OpenTSDB the plugin is meant to work with.
+   *
+   * @return A version string used to log the loaded version
+   */
+  public abstract String version();
+
+  /**
+   * Called by the TSD when a request for statistics collection has come in. The
+   * implementation may provide one or more statistics. If no statistics are
+   * available for the implementation, simply stub the method. This method is responsible
+   * both for collecting stats about the plugin, as well as emitting aggregations of the
+   * measurements it has been collecting
+   *
+   * @param collector  The collector used for emitting statistics
+   * @param metricName The name of the metric to emit aggregations to (should not be used for internal plugin metrics)
+   * @param xtratag    Extra tags to use when emitting aggregations (should not be used for internal plugin metrics)
+   */
+  public abstract void collectStats(final StatsCollector collector, String metricName, String xtratag);
+
+  /**
+   * Adds a value to be measured.
+   *
+   * @param value The value to add.
+   * @throws IllegalArgumentException may be thrown if the value given is negative.
+   */
+  public abstract void add(final int value);
+}

--- a/src/stats/StatsCollector.java
+++ b/src/stats/StatsCollector.java
@@ -108,14 +108,12 @@ public abstract class StatsCollector {
    * data points (ignored if {@code null}).
    * @throws IllegalArgumentException if {@code xtratag != null} and it
    * doesn't follow the {@code name=value} format.
+   * @deprecated Call collectStats() directly on the plugin
    */
   public final void record(final String name,
-                           final Histogram histo,
+                           final LatencyStatsPlugin histo,
                            final String xtratag) {
-    record(name + "_50pct", histo.percentile(50), xtratag);
-    record(name + "_75pct", histo.percentile(75), xtratag);
-    record(name + "_90pct", histo.percentile(90), xtratag);
-    record(name + "_95pct", histo.percentile(95), xtratag);
+      histo.collectStats(this, name, xtratag);
   }
 
   /**

--- a/src/stats/StatsCollector.java
+++ b/src/stats/StatsCollector.java
@@ -101,22 +101,6 @@ public abstract class StatsCollector {
   }
 
   /**
-   * Records a number of data points from a {@link Histogram}.
-   * @param name The name of the metric.
-   * @param histo The histogram to collect data points from.
-   * @param xtratag An extra tag ({@code name=value}) to add to those
-   * data points (ignored if {@code null}).
-   * @throws IllegalArgumentException if {@code xtratag != null} and it
-   * doesn't follow the {@code name=value} format.
-   * @deprecated Call collectStats() directly on the plugin
-   */
-  public final void record(final String name,
-                           final LatencyStatsPlugin histo,
-                           final String xtratag) {
-      histo.collectStats(this, name, xtratag);
-  }
-
-  /**
    * Records a data point.
    * @param name The name of the metric.
    * @param value The current value for that metric.

--- a/src/tsd/GraphHandler.java
+++ b/src/tsd/GraphHandler.java
@@ -35,6 +35,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
+import net.opentsdb.stats.LatencyStatsPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +46,6 @@ import net.opentsdb.core.Query;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.core.TSQuery;
 import net.opentsdb.graph.Plot;
-import net.opentsdb.stats.Histogram;
 import net.opentsdb.stats.StatsCollector;
 import net.opentsdb.utils.DateTime;
 import net.opentsdb.utils.JSON;
@@ -69,12 +69,10 @@ final class GraphHandler implements HttpRpc {
     = new AtomicInteger();
 
   /** Keep track of the latency of graphing requests. */
-  private static final Histogram graphlatency =
-    new Histogram(16000, (short) 2, 100);
+  private final LatencyStatsPlugin graphlatency;
 
   /** Keep track of the latency (in ms) introduced by running Gnuplot. */
-  private static final Histogram gnuplotlatency =
-    new Histogram(16000, (short) 2, 100);
+  private final LatencyStatsPlugin gnuplotlatency;
 
   /** Executor to run Gnuplot in separate bounded thread pool. */
   private final ThreadPoolExecutor gnuplot;
@@ -82,7 +80,10 @@ final class GraphHandler implements HttpRpc {
   /**
    * Constructor.
    */
-  public GraphHandler() {
+  public GraphHandler(LatencyStatsPlugin graphlatency, LatencyStatsPlugin gnuplotlatency) {
+    this.graphlatency = graphlatency;
+    this.gnuplotlatency = gnuplotlatency;
+
     // Gnuplot is mostly CPU bound and does only a little bit of IO at the
     // beginning to read the input data and at the end to write its output.
     // We want to avoid running too many Gnuplot instances concurrently as
@@ -213,7 +214,7 @@ final class GraphHandler implements HttpRpc {
     }
 
     try {
-      gnuplot.execute(new RunGnuplot(query, max_age, plot, basepath,
+      gnuplot.execute(new RunGnuplot(this, query, max_age, plot, basepath,
                                      aggregated_tags, npoints));
     } catch (RejectedExecutionException e) {
       query.internalError(new Exception("Too many requests pending,"
@@ -260,6 +261,7 @@ final class GraphHandler implements HttpRpc {
   // Runs Gnuplot in a subprocess to generate the graph.
   private static final class RunGnuplot implements Runnable {
 
+    private final GraphHandler outer;
     private final HttpQuery query;
     private final int max_age;
     private final Plot plot;
@@ -267,12 +269,14 @@ final class GraphHandler implements HttpRpc {
     private final HashSet<String>[] aggregated_tags;
     private final int npoints;
 
-    public RunGnuplot(final HttpQuery query,
+    public RunGnuplot(final GraphHandler outer,
+                      final HttpQuery query,
                       final int max_age,
                       final Plot plot,
                       final String basepath,
                       final HashSet<String>[] aggregated_tags,
                       final int npoints) {
+      this.outer = outer;
       this.query = query;
       this.max_age = max_age;
       this.plot = plot;
@@ -299,7 +303,7 @@ final class GraphHandler implements HttpRpc {
     }
 
     private void execute() throws IOException {
-      final int nplotted = runGnuplot(query, basepath, plot);
+      final int nplotted = outer.runGnuplot(query, basepath, plot);
       if (query.hasQueryStringParam("json")) {
         final HashMap<String, Object> results = new HashMap<String, Object>();
         results.put("plotted", nplotted);
@@ -321,7 +325,7 @@ final class GraphHandler implements HttpRpc {
       }
 
       // TODO(tsuna): Expire old files from the on-disk cache.
-      graphlatency.add(query.processingTimeMillis());
+      outer.graphlatency.add(query.processingTimeMillis());
       graphs_generated.incrementAndGet();
     }
 
@@ -336,9 +340,9 @@ final class GraphHandler implements HttpRpc {
    * Collects the stats and metrics tracked by this instance.
    * @param collector The collector to use.
    */
-  public static void collectStats(final StatsCollector collector) {
-    collector.record("http.latency", graphlatency, "type=graph");
-    collector.record("http.latency", gnuplotlatency, "type=gnuplot");
+  public void collectStats(final StatsCollector collector) {
+    graphlatency.collectStats(collector, "http.latency", "type=graph");
+    gnuplotlatency.collectStats(collector, "http.latency", "type=gnuplot");
     collector.record("http.graph.requests", graphs_diskcache_hit, "cache=disk");
     collector.record("http.graph.requests", graphs_generated, "cache=miss");
   }
@@ -713,7 +717,7 @@ final class GraphHandler implements HttpRpc {
    * graph from the file it produces, or if we have been interrupted.
    * @throws GnuplotException if Gnuplot returns non-zero.
    */
-  static int runGnuplot(final HttpQuery query,
+  int runGnuplot(final HttpQuery query,
                         final String basepath,
                         final Plot plot) throws IOException {
     final int nplotted = plot.dumpToFiles(basepath);

--- a/src/tsd/GraphHandler.java
+++ b/src/tsd/GraphHandler.java
@@ -46,6 +46,7 @@ import net.opentsdb.core.Query;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.core.TSQuery;
 import net.opentsdb.graph.Plot;
+import net.opentsdb.stats.Histogram;
 import net.opentsdb.stats.StatsCollector;
 import net.opentsdb.utils.DateTime;
 import net.opentsdb.utils.JSON;
@@ -341,8 +342,8 @@ final class GraphHandler implements HttpRpc {
    * @param collector The collector to use.
    */
   public void collectStats(final StatsCollector collector) {
-    graphlatency.collectStats(collector, "http.latency", "type=graph");
-    gnuplotlatency.collectStats(collector, "http.latency", "type=gnuplot");
+    graphlatency.collectStats(collector);
+    gnuplotlatency.collectStats(collector);
     collector.record("http.graph.requests", graphs_diskcache_hit, "cache=disk");
     collector.record("http.graph.requests", graphs_generated, "cache=miss");
   }
@@ -358,7 +359,7 @@ final class GraphHandler implements HttpRpc {
     qs.remove("png");
     qs.remove("json");
     qs.remove("ascii");
-    return tsdb.getConfig().getDirectoryName("tsd.http.cachedir") + 
+    return tsdb.getConfig().getDirectoryName("tsd.http.cachedir") +
         Integer.toHexString(qs.hashCode());
   }
 
@@ -845,7 +846,7 @@ final class GraphHandler implements HttpRpc {
     writer.print(timestamp / 1000L);
     writer.print(' ');
   }
-  
+
   /**
    * Parses the {@code /q} query in a list of {@link Query} objects.
    * @param tsdb The TSDB to use.
@@ -859,7 +860,7 @@ final class GraphHandler implements HttpRpc {
     q.validateAndSetQuery();
     return q.buildQueries(tsdb);
   }
-  
+
   private static final PlotThdFactory thread_factory = new PlotThdFactory();
 
   private static final class PlotThdFactory implements ThreadFactory {

--- a/src/tsd/PipelineFactory.java
+++ b/src/tsd/PipelineFactory.java
@@ -84,10 +84,11 @@ public final class PipelineFactory implements ChannelPipelineFactory {
    */
   public PipelineFactory(final TSDB tsdb, final RpcManager manager, final int connectionsLimit) {
     this.tsdb = tsdb;
-    this.socketTimeout = tsdb.getConfig().getInt("tsd.core.socket.timeout");
+    socketTimeout = tsdb.getConfig().getInt("tsd.core.socket.timeout");
     timer = tsdb.getTimer();
     this.timeoutHandler = new IdleStateHandler(timer, 0, 0, this.socketTimeout);
     this.rpchandler = new RpcHandler(tsdb, manager);
+    manager.setRpcHandler(rpchandler);
     this.connmgr = new ConnectionManager(connectionsLimit);
     try {
       HttpQuery.initializeSerializerMaps(tsdb);

--- a/src/tsd/RpcHandler.java
+++ b/src/tsd/RpcHandler.java
@@ -74,7 +74,7 @@ final class RpcHandler extends IdleStateAwareChannelUpstreamHandler {
   private final GraphHandler graph_handler;
 
   /**
-   * Constructor that loads the CORS domain list and prepares for handling 
+   * Constructor that loads the CORS domain list and prepares for handling
    * requests.
    * @param tsdb The TSDB to use.
    * @param manager instance of a ready-to-use {@link RpcManager}.
@@ -120,7 +120,7 @@ final class RpcHandler extends IdleStateAwareChannelUpstreamHandler {
       LOG.info("Loaded CORS headers (" + cors_headers + ")");
     }
 
-    httplatency = LatencyStats.getInstance(tsdb.getConfig(), "http_all");
+    httplatency = LatencyStats.getInstance(tsdb.getConfig(), "http_all", "http.latency", "type=all");
   }
 
   @Override
@@ -328,7 +328,7 @@ final class RpcHandler extends IdleStateAwareChannelUpstreamHandler {
     collector.record("rpc.received", http_rpcs_received, "type=http");
     collector.record("rpc.received", http_plugin_rpcs_received, "type=http_plugin");
     collector.record("rpc.exceptions", exceptions_caught);
-    httplatency.collectStats(collector, "http.latency", "type=all");
+    httplatency.collectStats(collector);
     graph_handler.collectStats(collector);
     PutDataPointRpc.collectStats(collector);
     QueryRpc.collectStats(collector);

--- a/src/tsd/RpcManager.java
+++ b/src/tsd/RpcManager.java
@@ -129,8 +129,8 @@ public final class RpcManager {
    */
   private RpcManager(final TSDB tsdb) {
     this.tsdb = tsdb;
-    graphlatency = LatencyStats.getInstance(tsdb.getConfig(), "http_graph");
-    gnuplotlatency = LatencyStats.getInstance(tsdb.getConfig(), "http_gnuplot");
+    graphlatency = LatencyStats.getInstance(tsdb.getConfig(), "http_graph", "http.latency", "type=graph");
+    gnuplotlatency = LatencyStats.getInstance(tsdb.getConfig(), "http_gnuplot", "http.latency", "type=gnuplot");
   }
   
   /**

--- a/src/tsd/StatsRpc.java
+++ b/src/tsd/StatsRpc.java
@@ -50,6 +50,14 @@ import com.stumbleupon.async.Deferred;
 public final class StatsRpc implements TelnetRpc, HttpRpc {
   private static final Logger LOG = LoggerFactory.getLogger(StatsRpc.class);
   
+  /** The rpc handler - we ask this for stats */
+  private RpcHandler rpc_handler;
+  
+  /** Provides the stats rpc with the rpc handler which it gets stats from */
+  public void setRpcHandler(RpcHandler rpc_handler) {
+    this.rpc_handler = rpc_handler;
+  }
+  
   /**
    * Telnet RPC responder that returns the stats in ASCII style
    * @param tsdb The TSDB to use for fetching stats
@@ -124,7 +132,7 @@ public final class StatsRpc implements TelnetRpc, HttpRpc {
     final SerializerCollector collector = new SerializerCollector("tsd", dps, 
         canonical);
     ConnectionManager.collectStats(collector);
-    RpcHandler.collectStats(collector);
+    rpc_handler.collectStats(collector);
     RpcManager.collectStats(collector);
     tsdb.collectStats(collector);
     query.sendReply(query.serializer().formatStatsV1(dps));
@@ -139,7 +147,7 @@ public final class StatsRpc implements TelnetRpc, HttpRpc {
       final boolean canonical) {
     collector.addHostTag(canonical);
     ConnectionManager.collectStats(collector);
-    RpcHandler.collectStats(collector);
+    rpc_handler.collectStats(collector);
     RpcManager.collectStats(collector);
     collectThreadStats(collector);
     tsdb.collectStats(collector);

--- a/test/META-INF/services/net.opentsdb.stats.LatencyStatsPlugin
+++ b/test/META-INF/services/net.opentsdb.stats.LatencyStatsPlugin
@@ -1,0 +1,1 @@
+net.opentsdb.stats.DummyLatencyStatsPlugin

--- a/test/core/TestIncomingDataPoints.java
+++ b/test/core/TestIncomingDataPoints.java
@@ -15,6 +15,8 @@ package net.opentsdb.core;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
+
+import net.opentsdb.stats.Histogram;
 import net.opentsdb.uid.NoSuchUniqueName;
 
 import org.junit.Test;
@@ -27,45 +29,45 @@ public class TestIncomingDataPoints extends BaseTsdbTest {
 
   @Test
   public void metricNameAsync() throws Exception {
-    final IncomingDataPoints dps = new IncomingDataPoints(tsdb);
+    final IncomingDataPoints dps = new IncomingDataPoints(tsdb, new Histogram());
     dps.setSeries(METRIC_STRING, tags);
     assertEquals(METRIC_STRING, dps.metricNameAsync().joinUninterruptibly());
   }
-  
+
   @Test
   public void metricNameAsyncSalted() throws Exception {
     PowerMockito.mockStatic(Const.class);
     PowerMockito.when(Const.SALT_WIDTH()).thenReturn(1);
     PowerMockito.when(Const.SALT_BUCKETS()).thenReturn(2);
     PowerMockito.when(Const.MAX_NUM_TAGS()).thenReturn((short) 8);
-    
-    final IncomingDataPoints dps = new IncomingDataPoints(tsdb);
+
+    final IncomingDataPoints dps = new IncomingDataPoints(tsdb, new Histogram());
     dps.setSeries(METRIC_STRING, tags);
     assertEquals(METRIC_STRING, dps.metricNameAsync().joinUninterruptibly());
   }
-  
+
   @Test (expected = IllegalStateException.class)
   public void metricNameAsyncRowNotSet() throws Exception {
-    final IncomingDataPoints dps = new IncomingDataPoints(tsdb);
+    final IncomingDataPoints dps = new IncomingDataPoints(tsdb, new Histogram());
     dps.metricNameAsync().joinUninterruptibly();
   }
-  
+
   @Test
   public void rowKeyTemplate() throws Exception {
     final byte[] expected = new byte[METRIC_BYTES.length + Const.TIMESTAMP_BYTES
                                      + TAGK_BYTES.length + TAGV_BYTES.length];
     System.arraycopy(METRIC_BYTES, 0, expected, 0, METRIC_BYTES.length);
-    System.arraycopy(TAGK_BYTES, 0, expected, 
+    System.arraycopy(TAGK_BYTES, 0, expected,
         METRIC_BYTES.length + Const.TIMESTAMP_BYTES, TAGK_BYTES.length);
-    System.arraycopy(TAGV_BYTES, 0, expected, 
-        METRIC_BYTES.length + Const.TIMESTAMP_BYTES + TAGK_BYTES.length, 
+    System.arraycopy(TAGV_BYTES, 0, expected,
+        METRIC_BYTES.length + Const.TIMESTAMP_BYTES + TAGK_BYTES.length,
         TAGV_BYTES.length);
-    
-    final byte[] key = IncomingDataPoints.rowKeyTemplate(tsdb, 
+
+    final byte[] key = IncomingDataPoints.rowKeyTemplate(tsdb,
         METRIC_STRING, tags);
     assertArrayEquals(expected, key);
   }
-  
+
   @Test
   public void rowKeyTemplateWithSalt1Byte() throws Exception {
     PowerMockito.mockStatic(Const.class);
@@ -73,17 +75,17 @@ public class TestIncomingDataPoints extends BaseTsdbTest {
     final byte[] expected = new byte[METRIC_BYTES.length + Const.TIMESTAMP_BYTES
                                      + TAGK_BYTES.length + TAGV_BYTES.length + 1];
     System.arraycopy(METRIC_BYTES, 0, expected, 1, METRIC_BYTES.length);
-    System.arraycopy(TAGK_BYTES, 0, expected, 
+    System.arraycopy(TAGK_BYTES, 0, expected,
         METRIC_BYTES.length + Const.TIMESTAMP_BYTES + 1, TAGK_BYTES.length);
-    System.arraycopy(TAGV_BYTES, 0, expected, 
-        METRIC_BYTES.length + Const.TIMESTAMP_BYTES + TAGK_BYTES.length + 1, 
+    System.arraycopy(TAGV_BYTES, 0, expected,
+        METRIC_BYTES.length + Const.TIMESTAMP_BYTES + TAGK_BYTES.length + 1,
         TAGV_BYTES.length);
-    
-    final byte[] key = IncomingDataPoints.rowKeyTemplate(tsdb, 
+
+    final byte[] key = IncomingDataPoints.rowKeyTemplate(tsdb,
         METRIC_STRING, tags);
     assertArrayEquals(expected, key);
   }
-  
+
   @Test
   public void rowKeyTemplateWithSalt2Bytes() throws Exception {
     PowerMockito.mockStatic(Const.class);
@@ -91,13 +93,13 @@ public class TestIncomingDataPoints extends BaseTsdbTest {
     final byte[] expected = new byte[METRIC_BYTES.length + Const.TIMESTAMP_BYTES
                                      + TAGK_BYTES.length + TAGV_BYTES.length + 2];
     System.arraycopy(METRIC_BYTES, 0, expected, 2, METRIC_BYTES.length);
-    System.arraycopy(TAGK_BYTES, 0, expected, 
+    System.arraycopy(TAGK_BYTES, 0, expected,
         METRIC_BYTES.length + Const.TIMESTAMP_BYTES + 2, TAGK_BYTES.length);
-    System.arraycopy(TAGV_BYTES, 0, expected, 
-        METRIC_BYTES.length + Const.TIMESTAMP_BYTES + TAGK_BYTES.length + 2, 
+    System.arraycopy(TAGV_BYTES, 0, expected,
+        METRIC_BYTES.length + Const.TIMESTAMP_BYTES + TAGK_BYTES.length + 2,
         TAGV_BYTES.length);
-    
-    final byte[] key = IncomingDataPoints.rowKeyTemplate(tsdb, 
+
+    final byte[] key = IncomingDataPoints.rowKeyTemplate(tsdb,
         METRIC_STRING, tags);
     assertArrayEquals(expected, key);
   }
@@ -106,49 +108,49 @@ public class TestIncomingDataPoints extends BaseTsdbTest {
   public void rowKeyTemplateNoSuchMetric() throws Exception {
     IncomingDataPoints.rowKeyTemplate(tsdb, NSUN_METRIC, tags);
   }
-  
+
   @Test (expected = NoSuchUniqueName.class)
   public void rowKeyTemplateNoSuchTagK() throws Exception {
     tags.clear();
     tags.put(NSUN_TAGK, TAGV_STRING);
     IncomingDataPoints.rowKeyTemplate(tsdb, NSUN_METRIC, tags);
   }
-  
+
   @Test (expected = NoSuchUniqueName.class)
   public void rowKeyTemplateNoSuchTagV() throws Exception {
     tags.put(TAGK_STRING, NSUN_TAGV);
     IncomingDataPoints.rowKeyTemplate(tsdb, NSUN_METRIC, tags);
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void rowKeyTemplateNullTSDB() throws Exception {
     IncomingDataPoints.rowKeyTemplate(null, NSUN_METRIC, tags);
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void rowKeyTemplateNullMetric() throws Exception {
     IncomingDataPoints.rowKeyTemplate(tsdb, null, tags);
   }
-  
+
   @Test (expected = NoSuchUniqueName.class)
   public void rowKeyTemplateEmptyMetric() throws Exception {
     when(metrics.getOrCreateId("")).thenThrow(new NoSuchUniqueName("metrics", ""));
     IncomingDataPoints.rowKeyTemplate(tsdb, "", tags);
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void rowKeyTemplateNullTags() throws Exception {
     IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, null);
   }
-  
+
   // NOTE: This method doesn't enforce that we have tags
   @Test
   public void rowKeyTemplateEmptyTags() throws Exception {
     tags.clear();
     final byte[] expected = new byte[METRIC_BYTES.length + Const.TIMESTAMP_BYTES];
     System.arraycopy(METRIC_BYTES, 0, expected, 0, METRIC_BYTES.length);
-    
-    final byte[] key = IncomingDataPoints.rowKeyTemplate(tsdb, 
+
+    final byte[] key = IncomingDataPoints.rowKeyTemplate(tsdb,
         METRIC_STRING, tags);
     assertArrayEquals(expected, key);
   }

--- a/test/core/TestTsdbQuery.java
+++ b/test/core/TestTsdbQuery.java
@@ -27,6 +27,7 @@ import java.util.List;
 import net.opentsdb.core.TsdbQuery.ForTesting;
 import net.opentsdb.query.filter.TagVFilter;
 import net.opentsdb.query.filter.TagVWildcardFilter;
+import net.opentsdb.stats.Histogram;
 import net.opentsdb.storage.MockBase;
 import net.opentsdb.uid.NoSuchUniqueName;
 import net.opentsdb.utils.DateTime;
@@ -43,7 +44,7 @@ import com.stumbleupon.async.DeferredGroupException;
 /**
  * This class is for unit testing the TsdbQuery class. Pretty much making sure
  * the various ctors and methods function as expected. For actually running the
- * queries and validating the group by and aggregation logic, see 
+ * queries and validating the group by and aggregation logic, see
  * {@link TestTsdbQueryQueries}
  */
 @RunWith(PowerMockRunner.class)
@@ -53,82 +54,82 @@ public final class TestTsdbQuery extends BaseTsdbTest {
 
   @Before
   public void beforeLocal() throws Exception {
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
   }
-  
+
   @Test
   public void setStartTime() throws Exception {
     query.setStartTime(1356998400L);
     assertEquals(1356998400L, query.getStartTime());
   }
-  
+
   @Test
   public void setStartTimeZero() throws Exception {
     query.setStartTime(0L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setStartTimeInvalidNegative() throws Exception {
     query.setStartTime(-1L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setStartTimeInvalidTooBig() throws Exception {
     query.setStartTime(17592186044416L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setStartTimeEqualtoEndTime() throws Exception {
     query.setEndTime(1356998400L);
     query.setStartTime(1356998400L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setStartTimeGreaterThanEndTime() throws Exception {
     query.setEndTime(1356998400L);
     query.setStartTime(1356998460L);
   }
-  
+
   @Test
   public void setEndTime() throws Exception {
     query.setEndTime(1356998400L);
     assertEquals(1356998400L, query.getEndTime());
   }
-  
+
   @Test (expected = IllegalStateException.class)
   public void getStartTimeNotSet() throws Exception {
     query.getStartTime();
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setEndTimeInvalidNegative() throws Exception {
     query.setEndTime(-1L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setEndTimeInvalidTooBig() throws Exception {
     query.setEndTime(17592186044416L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setEndTimeEqualtoEndTime() throws Exception {
     query.setStartTime(1356998400L);
     query.setEndTime(1356998400L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setEndTimeGreaterThanEndTime() throws Exception {
     query.setStartTime(1356998460L);
     query.setEndTime(1356998400L);
   }
-  
+
   @Test
   public void getEndTimeNotSet() throws Exception {
     PowerMockito.mockStatic(DateTime.class);
     PowerMockito.when(DateTime.currentTimeMillis()).thenReturn(1357300800000L);
     assertEquals(1357300800000L, query.getEndTime());
   }
-  
+
   @Test
   public void setTimeSeries() throws Exception {
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
@@ -139,34 +140,34 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     assertArrayEquals(TAGK_BYTES, ForTesting.getGroupBys(query).get(0));
     assertEquals(1, ForTesting.getRowKeyLiterals(query).size());
     assertEquals(1, ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES).length);
-    assertArrayEquals(TAGV_BYTES, 
+    assertArrayEquals(TAGV_BYTES,
         ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES)[0]);
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void setTimeSeriesNullTags() throws Exception {
     query.setTimeSeries(METRIC_STRING, null, Aggregators.SUM, false);
   }
-  
+
   @Test
   public void setTimeSeriesEmptyTags() throws Exception {
     tags.clear();
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     assertNotNull(query);
   }
-  
+
   @Test (expected = NoSuchUniqueName.class)
   public void setTimeSeriesNosuchMetric() throws Exception {
     query.setTimeSeries(NSUN_METRIC, tags, Aggregators.SUM, false);
   }
-  
+
   @Test (expected = NoSuchUniqueName.class)
   public void setTimeSeriesNosuchTagk() throws Exception {
     tags.clear();
     tags.put(NSUN_TAGK, TAGV_STRING);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
   }
-  
+
   @Test (expected = NoSuchUniqueName.class)
   public void setTimeSeriesNosuchTagv() throws Exception {
     tags.put(TAGK_STRING, NSUN_TAGV);
@@ -181,18 +182,18 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
     assertNotNull(query);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setTimeSeriesTSNullList() throws Exception {
     query.setTimeSeries(null, Aggregators.SUM, false);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setTimeSeriesTSEmptyList() throws Exception {
     final List<String> tsuids = new ArrayList<String>();
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setTimeSeriesTSDifferentMetrics() throws Exception {
     final List<String> tsuids = new ArrayList<String>(2);
@@ -200,22 +201,22 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     tsuids.add("000002000001000002");
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
   }
-  
+
   @Test
   public void configureFromQuery() throws Exception {
     setDataPointStorage();
     final TSQuery ts_query = getTSQuery();
     ts_query.validateAndSetQuery();
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertArrayEquals(TAGK_BYTES, ForTesting.getGroupBys(query).get(0));
     assertEquals(1, ForTesting.getGroupBys(query).size());
     assertNotNull(ForTesting.getRateOptions(query));
   }
-  
+
   @Test
   public void configureFromQueryWithRate() throws Exception {
     setDataPointStorage();
@@ -224,31 +225,31 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     rate_options.setResetValue(1024);
     ts_query.getQueries().get(0).setRateOptions(rate_options);
     ts_query.validateAndSetQuery();
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertArrayEquals(TAGK_BYTES, ForTesting.getGroupBys(query).get(0));
     assertEquals(1, ForTesting.getGroupBys(query).size());
     assertTrue(rate_options == ForTesting.getRateOptions(query));
   }
-  
+
   @Test
   public void configureFromQueryNoTags() throws Exception {
     setDataPointStorage();
     final TSQuery ts_query = getTSQuery();
     ts_query.getQueries().get(0).setTags(Collections.EMPTY_MAP);
     ts_query.validateAndSetQuery();
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(0, ForTesting.getFilters(query).size());
     assertNull(ForTesting.getGroupBys(query));
     assertNull(ForTesting.getRowKeyLiterals(query));
   }
-  
+
   @Test
   public void configureFromQueryGroupByAll() throws Exception {
     setDataPointStorage();
@@ -257,18 +258,18 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     tags.put(TAGK_STRING, "*");
     ts_query.getQueries().get(0).setTags(tags);
     ts_query.validateAndSetQuery();
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertEquals(1, ForTesting.getGroupBys(query).size());
-    assertArrayEquals(TAGK_BYTES, 
+    assertArrayEquals(TAGK_BYTES,
         ForTesting.getGroupBys(query).get(0));
     assertEquals(1, ForTesting.getRowKeyLiterals(query).size());
     assertNull(ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES));
   }
-  
+
   @Test
   public void configureFromQueryGroupByPipe() throws Exception {
     setDataPointStorage();
@@ -277,21 +278,21 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     tags.put(TAGK_STRING, TAGV_STRING + "|" + TAGV_B_STRING);
     ts_query.getQueries().get(0).setTags(tags);
     ts_query.validateAndSetQuery();
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertEquals(1, ForTesting.getGroupBys(query).size());
     assertArrayEquals(TAGK_BYTES, ForTesting.getGroupBys(query).get(0));
     assertEquals(1, ForTesting.getRowKeyLiterals(query).size());
     assertEquals(2, ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES).length);
-    assertArrayEquals(TAGV_BYTES, 
+    assertArrayEquals(TAGV_BYTES,
         ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES)[0]);
-    assertArrayEquals(TAGV_B_BYTES, 
+    assertArrayEquals(TAGV_B_BYTES,
         ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES)[1]);
   }
-  
+
   @Test
   public void configureFromQueryWithGroupByFilter() throws Exception {
     setDataPointStorage();
@@ -300,9 +301,9 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     tags.put("host", TagVWildcardFilter.FILTER_NAME + "(*imes)");
     ts_query.getQueries().get(0).setTags(tags);
     ts_query.validateAndSetQuery();
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertEquals(1, ForTesting.getGroupBys(query).size());
@@ -320,9 +321,9 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     filters.add(new TagVWildcardFilter("host", "*imes"));
     ts_query.getQueries().get(0).setFilters(filters);
     ts_query.validateAndSetQuery();
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertNull(ForTesting.getGroupBys(query));
@@ -330,7 +331,7 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     assertNull(ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES));
     assertNotNull(ForTesting.getRateOptions(query));
   }
-  
+
   @Test
   public void configureFromQueryWithGroupByAndRegularFilters() throws Exception {
     setDataPointStorage();
@@ -342,7 +343,7 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     ts_query.getQueries().get(0).setFilters(filters);
     ts_query.validateAndSetQuery();
 
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(2, ForTesting.getFilters(query).size());
@@ -352,42 +353,42 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     assertNull(ForTesting.getRowKeyLiterals(query).get(TAGK_BYTES));
     assertNotNull(ForTesting.getRateOptions(query));
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void configureFromQueryNullSubs() throws Exception {
     final TSQuery ts_query = new TSQuery();
-    new TsdbQuery(tsdb).configureFromQuery(ts_query, 0);
+    new TsdbQuery(tsdb, new Histogram()).configureFromQuery(ts_query, 0);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void configureFromQueryEmptySubs() throws Exception {
     final TSQuery ts_query = new TSQuery();
     ts_query.setQueries(new ArrayList<TSSubQuery>(0));
-    new TsdbQuery(tsdb).configureFromQuery(ts_query, 0);
+    new TsdbQuery(tsdb, new Histogram()).configureFromQuery(ts_query, 0);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void configureFromQueryNegativeIndex() throws Exception {
     final TSQuery ts_query = getTSQuery();
-    new TsdbQuery(tsdb).configureFromQuery(ts_query, -1);
+    new TsdbQuery(tsdb, new Histogram()).configureFromQuery(ts_query, -1);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void configureFromQueryIndexOutOfBounds() throws Exception {
     final TSQuery ts_query = getTSQuery();
-    new TsdbQuery(tsdb).configureFromQuery(ts_query, 2);
+    new TsdbQuery(tsdb, new Histogram()).configureFromQuery(ts_query, 2);
   }
-  
+
   @Test (expected = NoSuchUniqueName.class)
   public void configureFromQueryNSUMetric() throws Exception {
     setDataPointStorage();
     final TSQuery ts_query = getTSQuery();
     ts_query.getQueries().get(0).setMetric(NSUN_METRIC);
     ts_query.validateAndSetQuery();
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
   }
-  
+
   @Test (expected = DeferredGroupException.class)
   public void configureFromQueryNSUTagk() throws Exception {
     setDataPointStorage();
@@ -396,10 +397,10 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     tags.put(NSUN_TAGK, TAGV_STRING);
     ts_query.getQueries().get(0).setTags(tags);
     ts_query.validateAndSetQuery();
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
   }
-  
+
   @Test (expected = DeferredGroupException.class)
   public void configureFromQueryNSUTagv() throws Exception {
     setDataPointStorage();
@@ -408,10 +409,10 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     tags.put(TAGK_STRING, NSUN_TAGV);
     ts_query.getQueries().get(0).setTags(tags);
     ts_query.validateAndSetQuery();
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
   }
-  
+
   @Test (expected = DeferredGroupException.class)
   public void configureFromQueryGroupByPipeNSUTagk() throws Exception {
     setDataPointStorage();
@@ -420,10 +421,10 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     tags.put(NSUN_TAGK, TAGV_STRING + "|" + TAGV_B_STRING);
     ts_query.getQueries().get(0).setTags(tags);
     ts_query.validateAndSetQuery();
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
   }
-  
+
   @Test (expected = DeferredGroupException.class)
   public void configureFromQueryGroupByPipeNSUTagv() throws Exception {
     setDataPointStorage();
@@ -432,12 +433,12 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     tags.put(TAGK_STRING, TAGV_STRING + "|" + NSUN_TAGV);
     ts_query.getQueries().get(0).setTags(tags);
     ts_query.validateAndSetQuery();
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
   }
-  
+
   @Test
-  public void configureFromQueryGroupByPipeNSUTagvSkipUnresolved() 
+  public void configureFromQueryGroupByPipeNSUTagvSkipUnresolved()
       throws Exception {
     config.overrideConfig("tsd.query.skip_unresolved_tagvs", "true");
     setDataPointStorage();
@@ -446,24 +447,24 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     tags.put(TAGK_STRING, TAGV_STRING + "|" + NSUN_TAGV);
     ts_query.getQueries().get(0).setTags(tags);
     ts_query.validateAndSetQuery();
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertEquals(1, ForTesting.getGroupBys(query).size());
-    assertArrayEquals(TAGK_BYTES, 
+    assertArrayEquals(TAGK_BYTES,
         ForTesting.getGroupBys(query).get(0));
   }
-  
+
   @Test
   public void deleteDatapoints() throws Exception {
     setDataPointStorage();
-    
+
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
     query.setStartTime(1356998400);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     query.setDelete(true);
     final DataPoints[] dps1 = query.run();
     assertEquals(1, dps1.length);
@@ -471,14 +472,14 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     final DataPoints[] dps2 = query.run();
     assertEquals(0, dps2.length);
   }
-  
+
   @Test
   public void scannerException() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
     final RuntimeException ex = new RuntimeException("Boo!");
     storage.throwException(MockBase.stringToBytes(
         "00000150E22700000001000001"), ex, true);
-    
+
     storage.dumpToSystemOut();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
@@ -490,21 +491,21 @@ public final class TestTsdbQuery extends BaseTsdbTest {
       assertSame(ex, e);
     }
   }
-  
+
   /** @return a simple TSQuery object for testing */
   private TSQuery getTSQuery() {
     final TSQuery ts_query = new TSQuery();
     ts_query.setStart("1356998400");
-    
+
     final TSSubQuery sub_query = new TSSubQuery();
     sub_query.setMetric(METRIC_STRING);
     sub_query.setAggregator("sum");
 
     sub_query.setTags(tags);
-    
+
     final ArrayList<TSSubQuery> sub_queries = new ArrayList<TSSubQuery>(1);
     sub_queries.add(sub_query);
-    
+
     ts_query.setQueries(sub_queries);
     return ts_query;
   }

--- a/test/core/TestTsdbQueryAggregators.java
+++ b/test/core/TestTsdbQueryAggregators.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 
+import net.opentsdb.stats.Histogram;
 import org.hbase.async.Scanner;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +28,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
- * Integration testing for the various aggregators. We write data points to 
+ * Integration testing for the various aggregators. We write data points to
  * MockBase and then pull them out, following the full path for a TSDB query.
  */
 @RunWith(PowerMockRunner.class)
@@ -37,20 +38,20 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
 
   @Before
   public void beforeLocal() throws Exception {
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
   }
 
   @Test
   public void runZimSum() throws Exception {
     storeLongTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.ZIMSUM, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long ts = 1356998430000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(ts, dp.timestamp());
@@ -59,18 +60,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runZimSumFloat() throws Exception {
     storeFloatTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.ZIMSUM, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long ts = 1356998430000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(ts, dp.timestamp());
@@ -79,18 +80,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runZimSumOffset() throws Exception {
     storeLongTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.ZIMSUM, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v1 = 1;
     long v2 = 300;
     long ts = 1356998430000L;
@@ -98,7 +99,7 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     for (DataPoint dp : dps[0]) {
       assertEquals(ts, dp.timestamp());
       ts += 15000;
-      if (counter % 2 == 0) {        
+      if (counter % 2 == 0) {
         assertEquals(v1, dp.longValue());
         v1++;
       } else {
@@ -109,18 +110,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runZimSumFloatOffset() throws Exception {
     storeFloatTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.ZIMSUM, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     double v1 = 1.25;
     double v2 = 75.0;
     long ts = 1356998430000L;
@@ -139,7 +140,7 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runZimSumWithMissingData() throws Exception {
     storeLongTimeSeriesWithMissingData();
@@ -197,18 +198,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
 
     assertEquals(250, dps[0].size());
   }
-  
+
   @Test
   public void runMin() throws Exception {
     storeLongTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MIN, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v = 1;
     long ts = 1356998430000L;
     boolean decrement = false;
@@ -216,13 +217,13 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
       assertEquals(ts, dp.timestamp());
       ts += 30000;
       assertEquals(v, dp.longValue());
-      
+
       if (decrement) {
         v--;
       } else {
         v++;
       }
-      
+
       if (v == 151){
         v = 150;
         decrement = true;
@@ -230,18 +231,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMinFloat() throws Exception {
     storeFloatTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MIN, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     double v = 1.25;
     long ts = 1356998430000L;
     boolean decrement = false;
@@ -249,13 +250,13 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
       assertEquals(ts, dp.timestamp());
       ts += 30000;
       assertEquals(v, dp.doubleValue(), 0.0001);
-      
+
       if (decrement) {
         v -= .25;
       } else {
         v += .25;
       }
-      
+
       if (v > 38){
         v = 38.0;
         decrement = true;
@@ -263,18 +264,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMinOffset() throws Exception {
     storeLongTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MIN, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v = 1;
     long ts = 1356998430000L;
     int counter = 0;
@@ -298,18 +299,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runMinFloatOffset() throws Exception {
     storeFloatTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MIN, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     double v = 1.25;
     long ts = 1356998430000L;
     boolean decrement = false;
@@ -322,7 +323,7 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
       } else {
         v += 0.125;
       }
-      
+
       if (v > 38.125){
         v = 38.125;
         decrement = true;
@@ -330,18 +331,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runMax() throws Exception {
     storeLongTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MAX, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v = 300;
     long ts = 1356998430000L;
     boolean decrement = true;
@@ -363,18 +364,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMaxFloat() throws Exception {
     storeFloatTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MAX, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     double v = 75.0;
     long ts = 1356998430000L;
     boolean decrement = true;
@@ -396,18 +397,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMaxOffset() throws Exception {
     storeLongTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MAX, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v = 1;
     long ts = 1356998430000L;
     int counter = 0;
@@ -426,8 +427,8 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
         } else {
           v++;
         }
-      } 
-      
+      }
+
       if (v == 150){
         v = 151;
         decrement = false;
@@ -437,18 +438,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runMaxFloatOffset() throws Exception {
     storeFloatTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MAX, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     double v = 1.25;
     long ts = 1356998430000L;
     boolean decrement = true;
@@ -466,7 +467,7 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
         } else {
           v += .125;
         }
-        
+
         if (v < 38.25){
           v = 38.25;
           decrement = false;
@@ -475,18 +476,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runAvg() throws Exception {
     storeLongTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.AVG, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long ts = 1356998430000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(ts, dp.timestamp());
@@ -495,18 +496,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runAvgFloat() throws Exception {
     storeFloatTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.AVG, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long ts = 1356998430000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(ts, dp.timestamp());
@@ -515,18 +516,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runAvgOffset() throws Exception {
     storeLongTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.AVG, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v = 1;
     long ts = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -545,18 +546,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runAvgFloatOffset() throws Exception {
     storeFloatTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.AVG, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     double v = 1.25;
     long ts = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -571,18 +572,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runDev() throws Exception {
     storeLongTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.DEV, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v = 149;
     long ts = 1356998430000L;
     boolean decrement = true;
@@ -590,13 +591,13 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
       assertEquals(ts, dp.timestamp());
       ts += 30000;
       assertEquals(v, dp.longValue());
-      
+
       if (decrement) {
         v--;
       } else {
         v++;
       }
-      
+
       if (v < 0){
         v = 0;
         decrement = false;
@@ -604,18 +605,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runDevFloat() throws Exception {
     storeFloatTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.DEV, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     double v = 36.875;
     long ts = 1356998430000L;
     boolean decrement = true;
@@ -623,13 +624,13 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
       assertEquals(ts, dp.timestamp());
       ts += 30000;
       assertEquals(v, dp.doubleValue(), 0.001);
-      
+
       if (decrement) {
         v -= 0.25;
       } else {
         v += 0.25;
       }
-      
+
       if (v < 0.125){
         v = 0.125;
         decrement = false;
@@ -637,18 +638,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runDevOffset() throws Exception {
     storeLongTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.DEV, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v = 0;
     long ts = 1356998430000L;
     int counter = 0;
@@ -677,18 +678,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runDevFloatOffset() throws Exception {
     storeFloatTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.DEV, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     double v = 0;
     long ts = 1356998430000L;
     boolean decrement = true;
@@ -714,18 +715,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runMimMin() throws Exception {
     storeLongTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MIMMIN, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v = 1;
     long ts = 1356998430000L;
     boolean decrement = false;
@@ -733,13 +734,13 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
       assertEquals(ts, dp.timestamp());
       ts += 30000;
       assertEquals(v, dp.longValue());
-      
+
       if (decrement) {
         v--;
       } else {
         v++;
       }
-      
+
       if (v == 151){
         v = 150;
         decrement = true;
@@ -747,18 +748,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMimMinOffset() throws Exception {
     storeLongTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MIMMIN, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v1 = 1;
     long v2 = 300;
     long ts = 1356998430000L;
@@ -766,8 +767,8 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     for (DataPoint dp : dps[0]) {
       assertEquals(ts, dp.timestamp());
       ts += 15000;
-      
-      if (counter % 2 == 0) {        
+
+      if (counter % 2 == 0) {
         assertEquals(v1, dp.longValue());
         v1++;
       } else {
@@ -778,18 +779,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runMimMinFloat() throws Exception {
     storeFloatTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MIMMIN, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     double v = 1.25;
     long ts = 1356998430000L;
     boolean decrement = false;
@@ -797,13 +798,13 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
       assertEquals(ts, dp.timestamp());
       ts += 30000;
       assertEquals(v, dp.doubleValue(), 0.0001);
-      
+
       if (decrement) {
         v -= .25;
       } else {
         v += .25;
       }
-      
+
       if (v > 38){
         v = 38.0;
         decrement = true;
@@ -811,18 +812,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMimMinFloatOffset() throws Exception {
     storeFloatTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MIMMIN, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     double v1 = 1.25;
     double v2 = 75.0;
     long ts = 1356998430000L;
@@ -841,18 +842,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runMimMax() throws Exception {
     storeLongTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MIMMAX, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v = 300;
     long ts = 1356998430000L;
     boolean decrement = true;
@@ -874,18 +875,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMimMaxFloat() throws Exception {
     storeFloatTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MIMMAX, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     double v = 75.0;
     long ts = 1356998430000L;
     boolean decrement = true;
@@ -907,18 +908,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMimMaxOffset() throws Exception {
     storeLongTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MIMMAX, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v1 = 1;
     long v2 = 300;
     long ts = 1356998430000L;
@@ -926,8 +927,8 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     for (DataPoint dp : dps[0]) {
       assertEquals(ts, dp.timestamp());
       ts += 15000;
-      
-      if (counter % 2 == 0) {        
+
+      if (counter % 2 == 0) {
         assertEquals(v1, dp.longValue());
         v1++;
       } else {
@@ -938,18 +939,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runMimMaxFloatOffset() throws Exception {
     storeFloatTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.MIMMAX, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     double v1 = 1.25;
     double v2 = 75.0;
     long ts = 1356998430000L;
@@ -994,10 +995,10 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     testPercentile(Aggregators.ep99r7, 150, 150);
     testPercentile(Aggregators.ep999r7, 150, 150);
   }
-  
+
   public void runCount() throws Exception {
     storeLongTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
@@ -1013,18 +1014,18 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runCountFloat() throws Exception {
     storeFloatTimeSeriesSeconds(false, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.COUNT, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long ts = 1356998430000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(ts, dp.timestamp());
@@ -1033,19 +1034,19 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
-  // TODO - The count agg is inaccurate until we implement NaNs. 
+
+  // TODO - The count agg is inaccurate until we implement NaNs.
   @Test
   public void runCountOffset() throws Exception {
     storeLongTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.COUNT, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long ts = 1356998430000L;
     int counter = 0;
     for (DataPoint dp : dps[0]) {
@@ -1060,19 +1061,19 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
-  // TODO - The count agg is inaccurate until we implement NaNs. 
+
+  // TODO - The count agg is inaccurate until we implement NaNs.
   @Test
   public void runCountFloatOffset() throws Exception {
     storeFloatTimeSeriesSeconds(false, true);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.COUNT, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long ts = 1356998430000L;
     int counter = 0;
     for (DataPoint dp : dps[0]) {
@@ -1087,14 +1088,14 @@ public class TestTsdbQueryAggregators extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   /**
    * Helper to test the various percentiles
    * @param agg The aggregator
    * @param value The value to expect
-   * @param delta The variance to expect 
+   * @param delta The variance to expect
    */
-  private void testPercentile(final Aggregator agg, final long value, 
+  private void testPercentile(final Aggregator agg, final long value,
       final double delta) {
     tags.clear();
     query.setStartTime(1356998400);

--- a/test/core/TestTsdbQueryAggregatorsSalted.java
+++ b/test/core/TestTsdbQueryAggregatorsSalted.java
@@ -12,6 +12,7 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
+import net.opentsdb.stats.Histogram;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
@@ -24,15 +25,15 @@ import org.powermock.modules.junit4.PowerMockRunner;
  */
 @RunWith(PowerMockRunner.class)
 public class TestTsdbQueryAggregatorsSalted extends TestTsdbQueryAggregators {
-  
+
   @Before
   public void beforeLocal() throws Exception {
     PowerMockito.mockStatic(Const.class);
     PowerMockito.when(Const.SALT_WIDTH()).thenReturn(1);
     PowerMockito.when(Const.SALT_BUCKETS()).thenReturn(2);
     PowerMockito.when(Const.MAX_NUM_TAGS()).thenReturn((short) 8);
-    
-    query = new TsdbQuery(tsdb);
+
+    query = new TsdbQuery(tsdb, new Histogram());
   }
-  
+
 }

--- a/test/core/TestTsdbQueryAppend.java
+++ b/test/core/TestTsdbQueryAppend.java
@@ -12,14 +12,15 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
+import net.opentsdb.stats.Histogram;
 import org.junit.Before;
 import org.powermock.reflect.Whitebox;
 
 public class TestTsdbQueryAppend extends TestTsdbQueryQueries {
-  
+
   @Before
-  public void beforeLocal() { 
+  public void beforeLocal() {
     Whitebox.setInternalState(config, "enable_appends", true);
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
   }
 }

--- a/test/core/TestTsdbQueryDownsample.java
+++ b/test/core/TestTsdbQueryDownsample.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 
+import net.opentsdb.stats.Histogram;
 import net.opentsdb.utils.DateTime;
 
 import org.hbase.async.Scanner;
@@ -43,7 +44,7 @@ public class TestTsdbQueryDownsample extends BaseTsdbTest {
 
   @Before
   public void beforeLocal() throws Exception {
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
   }
 
   @Test
@@ -460,14 +461,14 @@ public class TestTsdbQueryDownsample extends BaseTsdbTest {
     // and the 149 intervals in the middle have two values for each.
     assertEquals(151, dps[0].size());
   }
-  
+
   @Test
   public void runLongSingleTSDownsampleAll() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
     final TSQuery ts_query = new TSQuery();
     ts_query.setStart("1356998400");
     ts_query.setEnd("1357041600");
-    
+
     final HashMap<String, String> tags = new HashMap<String, String>(1);
     tags.put("host", "web01");
     final TSSubQuery sub = new TSSubQuery();
@@ -475,11 +476,11 @@ public class TestTsdbQueryDownsample extends BaseTsdbTest {
     sub.setMetric("sys.cpu.user");
     sub.setAggregator("sum");
     sub.setDownsample("0all-sum");
-    
+
     ts_query.setQueries(Lists.newArrayList(sub));
     ts_query.validateAndSetQuery();
     query.configureFromQuery(ts_query, 0);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
 
@@ -493,14 +494,14 @@ public class TestTsdbQueryDownsample extends BaseTsdbTest {
     // and the 149 intervals in the middle have two values for each.
     assertEquals(1, dps[0].size());
   }
-  
+
   @Test
   public void runLongSingleTSDownsampleAllSubSet() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
     final TSQuery ts_query = new TSQuery();
     ts_query.setStart("1356998500");
     ts_query.setEnd("1356998600");
-    
+
     final HashMap<String, String> tags = new HashMap<String, String>(1);
     tags.put("host", "web01");
     final TSSubQuery sub = new TSSubQuery();
@@ -508,11 +509,11 @@ public class TestTsdbQueryDownsample extends BaseTsdbTest {
     sub.setMetric("sys.cpu.user");
     sub.setAggregator("sum");
     sub.setDownsample("0all-sum");
-    
+
     ts_query.setQueries(Lists.newArrayList(sub));
     ts_query.validateAndSetQuery();
     query.configureFromQuery(ts_query, 0);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
 
@@ -526,13 +527,13 @@ public class TestTsdbQueryDownsample extends BaseTsdbTest {
     // and the 149 intervals in the middle have two values for each.
     assertEquals(1, dps[0].size());
   }
-  
+
   @Test
   public void runLongSingleTSDownsampleAllNoEnd() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
     final TSQuery ts_query = new TSQuery();
     ts_query.setStart("1356998400");
-    
+
     final HashMap<String, String> tags = new HashMap<String, String>(1);
     tags.put("host", "web01");
     final TSSubQuery sub = new TSSubQuery();
@@ -540,11 +541,11 @@ public class TestTsdbQueryDownsample extends BaseTsdbTest {
     sub.setMetric("sys.cpu.user");
     sub.setAggregator("sum");
     sub.setDownsample("0all-sum");
-    
+
     ts_query.setQueries(Lists.newArrayList(sub));
     ts_query.validateAndSetQuery();
     query.configureFromQuery(ts_query, 0);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
 
@@ -558,7 +559,7 @@ public class TestTsdbQueryDownsample extends BaseTsdbTest {
     // and the 149 intervals in the middle have two values for each.
     assertEquals(1, dps[0].size());
   }
-  
+
   // this could happen.
   @Test
   public void runFloatSingleTSDownsampleAndRateAndCount() throws Exception {
@@ -607,14 +608,14 @@ public class TestTsdbQueryDownsample extends BaseTsdbTest {
     query.downsample(60000, Aggregators.NONE);
     query.setTimeSeries("sys.cpu.user", tags, Aggregators.SUM, false);
   }
-  
+
   @Test (expected = RuntimeException.class)
   public void runLongSingleTSDownsampleNoneSnuckIn() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
     final TSQuery ts_query = new TSQuery();
     ts_query.setStart("1356998400");
     ts_query.setEnd("1357041600");
-    
+
     final HashMap<String, String> tags = new HashMap<String, String>(1);
     tags.put("host", "web01");
     final TSSubQuery sub = new TSSubQuery();
@@ -622,21 +623,21 @@ public class TestTsdbQueryDownsample extends BaseTsdbTest {
     sub.setMetric("sys.cpu.user");
     sub.setAggregator("sum");
     sub.setDownsample("1m-sum");
-    
+
     ts_query.setQueries(Lists.newArrayList(sub));
     ts_query.validateAndSetQuery();
     query.configureFromQuery(ts_query, 0);
     Whitebox.setInternalState(query, "downsampler", Aggregators.NONE);
-    
+
     final DataPoints[] dps = query.run();
     for (DataPoint dp : dps[0]) {
       dp.timestamp();
     }
   }
-  
+
   /**
-   * A helper interface to be used by the filling-test code. 
-   */ 
+   * A helper interface to be used by the filling-test code.
+   */
   interface Validator {
     /** @return true if the argument is valid. */
     boolean isValidValue(double value);

--- a/test/core/TestTsdbQueryDownsampleSalted.java
+++ b/test/core/TestTsdbQueryDownsampleSalted.java
@@ -12,6 +12,7 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
+import net.opentsdb.stats.Histogram;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
@@ -31,8 +32,8 @@ public class TestTsdbQueryDownsampleSalted extends TestTsdbQueryDownsample {
     PowerMockito.when(Const.SALT_WIDTH()).thenReturn(1);
     PowerMockito.when(Const.SALT_BUCKETS()).thenReturn(2);
     PowerMockito.when(Const.MAX_NUM_TAGS()).thenReturn((short) 8);
-    
-    query = new TsdbQuery(tsdb);
+
+    query = new TsdbQuery(tsdb, new Histogram());
   }
-  
+
 }

--- a/test/core/TestTsdbQueryQueries.java
+++ b/test/core/TestTsdbQueryQueries.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.opentsdb.stats.Histogram;
 import net.opentsdb.storage.MockBase;
 import net.opentsdb.storage.MockBase.MockScanner;
 import net.opentsdb.uid.NoSuchUniqueId;
@@ -47,7 +48,7 @@ import com.stumbleupon.async.Deferred;
 
 /**
  * An integration test class that makes sure our query path is up to snuff.
- * This class should have tests for different data point types, rates, 
+ * This class should have tests for different data point types, rates,
  * compactions, etc. Other files can cover salting, aggregation and downsampling.
  */
 @RunWith(PowerMockRunner.class)
@@ -57,9 +58,9 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
   @Before
   public void beforeLocal() throws Exception {
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
   }
-  
+
   @Test
   public void runLongSingleTS() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
@@ -70,7 +71,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     verify(tag_values, times(1)).getNameAsync(TAGV_BYTES);
@@ -94,7 +95,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998400500L;
     for (DataPoint dp : dps[0]) {
@@ -105,7 +106,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].aggregatedSize());
   }
-  
+
   @Test
   public void runLongSingleTSNoData() throws Exception {
     setDataPointStorage();
@@ -113,24 +114,24 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertNotNull(dps);
     assertEquals(0, dps.length);
   }
-  
+
   @Test
   public void runLongTwoAggSum() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400L);
     query.setEndTime(1357041600L);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(301, dp.longValue());
@@ -139,19 +140,19 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runLongTwoAggSumMs() throws Exception {
     storeLongTimeSeriesMs();
-    
+
     tags.clear();
     query.setStartTime(1356998400L);
     query.setEndTime(1357041600L);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long timestamp = 1356998400500L;
     for (DataPoint dp : dps[0]) {
       assertEquals(301, dp.longValue());
@@ -160,22 +161,22 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runLongTwoGroup() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
-    
+
     tags.clear();
     tags.put(TAGK_STRING , "*");
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
     assertMeta(dps, 1, false);
     assertEquals(2, dps.length);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -185,7 +186,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       timestamp += 30000;
     }
     assertEquals(300, dps[0].size());
-    
+
     value = 300;
     timestamp = 1356998430000L;
     for (DataPoint dp : dps[1]) {
@@ -196,7 +197,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[1].size());
   }
-  
+
   @Test
   public void runLongSingleTSRate() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
@@ -204,10 +205,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, true);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998460000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(0.033F, dp.doubleValue(), 0.001);
@@ -216,7 +217,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(299, dps[0].size());
   }
-  
+
   @Test
   public void runLongSingleTSRateMs() throws Exception {
     storeLongTimeSeriesMs();
@@ -224,10 +225,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, true);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998401000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(2.0F, dp.doubleValue(), 0.001);
@@ -244,10 +245,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     double value = 1.25D;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -258,7 +259,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runFloatSingleTSMs() throws Exception {
     storeFloatTimeSeriesMs();
@@ -266,10 +267,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     double value = 1.25D;
     long timestamp = 1356998400500L;
     for (DataPoint dp : dps[0]) {
@@ -280,19 +281,19 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runFloatTwoAggSum() throws Exception {
     storeFloatTimeSeriesSeconds(true, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(76.25, dp.doubleValue(), 0.00001);
@@ -301,16 +302,16 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runFloatTwoAggNoneAgg() throws Exception {
     storeFloatTimeSeriesSeconds(true, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.NONE, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
     assertMeta(dps, 1, false);
@@ -325,7 +326,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       timestamp += 30000;
     }
     assertEquals(300, dps[0].size());
-    
+
     value = 75D;
     timestamp = 1356998430000L;
     for (DataPoint dp : dps[1]) {
@@ -336,7 +337,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[1].size());
   }
-  
+
   @Test
   public void runFloatTwoAggSumMs() throws Exception {
     storeFloatTimeSeriesMs();
@@ -345,10 +346,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long timestamp = 1356998400500L;
     for (DataPoint dp : dps[0]) {
       assertEquals(76.25, dp.doubleValue(), 0.00001);
@@ -357,7 +358,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runFloatTwoGroup() throws Exception {
     storeFloatTimeSeriesSeconds(true, false);
@@ -366,7 +367,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
     assertMeta(dps, 1, false);
@@ -381,7 +382,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       timestamp += 30000;
     }
     assertEquals(300, dps[0].size());
-    
+
     value = 75D;
     timestamp = 1356998430000L;
     for (DataPoint dp : dps[1]) {
@@ -392,7 +393,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[1].size());
   }
-  
+
   @Test
   public void runFloatSingleTSRate() throws Exception {
     storeFloatTimeSeriesSeconds(true, false);
@@ -400,10 +401,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, true);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998460000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(0.00833F, dp.doubleValue(), 0.00001);
@@ -412,7 +413,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(299, dps[0].size());
   }
-  
+
   @Test
   public void runFloatSingleTSRateMs() throws Exception {
     storeFloatTimeSeriesMs();
@@ -420,10 +421,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, true);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998401000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(0.5F, dp.doubleValue(), 0.00001);
@@ -441,10 +442,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998430000L;
     double value = 1.25D;
     for (DataPoint dp : dps[0]) {
@@ -455,7 +456,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMixedSingleTS() throws Exception {
     storeMixedTimeSeriesSeconds();
@@ -463,10 +464,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.AVG, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998430000L;
     double float_value = 1.25D;
     int int_value = 76;
@@ -487,7 +488,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMixedSingleTSMsAndS() throws Exception {
     storeMixedTimeSeriesMsAndS();
@@ -495,10 +496,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.AVG, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998400500L;
     double float_value = 1.25D;
     int int_value = 76;
@@ -519,11 +520,11 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMixedSingleTSPostCompaction() throws Exception {
     storeMixedTimeSeriesSeconds();
-    
+
     final Field compact = Config.class.getDeclaredField("enable_compactions");
     compact.setAccessible(true);
     compact.set(config, true);
@@ -534,24 +535,24 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     // this should only compact the rows for the time series that we fetched and
     // leave the others alone
-    
-    final byte[] key = 
+
+    final byte[] key =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key);
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key, 
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key));
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key, 
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key));
-    System.arraycopy(Bytes.fromInt(1357005600), 0, key, 
+    System.arraycopy(Bytes.fromInt(1357005600), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key));
 
     // run it again to verify the compacted data uncompacts properly
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998430000L;
     double float_value = 1.25D;
     int int_value = 76;
@@ -572,7 +573,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
- 
+
   @Test
   public void runEndTime() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
@@ -582,7 +583,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -593,11 +594,11 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(119, dps[0].size());
   }
-  
+
   @Test
   public void runCompactPostQuery() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
-    
+
     final Field compact = Config.class.getDeclaredField("enable_compactions");
     compact.setAccessible(true);
     compact.set(config, true);
@@ -607,47 +608,47 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-  
+
     // this should only compact the rows for the time series that we fetched and
     // leave the others alone
-    final byte[] key_a = 
+    final byte[] key_a =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key_a);
     final Map<String, String> tags_copy = new HashMap<String, String>(tags);
     tags_copy.put(TAGK_STRING, TAGV_B_STRING);
-    final byte[] key_b = 
+    final byte[] key_b =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags_copy);
     RowKey.prefixKeyWithSalt(key_b);
-    
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key_a, 
+
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key_a,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key_a));
-    
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key_b, 
+
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key_b,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     if (config.enable_appends()) {
       assertEquals(1, storage.numColumns(key_b));
     } else {
       assertEquals(119, storage.numColumns(key_b));
     }
-    
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key_a, 
+
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key_a,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key_a));
-    
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key_b, 
+
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key_b,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     if (config.enable_appends()) {
       assertEquals(1, storage.numColumns(key_b));
     } else {
       assertEquals(120, storage.numColumns(key_b));
     }
-    
-    System.arraycopy(Bytes.fromInt(1357005600), 0, key_a, 
+
+    System.arraycopy(Bytes.fromInt(1357005600), 0, key_a,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key_a));
-    
-    System.arraycopy(Bytes.fromInt(1357005600), 0, key_b, 
+
+    System.arraycopy(Bytes.fromInt(1357005600), 0, key_b,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     if (config.enable_appends()) {
       assertEquals(1, storage.numColumns(key_b));
@@ -658,7 +659,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     // run it again to verify the compacted data uncompacts properly
     dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -669,7 +670,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test (expected = IllegalStateException.class)
   public void runStartNotSet() throws Exception {
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
@@ -688,11 +689,11 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     if (config.enable_appends()) {
       DataPoints[] dps = query.run();
       assertMeta(dps, 0, false, false);
-      
+
       int value = 1;
       long timestamp = 1356998430000L;
       for (DataPoint dp : dps[0]) {
@@ -714,7 +715,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       } catch (IllegalDataException ide) { }
     }
   }
-  
+
   @Test
   public void runFloatAndIntSameTSFix() throws Exception {
     config.setFixDuplicates(true);
@@ -729,7 +730,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -744,7 +745,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].aggregatedSize());
   }
-  
+
   @Test
   public void runWithAnnotation() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
@@ -756,7 +757,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false, true);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -767,7 +768,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runWithAnnotationPostCompact() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
@@ -785,32 +786,32 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     // this should only compact the rows for the time series that we fetched and
     // leave the others alone
-    final byte[] key_a = 
+    final byte[] key_a =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key_a);
     final Map<String, String> tags_copy = new HashMap<String, String>(tags);
     tags_copy.put(TAGK_STRING, TAGV_B_STRING);
-    final byte[] key_b = 
+    final byte[] key_b =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags_copy);
     RowKey.prefixKeyWithSalt(key_b);
 
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key_a, 
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key_a,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(2, storage.numColumns(key_a));
-    
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key_b, 
+
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key_b,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     if (config.enable_appends()) {
       assertEquals(1, storage.numColumns(key_b));
     } else {
       assertEquals(119, storage.numColumns(key_b));
     }
-    
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key_a, 
+
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key_a,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key_a));
-    
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key_b, 
+
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key_b,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     if (config.enable_appends()) {
       assertEquals(1, storage.numColumns(key_b));
@@ -818,21 +819,21 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       assertEquals(120, storage.numColumns(key_b));
     }
 
-    System.arraycopy(Bytes.fromInt(1357005600), 0, key_a, 
+    System.arraycopy(Bytes.fromInt(1357005600), 0, key_a,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key_a));
-    
-    System.arraycopy(Bytes.fromInt(1357005600), 0, key_b, 
+
+    System.arraycopy(Bytes.fromInt(1357005600), 0, key_b,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     if (config.enable_appends()) {
       assertEquals(1, storage.numColumns(key_b));
     } else {
       assertEquals(61, storage.numColumns(key_b));
     }
-    
+
     dps = query.run();
     assertMeta(dps, 0, false, true);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -850,15 +851,15 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     // verifies that we can pickup an annotation stored all by it's lonesome
     // in a row without any data
-    final byte[] key = 
+    final byte[] key =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key);
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key, 
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     storage.flushRow(key);
-    
+
     storeAnnotation(1357002090);
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
@@ -891,13 +892,13 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     // verifies that we can pickup an annotation stored all by it's lonesome
     // in a row without any data
-    final byte[] key = 
+    final byte[] key =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key);
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key, 
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     storage.flushRow(key);
-    
+
     storeAnnotation(1357002090);
 
     query.setStartTime(1356998400);
@@ -905,7 +906,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
 
     final DataPoints[] dps = query.run();
-    // TODO - apparently if you only fetch annotations, the metric and tags 
+    // TODO - apparently if you only fetch annotations, the metric and tags
     // may not be set. Check this
     //assertMeta(dps, 0, false, true);
     assertEquals(1, dps[0].getAnnotations().size());
@@ -920,14 +921,14 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     setDataPointStorage();
     long timestamp = 1356998410;
     tsdb.addPoint(METRIC_STRING, timestamp, 42, tags).joinUninterruptibly();
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     storage.dumpToSystemOut();
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     assertEquals(1, dps[0].size());
     assertEquals(42, dps[0].longValue(0));
     assertEquals(1356998410000L, dps[0].timestamp(0));
@@ -938,23 +939,23 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     setDataPointStorage();
     long timestamp = 1356998410;
     tsdb.addPoint(METRIC_STRING, timestamp, 42, tags).joinUninterruptibly();
-    
-    final byte[] key = 
+
+    final byte[] key =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key);
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key, 
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     storage.flushRow(key);
-    
+
     storeAnnotation(1357002090);
 
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false, true);
-    
+
     assertEquals(1, dps[0].size());
     assertEquals(42, dps[0].longValue(0));
     assertEquals(1356998410000L, dps[0].timestamp(0));
@@ -963,16 +964,16 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
   @Test
   public void runTSUIDQuery() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     final List<String> tsuids = new ArrayList<String>(1);
     tsuids.add("000001000001000001");
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -983,21 +984,21 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].aggregatedSize());
   }
-  
+
   @Test
   public void runTSUIDsAggSum() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     final List<String> tsuids = new ArrayList<String>(1);
     tsuids.add("000001000001000001");
     tsuids.add("000001000001000002");
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(301, dp.longValue());
@@ -1006,57 +1007,57 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runTSUIDQueryNoData() throws Exception {
     setDataPointStorage();
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
-    
+
     final List<String> tsuids = new ArrayList<String>(1);
     tsuids.add("000001000001000001");
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertNotNull(dps);
     assertEquals(0, dps.length);
   }
-  
+
   @Test
   public void runTSUIDQueryNoDataForTSUID() throws Exception {
     // this doesn't throw an exception since the UIDs are only looked for when
     // the query completes.
     setDataPointStorage();
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     final List<String> tsuids = new ArrayList<String>(1);
     tsuids.add("000001000001000005");
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertNotNull(dps);
     assertEquals(0, dps.length);
   }
-  
+
   @Test (expected = NoSuchUniqueId.class)
   public void runTSUIDQueryNSU() throws Exception {
     when(metrics.getNameAsync(new byte[] { 0, 0, 1 }))
       .thenThrow(new NoSuchUniqueId("metrics", new byte[] { 0, 0, 1 }));
     storeLongTimeSeriesSeconds(true, false);
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     final List<String> tsuids = new ArrayList<String>(1);
     tsuids.add("000001000001000001");
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertNotNull(dps);
     dps[0].metricName();
   }
-  
+
   @Test
   public void runRateCounterDefault() throws Exception {
     setDataPointStorage();
@@ -1066,14 +1067,14 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, timestamp += 30, Long.MAX_VALUE - 25, tags)
       .joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 5, tags).joinUninterruptibly();
-    
+
     final RateOptions ro = new RateOptions(true, Long.MAX_VALUE, 0);
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, true, ro);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     timestamp = 1356998460000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(1.0, dp.doubleValue(), 0.001);
@@ -1082,7 +1083,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(2, dps[0].size());
   }
-  
+
   @Test
   public void runRateCounterDefaultNoOp() throws Exception {
     setDataPointStorage();
@@ -1090,14 +1091,14 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 30, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 60, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 90, tags).joinUninterruptibly();
-    
+
     final RateOptions ro = new RateOptions(true, Long.MAX_VALUE, 0);
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, true, ro);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     timestamp = 1356998460000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(1.0, dp.doubleValue(), 0.001);
@@ -1106,7 +1107,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(2, dps[0].size());
   }
-  
+
   @Test
   public void runRateCounterMaxSet() throws Exception {
     setDataPointStorage();
@@ -1114,7 +1115,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 45, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 75, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 5, tags).joinUninterruptibly();
-    
+
     final RateOptions ro = new RateOptions(true, 100, 0);
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
@@ -1130,7 +1131,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(2, dps[0].size());
   }
-  
+
   @Test
   public void runRateCounterAnomally() throws Exception {
     setDataPointStorage();
@@ -1138,7 +1139,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 45, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 75, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 25, tags).joinUninterruptibly();
-    
+
     final RateOptions ro = new RateOptions(true, 10000, 35);
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
@@ -1161,7 +1162,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 75, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 25, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 55, tags).joinUninterruptibly();
-    
+
     final RateOptions ro = new RateOptions(true, 10000, 35, true);
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
@@ -1175,7 +1176,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     assertEquals(1356998520000L, dps[0].timestamp(1));
     assertEquals(2, dps[0].size());
   }
-  
+
   @Test
   public void runMultiCompact() throws Exception {
     final byte[] qual1 = { 0x00, 0x17 };
@@ -1197,20 +1198,20 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     final byte[] key = IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key);
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key, 
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
-    
+
     setDataPointStorage();
-    storage.addColumn(key, 
-        MockBase.concatByteArrays(qual1, qual2), 
+    storage.addColumn(key,
+        MockBase.concatByteArrays(qual1, qual2),
         MockBase.concatByteArrays(val1, val2, new byte[] { 0 }));
-    storage.addColumn(key, 
-        MockBase.concatByteArrays(qual3, qual4), 
+    storage.addColumn(key,
+        MockBase.concatByteArrays(qual3, qual4),
         MockBase.concatByteArrays(val3, val4, new byte[] { 0 }));
-    storage.addColumn(key, 
-        MockBase.concatByteArrays(qual5, qual6), 
+    storage.addColumn(key,
+        MockBase.concatByteArrays(qual5, qual6),
         MockBase.concatByteArrays(val5, val6, new byte[] { 0 }));
-    
+
     HashMap<String, String> tags = new HashMap<String, String>(1);
     tags.put(TAGK_STRING , TAGV_STRING );
     query.setStartTime(1356998400);
@@ -1219,7 +1220,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998401000L;
     for (DataPoint dp : dps[0]) {
@@ -1252,26 +1253,26 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     final byte[] key = IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key);
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key, 
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
-    
+
     setDataPointStorage();
-    storage.addColumn(key, 
-        MockBase.concatByteArrays(qual1, qual2), 
+    storage.addColumn(key,
+        MockBase.concatByteArrays(qual1, qual2),
         MockBase.concatByteArrays(val1, val2, new byte[] { 0 }));
     storage.addColumn(key, qual3, val3);
     storage.addColumn(key, qual4, val4);
-    storage.addColumn(key, 
-        MockBase.concatByteArrays(qual5, qual6), 
+    storage.addColumn(key,
+        MockBase.concatByteArrays(qual5, qual6),
         MockBase.concatByteArrays(val5, val6, new byte[] { 0 }));
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
 
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998401000L;
     for (DataPoint dp : dps[0]) {
@@ -1282,7 +1283,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(6, dps[0].aggregatedSize());
   }
-  
+
   @Test
   public void runInterpolationSeconds() throws Exception {
     setDataPointStorage();
@@ -1298,21 +1299,21 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       tsdb.addPoint(METRIC_STRING, timestamp += 30, i, tags)
         .joinUninterruptibly();
     }
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v = 1;
     long ts = 1356998430000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(ts, dp.timestamp());
       ts += 15000;
       assertEquals(v, dp.longValue());
-      
+
       if (dp.timestamp() == 1357007400000L) {
         v = 1;
       } else if (v == 1 || v == 302) {
@@ -1323,7 +1324,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runInterpolationMs() throws Exception {
     setDataPointStorage();
@@ -1339,21 +1340,21 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       tsdb.addPoint(METRIC_STRING, timestamp += 500, i, tags)
         .joinUninterruptibly();
     }
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v = 1;
     long ts = 1356998400500L;
     for (DataPoint dp : dps[0]) {
       assertEquals(ts, dp.timestamp());
       ts += 250;
       assertEquals(v, dp.longValue());
-      
+
       if (dp.timestamp() == 1356998550000L) {
         v = 1;
       } else if (v == 1 || v == 302) {
@@ -1364,7 +1365,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runInterpolationMsDownsampled() throws Exception {
     setDataPointStorage();
@@ -1387,7 +1388,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       tsdb.addPoint(METRIC_STRING, timestamp, i, tags)
         .joinUninterruptibly();
     }
-    
+
     // ts = 1356998400750, v = 300
     // ts = 1356998401250, v = 299
     // ts = 1356998401750, v = 298
@@ -1404,13 +1405,13 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       tsdb.addPoint(METRIC_STRING, timestamp += 500, i, tags)
         .joinUninterruptibly();
     }
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     query.downsample(1000, Aggregators.SUM);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
 
@@ -1471,7 +1472,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].aggregatedSize());
   }
-  
+
   @Test
   public void runRegexpNoMatch() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
@@ -1500,13 +1501,13 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setTimeSeries("sys.cpu.user", tags, Aggregators.SUM, false);
 
     final DataPoints[] dps = query.run();
-    
+
     assertNotNull(dps);
     assertEquals("sys.cpu.user", dps[0].metricName());
     assertTrue(dps[0].getAggregatedTags().isEmpty());
     assertNull(dps[0].getAnnotations());
     assertEquals("web01", dps[0].getTags().get("host"));
-    
+
     int value = 1;
     for (DataPoint dp : dps[0]) {
       assertEquals(value, dp.longValue());
@@ -1518,7 +1519,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       assertTrue(scanner.getFilter() instanceof FilterList);
     }
   }
-  
+
   @Test
   public void filterExplicitTagsGroupByOK() throws Exception {
     tsdb.getConfig().overrideConfig("tsd.query.enable_fuzzy", "true");
@@ -1531,13 +1532,13 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setTimeSeries("sys.cpu.user", tags, Aggregators.SUM, false);
 
     final DataPoints[] dps = query.run();
-    
+
     assertNotNull(dps);
     assertEquals("sys.cpu.user", dps[0].metricName());
     assertTrue(dps[0].getAggregatedTags().isEmpty());
     assertNull(dps[0].getAnnotations());
     assertEquals("web01", dps[0].getTags().get("host"));
-    
+
     int value = 1;
     for (DataPoint dp : dps[0]) {
       assertEquals(value, dp.longValue());
@@ -1549,7 +1550,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       assertTrue(scanner.getFilter() instanceof FilterList);
     }
   }
-  
+
   @Test
   public void filterExplicitTagsMissing() throws Exception {
     tsdb.getConfig().overrideConfig("tsd.query.enable_fuzzy", "true");
@@ -1567,7 +1568,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setTimeSeries("sys.cpu.user", tags, Aggregators.SUM, false);
 
     final DataPoints[] dps = query.run();
-    
+
     assertNotNull(dps);
     assertEquals(0, dps.length);
     // assert fuzzy
@@ -1575,5 +1576,5 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       assertTrue(scanner.getFilter() instanceof FilterList);
     }
   }
-  
+
 }

--- a/test/core/TestTsdbQuerySalted.java
+++ b/test/core/TestTsdbQuerySalted.java
@@ -12,13 +12,14 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
+import net.opentsdb.stats.Histogram;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
- * An integration test class that runs all of the tests in 
+ * An integration test class that runs all of the tests in
  * {@see TestTsdbQueryAggregators} but with salting enabled.
  */
 @RunWith(PowerMockRunner.class)
@@ -30,7 +31,7 @@ public class TestTsdbQuerySalted extends TestTsdbQueryQueries {
     PowerMockito.when(Const.SALT_WIDTH()).thenReturn(1);
     PowerMockito.when(Const.SALT_BUCKETS()).thenReturn(2);
     PowerMockito.when(Const.MAX_NUM_TAGS()).thenReturn((short) 8);
-    
-    query = new TsdbQuery(tsdb);
+
+    query = new TsdbQuery(tsdb, new Histogram());
   }
 }

--- a/test/core/TestTsdbQuerySaltedAppend.java
+++ b/test/core/TestTsdbQuerySaltedAppend.java
@@ -12,19 +12,20 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
+import net.opentsdb.stats.Histogram;
 import org.junit.Before;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.reflect.Whitebox;
 
 public class TestTsdbQuerySaltedAppend extends TestTsdbQueryQueries {
-  
+
   @Before
-  public void beforeLocal() { 
+  public void beforeLocal() {
     Whitebox.setInternalState(config, "enable_appends", true);
     PowerMockito.mockStatic(Const.class);
     PowerMockito.when(Const.SALT_WIDTH()).thenReturn(1);
     PowerMockito.when(Const.SALT_BUCKETS()).thenReturn(2);
     PowerMockito.when(Const.MAX_NUM_TAGS()).thenReturn((short) 8);
-    query = new TsdbQuery(tsdb);
+    query = new TsdbQuery(tsdb, new Histogram());
   }
 }

--- a/test/stats/DummyLatencyStatsPlugin.java
+++ b/test/stats/DummyLatencyStatsPlugin.java
@@ -31,9 +31,9 @@ public class DummyLatencyStatsPlugin extends LatencyStatsPlugin {
   }
 
   @Override
-  public void initialize(Config config) {
+  public void initialize(Config config, String metricName, String xtratag) {
     if (mock != null) {
-      mock.initialize(config);
+      mock.initialize(config, metricName, xtratag);
     }
   }
 
@@ -61,9 +61,9 @@ public class DummyLatencyStatsPlugin extends LatencyStatsPlugin {
   }
 
   @Override
-  public void collectStats(StatsCollector collector, String metricName, String xtratag) {
+  public void collectStats(StatsCollector collector) {
     if (mock != null) {
-      mock.collectStats(collector, metricName, xtratag);
+      mock.collectStats(collector);
     }
   }
 

--- a/test/stats/DummyLatencyStatsPlugin.java
+++ b/test/stats/DummyLatencyStatsPlugin.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015, Simon Matić Langford
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.opentsdb.stats;
+
+import com.stumbleupon.async.Deferred;
+import net.opentsdb.utils.Config;
+
+/**
+ *
+ */
+public class DummyLatencyStatsPlugin extends LatencyStatsPlugin {
+  
+  private static LatencyStatsPlugin mock;
+
+  public static void setMock(LatencyStatsPlugin mock) {
+    DummyLatencyStatsPlugin.mock = mock;
+  }
+
+  @Override
+  public void initialize(Config config) {
+    if (mock != null) {
+      mock.initialize(config);
+    }
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    if (mock != null) {
+      return mock.shutdown();
+    }
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public void start() {
+    if (mock != null) {
+      mock.start();
+    }
+  }
+
+  @Override
+  public String version() {
+    if (mock != null) {
+      return mock.version();
+    }
+    return null;
+  }
+
+  @Override
+  public void collectStats(StatsCollector collector, String metricName, String xtratag) {
+    if (mock != null) {
+      mock.collectStats(collector, metricName, xtratag);
+    }
+  }
+
+  @Override
+  public void add(int value) {
+    if (mock != null) {
+      mock.add(value);
+    }
+  }
+}

--- a/test/stats/TestHistogram.java
+++ b/test/stats/TestHistogram.java
@@ -12,10 +12,24 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.stats;
 
-import junit.framework.TestCase;
+import net.opentsdb.utils.Config;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-public final class TestHistogram extends TestCase {
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({StatsCollector.class, Config.class})
+public final class TestHistogram {
+
+  @Test
   public void test_percentile_empty_histogram() {
     final Histogram histo = new Histogram(16000, (short) 2, 100);
     assertEquals(0, histo.percentile(1));
@@ -23,6 +37,7 @@ public final class TestHistogram extends TestCase {
     assertEquals(0, histo.percentile(99));
   }
 
+  @Test
   public void test_16Max_1Interval_5Cutoff() {
     final Histogram histo = new Histogram(16, (short) 1, 5);
     assertEquals(10, histo.buckets());
@@ -63,6 +78,7 @@ public final class TestHistogram extends TestCase {
     assertBucketEquals(histo, 9, 1);
   }
 
+  @Test
   public void test_16Max_2Interval_5Cutoff() {
     final Histogram histo = new Histogram(16, (short) 2, 5);
     assertEquals(6, histo.buckets());
@@ -105,6 +121,7 @@ public final class TestHistogram extends TestCase {
     assertBucketEquals(histo, 5, 1);
   }
 
+  @Test
   public void test_160Max_20Interval_50Cutoff() {
     final Histogram histo = new Histogram(160, (short) 20, 50);
     assertEquals(6, histo.buckets());
@@ -154,6 +171,44 @@ public final class TestHistogram extends TestCase {
     assertBucketEquals(histo, 3, 2);
     assertBucketEquals(histo, 4, 4);
     assertBucketEquals(histo, 5, 2);
+  }
+
+  @Test
+  public void statsCollection() {
+    StatsCollector collector = mock(StatsCollector.class);
+    
+    LatencyStatsPlugin histo = new Histogram();
+    
+    histo.collectStats(collector, "tsd.somestat.latency", "type=t");
+    
+    verify(collector).record("tsd.somestat.latency_50pct", 0, "type=t");
+    verify(collector).record("tsd.somestat.latency_75pct", 0, "type=t");
+    verify(collector).record("tsd.somestat.latency_90pct", 0, "type=t");
+    verify(collector).record("tsd.somestat.latency_95pct", 0, "type=t");
+  }
+  
+  @Test
+  public void startNoErrors() {
+    LatencyStatsPlugin histo = new Histogram();
+    histo.start();
+  }
+  
+  @Test
+  public void shutdownNoErros() throws Exception {
+    LatencyStatsPlugin histo = new Histogram();
+    assertNull(histo.shutdown().join());
+  }
+  
+  @Test
+  public void initialiseNoErrors() {
+    LatencyStatsPlugin histo = new Histogram();
+    histo.initialize(mock(Config.class));
+  }
+  
+  @Test
+  public void version() {
+    LatencyStatsPlugin histo = new Histogram();
+    assertNotNull(histo.version());
   }
 
   static void assertBucketEquals(final Histogram histo,

--- a/test/stats/TestHistogram.java
+++ b/test/stats/TestHistogram.java
@@ -18,6 +18,8 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.IOException;
+
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
@@ -174,12 +176,14 @@ public final class TestHistogram {
   }
 
   @Test
-  public void statsCollection() {
+  public void statsCollection() throws IOException {
     StatsCollector collector = mock(StatsCollector.class);
+    Config config = mock(Config.class);
     
     LatencyStatsPlugin histo = new Histogram();
+    histo.initialize(config, "tsd.somestat.latency", "type=t");
     
-    histo.collectStats(collector, "tsd.somestat.latency", "type=t");
+    histo.collectStats(collector);
     
     verify(collector).record("tsd.somestat.latency_50pct", 0, "type=t");
     verify(collector).record("tsd.somestat.latency_75pct", 0, "type=t");
@@ -202,7 +206,7 @@ public final class TestHistogram {
   @Test
   public void initialiseNoErrors() {
     LatencyStatsPlugin histo = new Histogram();
-    histo.initialize(mock(Config.class));
+    histo.initialize(mock(Config.class), "some.metric", "");
   }
   
   @Test

--- a/test/stats/TestLatencyStats.java
+++ b/test/stats/TestLatencyStats.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2015, Simon Matić Langford
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.opentsdb.stats;
+
+import com.stumbleupon.async.Deferred;
+import net.opentsdb.utils.Config;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+/**
+ *
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Config.class, LatencyStatsPlugin.class})
+public class TestLatencyStats {
+  
+  private Config config;
+  
+  @Before
+  public void before() {
+    config = mock(Config.class);
+    LatencyStats.clear();
+  }
+  
+  @Test
+  public void defaultPlugin() throws IOException {
+    when(config.hasProperty("tsd.latency_stats.plugin.default_plugin")).thenReturn(false);
+    when(config.hasProperty("tsd.latency_stats.plugin")).thenReturn(false);
+    
+    LatencyStatsPlugin plugin = LatencyStats.getInstance(config, "default_plugin");
+    assertTrue("Default plugin implementation should be Histogram", plugin instanceof Histogram);
+  }
+  
+  @Test
+  public void globalPlugin() {
+    when(config.hasProperty("tsd.latency_stats.plugin.global_plugin")).thenReturn(false);
+    when(config.hasProperty("tsd.latency_stats.plugin")).thenReturn(true);
+    when(config.getString("tsd.latency_stats.plugin")).thenReturn("net.opentsdb.stats.DummyLatencyStatsPlugin");
+
+    LatencyStatsPlugin plugin = LatencyStats.getInstance(config, "global_plugin");
+    assertTrue("Global plugin implementation should be DummyLatencyStatsPlugin", plugin instanceof DummyLatencyStatsPlugin);
+  }
+  
+  @Test
+  public void globalPluginNotFound() {
+    when(config.hasProperty("tsd.latency_stats.plugin.global_plugin_not_found")).thenReturn(false);
+    when(config.hasProperty("tsd.latency_stats.plugin")).thenReturn(true);
+    when(config.getString("tsd.latency_stats.plugin")).thenReturn("net.opentsdb.stats.MissingPlugin");
+
+    try {
+      LatencyStats.getInstance(config, "global_plugin_not_found");
+      fail("Getting a missing plugin should have failed");
+    }
+    catch (Exception e) {
+      assertTrue("Expected message should contain the missing plugin class name", e.getMessage().contains("net.opentsdb.stats.MissingPlugin"));
+    }
+  }
+  
+  @Test
+  public void specificPlugin() {
+    when(config.hasProperty("tsd.latency_stats.plugin.specific_plugin")).thenReturn(true);
+    when(config.hasProperty("tsd.latency_stats.plugin")).thenReturn(false);
+    when(config.getString("tsd.latency_stats.plugin.specific_plugin")).thenReturn("net.opentsdb.stats.DummyLatencyStatsPlugin");
+
+    LatencyStatsPlugin plugin = LatencyStats.getInstance(config, "specific_plugin");
+    assertTrue("Specific plugin implementation should be DummyLatencyStatsPlugin", plugin instanceof DummyLatencyStatsPlugin);
+  }
+  
+  @Test
+  public void specificPluginNotFound() {
+    when(config.hasProperty("tsd.latency_stats.plugin.specific_plugin_not_found")).thenReturn(true);
+    when(config.hasProperty("tsd.latency_stats.plugin")).thenReturn(false);
+    when(config.getString("tsd.latency_stats.plugin.specific_plugin_not_found")).thenReturn("net.opentsdb.stats.MissingPlugin");
+
+    try {
+      LatencyStats.getInstance(config, "specific_plugin_not_found");
+      fail("Getting a missing plugin should have failed");
+    }
+    catch (Exception e) {
+      assertTrue("Expected message should contain the missing plugin class name", e.getMessage().contains("net.opentsdb.stats.MissingPlugin"));
+    }
+    
+  }
+  
+  @Test
+  public void pluginLifecycle() {
+    LatencyStatsPlugin mockPlugin = mock(LatencyStatsPlugin.class);
+    DummyLatencyStatsPlugin.setMock(mockPlugin);
+    try {
+      when(config.hasProperty("tsd.latency_stats.plugin.plugin_lifecycle")).thenReturn(true);
+      when(config.getString("tsd.latency_stats.plugin.plugin_lifecycle")).thenReturn("net.opentsdb.stats.DummyLatencyStatsPlugin");
+      when(mockPlugin.shutdown()).thenReturn(Deferred.fromResult(null));
+
+      LatencyStats.getInstance(config, "plugin_lifecycle");
+      LatencyStats.shutdownAll();
+      
+      InOrder inOrder = inOrder(mockPlugin);
+      inOrder.verify(mockPlugin).initialize(any(Config.class));
+      inOrder.verify(mockPlugin).version();
+      inOrder.verify(mockPlugin).start();
+      inOrder.verify(mockPlugin).shutdown();
+    }
+    finally {
+      DummyLatencyStatsPlugin.setMock(null);
+    }
+  }
+  
+  
+  
+}

--- a/test/stats/TestLatencyStats.java
+++ b/test/stats/TestLatencyStats.java
@@ -18,6 +18,7 @@ package net.opentsdb.stats;
 
 import com.stumbleupon.async.Deferred;
 import net.opentsdb.utils.Config;
+import net.opentsdb.utils.PluginLoader;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,6 +27,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -47,9 +49,10 @@ public class TestLatencyStats {
   private Config config;
   
   @Before
-  public void before() {
+  public void before() throws Exception {
     config = mock(Config.class);
     LatencyStats.clear();
+    PluginLoader.loadJAR("plugin_test.jar");
   }
   
   @Test

--- a/test/tsd/TestAnnotationRpc.java
+++ b/test/tsd/TestAnnotationRpc.java
@@ -19,6 +19,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import java.nio.charset.Charset;
 
 import net.opentsdb.core.TSDB;
+import net.opentsdb.stats.Histogram;
 import net.opentsdb.storage.MockBase;
 import net.opentsdb.utils.Config;
 
@@ -44,133 +45,133 @@ import org.powermock.modules.junit4.PowerMockRunner;
   "ch.qos.*", "org.slf4j.*",
   "com.sum.*", "org.xml.*"})
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({TSDB.class, Config.class, HBaseClient.class, RowLock.class, 
+@PrepareForTest({TSDB.class, Config.class, HBaseClient.class, RowLock.class,
   AnnotationRpc.class, KeyValue.class, GetRequest.class, Scanner.class})
 public final class TestAnnotationRpc {
   private TSDB tsdb = null;
   private HBaseClient client = mock(HBaseClient.class);
   private MockBase storage;
   private AnnotationRpc rpc = new AnnotationRpc();
-  
-  final private byte[] global_row_key = 
+
+  final private byte[] global_row_key =
       new byte[] { 0, 0, 0, (byte) 0x4F, (byte) 0x29, (byte) 0xD2, 0 };
-  final private byte[] tsuid_row_key = 
-      new byte[] { 0, 0, 1, (byte) 0x52, (byte) 0xC2, (byte) 0x09, 0, 0, 0, 
+  final private byte[] tsuid_row_key =
+      new byte[] { 0, 0, 1, (byte) 0x52, (byte) 0xC2, (byte) 0x09, 0, 0, 0,
         1, 0, 0, 1 };
-  
+
   @Before
   public void before() throws Exception {
     final Config config = new Config(false);
     tsdb = new TSDB(client, config);
-    
+
     storage = new MockBase(tsdb, client, true, true, true, true);
-    
+
     // add a global
-    storage.addColumn(global_row_key, 
-        new byte[] { 1, 0, 0 }, 
-        ("{\"startTime\":1328140800,\"endTime\":1328140801,\"description\":" + 
-            "\"Description\",\"notes\":\"Notes\",\"custom\":{\"owner\":" + 
+    storage.addColumn(global_row_key,
+        new byte[] { 1, 0, 0 },
+        ("{\"startTime\":1328140800,\"endTime\":1328140801,\"description\":" +
+            "\"Description\",\"notes\":\"Notes\",\"custom\":{\"owner\":" +
             "\"ops\"}}").getBytes(MockBase.ASCII()));
-    
-    storage.addColumn(global_row_key, 
-        new byte[] { 1, 0, 1 }, 
-        ("{\"startTime\":1328140801,\"endTime\":1328140803,\"description\":" + 
+
+    storage.addColumn(global_row_key,
+        new byte[] { 1, 0, 1 },
+        ("{\"startTime\":1328140801,\"endTime\":1328140803,\"description\":" +
             "\"Global 2\",\"notes\":\"Nothing\"}").getBytes(MockBase.ASCII()));
-    
+
     // add a local
-    storage.addColumn(tsuid_row_key, 
-        new byte[] { 1, 0x0A, 0x02 }, 
+    storage.addColumn(tsuid_row_key,
+        new byte[] { 1, 0x0A, 0x02 },
         ("{\"tsuid\":\"000001000001000001\",\"startTime\":1388450562," +
-            "\"endTime\":1419984000,\"description\":\"Hello!\",\"notes\":" + 
+            "\"endTime\":1419984000,\"description\":\"Hello!\",\"notes\":" +
             "\"My Notes\",\"custom\":{\"owner\":\"ops\"}}")
             .getBytes(MockBase.ASCII()));
-    
-    storage.addColumn(tsuid_row_key, 
-        new byte[] { 1, 0x0A, 0x03 }, 
+
+    storage.addColumn(tsuid_row_key,
+        new byte[] { 1, 0x0A, 0x03 },
         ("{\"tsuid\":\"000001000001000001\",\"startTime\":1388450563," +
-            "\"endTime\":1419984000,\"description\":\"Note2\",\"notes\":" + 
+            "\"endTime\":1419984000,\"description\":\"Note2\",\"notes\":" +
             "\"Nothing\"}")
             .getBytes(MockBase.ASCII()));
-    
+
     // add some data points too
-    storage.addColumn(tsuid_row_key, 
+    storage.addColumn(tsuid_row_key,
         new byte[] { 0x50, 0x10 }, new byte[] { 1 });
-    
-    storage.addColumn(tsuid_row_key, 
+
+    storage.addColumn(tsuid_row_key,
         new byte[] { 0x50, 0x18 }, new byte[] { 2 });
   }
-  
+
   @Test
   public void constructor() throws Exception {
     new AnnotationRpc();
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void badMethod() throws Exception {
     final Channel channelMock = NettyMocks.fakeChannel();
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.TRACE, "/api/annotation");
-    final HttpQuery query = new HttpQuery(tsdb, req, channelMock);
+    final HttpQuery query = new HttpQuery(tsdb, req, channelMock, new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void get() throws Exception {
     storage.dumpToSystemOut();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation?tsuid=000001000001000001&start_time=1388450562");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
   }
-  
+
   @Test
   public void getGlobal() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation?start_time=1328140800");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
   }
-  
+
   @Test
   public void getGlobals() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/annotations?start_time=1328140800");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void getNotFound() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation?tsuid=000001000001000001&start_time=1388450568");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void getGlobalNotFound() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation?start_time=1388450563");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void getGlobalsNotFound() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/annotation?start_time=1388450563");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void getMissingStart() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation?tsuid=000001000001000001");
     rpc.execute(tsdb, query);
   }
- 
+
   @Test
   public void postNew() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
-    "/api/annotation?tsuid=000001000001000001&start_time=1388450564" + 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
+    "/api/annotation?tsuid=000001000001000001&start_time=1388450564" +
     "&description=Boo&method_override=post");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -180,11 +181,11 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"notes\":\"\""));
     assertEquals(5, storage.numColumns(tsuid_row_key));
   }
-  
+
   @Test
   public void postNewGlobal() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
-    "/api/annotation?start_time=1328140802" + 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
+    "/api/annotation?start_time=1328140802" +
     "&description=Boo&method_override=post");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -194,19 +195,19 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"notes\":\"\""));
     assertEquals(3, storage.numColumns(global_row_key));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void postNewMissingStart() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
-    "/api/annotation?tsuid=000001000001000001" + 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
+    "/api/annotation?tsuid=000001000001000001" +
     "&description=Boo&method_override=post");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void modify() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
-    "/api/annotation?tsuid=000001000001000001&start_time=1388450562" + 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
+    "/api/annotation?tsuid=000001000001000001&start_time=1388450562" +
     "&description=Boo&method_override=post");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -215,11 +216,11 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"description\":\"Boo\""));
     assertTrue(data.contains("\"notes\":\"My Notes\""));
   }
-  
+
   @Test
   public void modifyGlobal() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
-    "/api/annotation?start_time=1328140800" + 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
+    "/api/annotation?start_time=1328140800" +
     "&description=Boo&method_override=post");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -228,10 +229,10 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"description\":\"Boo\""));
     assertTrue(data.contains("\"notes\":\"Notes\""));
   }
-  
+
   @Test
   public void modifyPOST() throws Exception {
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
     "/api/annotation", "{\"tsuid\":\"000001000001000001\",\"startTime\":" +
     "1388450562,\"description\":\"Boo\"}");
     rpc.execute(tsdb, query);
@@ -241,11 +242,11 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"description\":\"Boo\""));
     assertTrue(data.contains("\"notes\":\"My Notes\""));
   }
-  
+
   @Test
   public void modifyGlobalPOST() throws Exception {
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
-    "/api/annotation", "{\"startTime\":1328140800" + 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
+    "/api/annotation", "{\"startTime\":1328140800" +
     ",\"description\":\"Boo\"}");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -257,8 +258,8 @@ public final class TestAnnotationRpc {
 
   @Test
   public void modifyPut() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
-    "/api/annotation?tsuid=000001000001000001&start_time=1388450562" + 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
+    "/api/annotation?tsuid=000001000001000001&start_time=1388450562" +
     "&description=Boo&method_override=put");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -268,11 +269,11 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"notes\":\"\""));
     assertTrue(data.contains("\"startTime\":1388450562"));
   }
-  
+
   @Test
   public void modifyPutGlobal() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
-    "/api/annotation?start_time=1328140800" + 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
+    "/api/annotation?start_time=1328140800" +
     "&description=Boo&method_override=put");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -285,27 +286,27 @@ public final class TestAnnotationRpc {
 
   @Test
   public void modifyNoChange() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
-      "/api/annotation?tsuid=000001000001000001&start_time=1388450562" + 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
+      "/api/annotation?tsuid=000001000001000001&start_time=1388450562" +
       "&method_override=post");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.NOT_MODIFIED, query.response().getStatus());
   }
-  
+
   @Test
   public void delete() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
-      "/api/annotation?tsuid=000001000001000001&start_time=1388450562" + 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
+      "/api/annotation?tsuid=000001000001000001&start_time=1388450562" +
       "&method_override=delete");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
     assertEquals(3, storage.numColumns(tsuid_row_key));
   }
-  
+
   @Test
   public void deleteGlobal() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
-      "/api/annotation?start_time=1328140800" + 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
+      "/api/annotation?start_time=1328140800" +
       "&method_override=delete");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
@@ -317,33 +318,33 @@ public final class TestAnnotationRpc {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/api/annotation/bulk");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void bulkMissingContent() throws Exception {
     HttpQuery query = NettyMocks.postQuery(tsdb, "/api/annotation/bulk", "");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void bulkMissingInvalidContent() throws Exception {
-    HttpQuery query = NettyMocks.postQuery(tsdb, "/api/annotation/bulk", 
+    HttpQuery query = NettyMocks.postQuery(tsdb, "/api/annotation/bulk",
         "Not a json object");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void bulkMissingInvalidSingleObject() throws Exception {
-    HttpQuery query = NettyMocks.postQuery(tsdb, "/api/annotation/bulk", 
+    HttpQuery query = NettyMocks.postQuery(tsdb, "/api/annotation/bulk",
         "{\"tsuid\":\"000001000001000001\",\"startTime\":" +
             "1388450562,\"description\":\"Boo\"}");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void bulkModifyPOST() throws Exception {
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
     "/api/annotation/bulk", "[{\"tsuid\":\"000001000001000001\",\"startTime\":" +
-    "1388450562,\"description\":\"Boo\"},{\"tsuid\":\"000001000001000002\"," + 
+    "1388450562,\"description\":\"Boo\"},{\"tsuid\":\"000001000001000002\"," +
     "\"startTime\":1388450562,\"description\":\"Gum\"}]");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -353,11 +354,11 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"notes\":\"My Notes\""));
     assertTrue(data.contains("\"description\":\"Gum\""));
   }
-  
+
   @Test
   public void bulkModifyGlobalPOST() throws Exception {
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
-    "/api/annotation/bulk", "[{\"startTime\":1328140800" + 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
+    "/api/annotation/bulk", "[{\"startTime\":1328140800" +
     ",\"description\":\"Boo\"},{\"startTime\":1388450562,\"description\":" +
     "\"Gum\"}]");
     rpc.execute(tsdb, query);
@@ -371,9 +372,9 @@ public final class TestAnnotationRpc {
 
   @Test (expected = BadRequestException.class)
   public void bulkModifyPOSTMissingStart() throws Exception {
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
     "/api/annotation/bulk", "[{\"tsuid\":\"000001000001000001\",\"startTime\":" +
-    "1388450562,\"description\":\"Boo\"},{\"tsuid\":\"000001000001000002\"," + 
+    "1388450562,\"description\":\"Boo\"},{\"tsuid\":\"000001000001000002\"," +
     "\"description\":\"Gum\"}]");
     rpc.execute(tsdb, query);
   }
@@ -382,7 +383,7 @@ public final class TestAnnotationRpc {
   public void bulkModifyPut() throws Exception {
     HttpQuery query = NettyMocks.putQuery(tsdb, "/api/annotation/bulk",
     "[{\"tsuid\":\"000001000001000001\",\"startTime\":" +
-    "1328140800,\"description\":\"Boo\"},{\"tsuid\":\"000001000001000002\"," + 
+    "1328140800,\"description\":\"Boo\"},{\"tsuid\":\"000001000001000002\"," +
     "\"startTime\":1328140800,\"description\":\"Gum\"}]");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -392,11 +393,11 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"notes\":\"\""));
     assertTrue(data.contains("\"description\":\"Gum\""));
   }
-  
+
   @Test
   public void bulkModifyPutGlobal() throws Exception {
     HttpQuery query = NettyMocks.putQuery(tsdb, "/api/annotation/bulk",
-    "[{\"startTime\":1328140800,\"description\":\"Boo\"},{" + 
+    "[{\"startTime\":1328140800,\"description\":\"Boo\"},{" +
     "\"startTime\":1328140800,\"description\":\"Gum\"}]");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -410,7 +411,7 @@ public final class TestAnnotationRpc {
 
   @Test
   public void bulkDelete() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation/bulk?tsuids=000001000001000001,000001000001000002" +
     "&start_time=1388450560000&end_time=1388450562000&method_override=delete");
     rpc.execute(tsdb, query);
@@ -420,10 +421,10 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"totalDeleted\":1"));
     assertEquals(3, storage.numColumns(tsuid_row_key));
   }
-  
+
   @Test
   public void bulkDeleteNotFound() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation/bulk?tsuids=000001000001000001,000001000001000002" +
     "&start_time=1388450550000&end_time=1388450560000&method_override=delete");
     rpc.execute(tsdb, query);
@@ -433,10 +434,10 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"totalDeleted\":0"));
     assertEquals(4, storage.numColumns(tsuid_row_key));
   }
-  
+
   @Test
   public void bulkDeleteAllTime() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation/bulk?tsuids=000001000001000001,000001000001000002" +
     "&start_time=1000000000000&method_override=delete");
     rpc.execute(tsdb, query);
@@ -449,7 +450,7 @@ public final class TestAnnotationRpc {
 
   @Test
   public void bulkDeleteGlobal() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation/bulk?start_time=1328140799000&end_time=1328140800000" +
     "&global=true&method_override=delete");
     rpc.execute(tsdb, query);
@@ -459,10 +460,10 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"totalDeleted\":1"));
     assertEquals(1, storage.numColumns(global_row_key));
   }
-  
+
   @Test
   public void bulkDeleteGlobalNotFound() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation/bulk?start_time=1328140600000&end_time=1328140700000" +
     "&global=true&method_override=delete");
     rpc.execute(tsdb, query);
@@ -472,10 +473,10 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"totalDeleted\":0"));
     assertEquals(2, storage.numColumns(global_row_key));
   }
-  
+
   @Test
   public void bulkDeleteGlobalAllTime() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation/bulk?start_time=1000000000000" +
     "&global=true&method_override=delete");
     rpc.execute(tsdb, query);
@@ -485,32 +486,32 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"totalDeleted\":2"));
     assertEquals(-1, storage.numColumns(global_row_key));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void bulkDeleteMissingStart() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation/bulk?tsuids=000001000001000001,000001000001000002" +
     "&end_time=1388450562000&method_override=delete");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void bulkDeleteMissingTsuidsAndGlobal() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation/bulk?&start_time=1388450562000&method_override=delete");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void bulkDeleteEmptyTsuids() throws Exception {
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
     "/api/annotation/bulk?&start_time=1388450562000&tsuids=&method_override=delete");
     rpc.execute(tsdb, query);
   }
 
   @Test
   public void bulkDeleteDELETE() throws Exception {
-    HttpQuery query = NettyMocks.deleteQuery(tsdb, 
+    HttpQuery query = NettyMocks.deleteQuery(tsdb,
     "/api/annotation/bulk", "{\"tsuids\":[\"000001000001000001\"," +
     "\"000001000001000002\"],\"startTime\":\"1388450560000\",\"endTime\":" +
     "\"1388450562000\"}");
@@ -521,10 +522,10 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"totalDeleted\":1"));
     assertEquals(3, storage.numColumns(tsuid_row_key));
   }
-  
+
   @Test
   public void bulkDeleteGlobalDELETE() throws Exception {
-    HttpQuery query = NettyMocks.deleteQuery(tsdb, 
+    HttpQuery query = NettyMocks.deleteQuery(tsdb,
     "/api/annotation/bulk", "{\"startTime\":\"1328140799000\",\"endTime\":" +
         "\"1328140800000\",\"global\":true}");
     rpc.execute(tsdb, query);
@@ -534,34 +535,34 @@ public final class TestAnnotationRpc {
     assertTrue(data.contains("\"totalDeleted\":1"));
     assertEquals(1, storage.numColumns(global_row_key));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void bulkDeleteMissingStartDELETE() throws Exception {
-    HttpQuery query = NettyMocks.deleteQuery(tsdb, 
+    HttpQuery query = NettyMocks.deleteQuery(tsdb,
     "/api/annotation/bulk?", "{\"tsuids\":[\"000001000001000001\"," +
         "\"000001000001000002\"],\"endTime\":" +
         "\"1388450562000\"}");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void bulkDeleteEmptyTsuidsDELETE() throws Exception {
-    HttpQuery query = NettyMocks.deleteQuery(tsdb, 
+    HttpQuery query = NettyMocks.deleteQuery(tsdb,
     "/api/annotation/bulk", "{\"startTime\":\"1328140799000\",\"endTime\":" +
         "\"1328140800000\"}");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void bulkDeleteNoBodyDELETE() throws Exception {
-    HttpQuery query = NettyMocks.deleteQuery(tsdb, 
+    HttpQuery query = NettyMocks.deleteQuery(tsdb,
     "/api/annotation/bulk", null);
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void bulkDeleteBadJSONDELETE() throws Exception {
-    HttpQuery query = NettyMocks.deleteQuery(tsdb, 
+    HttpQuery query = NettyMocks.deleteQuery(tsdb,
     "/api/annotation/bulk", "{thisisnotjson}");
     rpc.execute(tsdb, query);
   }

--- a/test/tsd/TestHttpQuery.java
+++ b/test/tsd/TestHttpQuery.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import net.opentsdb.core.TSDB;
+import net.opentsdb.stats.Histogram;
 import net.opentsdb.utils.Config;
 import net.opentsdb.utils.PluginLoader;
 
@@ -80,128 +81,128 @@ public final class TestHttpQuery {
       throw new RuntimeException("Failed in static initializer", e);
     }
   }
-  
+
   @Before
   public void before() throws Exception {
     tsdb = NettyMocks.getMockedHTTPTSDB();
   }
-  
+
   @Test
   public void getQueryString() {
     final Channel channelMock = NettyMocks.fakeChannel();
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.GET, "/api/v1/put?param=value&param2=value2");
-    final HttpQuery query = new HttpQuery(tsdb, req, channelMock);
+    final HttpQuery query = new HttpQuery(tsdb, req, channelMock, new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     Map<String, List<String>> params = query.getQueryString();
     assertNotNull(params);
     assertEquals("value", params.get("param").get(0));
     assertEquals("value2", params.get("param2").get(0));
   }
-  
+
   @Test
   public void getQueryStringEmpty() {
-    Map<String, List<String>> params = 
+    Map<String, List<String>> params =
       NettyMocks.getQuery(tsdb, "/api/v1/put").getQueryString();
     assertNotNull(params);
     assertEquals(0, params.size());
   }
-  
+
   @Test
   public void getQueryStringMulti() {
-    Map<String, List<String>> params = 
-      NettyMocks.getQuery(tsdb, 
+    Map<String, List<String>> params =
+      NettyMocks.getQuery(tsdb,
           "/api/v1/put?param=v1&param=v2&param=v3").getQueryString();
     assertNotNull(params);
     assertEquals(1, params.size());
     assertEquals(3, params.get("param").size());
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void getQueryStringNULL() {
     NettyMocks.getQuery(tsdb, null).getQueryString();
   }
-  
+
   @Test
   public void getQueryStringParam() {
-    assertEquals("value", 
-        NettyMocks.getQuery(tsdb, 
+    assertEquals("value",
+        NettyMocks.getQuery(tsdb,
         "/api/v1/put?param=value&param2=value2")
         .getQueryStringParam("param"));
   }
-  
+
   @Test
   public void getQueryStringParamNull() {
-    assertNull(NettyMocks.getQuery(tsdb, 
+    assertNull(NettyMocks.getQuery(tsdb,
         "/api/v1/put?param=value&param2=value2").
         getQueryStringParam("nothere"));
   }
-  
+
   @Test
   public void getRequiredQueryStringParam() {
-    assertEquals("value", 
-        NettyMocks.getQuery(tsdb, 
+    assertEquals("value",
+        NettyMocks.getQuery(tsdb,
         "/api/v1/put?param=value&param2=value2").
         getRequiredQueryStringParam("param"));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void getRequiredQueryStringParamMissing() {
     NettyMocks.getQuery(tsdb, "/api/v1/put?param=value&param2=value2").
       getRequiredQueryStringParam("nothere");
   }
-  
+
   @Test
   public void hasQueryStringParam() {
-    assertTrue(NettyMocks.getQuery(tsdb, 
+    assertTrue(NettyMocks.getQuery(tsdb,
         "/api/v1/put?param=value&param2=value2").
         hasQueryStringParam("param"));
   }
-  
+
   @Test
   public void hasQueryStringMissing() {
-    assertFalse(NettyMocks.getQuery(tsdb, 
+    assertFalse(NettyMocks.getQuery(tsdb,
         "/api/v1/put?param=value&param2=value2").
         hasQueryStringParam("nothere"));
   }
-  
+
   @Test
   public void getQueryStringParams() {
-    List<String> params = NettyMocks.getQuery(tsdb, 
+    List<String> params = NettyMocks.getQuery(tsdb,
         "/api/v1/put?param=v1&param=v2&param=v3").
       getQueryStringParams("param");
     assertNotNull(params);
     assertEquals(3, params.size());
   }
-  
+
   @Test
   public void getQueryStringParamsNull() {
-    List<String> params = NettyMocks.getQuery(tsdb, 
+    List<String> params = NettyMocks.getQuery(tsdb,
         "/api/v1/put?param=v1&param=v2&param=v3").
       getQueryStringParams("nothere");
     assertNull(params);
   }
-  
+
   @Test
   public void getQueryPathA() {
-    assertEquals("/api/v1/put", 
-        NettyMocks.getQuery(tsdb, 
+    assertEquals("/api/v1/put",
+        NettyMocks.getQuery(tsdb,
         "/api/v1/put?param=value&param2=value2").
         getQueryPath());
   }
-  
+
   @Test
   public void getQueryPathB() {
     assertEquals("/", NettyMocks.getQuery(tsdb, "/").getQueryPath());
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void getQueryPathNull() {
     NettyMocks.getQuery(tsdb, null).getQueryPath();
   }
-  
+
   @Test
   public void explodePath() {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/v1/put?param=value&param2=value2");
     final String[] path = query.explodePath();
     assertNotNull(path);
@@ -210,7 +211,7 @@ public final class TestHttpQuery {
     assertEquals("v1", path[1]);
     assertEquals("put", path[2]);
   }
-  
+
   @Test
   public void explodePathEmpty() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/");
@@ -219,563 +220,563 @@ public final class TestHttpQuery {
     assertEquals(1, path.length);
     assertEquals("", path[0]);
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void explodePathNull() {
     NettyMocks.getQuery(tsdb, null).explodePath();
   }
-  
+
   @Test
   public void getQueryBaseRouteRoot() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     assertEquals("", query.getQueryBaseRoute());
     assertEquals(0, query.apiVersion());
   }
-  
+
   @Test
   public void explodeAPIPath() {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/v1/put?param=value&param2=value2");
     final String[] path = query.explodeAPIPath();
     assertNotNull(path);
     assertEquals("put", path[0]);
   }
-  
+
   @Test
   public void explodeAPIPathNoVersion() {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/put?param=value&param2=value2");
     final String[] path = query.explodeAPIPath();
     assertNotNull(path);
     assertEquals("put", path[0]);
   }
-  
+
   @Test
   public void explodeAPIPathExtended() {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/v1/uri/assign");
     final String[] path = query.explodeAPIPath();
     assertNotNull(path);
     assertEquals("uri", path[0]);
     assertEquals("assign", path[1]);
   }
-  
+
   @Test
   public void explodeAPIPathExtendedNoVersion() {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/uri/assign");
     final String[] path = query.explodeAPIPath();
     assertNotNull(path);
     assertEquals("uri", path[0]);
     assertEquals("assign", path[1]);
   }
-  
+
   @Test
   public void explodeAPIPathCase() {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/Api/Uri");
     final String[] path = query.explodeAPIPath();
     assertNotNull(path);
     assertEquals("Uri", path[0]);
   }
-  
+
   @Test
   public void explodeAPIPathRoot() {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api");
     final String[] path = query.explodeAPIPath();
     assertNotNull(path);
     assertTrue(path[0].isEmpty());
   }
-  
+
   @Test
   public void explodeAPIPathRootVersion() {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/v1");
     final String[] path = query.explodeAPIPath();
     assertNotNull(path);
     assertTrue(path[0].isEmpty());
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void explodeAPIPathNotAPI() {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/q?hello=world");
     query.explodeAPIPath();
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void explodeAPIPathHome() {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/");
     query.explodeAPIPath();
   }
-  
+
   @Test
   public void getQueryBaseRouteRootQS() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/?param=value");
     assertEquals("", query.getQueryBaseRoute());
     assertEquals(0, query.apiVersion());
   }
-  
+
   @Test
   public void getQueryBaseRouteQ() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/q");
     assertEquals("q", query.getQueryBaseRoute());
     assertEquals(0, query.apiVersion());
   }
-  
+
   @Test
   public void getQueryBaseRouteQSlash() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/q/");
     assertEquals("q", query.getQueryBaseRoute());
     assertEquals(0, query.apiVersion());
   }
-  
+
   @Test
   public void getQueryBaseRouteLogs() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/logs");
     assertEquals("logs", query.getQueryBaseRoute());
     assertEquals(0, query.apiVersion());
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void getQueryBaseRouteAPIVNotImplemented() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/api/v3/put");
     assertEquals("api/put", query.getQueryBaseRoute());
     assertEquals(1, query.apiVersion());
   }
-  
+
   @Test
   public void getQueryBaseRouteAPICap() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/API/V1/PUT");
     assertEquals("api/put", query.getQueryBaseRoute());
     assertEquals(1, query.apiVersion());
   }
-  
+
   @Test
   public void getQueryBaseRouteAPIDefaultV() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/api/put");
     assertEquals("api/put", query.getQueryBaseRoute());
     assertEquals(1, query.apiVersion());
   }
-  
+
   @Test
   public void getQueryBaseRouteAPIQS() {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/v1/put?metric=mine");
     assertEquals("api/put", query.getQueryBaseRoute());
     assertEquals(1, query.apiVersion());
   }
-  
+
   @Test
   public void getQueryBaseRouteAPINoEP() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/api");
     assertEquals("api", query.getQueryBaseRoute());
     assertEquals(1, query.apiVersion());
   }
-  
+
   @Test
   public void getQueryBaseRouteAPINoEPSlash() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/api/");
     assertEquals("api", query.getQueryBaseRoute());
     assertEquals(1, query.apiVersion());
   }
-  
+
   @Test
   public void getQueryBaseRouteFavicon() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/favicon.ico");
     assertEquals("favicon.ico", query.getQueryBaseRoute());
     assertEquals(0, query.apiVersion());
   }
-  
+
   @Test
   public void getQueryBaseRouteVersion() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/api/version/query");
     assertEquals("api/version", query.getQueryBaseRoute());
     assertEquals(1, query.apiVersion());
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void getQueryBaseRouteVBadNumber() {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/api/v2d/query");
     query.getQueryBaseRoute();
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void getQueryBaseRouteNull() {
     NettyMocks.getQuery(tsdb, null).getQueryBaseRoute();
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void getQueryBaseRouteBad() {
     NettyMocks.getQuery(tsdb, "notavalidquery").getQueryBaseRoute();
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void getQueryBaseRouteEmpty() {
     NettyMocks.getQuery(tsdb, "").getQueryBaseRoute();
   }
-  
+
   @Test
   public void getCharsetDefault() {
     final Channel channelMock = NettyMocks.fakeChannel();
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.GET, "/");
     req.headers().add("Content-Type", "text/plain");
-    final HttpQuery query = new HttpQuery(tsdb, req, channelMock);
+    final HttpQuery query = new HttpQuery(tsdb, req, channelMock, new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     assertEquals(Charset.forName("UTF-8"), query.getCharset());
   }
-  
+
   @Test
   public void getCharsetDefaultNoHeader() {
-    assertEquals(Charset.forName("UTF-8"), 
+    assertEquals(Charset.forName("UTF-8"),
         NettyMocks.getQuery(tsdb, "/").getCharset());
   }
-  
+
   @Test
   public void getCharsetSupplied() {
     final Channel channelMock = NettyMocks.fakeChannel();
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.GET, "/");
     req.headers().add("Content-Type", "text/plain; charset=UTF-16");
-    final HttpQuery query = new HttpQuery(tsdb, req, channelMock);
+    final HttpQuery query = new HttpQuery(tsdb, req, channelMock, new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     assertEquals(Charset.forName("UTF-16"), query.getCharset());
   }
-  
+
   @Test (expected = UnsupportedCharsetException.class)
   public void getCharsetInvalid() {
     final Channel channelMock = NettyMocks.fakeChannel();
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.GET, "/");
     req.headers().add("Content-Type", "text/plain; charset=foobar");
-    final HttpQuery query = new HttpQuery(tsdb, req, channelMock);
+    final HttpQuery query = new HttpQuery(tsdb, req, channelMock, new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     assertEquals(Charset.forName("UTF-16"), query.getCharset());
   }
-  
+
   @Test
   public void hasContent() {
     HttpQuery query = NettyMocks.postQuery(tsdb, "/", "Hello World", "");
     assertTrue(query.hasContent());
   }
-  
+
   @Test
   public void hasContentFalse() {
     HttpQuery query = NettyMocks.postQuery(tsdb, "/", null, "");
     assertFalse(query.hasContent());
   }
-  
+
   @Test
   public void hasContentNotReadable() {
     HttpQuery query = NettyMocks.postQuery(tsdb, "/", "", "");
     assertFalse(query.hasContent());
   }
-  
+
   @Test
   public void getContentEncoding() {
     final Channel channelMock = NettyMocks.fakeChannel();
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.GET, "/");
     req.headers().add("Content-Type", "text/plain; charset=UTF-16");
-    final ChannelBuffer buf = ChannelBuffers.copiedBuffer("S\u00ED Se\u00F1or", 
+    final ChannelBuffer buf = ChannelBuffers.copiedBuffer("S\u00ED Se\u00F1or",
         CharsetUtil.UTF_16);
     req.setContent(buf);
-    final HttpQuery query = new HttpQuery(tsdb, req, channelMock);
+    final HttpQuery query = new HttpQuery(tsdb, req, channelMock, new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     assertEquals("S\u00ED Se\u00F1or", query.getContent());
   }
-  
+
   @Test
   public void getContentDefault() {
     final Channel channelMock = NettyMocks.fakeChannel();
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.GET, "/");
-    final ChannelBuffer buf = ChannelBuffers.copiedBuffer("S\u00ED Se\u00F1or", 
+    final ChannelBuffer buf = ChannelBuffers.copiedBuffer("S\u00ED Se\u00F1or",
         CharsetUtil.UTF_8);
     req.setContent(buf);
-    final HttpQuery query = new HttpQuery(tsdb, req, channelMock);
+    final HttpQuery query = new HttpQuery(tsdb, req, channelMock, new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     assertEquals("S\u00ED Se\u00F1or", query.getContent());
   }
-  
+
   @Test
   public void getContentBadEncoding() {
     final Channel channelMock = NettyMocks.fakeChannel();
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.GET, "/");
-    final ChannelBuffer buf = ChannelBuffers.copiedBuffer("S\u00ED Se\u00F1or", 
+    final ChannelBuffer buf = ChannelBuffers.copiedBuffer("S\u00ED Se\u00F1or",
         CharsetUtil.ISO_8859_1);
     req.setContent(buf);
-    final HttpQuery query = new HttpQuery(tsdb, req, channelMock);
+    final HttpQuery query = new HttpQuery(tsdb, req, channelMock, new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     assertThat("S\u00ED Se\u00F1or", not(equalTo(query.getContent())));
   }
-  
+
   @Test
   public void getContentEmpty() {
     assertTrue(NettyMocks.getQuery(tsdb, "/").getContent().isEmpty());
   }
-  
+
   @Test
   public void getAPIMethodGet() {
-    assertEquals(HttpMethod.GET, 
+    assertEquals(HttpMethod.GET,
         NettyMocks.getQuery(tsdb, "/").getAPIMethod());
   }
-  
+
   @Test
   public void getAPIMethodPost() {
-    assertEquals(HttpMethod.POST, 
+    assertEquals(HttpMethod.POST,
         NettyMocks.postQuery(tsdb, "/", null).getAPIMethod());
   }
-  
+
   @Test
   public void getAPIMethodPut() {
     final Channel channelMock = NettyMocks.fakeChannel();
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.PUT, "/");
-    HttpQuery query = new HttpQuery(tsdb, req, channelMock);
+    HttpQuery query = new HttpQuery(tsdb, req, channelMock, new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     assertEquals(HttpMethod.PUT, query.getAPIMethod());
   }
-  
+
   @Test
   public void getAPIMethodDelete() {
     final Channel channelMock = NettyMocks.fakeChannel();
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.DELETE, "/");
-    HttpQuery query = new HttpQuery(tsdb, req, channelMock);
+    HttpQuery query = new HttpQuery(tsdb, req, channelMock, new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     assertEquals(HttpMethod.DELETE, query.getAPIMethod());
   }
-  
+
   @Test
   public void getAPIMethodOverrideGet() {
-    assertEquals(HttpMethod.GET, 
+    assertEquals(HttpMethod.GET,
         NettyMocks.getQuery(tsdb, "/?method_override=get").getAPIMethod());
   }
-  
+
   @Test
   public void getAPIMethodOverridePost() {
-    assertEquals(HttpMethod.POST, 
+    assertEquals(HttpMethod.POST,
         NettyMocks.getQuery(tsdb, "/?method_override=post").getAPIMethod());
   }
-  
+
   @Test
   public void getAPIMethodOverridePut() {
-    assertEquals(HttpMethod.PUT, 
+    assertEquals(HttpMethod.PUT,
         NettyMocks.getQuery(tsdb, "/?method_override=put").getAPIMethod());
   }
-  
+
   @Test
   public void getAPIMethodOverrideDelete() {
-    assertEquals(HttpMethod.DELETE, 
+    assertEquals(HttpMethod.DELETE,
         NettyMocks.getQuery(tsdb, "/?method_override=delete").getAPIMethod());
   }
-  
+
   @Test
   public void getAPIMethodOverrideDeleteCase() {
-    assertEquals(HttpMethod.DELETE, 
+    assertEquals(HttpMethod.DELETE,
         NettyMocks.getQuery(tsdb, "/?method_override=DeLeTe").getAPIMethod());
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void getAPIMethodOverrideMissingValue() {
     NettyMocks.getQuery(tsdb, "/?method_override").getAPIMethod();
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void getAPIMethodOverrideInvalidMEthod() {
     NettyMocks.getQuery(tsdb, "/?method_override=notaverb").getAPIMethod();
   }
-  
+
   @Test
   public void guessMimeTypeFromUriPNG() throws Exception {
-    assertEquals("image/png", 
+    assertEquals("image/png",
         guessMimeTypeFromUri.invoke(null, "abcd.png"));
   }
-  
+
   @Test
   public void guessMimeTypeFromUriHTML() throws Exception {
-    assertEquals("text/html; charset=UTF-8", 
+    assertEquals("text/html; charset=UTF-8",
         guessMimeTypeFromUri.invoke(null, "abcd.html"));
   }
-  
+
   @Test
   public void guessMimeTypeFromUriCSS() throws Exception {
-    assertEquals("text/css", 
+    assertEquals("text/css",
         guessMimeTypeFromUri.invoke(null, "abcd.css"));
   }
-  
+
   @Test
   public void guessMimeTypeFromUriJS() throws Exception {
-    assertEquals("text/javascript", 
+    assertEquals("text/javascript",
         guessMimeTypeFromUri.invoke(null, "abcd.js"));
   }
-  
+
   @Test
   public void guessMimeTypeFromUriGIF() throws Exception {
-    assertEquals("image/gif", 
+    assertEquals("image/gif",
         guessMimeTypeFromUri.invoke(null, "abcd.gif"));
   }
-  
+
   @Test
   public void guessMimeTypeFromUriICO() throws Exception {
-    assertEquals("image/x-icon", 
+    assertEquals("image/x-icon",
         guessMimeTypeFromUri.invoke(null, "abcd.ico"));
   }
-  
+
   @Test
   public void guessMimeTypeFromUriOther() throws Exception {
     assertNull(guessMimeTypeFromUri.invoke(null, "abcd.jpg"));
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void guessMimeTypeFromUriNull() throws Exception {
     guessMimeTypeFromUri.invoke(null, (Object[])null);
   }
-  
-  @Test 
+
+  @Test
   public void guessMimeTypeFromUriEmpty() throws Exception {
     assertNull(guessMimeTypeFromUri.invoke(null, ""));
   }
 
   @Test
   public void guessMimeTypeFromContentsHTML() throws Exception {
-    assertEquals("text/html; charset=UTF-8", 
+    assertEquals("text/html; charset=UTF-8",
         guessMimeTypeFromContents.invoke(
             NettyMocks.getQuery(tsdb, ""),
             ChannelBuffers.copiedBuffer(
                 "<HTML>...", Charset.forName("UTF-8"))));
   }
-  
+
   @Test
   public void guessMimeTypeFromContentsJSONObj() throws Exception {
-    assertEquals("application/json", 
+    assertEquals("application/json",
         guessMimeTypeFromContents.invoke(
             NettyMocks.getQuery(tsdb, ""),
             ChannelBuffers.copiedBuffer(
                 "{\"hello\":\"world\"}", Charset.forName("UTF-8"))));
   }
-  
+
   @Test
   public void guessMimeTypeFromContentsJSONArray() throws Exception {
-    assertEquals("application/json", 
+    assertEquals("application/json",
         guessMimeTypeFromContents.invoke(
             NettyMocks.getQuery(tsdb, ""),
             ChannelBuffers.copiedBuffer(
                 "[\"hello\",\"world\"]", Charset.forName("UTF-8"))));
   }
-  
+
   @Test
   public void guessMimeTypeFromContentsPNG() throws Exception {
-    assertEquals("image/png", 
+    assertEquals("image/png",
         guessMimeTypeFromContents.invoke(
             NettyMocks.getQuery(tsdb, ""),
             ChannelBuffers.copiedBuffer(
                 new byte[] {(byte) 0x89, 0x00})));
   }
-  
+
   @Test
   public void guessMimeTypeFromContentsText() throws Exception {
-    assertEquals("text/plain", 
+    assertEquals("text/plain",
         guessMimeTypeFromContents.invoke(
             NettyMocks.getQuery(tsdb, ""),
             ChannelBuffers.copiedBuffer(
                 "Just plain text", Charset.forName("UTF-8"))));
   }
-  
-  @Test 
+
+  @Test
   public void guessMimeTypeFromContentsEmpty() throws Exception {
-    assertEquals("text/plain", 
+    assertEquals("text/plain",
         guessMimeTypeFromContents.invoke(
             NettyMocks.getQuery(tsdb, ""),
             ChannelBuffers.copiedBuffer(
                 "", Charset.forName("UTF-8"))));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void guessMimeTypeFromContentsNull() throws Exception {
     ChannelBuffer buf = null;
     guessMimeTypeFromContents.invoke(
         NettyMocks.getQuery(tsdb, ""), buf);
   }
-  
+
   @Test
   public void initializeSerializerMaps() throws Exception {
     HttpQuery.initializeSerializerMaps(null);
   }
-  
+
   @Test
   public void setSerializer() throws Exception {
     HttpQuery.initializeSerializerMaps(null);
     HttpQuery query = NettyMocks.getQuery(tsdb, "/aggregators");
     query.setSerializer();
-    assertEquals(HttpJsonSerializer.class.getCanonicalName(), 
+    assertEquals(HttpJsonSerializer.class.getCanonicalName(),
         query.serializer().getClass().getCanonicalName());
   }
-  
+
   @Test
   public void setFormatterQS() throws Exception {
     HttpQuery.initializeSerializerMaps(null);
     HttpQuery query = NettyMocks.getQuery(tsdb, "/aggregators?formatter=json");
     query.setSerializer();
-    assertEquals(HttpJsonSerializer.class.getCanonicalName(), 
+    assertEquals(HttpJsonSerializer.class.getCanonicalName(),
         query.serializer().getClass().getCanonicalName());
   }
-  
+
   @Test
   public void setSerializerDummyQS() throws Exception {
     PluginLoader.loadJAR("plugin_test.jar");
     HttpQuery.initializeSerializerMaps(null);
     HttpQuery query = NettyMocks.getQuery(tsdb, "/aggregators?serializer=dummy");
     query.setSerializer();
-    assertEquals("net.opentsdb.tsd.DummyHttpSerializer", 
+    assertEquals("net.opentsdb.tsd.DummyHttpSerializer",
         query.serializer().getClass().getCanonicalName());
   }
-  
+
   @Test
   public void setSerializerCT() throws Exception {
     HttpQuery.initializeSerializerMaps(null);
     final Channel channelMock = NettyMocks.fakeChannel();
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.GET, "/");
     req.headers().add("Content-Type", "application/json");
-    final HttpQuery query = new HttpQuery(tsdb, req, channelMock);
+    final HttpQuery query = new HttpQuery(tsdb, req, channelMock, new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     query.setSerializer();
-    assertEquals(HttpJsonSerializer.class.getCanonicalName(), 
+    assertEquals(HttpJsonSerializer.class.getCanonicalName(),
         query.serializer().getClass().getCanonicalName());
   }
-  
+
   @Test
   public void setSerializerDummyCT() throws Exception {
     PluginLoader.loadJAR("plugin_test.jar");
     HttpQuery.initializeSerializerMaps(null);
     final Channel channelMock = NettyMocks.fakeChannel();
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.GET, "/");
     req.headers().add("Content-Type", "application/tsdbdummy");
-    final HttpQuery query = new HttpQuery(tsdb, req, channelMock);
+    final HttpQuery query = new HttpQuery(tsdb, req, channelMock, new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     query.setSerializer();
-    assertEquals("net.opentsdb.tsd.DummyHttpSerializer", 
+    assertEquals("net.opentsdb.tsd.DummyHttpSerializer",
         query.serializer().getClass().getCanonicalName());
   }
-  
+
   @Test
   public void setSerializerDefaultCT() throws Exception {
     HttpQuery.initializeSerializerMaps(null);
     final Channel channelMock = NettyMocks.fakeChannel();
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.GET, "/");
     req.headers().add("Content-Type", "invalid/notfoundtype");
-    final HttpQuery query = new HttpQuery(tsdb, req, channelMock);
+    final HttpQuery query = new HttpQuery(tsdb, req, channelMock, new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     query.setSerializer();
-    assertEquals(HttpJsonSerializer.class.getCanonicalName(), 
+    assertEquals(HttpJsonSerializer.class.getCanonicalName(),
         query.serializer().getClass().getCanonicalName());
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void setSerializerNotFound() throws Exception {
     HttpQuery.initializeSerializerMaps(null);
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/suggest?serializer=notfound");
     query.setSerializer();
   }
-  
+
   @Test
   public void internalErrorDeprecated() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "");
@@ -784,14 +785,14 @@ public final class TestHttpQuery {
     } catch (Exception e) {
       query.internalError(e);
     }
-    assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, 
+    assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
         query.response().getStatus());
     assertEquals(
-        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">", 
+        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">",
         query.response().getContent().toString(Charset.forName("UTF-8"))
         .substring(0, 63));
   }
-  
+
   @Test
   public void internalErrorDeprecatedJSON() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/?json");
@@ -800,14 +801,14 @@ public final class TestHttpQuery {
     } catch (Exception e) {
       query.internalError(e);
     }
-    assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, 
-        query.response().getStatus());    
+    assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+        query.response().getStatus());
     assertEquals(
-        "{\"err\":\"java.lang.Exception: Internal Error", 
+        "{\"err\":\"java.lang.Exception: Internal Error",
         query.response().getContent().toString(Charset.forName("UTF-8"))
         .substring(0, 43));
   }
-  
+
   @Test
   public void internalErrorDefaultSerializer() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/api/error");
@@ -817,20 +818,20 @@ public final class TestHttpQuery {
     } catch (Exception e) {
       query.internalError(e);
     }
-    assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, 
-        query.response().getStatus());    
+    assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+        query.response().getStatus());
     assertEquals(
-        "{\"error\":{\"code\":500,\"message\":\"Internal Error\"", 
+        "{\"error\":{\"code\":500,\"message\":\"Internal Error\"",
         query.response().getContent().toString(Charset.forName("UTF-8"))
         .substring(0, 47));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void internalErrorNull() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "");
     query.internalError(null);
   }
-  
+
   @Test
   public void badRequestDeprecated() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
@@ -839,13 +840,13 @@ public final class TestHttpQuery {
     } catch (BadRequestException e) {
       query.badRequest(e);
     }
-    assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus());    
+    assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus());
     assertEquals(
-        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">", 
+        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">",
         query.response().getContent().toString(Charset.forName("UTF-8"))
         .substring(0, 63));
   }
-  
+
   @Test
   public void badRequestDeprecatedJSON() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/?json");
@@ -854,12 +855,12 @@ public final class TestHttpQuery {
     } catch (BadRequestException e) {
       query.badRequest(e);
     }
-    assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus());  
+    assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus());
     assertEquals(
-        "{\"err\":\"Bad user error\"}", 
+        "{\"err\":\"Bad user error\"}",
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test
   public void badRequestDefaultSerializer() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/api/error");
@@ -869,13 +870,13 @@ public final class TestHttpQuery {
     } catch (BadRequestException e) {
       query.badRequest(e);
     }
-    assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus()); 
+    assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus());
     assertEquals(
-        "{\"error\":{\"code\":400,\"message\":\"Bad user error\"", 
+        "{\"error\":{\"code\":400,\"message\":\"Bad user error\"",
         query.response().getContent().toString(Charset.forName("UTF-8"))
         .substring(0, 47));
   }
-  
+
   @Test
   public void badRequestDefaultSerializerDiffStatus() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/api/error");
@@ -886,13 +887,13 @@ public final class TestHttpQuery {
     } catch (BadRequestException e) {
       query.badRequest(e);
     }
-    assertEquals(HttpResponseStatus.FORBIDDEN, query.response().getStatus()); 
+    assertEquals(HttpResponseStatus.FORBIDDEN, query.response().getStatus());
     assertEquals(
-        "{\"error\":{\"code\":403,\"message\":\"Bad user error\"", 
+        "{\"error\":{\"code\":403,\"message\":\"Bad user error\"",
         query.response().getContent().toString(Charset.forName("UTF-8"))
         .substring(0, 47));
   }
-  
+
   @Test
   public void badRequestDefaultSerializerDetails() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/api/error");
@@ -903,92 +904,92 @@ public final class TestHttpQuery {
     } catch (BadRequestException e) {
       query.badRequest(e);
     }
-    assertEquals(HttpResponseStatus.FORBIDDEN, query.response().getStatus()); 
+    assertEquals(HttpResponseStatus.FORBIDDEN, query.response().getStatus());
     assertEquals(
-        "{\"error\":{\"code\":403,\"message\":\"Bad user error\",\"details\":\"Got Details\"", 
+        "{\"error\":{\"code\":403,\"message\":\"Bad user error\",\"details\":\"Got Details\"",
         query.response().getContent().toString(Charset.forName("UTF-8"))
         .substring(0, 71));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void badRequestNull() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.badRequest((BadRequestException)null);
   }
-  
+
   @Test
   public void badRequestDeprecatedString() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.badRequest("Bad user error");
-    assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus());    
+    assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus());
     assertEquals(
-        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">", 
+        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">",
         query.response().getContent().toString(Charset.forName("UTF-8"))
         .substring(0, 63));
   }
-  
+
   @Test
   public void badRequestDeprecatedJSONString() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/?json");
     query.badRequest("Bad user error");
-    assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus());  
+    assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus());
     assertEquals(
-        "{\"err\":\"Bad user error\"}", 
+        "{\"err\":\"Bad user error\"}",
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test
   public void badRequestDefaultSerializerString() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/api/error");
     query.getQueryBaseRoute();
     query.badRequest("Bad user error");
-    assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus()); 
+    assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus());
     assertEquals(
-        "{\"error\":{\"code\":400,\"message\":\"Bad user error\"", 
+        "{\"error\":{\"code\":400,\"message\":\"Bad user error\"",
         query.response().getContent().toString(Charset.forName("UTF-8"))
         .substring(0, 47));
   }
-  
+
   @Test
   public void badRequestNullString() {
-    // this won't throw an error, just report "null" back to the user with a 
+    // this won't throw an error, just report "null" back to the user with a
     // stack trace
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.badRequest((String)null);
   }
-  
+
   @Test
   public void notFoundDeprecated() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.notFound();
-    assertEquals(HttpResponseStatus.NOT_FOUND, query.response().getStatus());    
+    assertEquals(HttpResponseStatus.NOT_FOUND, query.response().getStatus());
     assertEquals(
-        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">", 
+        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">",
         query.response().getContent().toString(Charset.forName("UTF-8"))
         .substring(0, 63));
   }
-  
+
   @Test
   public void notFoundDeprecatedJSON() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/?json");
     query.notFound();
-    assertEquals(HttpResponseStatus.NOT_FOUND, query.response().getStatus());  
+    assertEquals(HttpResponseStatus.NOT_FOUND, query.response().getStatus());
     assertEquals(
-        "{\"err\":\"Page Not Found\"}", 
+        "{\"err\":\"Page Not Found\"}",
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test
   public void notFoundDefaultSerializer() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/api/error");
     query.getQueryBaseRoute();
     query.notFound();
-    assertEquals(HttpResponseStatus.NOT_FOUND, query.response().getStatus()); 
+    assertEquals(HttpResponseStatus.NOT_FOUND, query.response().getStatus());
     assertEquals(
-        "{\"error\":{\"code\":404,\"message\":\"Endpoint not found\"}}", 
+        "{\"error\":{\"code\":404,\"message\":\"Endpoint not found\"}}",
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test
   public void redirect() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
@@ -996,16 +997,16 @@ public final class TestHttpQuery {
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
     assertEquals("/redirect", query.response().headers().get("Location"));
     assertEquals("<html></head><meta http-equiv=\"refresh\" content=\"0; url="
-        + "/redirect\"></head></html>", 
+        + "/redirect\"></head></html>",
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void redirectNull() {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.redirect(null);
   }
-  
+
   @Test
   public void escapeJson() {
     StringBuilder sb = new StringBuilder();
@@ -1018,137 +1019,137 @@ public final class TestHttpQuery {
     HttpQuery.escapeJson(json, sb);
     assertEquals("\\\" \\\\ \\b \\f \\n \\r \\t", sb.toString());
   }
-  
+
   @Test
   public void sendReplyBytes() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendReply("Hello World".getBytes());
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    assertEquals("Hello World", 
+    assertEquals("Hello World",
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void sendReplyBytesNull() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendReply((byte[])null);
   }
-  
+
   @Test
   public void sendReplyStatusBytes() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendReply(HttpResponseStatus.CREATED, "Hello World".getBytes());
     assertEquals(HttpResponseStatus.CREATED, query.response().getStatus());
-    assertEquals("Hello World", 
+    assertEquals("Hello World",
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void sendReplyStatusBytesNullStatus() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendReply(null, "Hello World".getBytes());
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void sendReplyStatusBytesNullBytes() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendReply(HttpResponseStatus.CREATED, (byte[])null);
   }
-  
+
   @Test
   public void sendReplySB() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendReply(new StringBuilder("Hello World"));
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    assertEquals("Hello World", 
+    assertEquals("Hello World",
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void sendReplySBNull() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendReply((StringBuilder)null);
   }
-  
+
   @Test
   public void sendReplyString() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendReply("Hello World");
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    assertEquals("Hello World", 
+    assertEquals("Hello World",
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void sendReplyStringNull() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendReply((String)null);
   }
-  
+
   @Test
   public void sendReplyStatusSB() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
-    query.sendReply(HttpResponseStatus.CREATED, 
+    query.sendReply(HttpResponseStatus.CREATED,
         new StringBuilder("Hello World"));
     assertEquals(HttpResponseStatus.CREATED, query.response().getStatus());
-    assertEquals("Hello World", 
+    assertEquals("Hello World",
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void sendReplyStatusSBNullStatus() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendReply(null, new StringBuilder("Hello World"));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void sendReplyStatusSBNullSB() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendReply(HttpResponseStatus.CREATED, (StringBuilder)null);
   }
-  
+
   @Test
   public void sendReplyCB() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
-    ChannelBuffer cb = ChannelBuffers.copiedBuffer("Hello World", 
+    ChannelBuffer cb = ChannelBuffers.copiedBuffer("Hello World",
         Charset.forName("UTF-8"));
     query.sendReply(cb);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    assertEquals("Hello World", 
+    assertEquals("Hello World",
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void sendReplyCBNull() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendReply((ChannelBuffer)null);
   }
-  
+
   @Test
   public void sendReplyStatusCB() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
-    ChannelBuffer cb = ChannelBuffers.copiedBuffer("Hello World", 
+    ChannelBuffer cb = ChannelBuffers.copiedBuffer("Hello World",
         Charset.forName("UTF-8"));
     query.sendReply(HttpResponseStatus.CREATED, cb);
     assertEquals(HttpResponseStatus.CREATED, query.response().getStatus());
-    assertEquals("Hello World", 
+    assertEquals("Hello World",
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void sendReplyStatusCBNullStatus() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
-    ChannelBuffer cb = ChannelBuffers.copiedBuffer("Hello World", 
+    ChannelBuffer cb = ChannelBuffers.copiedBuffer("Hello World",
         Charset.forName("UTF-8"));
     query.sendReply(null, cb);
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void sendReplyStatusCBNullCB() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendReply(HttpResponseStatus.CREATED, (ChannelBuffer)null);
   }
-  
+
   @Test
   public void sendStatusOnly() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
@@ -1157,43 +1158,43 @@ public final class TestHttpQuery {
     assertEquals(0, query.response().getContent().capacity());
     assertNull(query.response().headers().get("Content-Type"));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void sendStatusOnlyNull() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/");
     query.sendStatusOnly(null);
   }
-  
+
   @Test
   public void sendBuffer() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "");
-    ChannelBuffer cb = ChannelBuffers.copiedBuffer("Hello World", 
+    ChannelBuffer cb = ChannelBuffers.copiedBuffer("Hello World",
         Charset.forName("UTF-8"));
     sendBuffer.invoke(query, HttpResponseStatus.OK, cb);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    assertEquals(cb.toString(Charset.forName("UTF-8")), 
+    assertEquals(cb.toString(Charset.forName("UTF-8")),
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test
   public void sendBufferEmptyCB() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "");
-    ChannelBuffer cb = ChannelBuffers.copiedBuffer("", 
+    ChannelBuffer cb = ChannelBuffers.copiedBuffer("",
         Charset.forName("UTF-8"));
     sendBuffer.invoke(query, HttpResponseStatus.OK, cb);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    assertEquals(cb.toString(Charset.forName("UTF-8")), 
+    assertEquals(cb.toString(Charset.forName("UTF-8")),
         query.response().getContent().toString(Charset.forName("UTF-8")));
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void sendBufferNullStatus() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "");
-    ChannelBuffer cb = ChannelBuffers.copiedBuffer("Hello World", 
+    ChannelBuffer cb = ChannelBuffers.copiedBuffer("Hello World",
         Charset.forName("UTF-8"));
     sendBuffer.invoke(query, null, cb);
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void sendBufferNullCB() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "");

--- a/test/tsd/TestSearchRpc.java
+++ b/test/tsd/TestSearchRpc.java
@@ -40,6 +40,7 @@ import net.opentsdb.search.SearchPlugin;
 import net.opentsdb.search.SearchQuery;
 import net.opentsdb.search.TestTimeSeriesLookup;
 import net.opentsdb.search.TimeSeriesLookup;
+import net.opentsdb.stats.Histogram;
 import net.opentsdb.storage.MockBase;
 import net.opentsdb.uid.NoSuchUniqueId;
 import net.opentsdb.uid.UniqueId;
@@ -66,29 +67,29 @@ import com.stumbleupon.async.Deferred;
 import com.sun.java_cup.internal.runtime.Scanner;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ TSDB.class, Config.class, HttpQuery.class, UniqueId.class, 
-  RowKey.class, Tags.class, TimeSeriesLookup.class, SearchRpc.class, 
+@PrepareForTest({ TSDB.class, Config.class, HttpQuery.class, UniqueId.class,
+  RowKey.class, Tags.class, TimeSeriesLookup.class, SearchRpc.class,
   SearchPlugin.class, Scanner.class })
 public final class TestSearchRpc extends BaseTsdbTest {
   private SearchPlugin mock_plugin;
   private SearchRpc rpc = new SearchRpc();
   private SearchQuery search_query = null;
   private static final Charset UTF = Charset.forName("UTF-8");
-  
+
   @Before
   public void beforeLocal() throws Exception {
     HttpQuery.initializeSerializerMaps(tsdb);
   }
-  
+
   @Test
   public void constructor() {
     assertNotNull(new SearchRpc());
   }
-  
+
   @Test
   public void searchTSMeta() throws Exception {
     setupAnswerSearchQuery();
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/search/tsmeta?query=*");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -96,11 +97,11 @@ public final class TestSearchRpc extends BaseTsdbTest {
     assertTrue(result.contains("\"results\":[{\"tsuid\""));
     assertEquals(1, search_query.getResults().size());
   }
-  
+
   @Test
   public void searchTSMeta_Summary() throws Exception {
     setupAnswerSearchQuery();
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/search/tsmeta_summary?query=*");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -108,11 +109,11 @@ public final class TestSearchRpc extends BaseTsdbTest {
     assertTrue(result.contains("\"results\":[{\"tags\""));
     assertEquals(1, search_query.getResults().size());
   }
-  
+
   @Test
   public void searchTSUIDs() throws Exception {
     setupAnswerSearchQuery();
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/search/tsuids?query=*");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -120,11 +121,11 @@ public final class TestSearchRpc extends BaseTsdbTest {
     assertTrue(result.contains("\"results\":[\"000001000001000001\""));
     assertEquals(2, search_query.getResults().size());
   }
-  
+
   @Test
   public void searchUIDMeta() throws Exception {
     setupAnswerSearchQuery();
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/search/uidmeta?query=*");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -132,11 +133,11 @@ public final class TestSearchRpc extends BaseTsdbTest {
     assertTrue(result.contains("\"results\":[{\"uid\""));
     assertEquals(2, search_query.getResults().size());
   }
-  
+
   @Test
   public void searchAnnotation() throws Exception {
     setupAnswerSearchQuery();
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/search/annotation?query=*");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -144,11 +145,11 @@ public final class TestSearchRpc extends BaseTsdbTest {
     assertTrue(result.contains("\"results\":[{\"tsuid\""));
     assertEquals(1, search_query.getResults().size());
   }
-  
+
   @Test
   public void searchEmptyResultSet() throws Exception {
     setupAnswerSearchQuery();
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/search/annotation?query=EMTPY");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -156,31 +157,31 @@ public final class TestSearchRpc extends BaseTsdbTest {
     assertTrue(result.contains("\"results\":[]"));
     assertEquals(0, search_query.getResults().size());
   }
-  
+
   @Test
   public void searchQSParseLimit() throws Exception {
     setupAnswerSearchQuery();
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/search/tsmeta?query=*&limit=42");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
     assertEquals(42, search_query.getLimit());
   }
-  
+
   @Test
   public void searchQSParseStartIndex() throws Exception {
     setupAnswerSearchQuery();
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/search/tsmeta?query=*&start_index=4");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
     assertEquals(4, search_query.getStartIndex());
   }
-  
+
   @Test
   public void searchPOST() throws Exception {
     setupAnswerSearchQuery();
-    final HttpQuery query = NettyMocks.postQuery(tsdb, 
+    final HttpQuery query = NettyMocks.postQuery(tsdb,
       "/api/search/tsmeta", "{\"query\":\"*\",\"limit\":42,\"startIndex\":2}");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -190,63 +191,63 @@ public final class TestSearchRpc extends BaseTsdbTest {
     assertEquals(42, search_query.getLimit());
     assertEquals(2, search_query.getStartIndex());
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void searchBadMethod() throws Exception {
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.PUT, "/api/search");
-    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel());
+    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel(), new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void searchMissingType() throws Exception {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/api/search?query=*");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void searchBadTypeType() throws Exception {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/search/badtype?query=*");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void searchMissingQuery() throws Exception {
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/api/search/tsmeta");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void searchPluginNotEnabled() throws Exception {
     Whitebox.setInternalState(tsdb, "search", (SearchPlugin)null);
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/search/tsmeta?query=*");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void searchInvalidLimit() throws Exception {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/search/tsmeta?query=*&limit=nan");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void searchInvalidStartIndex() throws Exception {
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/search/tsmeta?query=*&start_index=nan");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void searchLookupTagkOnlyMeta() throws Exception {
     setupLookup(true);
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/search/lookup?m={host=}");
     rpc.execute(tsdb, query);
-    
+
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
     final String result = query.response().getContent().toString(UTF);
     assertTrue(result.contains("\"host\":\"web01\""));
@@ -257,15 +258,15 @@ public final class TestSearchRpc extends BaseTsdbTest {
     assertTrue(result.contains("\"tsuid\":\"000004000001000001000003000005\""));
     assertTrue(result.contains("\"tsuid\":\"000004000001000002000003000005\""));
   }
-  
+
   @Test
   public void searchLookupPOSTTagkOnlyMeta() throws Exception {
     setupLookup(true);
-    final HttpQuery query = NettyMocks.postQuery(tsdb, 
+    final HttpQuery query = NettyMocks.postQuery(tsdb,
       "/api/search/lookup", "{\"tags\":[{\"key\":\"host\",\"value\":null}]}");
     query.setSerializer();
     rpc.execute(tsdb, query);
-    
+
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
     final String result = query.response().getContent().toString(UTF);
     assertTrue(result.contains("\"host\":\"web01\""));
@@ -276,14 +277,14 @@ public final class TestSearchRpc extends BaseTsdbTest {
     assertTrue(result.contains("\"tsuid\":\"000004000001000001000003000005\""));
     assertTrue(result.contains("\"tsuid\":\"000004000001000002000003000005\""));
   }
-  
+
   @Test
   public void searchLookupPOSTTagkOnlyData() throws Exception {
     setupLookup(false);
-    final HttpQuery query = NettyMocks.postQuery(tsdb, "/api/search/lookup", 
+    final HttpQuery query = NettyMocks.postQuery(tsdb, "/api/search/lookup",
       "{\"tags\":[{\"key\":\"host\",\"value\":null}],\"useMeta\":false}");
     rpc.execute(tsdb, query);
-    
+
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
     final String result = query.response().getContent().toString(UTF);
     assertTrue(result.contains("\"host\":\"web01\""));
@@ -294,48 +295,48 @@ public final class TestSearchRpc extends BaseTsdbTest {
     assertTrue(result.contains("\"tsuid\":\"000004000001000001000003000005\""));
     assertTrue(result.contains("\"tsuid\":\"000004000001000002000003000005\""));
   }
-  
+
   @Test
   public void searchLookupNoMetaTable() throws Exception {
     setupLookup(false);
-    final HttpQuery query = NettyMocks.postQuery(tsdb, "/api/search/lookup", 
+    final HttpQuery query = NettyMocks.postQuery(tsdb, "/api/search/lookup",
       "{\"tags\":[{\"key\":\"host\",\"value\":null}]}");
     rpc.execute(tsdb, query);
-    
-    assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, 
+
+    assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
         query.response().getStatus());
     final String result = query.response().getContent().toString(UTF);
     assertTrue(result.contains("\"code\":500"));
     assertTrue(result.contains("\"message\":\"Unexpected exception\""));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void searchLookupMissingQuery() throws Exception {
     setupLookup(true);
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/api/search/lookup");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void searchLookupBadQuery() throws Exception {
     setupLookup(true);
     final HttpQuery query = NettyMocks.getQuery(tsdb, "/api/search/lookup?m={");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void searchLookupNSUN() throws Exception {
     setupLookup(true);
-    final HttpQuery query = NettyMocks.getQuery(tsdb, 
+    final HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/search/lookup?m=" + NSUN_METRIC);
     rpc.execute(tsdb, query);
-    
+
     assertEquals(HttpResponseStatus.NOT_FOUND, query.response().getStatus());
     final String result = query.response().getContent().toString(UTF);
     assertTrue(result.contains("\"code\":404"));
     assertTrue(result.contains("\"details\":\"No such name"));
   }
-  
+
   @Test
   public void searchLookupNSUI() throws Exception {
     setupLookup(true);
@@ -348,26 +349,26 @@ public final class TestSearchRpc extends BaseTsdbTest {
                 new NoSuchUniqueId("metrics", new byte[] { 0, 0, 4 }));
           }
       });
-    final HttpQuery query = NettyMocks.postQuery(tsdb, 
+    final HttpQuery query = NettyMocks.postQuery(tsdb,
       "/api/search/lookup", "{\"tags\":[{\"key\":\"host\",\"value\":null}]}");
     query.setSerializer();
     rpc.execute(tsdb, query);
-    
+
     assertEquals(HttpResponseStatus.NOT_FOUND, query.response().getStatus());
     final String result = query.response().getContent().toString(UTF);
     assertTrue(result.contains("\"code\":404"));
     assertTrue(result.contains("\"details\":\"No such unique ID"));
   }
-  
+
   /**
-   * Configures an Answer to respond with when the tests call 
+   * Configures an Answer to respond with when the tests call
    * tsdb.executeSearch(), responding to the type of query requested with valid
    * responses for parsing tests.
    */
   private void setupAnswerSearchQuery() {
     mock_plugin = mock(SearchPlugin.class);
     Whitebox.setInternalState(tsdb, "search", mock_plugin);
-    
+
     when(mock_plugin.executeQuery((SearchQuery)any())).thenAnswer(
       new Answer<Deferred<SearchQuery>>() {
 
@@ -376,32 +377,32 @@ public final class TestSearchRpc extends BaseTsdbTest {
             throws Throwable {
           final Object[] args = invocation.getArguments();
           search_query = (SearchQuery)args[0];
-          
+
           List<Object> results = new ArrayList<Object>(1);
 
           // if we want an empty response, return an empty response
           if (search_query.getQuery().toUpperCase().equals("EMTPY")) {
             search_query.setResults(results);
             search_query.setTotalResults(0);
-            
+
             return Deferred.fromResult(search_query);
           }
-          
+
           switch(search_query.getType()) {
             case TSMETA:
               final TSMeta meta = new TSMeta("000001000001000001");
               meta.setCreated(1356998400);
               meta.setDescription("System CPU metric");
-              
+
               UIDMeta uid = new UIDMeta(UniqueIdType.METRIC, "000001");
               final Field uid_name = UIDMeta.class.getDeclaredField("name");
               uid_name.setAccessible(true);
               uid_name.set(uid, "sys.cpu.0");
-              
+
               final Field metric = TSMeta.class.getDeclaredField("metric");
               metric.setAccessible(true);
               metric.set(meta, uid);
-              
+
               final ArrayList<UIDMeta> tags = new ArrayList<UIDMeta>(2);
               uid = new UIDMeta(UniqueIdType.TAGK, "000001");
               uid_name.set(uid, "host");
@@ -409,18 +410,18 @@ public final class TestSearchRpc extends BaseTsdbTest {
               uid = new UIDMeta(UniqueIdType.TAGV, "000001");
               uid_name.set(uid, "web01");
               tags.add(uid);
-              
+
               final Field tags_field = TSMeta.class.getDeclaredField("tags");
               tags_field.setAccessible(true);
               tags_field.set(meta, tags);
               results.add(meta);
               break;
-            
+
             case LOOKUP:
             case TSMETA_SUMMARY:
               final HashMap<String, Object> ts = new HashMap<String, Object>(1);
               ts.put("metric", "sys.cpu.0");
-              final HashMap<String, String> tag_map = 
+              final HashMap<String, String> tag_map =
                 new HashMap<String, String>(2);
               tag_map.put("host", "web01");
               tag_map.put("owner", "ops");
@@ -428,24 +429,24 @@ public final class TestSearchRpc extends BaseTsdbTest {
               ts.put("tsuid", "000001000001000001");
               results.add(ts);
               break;
-              
+
             case TSUIDS:
               results.add("000001000001000001");
               results.add("000002000002000002");
               break;
-              
+
             case UIDMETA:
               UIDMeta uid2 = new UIDMeta(UniqueIdType.METRIC, "000001");
               final Field name_field = UIDMeta.class.getDeclaredField("name");
               name_field.setAccessible(true);
               name_field.set(uid2, "sys.cpu.0");
               results.add(uid2);
-              
+
               uid2 = new UIDMeta(UniqueIdType.TAGK, "000001");
               name_field.set(uid2, "host");
               results.add(uid2);
               break;
-              
+
             case ANNOTATION:
               final Annotation note = new Annotation();
               note.setStartTime(1356998400);
@@ -454,13 +455,13 @@ public final class TestSearchRpc extends BaseTsdbTest {
               note.setTSUID("000001000001000001");
               results.add(note);
               break;
-              
+
           }
-          
+
           search_query.setResults(results);
           search_query.setTotalResults(results.size());
           search_query.setTime(0.42F);
-          
+
           return Deferred.fromResult(search_query);
         }
 
@@ -474,7 +475,7 @@ public final class TestSearchRpc extends BaseTsdbTest {
     } else {
       TestTimeSeriesLookup.generateData(tsdb, storage);
     }
-    
+
     when(metrics.getNameAsync(new byte[] { 0, 0, 4 }))
       .thenAnswer(new Answer<Deferred<String>>() {
             @Override

--- a/test/tsd/TestStatsRpc.java
+++ b/test/tsd/TestStatsRpc.java
@@ -32,12 +32,12 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({HttpJsonSerializer.class, TSDB.class, Config.class, 
+@PrepareForTest({HttpJsonSerializer.class, TSDB.class, Config.class,
   HttpQuery.class, Thread.class, HBaseClient.class })
 public class TestStatsRpc {
   private TSDB tsdb;
   private HBaseClient client;
-  
+
   @Before
   public void before() throws Exception {
     tsdb = NettyMocks.getMockedHTTPTSDB();
@@ -51,21 +51,21 @@ public class TestStatsRpc {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/api/stats/threads");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    final String json = 
+    final String json =
         query.response().getContent().toString(Charset.forName("UTF-8"));
     assertNotNull(json);
     // check for some standard JVM threads since we can't mock Thread easily
     assertTrue(json.contains("\"name\":\"Finalizer\""));
     assertTrue(json.contains("java.lang.ref.Finalizer$FinalizerThread.run"));
   }
-  
+
   @Test
   public void printJVMStats() throws Exception {
     final StatsRpc rpc = new StatsRpc();
     HttpQuery query = NettyMocks.getQuery(tsdb, "/api/stats/jvm");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    final String json = 
+    final String json =
         query.response().getContent().toString(Charset.forName("UTF-8"));
     assertNotNull(json);
     assertTrue(json.contains("\"os\":{"));

--- a/test/tsd/TestTreeRpc.java
+++ b/test/tsd/TestTreeRpc.java
@@ -25,6 +25,7 @@ import java.util.TreeMap;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.meta.TSMeta;
 import net.opentsdb.meta.UIDMeta;
+import net.opentsdb.stats.Histogram;
 import net.opentsdb.storage.MockBase;
 import net.opentsdb.tree.Branch;
 import net.opentsdb.tree.Leaf;
@@ -68,7 +69,7 @@ public final class TestTreeRpc {
   private HBaseClient client = mock(HBaseClient.class);
   private MockBase storage;
   private TreeRpc rpc = new TreeRpc();
-  
+
   final static private Method branchToStorageJson;
   static {
     try {
@@ -78,7 +79,7 @@ public final class TestTreeRpc {
       throw new RuntimeException("Failed in static initializer", e);
     }
   }
-  
+
   final static private Method TreetoStorageJson;
   static {
     try {
@@ -88,7 +89,7 @@ public final class TestTreeRpc {
       throw new RuntimeException("Failed in static initializer", e);
     }
   }
-  
+
   final static private Method LeaftoStorageJson;
   static {
     try {
@@ -98,7 +99,7 @@ public final class TestTreeRpc {
       throw new RuntimeException("Failed in static initializer", e);
     }
   }
-  
+
   final static private Method TSMetagetStorageJSON;
   static {
     try {
@@ -108,7 +109,7 @@ public final class TestTreeRpc {
       throw new RuntimeException("Failed in static initializer", e);
     }
   }
-  
+
   final static private Method UIDMetagetStorageJSON;
   static {
     try {
@@ -118,7 +119,7 @@ public final class TestTreeRpc {
       throw new RuntimeException("Failed in static initializer", e);
     }
   }
-  
+
   @Before
   public void before() throws Exception {
     final Config config = new Config(false);
@@ -128,30 +129,30 @@ public final class TestTreeRpc {
     families.add(Tree.TREE_FAMILY());
     storage.addTable(TREE_TABLE, families);
   }
-  
+
   @Test
   public void constructor() throws Exception {
     new TreeRpc();
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void noRoute() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb,  "/api/tree/noroute");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleTreeBadMethod() throws Exception {
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.TRACE, "/api/tree");
-    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel());
+    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel(), new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleTreeGetAll() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -160,11 +161,11 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"name\":\"2nd Tree\""));
   }
-  
+
   @Test
   public void handleTreeGetSingle() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree?treeid=2");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -173,52 +174,52 @@ public final class TestTreeRpc {
     assertFalse(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"name\":\"Test Tree\""));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleTreeGetNotFound() throws Exception {
     setupStorage();
     HttpQuery query = NettyMocks.getQuery(tsdb, "/api/tree?treeid=3");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleTreeGetBadID655536() throws Exception {
     HttpQuery query = NettyMocks.getQuery(tsdb, "/api/tree?treeid=655536");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleTreeQSCreate() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree?name=NewTree&method_override=post");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
     assertEquals(1, storage.numColumns(TREE_TABLE, new byte[] { 0, 3 }));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleTreeQSCreateNoName() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree?method_override=post&description=HelloWorld");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleTreeQSCreateOutOfIDs() throws Exception {
     setupStorage();
-    storage.addColumn(new byte[] { (byte) 0xFF, (byte) 0xFF }, 
+    storage.addColumn(new byte[] { (byte) 0xFF, (byte) 0xFF },
         "tree".getBytes(MockBase.ASCII()), "{}".getBytes(MockBase.ASCII()));
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree?method_override=post");
     rpc.execute(tsdb, query);
   }
-    
+
   @Test
   public void handleTreePOSTCreate() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
       "/api/tree", "{\"name\":\"New Tree\"}");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -228,7 +229,7 @@ public final class TestTreeRpc {
   @Test
   public void handleTreeQSModify() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree?treeid=1&method_override=post&description=HelloWorld");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -237,28 +238,28 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"name\":\"Test Tree\""));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleTreeQSModifyNotFound() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree?treeid=3&method_override=post&description=HelloWorld");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleTreeQSModifyNotModified() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree?treeid=1&method_override=post");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.NOT_MODIFIED, query.response().getStatus());
   }
-  
+
   @Test
   public void handleTreePOSTModify() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
       "/api/tree", "{\"treeId\":1,\"description\":\"Hello World\"}");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -267,28 +268,28 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"name\":\"Test Tree\""));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleTreeQSPutNotFound() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree?treeid=3&method_override=put&description=HelloWorld");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleTreeQSPutNotModified() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree?treeid=1&method_override=put");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.NOT_MODIFIED, query.response().getStatus());
   }
-  
+
   @Test
   public void handleTreeQSPut() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree?treeid=1&method_override=put&description=HelloWorld");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -297,11 +298,11 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"name\":\"\""));
   }
-  
+
   @Test
   public void handleTreePOSTPut() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.putQuery(tsdb, 
+    HttpQuery query = NettyMocks.putQuery(tsdb,
       "/api/tree", "{\"treeId\":1,\"description\":\"Hello World\"}");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -314,7 +315,7 @@ public final class TestTreeRpc {
   @Test
   public void handleTreeQSDeleteDefault() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree?treeid=1&method_override=delete");
     // make sure the root is there BEFORE we delete
     assertEquals(4, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
@@ -322,16 +323,16 @@ public final class TestTreeRpc {
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
     // make sure the definition is still there but the root is gone
     assertEquals(3, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
-    assertEquals(-1, storage.numColumns(TREE_TABLE, 
+    assertEquals(-1, storage.numColumns(TREE_TABLE,
         Branch.stringToId("00010001BECD000181A8")));
-    assertEquals(-1, storage.numColumns(TREE_TABLE, 
+    assertEquals(-1, storage.numColumns(TREE_TABLE,
         Branch.stringToId("00010001BECD000181A8BF992A99")));
   }
-  
+
   @Test
   public void handleTreeQSDeleteDefinition() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree?treeid=1&method_override=delete&definition=true");
     // make sure the root is there BEFORE we delete
     assertEquals(4, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
@@ -339,16 +340,16 @@ public final class TestTreeRpc {
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
     // make sure the definition has been deleted too
     assertEquals(-1, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
-    assertEquals(-1, storage.numColumns(TREE_TABLE, 
+    assertEquals(-1, storage.numColumns(TREE_TABLE,
         Branch.stringToId("00010001BECD000181A8")));
-    assertEquals(-1, storage.numColumns(TREE_TABLE, 
+    assertEquals(-1, storage.numColumns(TREE_TABLE,
         Branch.stringToId("00010001BECD000181A8BF992A99")));
   }
-  
+
   @Test
   public void handleTreePOSTDeleteDefault() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.deleteQuery(tsdb, 
+    HttpQuery query = NettyMocks.deleteQuery(tsdb,
       "/api/tree", "{\"treeId\":1}");
     // make sure the root is there BEFORE we delete
     assertEquals(4, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
@@ -356,16 +357,16 @@ public final class TestTreeRpc {
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
     // make sure the definition is still there but the root is gone
     assertEquals(3, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
-    assertEquals(-1, storage.numColumns(TREE_TABLE, 
+    assertEquals(-1, storage.numColumns(TREE_TABLE,
         Branch.stringToId("00010001BECD000181A8")));
-    assertEquals(-1, storage.numColumns(TREE_TABLE, 
+    assertEquals(-1, storage.numColumns(TREE_TABLE,
         Branch.stringToId("00010001BECD000181A8BF992A99")));
   }
-  
+
   @Test
   public void handleTreePOSTDeleteDefinition() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.deleteQuery(tsdb, 
+    HttpQuery query = NettyMocks.deleteQuery(tsdb,
       "/api/tree", "{\"treeId\":1,\"definition\":true}");
     // make sure the root is there BEFORE we delete
     assertEquals(4, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
@@ -373,16 +374,16 @@ public final class TestTreeRpc {
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
     // make sure the definition has been deleted too
     assertEquals(-1, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
-    assertEquals(-1, storage.numColumns(TREE_TABLE, 
+    assertEquals(-1, storage.numColumns(TREE_TABLE,
         Branch.stringToId("00010001BECD000181A8")));
-    assertEquals(-1, storage.numColumns(TREE_TABLE, 
+    assertEquals(-1, storage.numColumns(TREE_TABLE,
         Branch.stringToId("00010001BECD000181A8BF992A99")));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleTreeQSDeleteNotFound() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree?treeid=3&method_override=delete");
     rpc.execute(tsdb, query);
   }
@@ -398,12 +399,12 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"branches\":null"));
   }
-  
+
   @Test
   public void handleBranchChild() throws Exception {
     setupStorage();
     setupBranch();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/branch?branch=00010001BECD000181A8");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -412,35 +413,35 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"branches\":["));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleBranchNotFound() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/branch?branch=00010001BECD000181A8BBBBB");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleBranchNoTree() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/branch");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleBranchBadMethod() throws Exception {
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.TRACE, "/api/tree/branch");
-    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel());
+    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel(), new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleRuleGetQS() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?treeid=1&level=1&order=0");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -449,51 +450,51 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"level\":1"));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRuleGetQSNotFound() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?treeid=1&level=2&order=2");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRuleGetQSTreeNotFound() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?treeid=4&level=1&order=0");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRuleGetQSMissingTree() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?level=1&order=0");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRuleGetQSMissingLevel() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?treeid=1&order=0");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRuleGetQSMissingOrder() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?treeid=1&level=1");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleRuleQSNew() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?treeid=1&level=2&order=1&description=Testing" +
       "&method_override=post&type=metric");
     rpc.execute(tsdb, query);
@@ -503,37 +504,37 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"level\":2"));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRuleQSNewFailValidation() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?treeid=1&level=2&order=1&description=Testing" +
       "&method_override=post&type=tagk");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRuleQSNewMissingType() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?treeid=1&level=2&order=1&description=Testing&method_override=post");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleRuleQSNotModified() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?treeid=1&level=1&order=0&method_override=post");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.NOT_MODIFIED, query.response().getStatus());
   }
-  
+
   @Test
   public void handleRuleQSModify() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?treeid=1&level=1&order=0&description=Testing&method_override=post");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -544,11 +545,11 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"notes\":\"Metric rule\""));
   }
-  
+
   @Test
   public void handleRulePOSTNew() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
       "/api/tree/rule", "{\"treeId\":1,\"level\":2,\"order\":2,\"description\":" +
       "\"Testing\",\"type\":\"metric\"}");
     rpc.execute(tsdb, query);
@@ -562,7 +563,7 @@ public final class TestTreeRpc {
   @Test
   public void handleRulePOSTModify() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
       "/api/tree/rule", "{\"treeId\":1,\"level\":1,\"order\":0,\"description\":" +
       "\"Testing\"}");
     rpc.execute(tsdb, query);
@@ -574,20 +575,20 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"notes\":\"Metric rule\""));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRulesPOSTNoRules() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
       "/api/tree/rules", "");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleRuleQSPut() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
-      "/api/tree/rule?treeid=1&level=1&order=0&description=Testing" + 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
+      "/api/tree/rule?treeid=1&level=1&order=0&description=Testing" +
       "&method_override=put&type=metric");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -598,19 +599,19 @@ public final class TestTreeRpc {
     assertFalse(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"notes\":\"Metric rule\""));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRuleQSPutMissingType() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?treeid=1&level=1&order=0&description=Testing&method_override=put");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleRulePUT() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.putQuery(tsdb, 
+    HttpQuery query = NettyMocks.putQuery(tsdb,
       "/api/tree/rule", "{\"treeId\":1,\"level\":1,\"order\":0,\"description\":" +
       "\"Testing\",\"type\":\"metric\"}");
     rpc.execute(tsdb, query);
@@ -622,55 +623,55 @@ public final class TestTreeRpc {
     assertFalse(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"notes\":\"Metric rule\""));
   }
-  
+
   @Test
   public void handleRuleQSDelete() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?treeid=1&level=1&order=0&method_override=delete");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
     assertEquals(3, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRuleQSDeleteNotFound() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rule?treeid=1&level=2&order=0&method_override=delete");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleRuleDELETE() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.deleteQuery(tsdb, 
+    HttpQuery query = NettyMocks.deleteQuery(tsdb,
       "/api/tree/rule", "{\"treeId\":1,\"level\":1,\"order\":0}");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
     assertEquals(3, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRuleBadMethod() throws Exception {
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.TRACE, "/api/tree/rule");
-    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel());
+    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel(), new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRulesGetQS() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rules?treeid=1");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleRulesPOST() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
       "/api/tree/rules", "[{\"treeId\":1,\"level\":0,\"order\":0,\"type\":" +
       "\"METRIC\"},{\"treeId\":1,\"level\":0,\"order\":1,\"type\":\"tagk\"," +
       "\"field\":\"fqdn\"},{\"treeId\":1,\"level\":1,\"order\":0,\"type\":" +
@@ -678,25 +679,25 @@ public final class TestTreeRpc {
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
     assertEquals(5, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
-    final String rule = new String(storage.getColumn(TREE_TABLE, 
-        new byte[] { 0, 1 }, Tree.TREE_FAMILY(), 
+    final String rule = new String(storage.getColumn(TREE_TABLE,
+        new byte[] { 0, 1 }, Tree.TREE_FAMILY(),
         "tree_rule:0:0".getBytes(MockBase.ASCII())), MockBase.ASCII());
     assertTrue(rule.contains("\"type\":\"METRIC\""));
     assertTrue(rule.contains("description\":\"Host Name\""));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRulesPOSTEmpty() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
       "/api/tree/rules", "[]]");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleRulesPUT() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.putQuery(tsdb, 
+    HttpQuery query = NettyMocks.putQuery(tsdb,
       "/api/tree/rules", "[{\"treeId\":1,\"level\":0,\"order\":0,\"type\":" +
       "\"METRIC\"},{\"treeId\":1,\"level\":0,\"order\":1,\"type\":\"tagk\"," +
       "\"field\":\"fqdn\"},{\"treeId\":1,\"level\":1,\"order\":0,\"type\":" +
@@ -704,58 +705,58 @@ public final class TestTreeRpc {
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
     assertEquals(5, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
-    final String rule = new String(storage.getColumn(TREE_TABLE, 
-        new byte[] { 0, 1 }, Tree.TREE_FAMILY(), 
+    final String rule = new String(storage.getColumn(TREE_TABLE,
+        new byte[] { 0, 1 }, Tree.TREE_FAMILY(),
         "tree_rule:0:0".getBytes(MockBase.ASCII())), MockBase.ASCII());
     assertTrue(rule.contains("\"type\":\"METRIC\""));
     assertFalse(rule.contains("\"description\":\"Host Name\""));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRulesPOSTTreeMissmatch() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
       "/api/tree/rules", "[{\"treeId\":2,\"level\":0,\"order\":0,\"type\":" +
       "\"METRIC\"},{\"treeId\":1,\"level\":0,\"order\":1,\"type\":\"tagk\"," +
       "\"field\":\"fqdn\"},{\"treeId\":1,\"level\":1,\"order\":0,\"type\":" +
       "\"tagk\",\"field\":\"host\"}]");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleRulesDeleteQS() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
       "/api/tree/rules?treeid=1&method_override=delete");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
     assertEquals(2, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
   }
-  
+
   @Test
   public void handleRulesDelete() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.deleteQuery(tsdb, 
+    HttpQuery query = NettyMocks.deleteQuery(tsdb,
       "/api/tree/rules?treeid=1", "");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
     assertEquals(2, storage.numColumns(TREE_TABLE, new byte[] { 0, 1 }));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleRulesDeleteTreeNotFound() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.deleteQuery(tsdb, 
+    HttpQuery query = NettyMocks.deleteQuery(tsdb,
       "/api/tree/rules?treeid=5", "");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleTestQS() throws Exception {
     setupStorage();
     setupBranch();
     setupTSMeta();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/test?treeid=1&tsuids=000001000001000001000002000002");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -764,13 +765,13 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("000001000001000001000002000002"));
   }
-  
+
   @Test
   public void handleTestQSMulti() throws Exception {
     setupStorage();
     setupBranch();
     setupTSMeta();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/test?treeid=1&tsuids=000001000001000001000002000002," +
         "000001000001000001000002000003");
     rpc.execute(tsdb, query);
@@ -784,14 +785,14 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("Unable to locate TSUID meta data"));
   }
-  
+
   @Test
   public void handleTestPOST() throws Exception {
     setupStorage();
     setupBranch();
     setupTSMeta();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
-        "/api/tree/test", "{\"treeId\":1,\"tsuids\":[" + 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
+        "/api/tree/test", "{\"treeId\":1,\"tsuids\":[" +
         "\"000001000001000001000002000002\"]}");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -800,14 +801,14 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("000001000001000001000002000002"));
   }
-  
+
   @Test
   public void handleTestPUT() throws Exception {
     setupStorage();
     setupBranch();
     setupTSMeta();
-    HttpQuery query = NettyMocks.putQuery(tsdb, 
-        "/api/tree/test", "{\"treeId\":1,\"tsuids\":[" + 
+    HttpQuery query = NettyMocks.putQuery(tsdb,
+        "/api/tree/test", "{\"treeId\":1,\"tsuids\":[" +
         "\"000001000001000001000002000002\"]}");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -816,14 +817,14 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("000001000001000001000002000002"));
   }
-  
+
   @Test
   public void handleTestPOSTMulti() throws Exception {
     setupStorage();
     setupBranch();
     setupTSMeta();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
-        "/api/tree/test", "{\"treeId\":1,\"tsuids\":[" + 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
+        "/api/tree/test", "{\"treeId\":1,\"tsuids\":[" +
         "\"000001000001000001000002000002\"," +
         "\"000001000001000001000002000003\"]}");
     rpc.execute(tsdb, query);
@@ -837,13 +838,13 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("Unable to locate TSUID meta data"));
   }
-  
+
   @Test
   public void handleTestTSUIDNotFound() throws Exception {
     setupStorage();
     setupBranch();
     setupTSMeta();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/test?treeid=1&tsuids=000001000001000001000002000003");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -851,16 +852,16 @@ public final class TestTreeRpc {
         .contains("Unable to locate TSUID meta data"));
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("000001000001000001000002000003"));
-    
+
   }
-  
+
   @Test
   public void handleTestNSU() throws Exception {
     setupStorage();
     setupBranch();
     setupTSMeta();
     storage.flushRow("tsdb-uid".getBytes(), new byte[] { 0, 0, 2 });
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/test?treeid=1&tsuids=000001000001000001000002000002");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -869,61 +870,61 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("000001000001000001000002000002"));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleTestTreeNotFound() throws Exception {
     setupStorage();
     setupBranch();
     setupTSMeta();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/test?treeid=3&tsuids=000001000001000001000002000002");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleTestMissingTreeId() throws Exception {
     setupStorage();
     setupBranch();
     setupTSMeta();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/test?tsuids=000001000001000001000002000002");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleTestQSMissingTSUIDs() throws Exception {
     setupStorage();
     setupBranch();
     setupTSMeta();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/test?treeid=1");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleTestPOSTMissingTSUIDs() throws Exception {
     setupStorage();
     setupBranch();
     setupTSMeta();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
         "/api/tree/test", "{\"treeId\":1}");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleTestBadMethod() throws Exception {
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.TRACE, "/api/tree/test");
-    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel());
+    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel(), new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleCollissionsQS() throws Exception {
     setupStorage();
     setupBranch();
     setupTSMeta();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/collisions?treeid=1");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -932,22 +933,22 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"020202\":\"BBBBBB\""));
   }
-  
+
   @Test
   public void handleCollissionsQSSingleTSUID() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/collisions?treeid=1&tsuids=010101");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    assertEquals("{\"010101\":\"AAAAAA\"}", 
+    assertEquals("{\"010101\":\"AAAAAA\"}",
         query.response().getContent().toString(MockBase.ASCII()));
   }
-  
+
   @Test
   public void handleCollissionsQSTSUIDs() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/collisions?treeid=1&tsuids=010101,020202");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -956,22 +957,22 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"020202\":\"BBBBBB\""));
   }
-  
+
   @Test
   public void handleCollissionsQSTSUIDNotFound() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/collisions?treeid=1&tsuids=030101");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    assertEquals("{}", 
+    assertEquals("{}",
         query.response().getContent().toString(MockBase.ASCII()));
   }
-  
+
   @Test
   public void handleCollissionsPOST() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
         "/api/tree/collisions", "{\"treeId\":1}");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -980,22 +981,22 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"020202\":\"BBBBBB\""));
   }
-  
+
   @Test
   public void handleCollissionsPOSTSingleTSUID() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
         "/api/tree/collisions", "{\"treeId\":1,\"tsuids\":[\"020202\"]}");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    assertEquals("{\"020202\":\"BBBBBB\"}", 
+    assertEquals("{\"020202\":\"BBBBBB\"}",
         query.response().getContent().toString(MockBase.ASCII()));
   }
-  
+
   @Test
   public void handleCollissionsPOSTTSUIDs() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
         "/api/tree/collisions", "{\"treeId\":1,\"tsuids\":" +
         "[\"010101\",\"020202\"]}");
     rpc.execute(tsdb, query);
@@ -1005,35 +1006,35 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"020202\":\"BBBBBB\""));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleCollissionsTreeNotFound() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/collisions?treeid=5");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleCollissionsMissingTreeId() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/collisions");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleCollissionsBadMethod() throws Exception {
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.TRACE, "/api/tree/collisions");
-    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel());
+    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel(), new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     rpc.execute(tsdb, query);
   }
-  
+
   @Test
   public void handleNotMatchedQS() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/notmatched?treeid=1");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -1042,22 +1043,22 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"020202\":\"Failed rule 1:1\""));
   }
-  
+
   @Test
   public void handleNotMatchedQSSingleTSUID() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/notmatched?treeid=1&tsuids=010101");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    assertEquals("{\"010101\":\"Failed rule 0:0\"}", 
+    assertEquals("{\"010101\":\"Failed rule 0:0\"}",
         query.response().getContent().toString(MockBase.ASCII()));
   }
-  
+
   @Test
   public void handleNotMatchedQSTSUIDs() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/notmatched?treeid=1&tsuids=010101,020202");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -1066,22 +1067,22 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"020202\":\"Failed rule 1:1\""));
   }
-  
+
   @Test
   public void handleNotMatchedQSTSUIDNotFound() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/notmatched?treeid=1&tsuids=030101");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    assertEquals("{}", 
+    assertEquals("{}",
         query.response().getContent().toString(MockBase.ASCII()));
   }
-  
+
   @Test
   public void handleNotMatchedPOST() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
         "/api/tree/notmatched", "{\"treeId\":1}");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
@@ -1090,22 +1091,22 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"020202\":\"Failed rule 1:1\""));
   }
-  
+
   @Test
   public void handleNotMatchedPOSTSingleTSUID() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
         "/api/tree/notmatched", "{\"treeId\":1,\"tsuids\":[\"020202\"]}");
     rpc.execute(tsdb, query);
     assertEquals(HttpResponseStatus.OK, query.response().getStatus());
-    assertEquals("{\"020202\":\"Failed rule 1:1\"}", 
+    assertEquals("{\"020202\":\"Failed rule 1:1\"}",
         query.response().getContent().toString(MockBase.ASCII()));
   }
-  
+
   @Test
   public void handleNotMatchedPOSTTSUIDs() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.postQuery(tsdb, 
+    HttpQuery query = NettyMocks.postQuery(tsdb,
         "/api/tree/notmatched", "{\"treeId\":1,\"tsuids\":" +
         "[\"010101\",\"020202\"]}");
     rpc.execute(tsdb, query);
@@ -1115,33 +1116,33 @@ public final class TestTreeRpc {
     assertTrue(query.response().getContent().toString(MockBase.ASCII())
         .contains("\"020202\":\"Failed rule 1:1\""));
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleNotMatchedNotFound() throws Exception {
     setupStorage();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/notmatched?treeid=5");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleNotMatchedMissingTreeId() throws Exception {
     setupStorage();
     setupBranch();
     setupTSMeta();
-    HttpQuery query = NettyMocks.getQuery(tsdb, 
+    HttpQuery query = NettyMocks.getQuery(tsdb,
         "/api/tree/notmatched");
     rpc.execute(tsdb, query);
   }
-  
+
   @Test (expected = BadRequestException.class)
   public void handleNotMatchedBadMethod() throws Exception {
-    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 
+    final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
         HttpMethod.TRACE, "/api/tree/notmatched");
-    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel());
+    final HttpQuery query = new HttpQuery(tsdb, req, NettyMocks.fakeChannel(), new Histogram(), new GraphHandler(new Histogram(), new Histogram()));
     rpc.execute(tsdb, query);
   }
-  
+
   /**
    * Setups objects in MockBase including two trees, rule sets, root branch,
    * child branch, leaves and some collisions and no matches. These are used for
@@ -1149,7 +1150,7 @@ public final class TestTreeRpc {
    */
   private void setupStorage() throws Exception {
     Tree tree = TestTree.buildTestTree();
- 
+
     // store root
     TreeMap<Integer, String> root_path = new TreeMap<Integer, String>();
     Branch root = new Branch(tree.getTreeId());
@@ -1157,22 +1158,22 @@ public final class TestTreeRpc {
     root_path.put(0, "ROOT");
     root.prependParentPath(root_path);
     storage.addColumn(TREE_TABLE, root.compileBranchId(), Tree.TREE_FAMILY(),
-        "branch".getBytes(MockBase.ASCII()), 
+        "branch".getBytes(MockBase.ASCII()),
         (byte[])branchToStorageJson.invoke(root));
-    
+
     // store the first tree
     byte[] key = new byte[] { 0, 1 };
-    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), 
-        "tree".getBytes(MockBase.ASCII()), 
+    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(),
+        "tree".getBytes(MockBase.ASCII()),
         (byte[])TreetoStorageJson.invoke(TestTree.buildTestTree()));
-    
+
     TreeRule rule = new TreeRule(1);
     rule.setField("host");
     rule.setDescription("Hostname rule");
     rule.setType(TreeRuleType.TAGK);
     rule.setDescription("Host Name");
-    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), 
-        "tree_rule:0:0".getBytes(MockBase.ASCII()), 
+    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(),
+        "tree_rule:0:0".getBytes(MockBase.ASCII()),
         JSON.serializeToBytes(rule));
 
     rule = new TreeRule(1);
@@ -1181,18 +1182,18 @@ public final class TestTreeRpc {
     rule.setNotes("Metric rule");
     rule.setType(TreeRuleType.METRIC);
     storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(),
-        "tree_rule:1:0".getBytes(MockBase.ASCII()), 
+        "tree_rule:1:0".getBytes(MockBase.ASCII()),
         JSON.serializeToBytes(rule));
-    
+
     root = new Branch(1);
     root.setDisplayName("ROOT");
     root_path = new TreeMap<Integer, String>();
     root_path.put(0, "ROOT");
     root.prependParentPath(root_path);
-    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), 
-        "branch".getBytes(MockBase.ASCII()), 
+    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(),
+        "branch".getBytes(MockBase.ASCII()),
         (byte[])branchToStorageJson.invoke(root));
-    
+
     // tree 2
     key = new byte[] { 0, 2 };
 
@@ -1200,83 +1201,83 @@ public final class TestTreeRpc {
     tree2.setTreeId(2);
     tree2.setName("2nd Tree");
     tree2.setDescription("Other Tree");
-    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), 
-        "tree".getBytes(MockBase.ASCII()), 
+    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(),
+        "tree".getBytes(MockBase.ASCII()),
         (byte[])TreetoStorageJson.invoke(tree2));
-    
+
     rule = new TreeRule(2);
     rule.setField("host");
     rule.setType(TreeRuleType.TAGK);
-    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), 
-        "tree_rule:0:0".getBytes(MockBase.ASCII()), 
+    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(),
+        "tree_rule:0:0".getBytes(MockBase.ASCII()),
         JSON.serializeToBytes(rule));
-    
+
     rule = new TreeRule(2);
     rule.setField("");
     rule.setLevel(1);
     rule.setType(TreeRuleType.METRIC);
-    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), 
-        "tree_rule:1:0".getBytes(MockBase.ASCII()), 
+    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(),
+        "tree_rule:1:0".getBytes(MockBase.ASCII()),
         JSON.serializeToBytes(rule));
-    
+
     root = new Branch(2);
     root.setDisplayName("ROOT");
     root_path = new TreeMap<Integer, String>();
     root_path.put(0, "ROOT");
     root.prependParentPath(root_path);
-    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), 
-        "branch".getBytes(MockBase.ASCII()), 
+    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(),
+        "branch".getBytes(MockBase.ASCII()),
         (byte[])branchToStorageJson.invoke(root));
-    
+
     // sprinkle in some collisions and no matches for fun
     // collisions
     key = new byte[] { 0, 1, 1 };
     String tsuid = "010101";
-    byte[] qualifier = new byte[Tree.COLLISION_PREFIX().length + 
+    byte[] qualifier = new byte[Tree.COLLISION_PREFIX().length +
                                       (tsuid.length() / 2)];
-    System.arraycopy(Tree.COLLISION_PREFIX(), 0, qualifier, 0, 
+    System.arraycopy(Tree.COLLISION_PREFIX(), 0, qualifier, 0,
         Tree.COLLISION_PREFIX().length);
     byte[] tsuid_bytes = UniqueId.stringToUid(tsuid);
-    System.arraycopy(tsuid_bytes, 0, qualifier, Tree.COLLISION_PREFIX().length, 
+    System.arraycopy(tsuid_bytes, 0, qualifier, Tree.COLLISION_PREFIX().length,
         tsuid_bytes.length);
-    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), qualifier, 
+    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), qualifier,
         "AAAAAA".getBytes(MockBase.ASCII()));
-    
+
     tsuid = "020202";
-    qualifier = new byte[Tree.COLLISION_PREFIX().length + 
+    qualifier = new byte[Tree.COLLISION_PREFIX().length +
                                       (tsuid.length() / 2)];
-    System.arraycopy(Tree.COLLISION_PREFIX(), 0, qualifier, 0, 
+    System.arraycopy(Tree.COLLISION_PREFIX(), 0, qualifier, 0,
         Tree.COLLISION_PREFIX().length);
     tsuid_bytes = UniqueId.stringToUid(tsuid);
-    System.arraycopy(tsuid_bytes, 0, qualifier, Tree.COLLISION_PREFIX().length, 
+    System.arraycopy(tsuid_bytes, 0, qualifier, Tree.COLLISION_PREFIX().length,
         tsuid_bytes.length);
-    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), qualifier, 
+    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), qualifier,
         "BBBBBB".getBytes(MockBase.ASCII()));
-    
+
     // not matched
     key = new byte[] { 0, 1, 2 };
     tsuid = "010101";
-    qualifier = new byte[Tree.NOT_MATCHED_PREFIX().length + 
+    qualifier = new byte[Tree.NOT_MATCHED_PREFIX().length +
                              (tsuid.length() / 2)];
-    System.arraycopy(Tree.NOT_MATCHED_PREFIX(), 0, qualifier, 0, 
+    System.arraycopy(Tree.NOT_MATCHED_PREFIX(), 0, qualifier, 0,
         Tree.NOT_MATCHED_PREFIX().length);
     tsuid_bytes = UniqueId.stringToUid(tsuid);
-    System.arraycopy(tsuid_bytes, 0, qualifier, Tree.NOT_MATCHED_PREFIX().length, 
+    System.arraycopy(tsuid_bytes, 0, qualifier, Tree.NOT_MATCHED_PREFIX().length,
     tsuid_bytes.length);
-    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), qualifier, 
+    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), qualifier,
         "Failed rule 0:0".getBytes(MockBase.ASCII()));
-    
+
     tsuid = "020202";
-    qualifier = new byte[Tree.NOT_MATCHED_PREFIX().length + 
+    qualifier = new byte[Tree.NOT_MATCHED_PREFIX().length +
                              (tsuid.length() / 2)];
-    System.arraycopy(Tree.NOT_MATCHED_PREFIX(), 0, qualifier, 0, 
+    System.arraycopy(Tree.NOT_MATCHED_PREFIX(), 0, qualifier, 0,
         Tree.NOT_MATCHED_PREFIX().length);
     tsuid_bytes = UniqueId.stringToUid(tsuid);
-    System.arraycopy(tsuid_bytes, 0, qualifier, Tree.NOT_MATCHED_PREFIX().length, 
+    System.arraycopy(tsuid_bytes, 0, qualifier, Tree.NOT_MATCHED_PREFIX().length,
     tsuid_bytes.length);
-    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), qualifier, 
+    storage.addColumn(TREE_TABLE, key, Tree.TREE_FAMILY(), qualifier,
         "Failed rule 1:1".getBytes(MockBase.ASCII()));
-    
+
     // drop some branches in for tree 1
     Branch branch = new Branch(1);
     TreeMap<Integer, String> path = new TreeMap<Integer, String>();
@@ -1286,37 +1287,37 @@ public final class TestTreeRpc {
     branch.prependParentPath(path);
     branch.setDisplayName("cpu");
     storage.addColumn(TREE_TABLE, branch.compileBranchId(), Tree.TREE_FAMILY(),
-        "branch".getBytes(MockBase.ASCII()), 
+        "branch".getBytes(MockBase.ASCII()),
         (byte[])branchToStorageJson.invoke(branch));
-    
+
     Leaf leaf = new Leaf("user", "000001000001000001");
     qualifier = leaf.columnQualifier();
     storage.addColumn(TREE_TABLE, branch.compileBranchId(), Tree.TREE_FAMILY(),
         qualifier, (byte[])LeaftoStorageJson.invoke(leaf));
-    
+
     leaf = new Leaf("nice", "000002000002000002");
     qualifier = leaf.columnQualifier();
     storage.addColumn(TREE_TABLE, branch.compileBranchId(), Tree.TREE_FAMILY(),
         qualifier, (byte[])LeaftoStorageJson.invoke(leaf));
-    
+
     // child branch
     branch = new Branch(1);
     path.put(3, "mboard");
     branch.prependParentPath(path);
     branch.setDisplayName("mboard");
     storage.addColumn(TREE_TABLE, branch.compileBranchId(), Tree.TREE_FAMILY(),
-        "branch".getBytes(MockBase.ASCII()), 
+        "branch".getBytes(MockBase.ASCII()),
         (byte[])branchToStorageJson.invoke(branch));
-    
+
     leaf = new Leaf("Asus", "000003000003000003");
     qualifier = leaf.columnQualifier();
     storage.addColumn(TREE_TABLE, branch.compileBranchId(), Tree.TREE_FAMILY(),
         qualifier, (byte[])LeaftoStorageJson.invoke(leaf));
   }
-  
+
   /**
-   * Sets up some UID name maps in storage for use when loading leaves from a 
-   * branch. Without these, the unit tests will fail since the leaves couldn't 
+   * Sets up some UID name maps in storage for use when loading leaves from a
+   * branch. Without these, the unit tests will fail since the leaves couldn't
    * find their name maps.
    */
   private void setupBranch() {
@@ -1330,9 +1331,9 @@ public final class TestTreeRpc {
         "tagv".getBytes(MockBase.ASCII()),
         "web01".getBytes(MockBase.ASCII()));
   }
-  
+
   /**
-   * Sets up a TSMeta object and associated UIDMeta objects in storage for 
+   * Sets up a TSMeta object and associated UIDMeta objects in storage for
    * testing the "test" call. These are necessary as the TSMeta is loaded when
    * parsed through the tree.
    */
@@ -1343,37 +1344,37 @@ public final class TestTreeRpc {
     families.add(TSMeta.FAMILY);
     storage.addTable(meta_table, families);
     final TSMeta meta = new TSMeta("000001000001000001000002000002");
-    storage.addColumn(meta_table, 
-        UniqueId.stringToUid("000001000001000001000002000002"), 
-        NAME_FAMILY, "ts_meta".getBytes(MockBase.ASCII()), 
+    storage.addColumn(meta_table,
+        UniqueId.stringToUid("000001000001000001000002000002"),
+        NAME_FAMILY, "ts_meta".getBytes(MockBase.ASCII()),
         (byte[])TSMetagetStorageJSON.invoke(meta));
-    
-    final UIDMeta metric = new UIDMeta(UniqueIdType.METRIC, new byte[] { 0, 0, 1 }, 
+
+    final UIDMeta metric = new UIDMeta(UniqueIdType.METRIC, new byte[] { 0, 0, 1 },
         "sys.cpu.0");
     storage.addColumn(uid_table, new byte[] { 0, 0, 1 }, NAME_FAMILY,
-        "metric_meta".getBytes(MockBase.ASCII()), 
+        "metric_meta".getBytes(MockBase.ASCII()),
         (byte[])UIDMetagetStorageJSON.invoke(metric));
-    final UIDMeta tagk1 = new UIDMeta(UniqueIdType.TAGK, new byte[] { 0, 0, 1 }, 
+    final UIDMeta tagk1 = new UIDMeta(UniqueIdType.TAGK, new byte[] { 0, 0, 1 },
         "host");
     storage.addColumn(uid_table, new byte[] { 0, 0, 1 }, NAME_FAMILY,
-        "tagk_meta".getBytes(MockBase.ASCII()), 
+        "tagk_meta".getBytes(MockBase.ASCII()),
         (byte[])UIDMetagetStorageJSON.invoke(tagk1));
-    final UIDMeta tagv1 = new UIDMeta(UniqueIdType.TAGV, new byte[] { 0, 0, 1 }, 
+    final UIDMeta tagv1 = new UIDMeta(UniqueIdType.TAGV, new byte[] { 0, 0, 1 },
         "web-01.lga.mysite.com");
     storage.addColumn(uid_table, new byte[] { 0, 0, 1 }, NAME_FAMILY,
-        "tagv_meta".getBytes(MockBase.ASCII()), 
+        "tagv_meta".getBytes(MockBase.ASCII()),
         (byte[])UIDMetagetStorageJSON.invoke(tagv1));
-    final UIDMeta tagk2 = new UIDMeta(UniqueIdType.TAGK, new byte[] { 0, 0, 2 }, 
+    final UIDMeta tagk2 = new UIDMeta(UniqueIdType.TAGK, new byte[] { 0, 0, 2 },
         "type");
     storage.addColumn(uid_table, new byte[] { 0, 0, 2 }, NAME_FAMILY,
-        "tagk_meta".getBytes(MockBase.ASCII()), 
+        "tagk_meta".getBytes(MockBase.ASCII()),
         (byte[])UIDMetagetStorageJSON.invoke(tagk2));
-    final UIDMeta tagv2 = new UIDMeta(UniqueIdType.TAGV, new byte[] { 0, 0, 2 }, 
+    final UIDMeta tagv2 = new UIDMeta(UniqueIdType.TAGV, new byte[] { 0, 0, 2 },
         "user");
     storage.addColumn(uid_table, new byte[] { 0, 0, 2 }, NAME_FAMILY,
-        "tagv_meta".getBytes(MockBase.ASCII()), 
+        "tagv_meta".getBytes(MockBase.ASCII()),
         (byte[])UIDMetagetStorageJSON.invoke(tagv2));
-    
+
     storage.addColumn(uid_table, new byte[] { 0, 0, 2 }, NAME_FAMILY,
         "tagk".getBytes(MockBase.ASCII()),
         "type".getBytes(MockBase.ASCII()));


### PR DESCRIPTION
As discussed on the mailing list earlier this week.

I've been looking at the http latency metrics recently and want to get more accurate percentiles (mainly for higher values) than what can be achieved with the current histogram approach.

Many companies use external aggregators like statsd for this kind of thing so have introduced an optional plugin api to emit the timing events to a plugin (which would process asynchronously) so not write to the same metrics.

It still requires some documentation to be written but allows users to configure both a global implementation and/or specific implementations for particular usages. If none is specified it drops back to using the current Histogram which implements the same interface now. I had to rejig various references to static member variables and generally replaced this with constructor injection which I feel is cleaner.
