### PR TITLE
Updated regex to match dotted timestamp

### DIFF
--- a/src/utils/DateTime.java
+++ b/src/utils/DateTime.java
@@ -125,9 +125,14 @@ public class DateTime {
       try {
         long time;
         Boolean containsDot = datetime.contains(".");
-        Boolean containsTwoDots =  datetime.matches(".*\\..*\\..*");
+        // [0-9]{10} ten digits
+        // \\. a dot
+        // [0-9]{1,3} one to three digits
+        Boolean isValidDottedMillesecond = datetime.matches("^[0-9]{10}\\.[0-9]{1,3}$");
+        // one to ten digits (0-9)
+        Boolean isValidSeconds = datetime.matches("^[0-9]{1,10}$");
         if (containsDot) {
-          if (datetime.charAt(10) != '.' || datetime.length() != 14 || containsTwoDots) {
+          if (!isValidDottedMillesecond) {
             throw new IllegalArgumentException("Invalid time: " + datetime  
                 + ". Millisecond timestamps must be in the format "
                 + "<seconds>.<ms> where the milliseconds are limited to 3 digits");
@@ -142,8 +147,9 @@ public class DateTime {
         }
         // this is a nasty hack to determine if the incoming request is
         // in seconds or milliseconds. This will work until November 2286
-        if (datetime.length() <= 10)
+        if (datetime.length() <= 10) {
           time *= 1000;
+        }
         return time;
       } catch (NumberFormatException e) {
         throw new IllegalArgumentException("Invalid time: " + datetime  

--- a/test/utils/TestDateTime.java
+++ b/test/utils/TestDateTime.java
@@ -144,9 +144,27 @@ public final class TestDateTime {
     DateTime.parseDateTimeString("-135596160", null);
   }
 
+  /*
+  1234567890.418 - match
+  1234567890.1235 - no match
+  1234567890.12 - matches
+  1234.56789.003 - no match
+  1234567890.3 - match
+  */
+
   @Test(expected = IllegalArgumentException.class)
   public void parseDateTimeStringMultipleDots() {
     DateTime.parseDateTimeString("1234567890.2.4", null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void parseDateTimeStringMultipleDotsEarlyDot() {
+    DateTime.parseDateTimeString("1234.56789.123", null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void parseDateTimeStringEarlyandExtraDots() {
+    DateTime.parseDateTimeString("1234.56789.0.3", null);
   }
   
   @Test
@@ -166,6 +184,18 @@ public final class TestDateTime {
   public void parseDateTimeStringUnixMSDot() {
     long t = DateTime.parseDateTimeString("1355961603.418", null);
     assertEquals(1355961603418L, t);
+  }
+
+  @Test
+  public void parseDateTimeStringUnixMSDotShorter() {
+    long t = DateTime.parseDateTimeString("1355961603.41", null);
+    assertEquals(135596160341L, t);
+  }
+
+  @Test
+  public void parseDateTimeStringUnixMSDotShortest() {
+    long t = DateTime.parseDateTimeString("1355961603.4", null);
+    assertEquals(13559616034L, t);
   }
   
   @Test (expected = IllegalArgumentException.class)


### PR DESCRIPTION
        1234567890.2.3 - no match
        1234.56789.1234 - no match
        1234567890.1234 - matches
        1234.567890.2..3 - no match
        1234567890.2..3 - no match

Fixes #724