### PR TITLE
Impl for #743: Optionally add port to all TSD statistics

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -134,6 +134,7 @@ tsdb_SRC := \
 	src/tools/Search.java	\
   src/tools/StartupPlugin.java \
 	src/tools/TSDMain.java	\
+	src/tools/TSDPort.java	\
 	src/tools/TextImporter.java	\
 	src/tools/TreeSync.java	\
 	src/tools/UidManager.java	\
@@ -343,6 +344,7 @@ test_SRC := \
 	test/tsd/TestSuggestRpc.java	\
 	test/tsd/TestTreeRpc.java	\
 	test/tsd/TestUniqueIdRpc.java	\
+	test/tsd/TestStatsWithPort.java	\
 	test/uid/TestNoSuchUniqueId.java	\
 	test/uid/TestRandomUniqueId.java	\
 	test/uid/TestUniqueId.java \

--- a/src/stats/StatsCollector.java
+++ b/src/stats/StatsCollector.java
@@ -15,6 +15,8 @@ package net.opentsdb.stats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.opentsdb.tools.TSDPort;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
@@ -50,6 +52,9 @@ public abstract class StatsCollector {
    */
   public StatsCollector(final String prefix) {
     this.prefix = prefix;
+    if(TSDPort.isStatsWithPort()) {
+    	addExtraTag("port", "" + TSDPort.getTSDPort());
+    }
   }
 
   /**

--- a/src/tools/CliOptions.java
+++ b/src/tools/CliOptions.java
@@ -161,7 +161,9 @@ final class CliOptions {
         config.overrideConfig("tsd.network.worker_threads", entry.getValue());
       } else if (entry.getKey().toLowerCase().equals("--max-connections")) {
         config.overrideConfig("tsd.core.connections.limit", entry.getValue());
-      }
+      } else if (entry.getKey().toLowerCase().equals("--statswport")) {
+          config.overrideConfig("tsd.core.stats_with_port", "true");
+      }     	  
     }
   }
   

--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -101,6 +101,7 @@ final class TSDMain {
     argp.addOption("--flush-interval", "MSEC",
                    "Maximum time for which a new data point can be buffered"
                    + " (default: " + DEFAULT_FLUSH_INTERVAL + ").");
+    argp.addOption("--statswport", "Force all stats to include the port");
     CliOptions.addAutoMetricFlag(argp);
     args = CliOptions.parse(argp, args);
     args = null; // free().
@@ -220,6 +221,7 @@ final class TSDMain {
       if (startup != null) {
         startup.setReady(tsdb);
       }
+      TSDPort.set(config);
       log.info("Ready to serve on " + addr);
     } catch (Throwable e) {
       factory.releaseExternalResources();

--- a/src/tools/TSDPort.java
+++ b/src/tools/TSDPort.java
@@ -1,0 +1,56 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2012  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.tools;
+
+import net.opentsdb.utils.Config;
+
+/**
+ * Static reference to the TSD's listening port and stats port configuration
+ */
+
+public class TSDPort {
+	/** The RPC listening port  */
+	private static int rpcPort = -1;
+	/** Indicates if RPC stats include the listening port. Set by config <b><code>tsd.core.stats_with_port</code></b>
+	 or CLI option <b><code>--statswport</code></b>.  */
+	private static boolean statsWithPort = false;
+	
+	/**
+	 * Sets the rpc port and stats config on TSD startup
+	 * @param config The final config
+	 */
+	static void set(Config config) {
+		rpcPort = config.getInt("tsd.network.port");
+	    statsWithPort = config.getBoolean("tsd.core.stats_with_port");
+	}
+
+	/**
+	 * Returns the TSD's listening port
+	 * @return the port
+	 */
+	public static int getTSDPort()  {
+		return rpcPort;
+	}
+
+	/**
+	 * Indicates if stats should be reported with the port as a tag
+	 * @return true if stats should be reported with the port as a tag, false otherwise
+	 */
+	public static boolean isStatsWithPort() {
+		return statsWithPort;
+	}
+
+
+	private TSDPort() {}
+
+}

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -107,6 +107,10 @@ public class Config {
   /** tsd.http.request.enable_chunked */
   private boolean enable_chunked_requests = false;
   
+  /** tsd.core.stats_with_port */
+  private boolean stats_with_port = false;
+  
+  
   /** tsd.storage.fix_duplicates */
   private boolean fix_duplicates = false;
 
@@ -262,6 +266,11 @@ public class Config {
   /** @return whether or not chunked requests are supported */
   public boolean enable_chunked_requests() {
     return enable_chunked_requests;
+  }
+  
+  /** @return whether or not rpc stats should be broken out by port */
+  public boolean rpc_stats_withport() {
+    return stats_with_port;
   }
   
   /** @return max incoming chunk size in bytes */
@@ -563,6 +572,7 @@ public class Config {
     default_map.put("tsd.storage.compaction.min_flush_threshold", "100");
     default_map.put("tsd.storage.compaction.max_concurrent_flushes", "10000");
     default_map.put("tsd.storage.compaction.flush_speed", "2");
+    default_map.put("tsd.core.stats_with_port", "false");    
     default_map.put("tsd.http.show_stack_trace", "true");
     default_map.put("tsd.http.query.allow_delete", "false");
     default_map.put("tsd.http.request.enable_chunked", "false");
@@ -689,6 +699,7 @@ public class Config {
     enable_tree_processing = this.getBoolean("tsd.core.tree.enable_processing");
     fix_duplicates = this.getBoolean("tsd.storage.fix_duplicates");
     scanner_max_num_rows = this.getInt("tsd.storage.hbase.scanner.maxNumRows");
+    stats_with_port = this.getBoolean("tsd.core.stats_with_port");
 
   }
   

--- a/test/tsd/TestStatsWithPort.java
+++ b/test/tsd/TestStatsWithPort.java
@@ -1,0 +1,79 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2015  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+
+package net.opentsdb.tsd;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.opentsdb.stats.StatsCollector;
+import net.opentsdb.tools.TSDPort;
+
+public class TestStatsWithPort {
+	
+	static final Pattern PORT_MATCH = Pattern.compile(" port=");
+
+	@Test
+	public void testNoPort()  {
+		setPortConfig(4242, false);
+	}
+	
+	@Test
+	public void testDefaultPort()  {
+		setPortConfig(4242, true);
+	}
+	
+	
+	protected void doTest() {
+		final List<String> lines = new ArrayList<String>(); 
+		StatsCollector sc = new StatsCollector("tsd") {
+	        @Override
+	        public final void emit(final String line) {
+	          lines.add(line);
+	        }
+	      };
+	   sc.record("foo", -1);
+		
+	}
+	
+	protected void validateStats(final List<String> lines) {
+		Pattern portMatch = Pattern.compile(" port=" + TSDPort.getTSDPort());
+		for(String s: lines) {
+			if(!TSDPort.isStatsWithPort()) {
+				Assert.assertFalse("Stat had a port", PORT_MATCH.matcher(s).find());
+			} else {
+				Assert.assertTrue("Stat did not have port", portMatch.matcher(s).find());
+			}
+		}
+	}
+	  
+	  
+	public void setPortConfig(final Integer port, final Boolean statsWithPort) {
+		try {			
+			Field portField = TSDPort.class.getDeclaredField("rpcPort");
+			portField.setAccessible(true);
+			portField.set(null, port);
+			Field statsWPortField = TSDPort.class.getDeclaredField("statsWithPort");
+			statsWPortField.setAccessible(true);
+			statsWPortField.set(null, statsWithPort);			
+		} catch (Exception ex) {
+			throw new RuntimeException("Failed to set TCPPort fields", ex);
+		}
+	}
+
+}


### PR DESCRIPTION
This is a configuration item addition that adds the TSD's main listening port as a tag to all collected statistics. This is intended to demarcate stored statistics when multiple instances are running on the same host. Example:
![portstats](https://cloud.githubusercontent.com/assets/597608/14061774/69271e80-f35f-11e5-8864-7e88f7fef045.png)

The configuration can be activated by:

- Setting the boolean config property **tsd.core.stats_with_port** to **true**.
- Use the command line option **--statswport**.

## Changes

- Added **TSDPort** as a static reference to determine if the config option is activated and what the port is from an arbitrary location.
- Added **TestStatsWithPort** unit test
- Modified **TSDMain** to initialize TSDPort on TSD ready.
- Modified **Config** to add property.
- Modified **CliOptions** to add command line option.
- Modified **Makefile.am" to add new source files.

Doc web page additions pull request submitted separately.

Note that activating this option will effectively orphan all pre-existing statistics driven time series.