### PR TITLE
Fixes Issue #701/#711 broken build on some OSX based systems

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -565,7 +565,7 @@ install-data-local: staticroot install-data-lib install-data-tools \
 	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
           dstdir=`dirname "$(DESTDIR)$(staticdir)/$$p"`; \
           if test -d "$$dstdir"; then :; else \
-            echo " $(mkdir_p) '$$dstdir'"; $(mkdir_p) "$$dstdir"; fi; \
+            echo " $(mkdir_p) '$$dstdir'"; ../$(mkdir_p) "$$dstdir"; fi; \
 	  echo " $(INSTALL_DATA) '$$d$$p' '$(DESTDIR)$(staticdir)/$$p'"; \
 	  $(INSTALL_DATA) "$$d$$p" "$(DESTDIR)$(staticdir)/$$p"; \
 	done
@@ -718,7 +718,7 @@ manifest: .javac-stamp .git/HEAD
           echo "Implementation-Version: $(git_version)"; \
           echo "Implementation-Vendor: $(spec_vendor)"; } >"$@"
 
-$(jar): manifest .javac-stamp $(classes)
+$(jar): manifest .javac-stamp
 	$(JAR) cfm `basename $(jar)` manifest $(classes_with_nested_classes) $(get_expr_classes) \
          || { rv=$$? && rm -f `basename $(jar)` && exit $$rv; }
 #                       ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
mkdir_p is called from in a subdir of build so needs an extra `../` and there is no rule to create the `$(classes)` and everything builds without specifying them as dependencies of the jar.

I've only tested these changes on the Makefile.in
Conflicts:
	Makefile.am