### PR TITLE
Fix in regex for parsing the java version to determine ALPN version i…

### DIFF
--- a/third_party/alpn-boot/include.mk
+++ b/third_party/alpn-boot/include.mk
@@ -22,7 +22,7 @@ ALPN_BOOT_VERSION = $(shell version= ;\
     echo "Failed to parse Java version";\
     exit 1;\
   fi; \
-  if [[ $$version =~ ^([0-9]+\.[0-9]+)\.([0-9])[_Uu]([0-9]+)$$ ]]; then \
+  if [[ $$version =~ ^([0-9]+\.[0-9]+)\.([0-9])[_Uu]([0-9]+) ]]; then \
     major=$${BASH_REMATCH[1]};\
     minor=$${BASH_REMATCH[2]}; \
     sub=$${BASH_REMATCH[3]}; \


### PR DESCRIPTION
…n response to question on mailing list regarding big table builds failing on Debian (jesssie).  Java version on jessie has suffix '-internal' added to version line found in 'java -version'. Regex in make file was testing for EOL ($). This just isn't necessary and will break on any version with a suffix. Works fine just matching for major, minor and sub version. Tested on Debian jessie and Ubuntu 14.04 LTS