### PR TITLE
bit reversal metric uids to evenly distribute metrics across region servers with pre-split region

### DIFF
--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -179,12 +179,16 @@ public final class TSDB {
     treetable = config.getString("tsd.storage.hbase.tree_table").getBytes(CHARSET);
     meta_table = config.getString("tsd.storage.hbase.meta_table").getBytes(CHARSET);
 
-    if (config.getBoolean("tsd.core.uid.random_metrics")) {
-      metrics = new UniqueId(this.client, uidtable, METRICS_QUAL, METRICS_WIDTH, 
-          true);
-    } else {
-      metrics = new UniqueId(this.client, uidtable, METRICS_QUAL, METRICS_WIDTH);
+    boolean random_metrics = config.getBoolean("tsd.core.uid.random_metrics");
+    boolean reversal_metrics = config.getBoolean("tsd.core.uid.reversal_metrics");
+    if (random_metrics && reversal_metrics) {
+      reversal_metrics = false;
+      LOG.warn("The tsd.core.uid.reversal_metrics flag cannot be used with" +
+          " the tsd.core.uid.random_metrics. The tsd.core.uid.reversal_metrics" +
+          " will be ignored.");
     }
+    metrics = new UniqueId(this.client, uidtable, METRICS_QUAL, METRICS_WIDTH,
+        random_metrics, reversal_metrics);
     tag_names = new UniqueId(this.client, uidtable, TAG_NAME_QUAL, TAG_NAME_WIDTH);
     tag_values = new UniqueId(this.client, uidtable, TAG_VALUE_QUAL, TAG_VALUE_WIDTH);
     compactionq = new CompactionQueue(this);

--- a/src/tools/UidManager.java
+++ b/src/tools/UidManager.java
@@ -361,12 +361,13 @@ final class UidManager {
                             final byte[] table,
                             final short idwidth,
                             final String[] args) {
-    boolean randomize = false;
+    boolean randomize = false, reversal = false;
     if (UniqueId.stringToUniqueIdType(args[1]) == UniqueIdType.METRIC) {
       randomize = tsdb.getConfig().getBoolean("tsd.core.uid.random_metrics");
+      reversal = tsdb.getConfig().getBoolean("tsd.core.uid.reversal_metrics");
     }
     final UniqueId uid = new UniqueId(tsdb.getClient(), table, args[1], 
-        (int) idwidth, randomize);
+        (int) idwidth, randomize, reversal);
     for (int i = 2; i < args.length; i++) {
       try {
         uid.getOrCreateId(args[i]);

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -490,6 +490,7 @@ public class Config {
     default_map.put("tsd.core.preload_uid_cache.max_entries", "300000");
     default_map.put("tsd.core.storage_exception_handler.enable", "false");
     default_map.put("tsd.core.uid.random_metrics", "false");
+    default_map.put("tsd.core.uid.reversal_metrics", "false");
     default_map.put("tsd.query.filter.expansion_limit", "4096");
     default_map.put("tsd.query.skip_unresolved_tagvs", "false");
     default_map.put("tsd.query.allow_simultaneous_duplicates", "true");


### PR DESCRIPTION
Since OpenTSDB 2.2, you can use the random metric uid that enables each
metrics to evenly distribute on regions by a randomize fashion.
Although the random metric uid reduces the region hot spotting problem,
however, it may be possible to cause UID collisions when it creates a
new UID if many UIDs have been created.

By the way, there are another smart way to assign UIDs to metrics for
better region server write distribution that the bit reversal
fashion(it swaps between MSB and LSB) might be helped this problem
better effectively.

For example, when you have created 4 metrics without the random metric
option, you can see UIDs like the following:

```
\x00\x00\x01 (00000000 00000000 00000001)
\x00\x00\x02 (00000000 00000000 00000010)
\x00\x00\x03 (00000000 00000000 00000011)
\x00\x00\x04 (00000000 00000000 00000100)
```

In contrast, if you swap between MSB and LSB each other, you can get
the following result:

```
\x80\x00\x00 (10000000 00000000 00000000)
\x40\x00\x00 (01000000 00000000 00000000)
\xC0\x00\x00 (11000000 00000000 00000000)
\x20\x00\x00 (00100000 00000000 00000000)
```

Thereby, it distributes metric UIDs widely across the key space of
hbase regions by swapping bits manner in UID bytes. Even though it
creates the reversal bits metric UIDs, however, there are no changes
the way how it stores the last UID number in the `\x00` row of the
`tsdb-uid` table. The following is an example how it stores the last
UID number after you create the `\x20\x00\x00` metric UID in `tsdb-uid`
table.

```
\x00 column=id:metrics, timestamp=1459067561464,
value=\x00\x00\x00\x00\x00\x00\x00\x04
```

As you can see above, even if you created `\x20\x00\x00` metric UID by
the bit reversal way, the last UID is not
`\x20\x00\x00\x00\x00\x00\x00\x00` which means that the value in`\x00`
row will be increased same as before. Because of this, you can enable
or disable this feature by modifying the
`tsd.core.uid.reversal_metrics` flag at any time and also data is
backwards compatible for all versions of opentsdb. But, you cannot use
the `tsd.core.uid.reversal_metrics` flag with the
`tsd.core.uid.random_metrics` flag, it will ignore the
`tsd.core.uid.reversal_metrics` flag.