### PR TITLE
Use /usr/bin/env in shebang line

### DIFF
--- a/tools/check_tsd
+++ b/tools/check_tsd
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Script which queries TSDB with a given metric and alerts based on
 # supplied threshold.  Compatible with Nagios output format, so can be

--- a/tools/opentsdb_restart.py
+++ b/tools/opentsdb_restart.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """Restart opentsdb. Called using -XX:OnOutOfMemoryError=<this script>
 
 Because it's calling the 'service opentsdb' command, should be run as root.

--- a/tools/tsddrain.py
+++ b/tools/tsddrain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # This little script can be used to replace TSDs while performing prolonged
 # HBase or HDFS maintenances.  It runs a simple, low-end TCP server to accept


### PR DESCRIPTION
- /usr/bin/python does not exist on FreeBSD
- /usr/bin/env python will do the right thing
  on both Linux and BSD

Downstream report:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=208531