### PR TITLE
Typo: tsd.network.keepalive is actually called tsd.network.keep_alive according to code and documentation.

### DIFF
--- a/build-aux/deb/opentsdb.conf
+++ b/build-aux/deb/opentsdb.conf
@@ -12,7 +12,7 @@ tsd.network.port = 4242
 
 # Determines whether or not to send keepalive packets to peers, default 
 # is True
-#tsd.network.keepalive = true
+#tsd.network.keep_alive = true
 
 # Determines if the same socket should be used for new connections, default 
 # is True

--- a/build-aux/rpm/opentsdb.conf
+++ b/build-aux/rpm/opentsdb.conf
@@ -12,7 +12,7 @@ tsd.network.port = 4242
 
 # Determines whether or not to send keepalive packets to peers, default
 # is True
-#tsd.network.keepalive = true
+#tsd.network.keep_alive = true
 
 # Determines if the same socket should be used for new connections, default
 # is True

--- a/src/opentsdb.conf
+++ b/src/opentsdb.conf
@@ -12,7 +12,7 @@ tsd.network.port =
 
 # Determines whether or not to send keepalive packets to peers, default 
 # is True
-#tsd.network.keepalive = true
+#tsd.network.keep_alive = true
 
 # Determines if the same socket should be used for new connections, default 
 # is True


### PR DESCRIPTION
To match https://github.com/OpenTSDB/opentsdb/blob/master/src/utils/Config.java#L477