### PR TITLE
Fix comment for behavior of tsd.network.tcp_no_delay

### DIFF
--- a/build-aux/deb/opentsdb.conf
+++ b/build-aux/deb/opentsdb.conf
@@ -6,9 +6,8 @@ tsd.network.port = 4242
 # The IPv4 network address to bind to, defaults to all addresses
 # tsd.network.bind = 0.0.0.0
 
-# Enables Nagel's algorithm to reduce the number of packets sent over the
-# network, default is True
-#tsd.network.tcpnodelay = true
+# Disable Nagel's algorithm.  Default is True
+#tsd.network.tcp_no_delay = true
 
 # Determines whether or not to send keepalive packets to peers, default 
 # is True
@@ -16,7 +15,7 @@ tsd.network.port = 4242
 
 # Determines if the same socket should be used for new connections, default 
 # is True
-#tsd.network.reuseaddress = true
+#tsd.network.reuse_address = true
 
 # Number of worker threads dedicated to Netty, defaults to # of CPUs * 2
 #tsd.network.worker_threads = 8

--- a/build-aux/rpm/opentsdb.conf
+++ b/build-aux/rpm/opentsdb.conf
@@ -6,9 +6,8 @@ tsd.network.port = 4242
 # The IPv4 network address to bind to, defaults to all addresses
 # tsd.network.bind = 0.0.0.0
 
-# Enables Nagel's algorithm to reduce the number of packets sent over the
-# network, default is True
-#tsd.network.tcpnodelay = true
+# Disable Nagel's algorithm, default is True
+#tsd.network.tcp_no_delay = true
 
 # Determines whether or not to send keepalive packets to peers, default
 # is True
@@ -16,7 +15,7 @@ tsd.network.port = 4242
 
 # Determines if the same socket should be used for new connections, default
 # is True
-#tsd.network.reuseaddress = true
+#tsd.network.reuse_address = true
 
 # Number of worker threads dedicated to Netty, defaults to # of CPUs * 2
 #tsd.network.worker_threads = 8

--- a/src/opentsdb.conf
+++ b/src/opentsdb.conf
@@ -6,15 +6,14 @@ tsd.network.port =
 # The IPv4 network address to bind to, defaults to all addresses
 # tsd.network.bind = 0.0.0.0
 
-# Enables Nagel's algorithm to reduce the number of packets sent over the
-# network, default is True
+# Disable Nagel's algorithm, default is True
 #tsd.network.tcp_no_delay = true
 
-# Determines whether or not to send keepalive packets to peers, default 
+# Determines whether or not to send keepalive packets to peers, default
 # is True
 #tsd.network.keep_alive = true
 
-# Determines if the same socket should be used for new connections, default 
+# Determines if the same socket should be used for new connections, default
 # is True
 #tsd.network.reuse_address = true
 
@@ -42,7 +41,7 @@ tsd.http.cachedir =
 # Whether or not to enable data compaction in HBase, default is True
 #tsd.storage.enable_compaction = true
 
-# How often, in milliseconds, to flush the data point queue to storage, 
+# How often, in milliseconds, to flush the data point queue to storage,
 # default is 1,000
 # tsd.storage.flush_interval = 1000
 
@@ -58,7 +57,7 @@ tsd.http.cachedir =
 # Path under which the znode for the -ROOT- region is located, default is "/hbase"
 #tsd.storage.hbase.zk_basedir = /hbase
 
-# A comma separated list of Zookeeper hosts to connect to, with or without 
+# A comma separated list of Zookeeper hosts to connect to, with or without
 # port specifiers, default is "localhost"
 #tsd.storage.hbase.zk_quorum = localhost
 


### PR DESCRIPTION
And catch the rpm and deb confs up a bit.

I'm also not sure if the "Default is True" for these networking options is correct.  Does i.e. https://github.com/OpenTSDB/opentsdb/blob/e2efe9a4875f8cddd3404e9c6b64f5aab4b72c0a/src/tools/TSDMain.java#L171 default to True?