### PR TITLE
DumpSeries doesn't know AppendDataPoints

### DIFF
--- a/src/core/AppendDataPoints.java
+++ b/src/core/AppendDataPoints.java
@@ -252,4 +252,9 @@ public class AppendDataPoints {
   public Deferred<Object> repairedDeferred() {
     return repaired_deferred;
   }
+ 
+  /** @return whether or not a qualifier of AppendDataPoints */
+  public static boolean isAppendDataPoints(byte[] qualifier) {
+    return qualifier != null && qualifier.length == 3 && qualifier[0] == APPEND_COLUMN_PREFIX;
+  }
 }

--- a/src/tools/DumpSeries.java
+++ b/src/tools/DumpSeries.java
@@ -15,10 +15,12 @@ package net.opentsdb.tools;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import net.opentsdb.core.AppendDataPoints;
 import org.hbase.async.DeleteRequest;
 import org.hbase.async.HBaseClient;
 import org.hbase.async.KeyValue;
@@ -180,7 +182,7 @@ final class DumpSeries {
     final byte[] value = kv.value();
     final int q_len = qualifier.length;
 
-    if (q_len % 2 != 0) {
+    if (q_len != 3 && q_len % 2 != 0) {
       if (!importformat) {
         // custom data object, not a data point
         if (kv.qualifier()[0] == Annotation.PREFIX()) {
@@ -203,8 +205,16 @@ final class DumpSeries {
         appendImportCell(buf, cell, base_time, tags);
       }
     } else {
-      // compacted column
-      final ArrayList<Cell> cells = Internal.extractDataPoints(kv);
+      final Collection<Cell> cells;
+      if (q_len == 3) {
+        // append data points
+        final AppendDataPoints adps = new AppendDataPoints();
+        cells = adps.parseKeyValue(tsdb, kv);
+      } else {
+        // compacted column
+        cells = Internal.extractDataPoints(kv);
+      }
+
       if (!importformat) {
         buf.append(Arrays.toString(kv.qualifier()))
            .append('\t')

--- a/src/tools/DumpSeries.java
+++ b/src/tools/DumpSeries.java
@@ -182,7 +182,7 @@ final class DumpSeries {
     final byte[] value = kv.value();
     final int q_len = qualifier.length;
 
-    if (q_len != 3 && q_len % 2 != 0) {
+    if (!AppendDataPoints.isAppendDataPoints(qualifier) && q_len % 2 != 0) {
       if (!importformat) {
         // custom data object, not a data point
         if (kv.qualifier()[0] == Annotation.PREFIX()) {

--- a/test/tools/TestDumpSeries.java
+++ b/test/tools/TestDumpSeries.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 
+import net.opentsdb.core.AppendDataPoints;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.meta.Annotation;
 import net.opentsdb.storage.MockBase;
@@ -312,7 +313,18 @@ public class TestDumpSeries {
     assertEquals("sys.cpu.user 1356998400004 6 host=web01", log_lines[1]);
     assertEquals("sys.cpu.user 1356998400008 5 host=web01", log_lines[2]);
   }
-  
+
+  @Test
+  public void dumpImportAppendDataPoints() throws Exception {
+    writeAppendDataPoints();
+    doDump.invoke(null, tsdb, client, "tsdb".getBytes(MockBase.ASCII()), false,
+        true, new String[] { "1356998400", "1357002000", "sum", "sys.cpu.user" });
+    final String[] log_lines = buffer.toString("ISO-8859-1").split("\n");
+    assertNotNull(log_lines);
+    assertEquals("sys.cpu.user 1356998402 42 host=web01", log_lines[0]);
+    assertEquals("sys.cpu.user 1356998404 6 host=web01", log_lines[1]);
+  }
+
   @Test
   public void dumpRawCompactedAndDelete() throws Exception {
     writeCompactedData();
@@ -396,5 +408,12 @@ public class TestDumpSeries {
 //    final byte[] qual12 = MockBase.concatByteArrays(qual1, qual2);
 //    kvs.add(makekv(qual12, MockBase.concatByteArrays(val1, val2, ZERO)));
 
+  }
+
+  private void writeAppendDataPoints() throws Exception {
+    storage.addColumn(MockBase.stringToBytes("00000150E22700000001000001"),
+        "t".getBytes(MockBase.ASCII()),
+        AppendDataPoints.APPEND_COLUMN_QUALIFIER,
+        new byte[] { 0, 0x20, 42, 0, 0x40, 6 });
   }
 }


### PR DESCRIPTION
When it migrates from a source tsdb which has `tsd.storage.enable_appends = true` in configuration, DumpSeries ignores `AppendDataPoints`.