### PR TITLE
Log X-Forwarded-For address when handling HTTP requests

### DIFF
--- a/src/tsd/AbstractHttpQuery.java
+++ b/src/tsd/AbstractHttpQuery.java
@@ -467,21 +467,37 @@ public abstract class AbstractHttpQuery {
     return LOG;
   }
 
+  protected final String logChannel() {
+    if (request.containsHeader("X-Forwarded-For")) {
+        String inetAddress;
+        String proxyChain = request.getHeader("X-Forwarded-For");
+        int firstComma = proxyChain.indexOf(',');
+        if (firstComma != -1) {
+          inetAddress = proxyChain.substring(0, proxyChain.indexOf(','));
+        } else {
+          inetAddress = proxyChain;
+        }
+        return "[id: 0x" + Integer.toHexString(chan.hashCode()) + ", /" + inetAddress + " => " + chan.getLocalAddress() + ']';
+    } else {
+        return chan.toString();
+    }
+  }
+
   protected final void logInfo(final String msg) {
     if (logger().isInfoEnabled()) {
-      logger().info(chan.toString() + ' ' + msg);
+      logger().info(logChannel() + ' ' + msg);
     }
   }
 
   protected final void logWarn(final String msg) {
     if (logger().isWarnEnabled()) {
-      logger().warn(chan.toString() + ' ' + msg);
+      logger().warn(logChannel() + ' ' + msg);
     }
   }
 
   protected final void logError(final String msg, final Exception e) {
     if (logger().isErrorEnabled()) {
-      logger().error(chan.toString() + ' ' + msg, e);
+      logger().error(logChannel() + ' ' + msg, e);
     }
   }
 


### PR DESCRIPTION
We had an issue where we couldn't track source IP's through the load balancer as the netty Channel in the AbstractHttpQuery was only logging the connected socket IP.  This patch enhances the AbstractHttpQuery class to log the real client IP, if available in the headers, in a mostly compatible format to [AbstractChannel.toString()](http://netty.io/4.0/api/io/netty/channel/AbstractChannel.html#toString()).

Seems to work w/o issue so far, the only _issue_ I see right now is that I can't reliably put a port after the real client IP.  It's superfluous to do so as we aren't talking directly with the client, but we we need to be able to track down connections via channel ID as well as loadbalancer IP and remote IP.

This should be compatible with any frontend proxies (such as varnish, nginx, apache, haproxy, etc) as well as commercial platforms that follow the ["standard"](https://en.wikipedia.org/wiki/X-Forwarded-For).  This does not take into consideration [RFC7239](https://tools.ietf.org/html/rfc7239) which uses the new `Forwarded` header.