### PR TITLE
fix ALPN version comparisons in include.mk file

### DIFF
--- a/third_party/alpn-boot/include.mk
+++ b/third_party/alpn-boot/include.mk
@@ -27,25 +27,25 @@ ALPN_BOOT_VERSION = $(shell version= ;\
     minor=$${BASH_REMATCH[2]}; \
     sub=$${BASH_REMATCH[3]}; \
   if [[ $$major = "1.7" ]]; then \
-    if [[ $$sub < 71 ]]; then \
+    if [[ $$sub -lt 71 ]]; then \
       echo "7.1.0.v20141016"; \
-    elif [[ $$sub < 75 ]]; then \
+    elif [[ $$sub -lt 75 ]]; then \
       echo "7.1.2.v20141202"; \
     else \
        echo "7.1.3.v20150130"; \
     fi \
   elif [[ $$major = "1.8" ]]; then \
-    if [[ $$sub < 25 ]]; then \
+    if [[ $$sub -lt 25 ]]; then \
       echo "8.1.0.v20141016"; \
-    elif [[ $$sub < 31 ]]; then \
+    elif [[ $$sub -lt 31 ]]; then \
       echo "8.1.2.v20141202"; \
-    elif [[ $$sub < 51 ]]; then \
+    elif [[ $$sub -lt 51 ]]; then \
        echo "8.1.3.v20150130"; \
-    elif [[ $$sub < 60 ]]; then \
+    elif [[ $$sub -lt 60 ]]; then \
       echo "8.1.4.v20150727"; \
-    elif [[ $$sub < 65 ]]; then \
+    elif [[ $$sub -lt 65 ]]; then \
       echo "8.1.5.v20150921"; \
-    elif [[ $$sub < 71 ]]; then \
+    elif [[ $$sub -lt 71 ]]; then \
       echo "8.1.6.v20151105"; \
     else \
       echo "8.1.7.v20160121"; \


### PR DESCRIPTION
Fix incorrect bourne shell comparison in regards to ALPN build selections.  Originally was using lexicographical ordering instead of integer.  Fix is in accordance with the man page for bash.

Lexicographical
>       [[ expression ]]
              Return a status of 0 or 1 depending on the evaluation of the conditional expression expression.  Expressions are composed of the primaries described below  under  CONDITIONAL
              EXPRESSIONS.  Word splitting and pathname expansion are not performed on the words between the [[ and ]]; tilde expansion, parameter and variable expansion, arithmetic expan‐
              sion, command substitution, process substitution, and quote removal are performed.  Conditional operators such as -f must be unquoted to be recognized as primaries.

>               When used with [[, the < and > operators sort lexicographically using the current locale.


Integers
>        arg1 OP arg2
              OP is one of -eq, -ne, -lt, -le, -gt, or -ge.  These arithmetic binary operators return true if arg1 is equal to, not equal to, less than, less  than  or  equal  to,  greater
              than, or greater than or equal to arg2, respectively.  Arg1 and arg2 may be positive or negative integers.
