### PR TITLE
RPCManager, plugin loader refactor

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,7 +98,7 @@ tsdb_SRC := \
 	src/query/expression/PostAggregatedDataPoints.java	\
 	src/query/expression/Scale.java	\
 	src/query/expression/SumSeries.java	\
-  src/query/expression/TimeShift.java \
+	src/query/expression/TimeShift.java \
 	src/query/expression/TimeSyncedIterator.java	\
 	src/query/expression/UnionIterator.java	\
 	src/query/expression/VariableIterator.java	\
@@ -147,6 +147,7 @@ tsdb_SRC := \
 	src/tsd/AnnotationRpc.java	\
 	src/tsd/BadRequestException.java	\
 	src/tsd/ConnectionManager.java	\
+	src/tsd/DropCachesRpc.java \
 	src/tsd/GnuplotException.java	\
 	src/tsd/GraphHandler.java	\
 	src/tsd/HttpJsonSerializer.java	\
@@ -164,6 +165,7 @@ tsdb_SRC := \
 	src/tsd/RpcHandler.java	\
 	src/tsd/RpcPlugin.java	\
 	src/tsd/RpcManager.java	\
+	src/tsd/RpcUtil.java \
 	src/tsd/RTPublisher.java	\
 	src/tsd/SearchRpc.java	\
 	src/tsd/StaticFileRpc.java	\

--- a/src/opentsdb.conf
+++ b/src/opentsdb.conf
@@ -37,6 +37,14 @@ tsd.http.cachedir =
 # is False
 #tsd.core.auto_create_metrics = false
 
+# Whether or not to enable the built-in UI Rpc Plugins, default
+# is True
+#tsd.core.enable_ui = true
+
+# Whether or not to enable the built-in API Rpc Plugins, default
+# is True
+#tsd.core.enable_api = true
+
 # --------- STORAGE ----------
 # Whether or not to enable data compaction in HBase, default is True
 #tsd.storage.enable_compaction = true

--- a/src/tools/CliOptions.java
+++ b/src/tools/CliOptions.java
@@ -120,6 +120,10 @@ final class CliOptions {
       // map the overrides
       if (entry.getKey().toLowerCase().equals("--auto-metric")) {
         config.overrideConfig("tsd.core.auto_create_metrics", "true");
+      } else if (entry.getKey().toLowerCase().equals("--disable-ui")) {
+        config.overrideConfig("tsd.core.enable_ui", "false");
+      } else if (entry.getKey().toLowerCase().equals("--disable-api")) {
+        config.overrideConfig("tsd.core.enable_api", "false");
       } else if (entry.getKey().toLowerCase().equals("--table")) {
         config.overrideConfig("tsd.storage.hbase.data_table", entry.getValue());
       } else if (entry.getKey().toLowerCase().equals("--uidtable")) {

--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -93,6 +93,10 @@ final class TSDMain {
                    "Use async NIO (default true) or traditional blocking io");
     argp.addOption("--read-only", "true|false",
                    "Set tsd.mode to ro (default false)");
+    argp.addOption("--disable-ui", "true|false",
+                   "Set tsd.core.enable_ui to false (default true)");
+    argp.addOption("--disable-api", "true|false",
+                   "Set tsd.core.enable_api to false (default true)");
     argp.addOption("--backlog", "NUM",
                    "Size of connection attempt queue (default: 3072 or kernel"
                    + " somaxconn.");

--- a/src/tsd/DropCachesRpc.java
+++ b/src/tsd/DropCachesRpc.java
@@ -1,0 +1,88 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2013  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.tsd;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Atomics;
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.opentsdb.tools.BuildData;
+import net.opentsdb.core.Aggregators;
+import net.opentsdb.core.TSDB;
+import net.opentsdb.query.filter.TagVFilter;
+import net.opentsdb.stats.StatsCollector;
+import net.opentsdb.utils.Config;
+import net.opentsdb.utils.JSON;
+import net.opentsdb.utils.PluginLoader;
+
+import java.io.IOException;
+
+/** The "dropcaches" command. */
+public final class DropCachesRpc implements TelnetRpc, HttpRpc {
+    private static final Logger LOG = LoggerFactory.getLogger(DropCachesRpc.class);
+
+    public Deferred<Object> execute(final TSDB tsdb, final Channel chan,
+                                    final String[] cmd) {
+        dropCaches(tsdb, chan);
+        chan.write("Caches dropped.\n");
+        return Deferred.fromResult(null);
+    }
+
+    public void execute(final TSDB tsdb, final HttpQuery query)
+            throws IOException {
+
+        // only accept GET/DELETE
+        RpcUtil.allowedMethods(query.method(), HttpMethod.GET.getName(), HttpMethod.DELETE.getName());
+
+        dropCaches(tsdb, query.channel());
+
+        if (query.apiVersion() > 0) {
+            final HashMap<String, String> response = new HashMap<String, String>();
+            response.put("status", "200");
+            response.put("message", "Caches dropped");
+            query.sendReply(query.serializer().formatDropCachesV1(response));
+        } else { // deprecated API
+            query.sendReply("Caches dropped.\n");
+        }
+    }
+
+    /** Drops in memory caches.  */
+    private void dropCaches(final TSDB tsdb, final Channel chan) {
+        LOG.warn(chan + " Dropping all in-memory caches.");
+        tsdb.dropCaches();
+    }
+}

--- a/src/tsd/RpcManager.java
+++ b/src/tsd/RpcManager.java
@@ -52,26 +52,26 @@ import net.opentsdb.utils.PluginLoader;
 /**
  * Manager for the lifecycle of <code>HttpRpc</code>s, <code>TelnetRpc</code>s,
  * <code>RpcPlugin</code>s, and <code>HttpRpcPlugin</code>.  This is a
- * singleton.  Its lifecycle must be managed by the "container".  If you are 
- * launching via {@code TSDMain} then shutdown (and non-lazy initialization) 
+ * singleton.  Its lifecycle must be managed by the "container".  If you are
+ * launching via {@code TSDMain} then shutdown (and non-lazy initialization)
  * is taken care of. Outside of the use of {@code TSDMain}, you are responsible
  * for shutdown, at least.
- * 
+ *
  * <p> Here's an example of how to correctly handle shutdown manually:
- * 
+ *
  * <pre>
  * // Startup our TSDB instance...
  * TSDB tsdb_instance = ...;
- * 
+ *
  * // ... later, during shtudown ..
- * 
+ *
  * if (RpcManager.isInitialized()) {
  *   // Check that its actually been initialized.  We don't want to
  *   // create a new instance only to shutdown!
  *   RpcManager.instance(tsdb_instance).shutdown().join();
  * }
  * </pre>
- * 
+ *
  * @since 2.2
  */
 public final class RpcManager {
@@ -81,7 +81,7 @@ public final class RpcManager {
    * to match incoming requests. */
   @VisibleForTesting
   protected static final String PLUGIN_BASE_WEBPATH = "plugin";
-  
+
   /** Splitter for web paths.  Removes empty strings to handle trailing or
    * leading slashes.  For instance, all of <code>/plugin/mytest</code>,
    * <code>plugin/mytest/</code>, and <code>plugin/mytest</code> will be
@@ -89,13 +89,13 @@ public final class RpcManager {
   private static final Splitter WEBPATH_SPLITTER = Splitter.on('/')
       .trimResults()
       .omitEmptyStrings();
-  
+
   /** Matches paths declared by {@link HttpRpcPlugin}s that are rooted in
    * the system's plugins path. */
   private static final Pattern HAS_PLUGIN_BASE_WEBPATH = Pattern.compile(
-      "^/?" + PLUGIN_BASE_WEBPATH + "/?.*", 
+      "^/?" + PLUGIN_BASE_WEBPATH + "/?.*",
       Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-  
+
   /** Reference to our singleton instance.  Set in {@link #initialize}. */
   private static final AtomicReference<RpcManager> INSTANCE = Atomics.newReference();
 
@@ -107,10 +107,10 @@ public final class RpcManager {
   private ImmutableMap<String, HttpRpcPlugin> http_plugin_commands;
   /** List of activated RPC plugins */
   private ImmutableList<RpcPlugin> rpc_plugins;
-  
+
   /** The TSDB that owns us. */
   private TSDB tsdb;
-  
+
   /**
    * Constructor used by singleton factory method.
    * @param tsdb the owning TSDB instance.
@@ -118,7 +118,7 @@ public final class RpcManager {
   private RpcManager(final TSDB tsdb) {
     this.tsdb = tsdb;
   }
-  
+
   /**
    * Get or create the singleton instance of the manager, loading all the
    * plugins enabled in the given TSDB's {@link Config}.
@@ -135,7 +135,7 @@ public final class RpcManager {
     final String mode = Strings.nullToEmpty(tsdb.getConfig().getString("tsd.mode"));
 
     // Load any plugins that are enabled via Config.  Fail if any plugin cannot be loaded.
-  
+
     final ImmutableList.Builder<RpcPlugin> rpcBuilder = ImmutableList.builder();
     if (tsdb.getConfig().hasProperty("tsd.rpc.plugins")) {
       final String[] plugins = tsdb.getConfig().getString("tsd.rpc.plugins").split(",");
@@ -155,13 +155,13 @@ public final class RpcManager {
       manager.initializeHttpRpcPlugins(mode, plugins, httpPluginsBuilder);
     }
     manager.http_plugin_commands = httpPluginsBuilder.build();
-    
+
     INSTANCE.set(manager);
     return manager;
   }
-  
+
   /**
-   * @return {@code true} if the shared instance has been initialized; 
+   * @return {@code true} if the shared instance has been initialized;
    * {@code false} otherwise.
    */
   public static synchronized boolean isInitialized() {
@@ -169,17 +169,17 @@ public final class RpcManager {
   }
 
   /**
-   * @return list of loaded {@link RpcPlugin}s.  Possibly empty but 
+   * @return list of loaded {@link RpcPlugin}s.  Possibly empty but
    * never {@code null}.
    */
   @VisibleForTesting
   protected ImmutableList<RpcPlugin> getRpcPlugins() {
     return rpc_plugins;
   }
-  
+
   /**
    * Lookup a {@link TelnetRpc} based on given command name.  Note that this
-   * lookup is case sensitive in that the {@code command} passed in must 
+   * lookup is case sensitive in that the {@code command} passed in must
    * match a registered RPC command exactly.
    * @param command a telnet API command name.
    * @return the {@link TelnetRpc} for the given {@code command} or {@code null}
@@ -188,36 +188,36 @@ public final class RpcManager {
   TelnetRpc lookupTelnetRpc(final String command) {
     return telnet_commands.get(command);
   }
-  
+
   /**
    * Lookup a built-in {@link HttpRpc} based on the given {@code queryBaseRoute}.
    * The lookup is based on exact match of the input parameter and the registered
    * {@link HttpRpc}s.
-   * @param queryBaseRoute the HTTP query's base route, with no trailing or 
+   * @param queryBaseRoute the HTTP query's base route, with no trailing or
    * leading slashes.  For example: {@code api/query}
-   * @return the {@link HttpRpc} for the given {@code queryBaseRoute} or 
+   * @return the {@link HttpRpc} for the given {@code queryBaseRoute} or
    * {@code null} if not found.
    */
   HttpRpc lookupHttpRpc(final String queryBaseRoute) {
     return http_commands.get(queryBaseRoute);
   }
-  
+
   /**
-   * Lookup a user-supplied {@link HttpRpcPlugin} for the given 
-   * {@code queryBaseRoute}. The lookup is based on exact match of the input 
+   * Lookup a user-supplied {@link HttpRpcPlugin} for the given
+   * {@code queryBaseRoute}. The lookup is based on exact match of the input
    * parameter and the registered {@link HttpRpcPlugin}s.
    * @param queryBaseRoute the value of {@link HttpRpcPlugin#getPath()} with no
    * trailing or leading slashes.
-   * @return the {@link HttpRpcPlugin} for the given {@code queryBaseRoute} or 
+   * @return the {@link HttpRpcPlugin} for the given {@code queryBaseRoute} or
    * {@code null} if not found.
    */
   HttpRpcPlugin lookupHttpRpcPlugin(final String queryBaseRoute) {
     return http_plugin_commands.get(queryBaseRoute);
   }
-  
+
   /**
    * @param uri HTTP request URI, with or without query parameters.
-   * @return {@code true} if the URI represents a request for a 
+   * @return {@code true} if the URI represents a request for a
    * {@link HttpRpcPlugin}; {@code false} otherwise.  Note that this
    * method returning true <strong>says nothing</strong> about
    * whether or not there is a {@link HttpRpcPlugin} registered
@@ -233,12 +233,12 @@ public final class RpcManager {
       if (qmark != -1) {
         path = uri.substring(0, qmark);
       }
-      
+
       final List<String> parts = WEBPATH_SPLITTER.splitToList(path);
       return (parts.size() > 1 && parts.get(0).equals(PLUGIN_BASE_WEBPATH));
     }
   }
-  
+
   /**
    * Load and init instances of {@link TelnetRpc}s and {@link HttpRpc}s.
    * These are not generally configurable via TSDB config.
@@ -256,6 +256,8 @@ public final class RpcManager {
     final Boolean enableUi = tsdb.getConfig().getString("tsd.core.enable_ui").equals("true");
     final Boolean enableDieDieDie = tsdb.getConfig().getString("tsd.no_diediedie").equals("false");
 
+    LOG.info("Mode: {}, HTTP UI Enabled: {}, HTTP API Enabled: {}", mode, enableUi, enableApi);
+
     if (mode.equals("rw") || mode.equals("wo")) {
       final PutDataPointRpc put = new PutDataPointRpc();
       telnet.put("put", put);
@@ -263,7 +265,7 @@ public final class RpcManager {
         http.put("api/put", put);
       }
     }
-    
+
     if (mode.equals("rw") || mode.equals("ro")) {
       final StaticFileRpc staticfile = new StaticFileRpc();
       final StatsRpc stats = new StatsRpc();
@@ -323,10 +325,10 @@ public final class RpcManager {
    * {@code pluginClassNames}.
    * @param mode is this TSD in read/write ("rw") or read-only ("ro")
    * mode?
-   * @param pluginClassNames fully-qualified class names that are 
+   * @param pluginClassNames fully-qualified class names that are
    * instances of {@link HttpRpcPlugin}s
-   * @param http a map of canonicalized paths 
-   * (obtained via {@link #canonicalizePluginPath(String)}) 
+   * @param http a map of canonicalized paths
+   * (obtained via {@link #canonicalizePluginPath(String)})
    * to {@link HttpRpcPlugin} instance.
    */
   @VisibleForTesting
@@ -344,7 +346,7 @@ public final class RpcManager {
   }
 
   /**
-   * Ensure that the given path for an {@link HttpRpcPlugin} is valid.  This 
+   * Ensure that the given path for an {@link HttpRpcPlugin} is valid.  This
    * method simply returns for valid inputs; throws and exception otherwise.
    * @param path a request path, no query parameters, etc.
    * @throws IllegalArgumentException on invalid paths.
@@ -355,9 +357,9 @@ public final class RpcManager {
         "Invalid HttpRpcPlugin path. Path is null or empty.");
     final String testPath = path.trim();
     Preconditions.checkArgument(!HAS_PLUGIN_BASE_WEBPATH.matcher(path).matches(),
-        "Invalid HttpRpcPlugin path %s. Path contains system's plugin base path.", 
+        "Invalid HttpRpcPlugin path %s. Path contains system's plugin base path.",
         testPath);
-    
+
     URI uri = URI.create(testPath);
     Preconditions.checkArgument(!Strings.isNullOrEmpty(uri.getPath()),
         "Invalid HttpRpcPlugin path %s. Parsed path is null or empty.", testPath);
@@ -390,18 +392,18 @@ public final class RpcManager {
   /**
    * Load and init the {@link RpcPlugin}s provided as an array of
    * {@code pluginClassNames}.
-   * @param pluginClassNames fully-qualified class names that are 
+   * @param pluginClassNames fully-qualified class names that are
    * instances of {@link RpcPlugin}s
    * @param rpcs a list of loaded and initialized plugins
    */
-  private void initializeRpcPlugins(final String[] pluginClassNames, 
+  private void initializeRpcPlugins(final String[] pluginClassNames,
         final ImmutableList.Builder<RpcPlugin> rpcs) {
     for (final String plugin : pluginClassNames) {
       final RpcPlugin rpc = createAndInitialize(plugin, RpcPlugin.class);
       rpcs.add(rpc);
     }
   }
-  
+
   /**
    * Helper method to load and initialize a given plugin class. This uses reflection
    * because plugins share no common interfaces. (They could though!)
@@ -412,7 +414,7 @@ public final class RpcManager {
   @VisibleForTesting
   protected <T> T createAndInitialize(final String pluginClassName, final Class<T> pluginClass) {
     final T instance = PluginLoader.loadSpecificPlugin(pluginClassName, pluginClass);
-    Preconditions.checkState(instance != null, 
+    Preconditions.checkState(instance != null,
         "Unable to locate %s using name '%s", pluginClass, pluginClassName);
     try {
       final Method initMeth = instance.getClass().getMethod("initialize", TSDB.class);
@@ -427,9 +429,9 @@ public final class RpcManager {
       throw new RuntimeException("Failed to initialize " + instance.getClass(), e);
     }
   }
-  
+
   /**
-   * Called to gracefully shutdown the plugin. Implementations should close 
+   * Called to gracefully shutdown the plugin. Implementations should close
    * any IO they have open
    * @return A deferred object that indicates the completion of the request.
    * The {@link Object} has not special meaning and can be {@code null}
@@ -440,22 +442,22 @@ public final class RpcManager {
     INSTANCE.set(null);
 
     final Collection<Deferred<Object>> deferreds = Lists.newArrayList();
-    
+
     if (http_plugin_commands != null) {
       for (final Map.Entry<String, HttpRpcPlugin> entry : http_plugin_commands.entrySet()) {
         deferreds.add(entry.getValue().shutdown());
       }
     }
-    
+
     if (rpc_plugins != null) {
       for (final RpcPlugin rpc : rpc_plugins) {
         deferreds.add(rpc.shutdown());
       }
     }
-    
+
     return Deferred.groupInOrder(deferreds);
   }
-  
+
   /**
    * Collect stats on the shared instance of {@link RpcManager}.
    */
@@ -476,7 +478,7 @@ public final class RpcManager {
       if (manager.http_plugin_commands != null) {
         try {
           collector.addExtraTag("plugin", "httprpc");
-          for (final Map.Entry<String, HttpRpcPlugin> entry 
+          for (final Map.Entry<String, HttpRpcPlugin> entry
               : manager.http_plugin_commands.entrySet()) {
             entry.getValue().collectStats(collector);
           }
@@ -486,7 +488,7 @@ public final class RpcManager {
       }
     }
   }
-  
+
   // ---------------------------- //
   // Individual command handlers. //
   // ---------------------------- //
@@ -563,7 +565,7 @@ public final class RpcManager {
 
   /** The home page ("GET /"). */
   private static final class HomePage implements HttpRpc {
-    public void execute(final TSDB tsdb, final HttpQuery query) 
+    public void execute(final TSDB tsdb, final HttpQuery query)
       throws IOException {
       final StringBuilder buf = new StringBuilder(2048);
       buf.append("<div id=queryuimain></div>"
@@ -577,15 +579,15 @@ public final class RpcManager {
         "OpenTSDB", "", buf.toString()));
     }
   }
-  
+
   /** The "/aggregators" endpoint. */
   private static final class ListAggregators implements HttpRpc {
-    public void execute(final TSDB tsdb, final HttpQuery query) 
+    public void execute(final TSDB tsdb, final HttpQuery query)
       throws IOException {
-      
+
       // only accept GET / POST
       RpcUtil.allowedMethods(query.method(), HttpMethod.GET.getName(), HttpMethod.POST.getName());
-      
+
       if (query.apiVersion() > 0) {
         query.sendReply(
             query.serializer().formatAggregatorsV1(Aggregators.set()));
@@ -606,12 +608,12 @@ public final class RpcManager {
       return Deferred.fromResult(null);
     }
 
-    public void execute(final TSDB tsdb, final HttpQuery query) throws 
+    public void execute(final TSDB tsdb, final HttpQuery query) throws
       IOException {
-      
+
       // only accept GET / POST
       RpcUtil.allowedMethods(query.method(), HttpMethod.GET.getName(), HttpMethod.POST.getName());
-      
+
       final HashMap<String, String> version = new HashMap<String, String>();
       version.put("version", BuildData.version);
       version.put("short_revision", BuildData.short_revision);
@@ -626,7 +628,7 @@ public final class RpcManager {
       if (query.apiVersion() > 0) {
         query.sendReply(query.serializer().formatVersionV1(version));
       } else {
-        final boolean json = query.request().getUri().endsWith("json");      
+        final boolean json = query.request().getUri().endsWith("json");
         if (json) {
           query.sendReply(JSON.serializeToBytes(version));
         } else {
@@ -662,7 +664,7 @@ public final class RpcManager {
       }
     }
   }
-  
+
   private static final class ShowConfig implements HttpRpc {
     @Override
     public void execute(TSDB tsdb, HttpQuery query) throws IOException {
@@ -671,7 +673,7 @@ public final class RpcManager {
 
       final String[] uri = query.explodeAPIPath();
       final String endpoint = uri.length > 1 ? uri[1].toLowerCase() : "";
-      
+
       if (endpoint.equals("filters")) {
         switch (query.apiVersion()) {
         case 0:
@@ -679,9 +681,9 @@ public final class RpcManager {
           query.sendReply(query.serializer().formatFilterConfigV1(
               TagVFilter.loadedFilters()));
           break;
-        default: 
-          throw new BadRequestException(HttpResponseStatus.NOT_IMPLEMENTED, 
-              "Requested API version not implemented", "Version " + 
+        default:
+          throw new BadRequestException(HttpResponseStatus.NOT_IMPLEMENTED,
+              "Requested API version not implemented", "Version " +
               query.apiVersion() + " is not implemented");
         }
       } else {
@@ -690,9 +692,9 @@ public final class RpcManager {
           case 1:
             query.sendReply(query.serializer().formatConfigV1(tsdb.getConfig()));
             break;
-          default: 
-            throw new BadRequestException(HttpResponseStatus.NOT_IMPLEMENTED, 
-                "Requested API version not implemented", "Version " + 
+          default:
+            throw new BadRequestException(HttpResponseStatus.NOT_IMPLEMENTED,
+                "Requested API version not implemented", "Version " +
                 query.apiVersion() + " is not implemented");
         }
       }

--- a/src/tsd/RpcUtil.java
+++ b/src/tsd/RpcUtil.java
@@ -1,0 +1,37 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2014  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.tsd;
+
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class RpcUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RpcUtil.class);
+
+    public static void allowedMethods(HttpMethod requestMethod, String... allowedMethods) {
+        for(String method : allowedMethods) {
+            LOG.debug(String.format("Trying Method: %s", method));
+            if (requestMethod.getName() == method) {
+                LOG.debug(String.format("Method Allowed: %s", method));
+                return;
+            }
+        }
+        throw new BadRequestException(HttpResponseStatus.METHOD_NOT_ALLOWED,
+                "Method not allowed", "The HTTP method [" + requestMethod.getName() + "] is not permitted for this endpoint");
+    }
+}

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -488,6 +488,8 @@ public class Config {
     default_map.put("tsd.core.auto_create_tagks", "true");
     default_map.put("tsd.core.auto_create_tagvs", "true");
     default_map.put("tsd.core.connections.limit", "0");
+    default_map.put("tsd.core.enable_api", "true");
+    default_map.put("tsd.core.enable_ui", "true");
     default_map.put("tsd.core.meta.enable_realtime_ts", "false");
     default_map.put("tsd.core.meta.enable_realtime_uid", "false");
     default_map.put("tsd.core.meta.enable_tsuid_incrementing", "false");

--- a/test/tsd/TestRpcManager.java
+++ b/test/tsd/TestRpcManager.java
@@ -46,6 +46,12 @@ public class TestRpcManager {
   @Before
   public void before() {
     Config config = mock(Config.class);
+    when(config.getString("tsd.core.enable_api"))
+      .thenReturn("true");
+    when(config.getString("tsd.core.enable_ui"))
+      .thenReturn("true");
+    when(config.getString("tsd.no_diediedie"))
+      .thenReturn("false");
     TSDB tsdb = mock(TSDB.class);
     when(tsdb.getConfig()).thenReturn(config);
     mock_tsdb_no_plugins = tsdb;
@@ -62,10 +68,10 @@ public class TestRpcManager {
   public void loadHttpRpcPlugins() throws Exception {
     Config config = mock(Config.class);
     when(config.hasProperty("tsd.http.rpc.plugins"))
-    .thenReturn(true);
+      .thenReturn(true);
     when(config.getString("tsd.http.rpc.plugins"))
       .thenReturn("net.opentsdb.tsd.DummyHttpRpcPlugin");
-    
+
     TSDB tsdb = mock(TSDB.class);
     when(tsdb.getConfig()).thenReturn(config);
     
@@ -85,12 +91,12 @@ public class TestRpcManager {
       .thenReturn("net.opentsdb.tsd.DummyRpcPlugin");
     
     when(config.hasProperty("tsd.rpcplugin.DummyRPCPlugin.hosts"))
-    .thenReturn(true);
+      .thenReturn(true);
     when(config.getString("tsd.rpcplugin.DummyRPCPlugin.hosts"))
       .thenReturn("blah");
     when(config.getInt("tsd.rpcplugin.DummyRPCPlugin.port"))
       .thenReturn(1000);
-    
+
     TSDB tsdb = mock(TSDB.class);
     when(tsdb.getConfig()).thenReturn(config);
     

--- a/test/tsd/TestRpcManager.java
+++ b/test/tsd/TestRpcManager.java
@@ -71,6 +71,12 @@ public class TestRpcManager {
       .thenReturn(true);
     when(config.getString("tsd.http.rpc.plugins"))
       .thenReturn("net.opentsdb.tsd.DummyHttpRpcPlugin");
+    when(config.getString("tsd.core.enable_api"))
+      .thenReturn("true");
+    when(config.getString("tsd.core.enable_ui"))
+      .thenReturn("true");
+    when(config.getString("tsd.no_diediedie"))
+     .thenReturn("false");
 
     TSDB tsdb = mock(TSDB.class);
     when(tsdb.getConfig()).thenReturn(config);
@@ -86,16 +92,21 @@ public class TestRpcManager {
   public void loadRpcPlugin() throws Exception {
     Config config = mock(Config.class);
     when(config.hasProperty("tsd.rpc.plugins"))
-    .thenReturn(true);
+      .thenReturn(true);
     when(config.getString("tsd.rpc.plugins"))
       .thenReturn("net.opentsdb.tsd.DummyRpcPlugin");
-    
     when(config.hasProperty("tsd.rpcplugin.DummyRPCPlugin.hosts"))
       .thenReturn(true);
     when(config.getString("tsd.rpcplugin.DummyRPCPlugin.hosts"))
       .thenReturn("blah");
     when(config.getInt("tsd.rpcplugin.DummyRPCPlugin.port"))
       .thenReturn(1000);
+    when(config.getString("tsd.core.enable_api"))
+      .thenReturn("true");
+    when(config.getString("tsd.core.enable_ui"))
+      .thenReturn("true");
+    when(config.getString("tsd.no_diediedie"))
+      .thenReturn("false");
 
     TSDB tsdb = mock(TSDB.class);
     when(tsdb.getConfig()).thenReturn(config);


### PR DESCRIPTION
* Fixed inconsistency with dropCache endpoint
*  Added configuration options tsd.core.enable_api, tsd.core.enable_ui
* Refactored RPCManager, allowed for disabling the built-in UI or API via configuration options

Fix #830