### PR TITLE
Tags via custom HTTP header - provide some authentication

### DIFF
--- a/src/core/IncomingDataPoint.java
+++ b/src/core/IncomingDataPoint.java
@@ -135,7 +135,12 @@ public class IncomingDataPoint {
   public final String getTSUID() {
     return tsuid;
   }
-  
+
+  /** @param moretags the hashmap of kv pair to add */
+  public final void addTags(HashMap<String, String> moretags) {
+    this.tags.putAll(moretags);
+  }
+
   /** @param metric the metric to set */
   public final void setMetric(String metric) {
     this.metric = metric;

--- a/src/tsd/AbstractHttpQuery.java
+++ b/src/tsd/AbstractHttpQuery.java
@@ -165,6 +165,16 @@ public abstract class AbstractHttpQuery {
     return headers;
   }
   
+  /**
+  * Return the value of the given HTTP Header
+  * first match wins
+  * @return Header value as string
+  */
+  public String getHeaderValue(final String headerName) {
+    if (headerName == null) { return null; }
+    return request.headers().get(headerName);
+  }
+  
   /** @param stats The stats object to mark after writing is complete */
   public void setStats(final QueryStats stats) {
     this.stats = stats;

--- a/src/tsd/PutDataPointRpc.java
+++ b/src/tsd/PutDataPointRpc.java
@@ -278,6 +278,7 @@ class PutDataPointRpc implements TelnetRpc, HttpRpc {
       throw new BadRequestException("No datapoints found in content");
     }
 
+    final HashMap<String, String> query_tags = new HashMap<String, String>();
     final boolean show_details = query.hasQueryStringParam("details");
     final boolean show_summary = query.hasQueryStringParam("summary");
     final boolean synchronous = query.hasQueryStringParam("sync");
@@ -292,7 +293,18 @@ class PutDataPointRpc implements TelnetRpc, HttpRpc {
     int queued = 0;
     final List<Deferred<Boolean>> deferreds = synchronous ? 
         new ArrayList<Deferred<Boolean>>(dps.size()) : null;
-    
+
+    if (tsdb.getConfig().enable_header_tag()) {
+      LOG.debug("Looking for tag header " + tsdb.getConfig().get_name_header_tag());
+      final String header_tag_value = query.getHeaderValue(tsdb.getConfig().get_name_header_tag()) ;
+      if (header_tag_value != null) {
+        LOG.debug(" header found with value:" + header_tag_value);
+        Tags.parse(query_tags, header_tag_value);
+      } else {
+        LOG.debug(" no such header in request");
+      }
+    }
+
     for (final IncomingDataPoint dp : dps) {
       final DataPointType type;
       if (dp instanceof RollUpDataPoint) {
@@ -351,6 +363,12 @@ class PutDataPointRpc implements TelnetRpc, HttpRpc {
           illegal_arguments.incrementAndGet();
           continue;
         }
+        
+        /** Add additionnal tags from HTTP header */
+        if ( (query_tags != null) && (query_tags.size() > 0) ) {
+          dp.addTags(query_tags);
+        }
+
         // TODO - refactor the add calls someday or move some of this into the 
         // actual data point class.
         final Deferred<Boolean> deferred;

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -97,6 +97,9 @@ public class Config {
   /** tsd.storage.fix_duplicates */
   private boolean fix_duplicates = false;
 
+  /** tsd.http.header_tag */
+  private String http_header_tag = null;
+
   /** tsd.http.request.max_chunk */
   private int max_chunked_requests = 4096; 
   
@@ -237,6 +240,16 @@ public class Config {
   /** @return maximum number of rows to be fetched per round trip while scanning HBase */
   public int scanner_maxNumRows() {
     return scanner_max_num_rows;
+  }
+
+  /** @return whether or not additional http header tag is allowed */
+  public boolean enable_header_tag() {
+    return http_header_tag != null ;
+  }
+  
+  /** @return the lookup value for additional http header tag */
+  public String get_name_header_tag() {
+    return http_header_tag ;
   }
   
   /** @return whether or not chunked requests are supported */
@@ -564,6 +577,7 @@ public class Config {
     default_map.put("tsd.core.stats_with_port", "false");    
     default_map.put("tsd.http.show_stack_trace", "true");
     default_map.put("tsd.http.query.allow_delete", "false");
+    default_map.put("tsd.http.header_tag", "");
     default_map.put("tsd.http.request.enable_chunked", "false");
     default_map.put("tsd.http.request.max_chunk", "4096");
     default_map.put("tsd.http.request.cors_domains", "");
@@ -682,6 +696,9 @@ public class Config {
       this.getBoolean("tsd.core.meta.enable_tsuid_tracking");
     if (this.hasProperty("tsd.http.request.max_chunk")) {
       max_chunked_requests = this.getInt("tsd.http.request.max_chunk");
+    }
+    if (this.hasProperty("tsd.http.header_tag")) {
+      http_header_tag = this.getString("tsd.http.header_tag");
     }
     enable_tree_processing = this.getBoolean("tsd.core.tree.enable_processing");
     fix_duplicates = this.getBoolean("tsd.storage.fix_duplicates");


### PR DESCRIPTION
Hi there,

Here is a PR we're using on a multi-tenant TSDB cluster (2.2.1). It allows to give tags to TSDB API via custom HTTP headers.

It basically allow to authenticate HTTP client on reverse proxy (nginx etc) with various mechanisms (SSL cert, IP address, basic auth, even SAML) and to push this info to TSDB within a custom header. This aims to securely separate data between our customers, given that the reverse proxy will properly deal with authentication.

You have to put the name of the header in your config, such as :
`tsd.http.header_tag = X-TSDB-TAG`

Then if you push data via the /api/put endpoint, just add key/value tags in this header :
`X-TSDB-TAG: customer=john,dc=virginia`

These tags and values will be added to the tags already present in JSON payload.
Example with haproxy and SSL client auth :
`http-request set-header X-TSDB-TAG customer=ssl_c_s_dn(cn)`

I am aware that some people are currently working on a real authentication framework (see #667). This patch does not aim to deal with user authentication but to permit customer isolation via third party authentication (ie: http reverse proxy).

We can write some docs about this, given that this PR is on the right track.

Note1 : tags in headers only work on "put" endpoint. It should be easy to use it also in "query" endpoint
Note2 : this PR is against next, but you can find a commit against master on our fork

Regards