### PR TITLE
Tiered compaction

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -193,7 +193,8 @@ tsdb_SRC := \
 	src/utils/JSONException.java	\
 	src/utils/Pair.java	\
 	src/utils/PluginLoader.java	\
-	src/utils/Threads.java
+	src/utils/Threads.java \
+	src/core/RequestBuilder.java
 
 tsdb_DEPS = \
 	$(COMMONS_LOGGING)	\
@@ -271,6 +272,7 @@ test_SRC := \
 	test/core/TestTsdbQuerySaltedAppend.java	\
 	test/core/TestTSQuery.java	\
 	test/core/TestTSSubQuery.java	\
+	test/core/TestTsdbTSConfig.java \
 	test/plugin/DummyPlugin.java \
 	test/meta/TestAnnotation.java	\
 	test/meta/TestTSMeta.java	\

--- a/src/core/AppendDataPoints.java
+++ b/src/core/AppendDataPoints.java
@@ -227,8 +227,8 @@ public class AppendDataPoints {
       
     if (repair && needs_repair) {
       LOG.debug("Repairing appended data column " + kv);
-      final PutRequest put = new PutRequest(tsdb.table, kv.key(),  
-          TSDB.FAMILY(), kv.qualifier(), healed_cell);
+      final PutRequest put = RequestBuilder.buildPutRequest(tsdb.getConfig(), tsdb.table, kv.key(),
+          TSDB.FAMILY(), kv.qualifier(), healed_cell, kv.timestamp());
       repaired_deferred = tsdb.getClient().put(put);
     }
     

--- a/src/core/BatchedDataPoints.java
+++ b/src/core/BatchedDataPoints.java
@@ -138,7 +138,7 @@ final class BatchedDataPoints implements WritableDataPoints {
     final byte[] v = Arrays.copyOfRange(batched_value, 0, value_index);
     final byte[] r = Arrays.copyOfRange(row_key, 0, row_key.length);
     reset();
-    return tsdb.put(r, q, v);
+    return tsdb.put(r, q, v, base_time);
   }
 
   @Override

--- a/src/core/IncomingDataPoints.java
+++ b/src/core/IncomingDataPoints.java
@@ -341,13 +341,13 @@ final class IncomingDataPoints implements WritableDataPoints {
         // TODO(tsuna): Add an errback to handle some error cases here.
         if (tsdb.getConfig().enable_appends()) {
           final AppendDataPoints kv = new AppendDataPoints(qualifier, value);
-          final AppendRequest point = new AppendRequest(tsdb.table, row, TSDB.FAMILY, 
-              AppendDataPoints.APPEND_COLUMN_QUALIFIER, kv.getBytes());
+          final AppendRequest point = RequestBuilder.buildAppendRequest(tsdb.getConfig(), tsdb.table, row, TSDB.FAMILY,
+                  AppendDataPoints.APPEND_COLUMN_QUALIFIER, kv.getBytes(), timestamp);
           point.setDurable(!batch_import);
           return tsdb.client.append(point);/* .addBoth(cb) */
         } else {
-          final PutRequest point = new PutRequest(tsdb.table, row, TSDB.FAMILY, 
-              qualifier, value);
+          final PutRequest point = RequestBuilder.buildPutRequest(tsdb.getConfig(), tsdb.table, row, TSDB.FAMILY,
+              qualifier, value, timestamp);
           point.setDurable(!batch_import);
           return tsdb.client.put(point)/* .addBoth(cb) */;
         }

--- a/src/core/RequestBuilder.java
+++ b/src/core/RequestBuilder.java
@@ -1,0 +1,33 @@
+package net.opentsdb.core;
+
+import org.hbase.async.AppendRequest;
+import org.hbase.async.HBaseRpc;
+import org.hbase.async.PutRequest;
+
+import net.opentsdb.utils.Config;
+
+public class RequestBuilder {
+	
+	public static PutRequest buildPutRequest(Config config, byte[] tableName, byte[] row, byte[] family, byte[] qualifier, byte[] value, long timestamp) {
+		
+		if(config.use_otsdb_timestamp()) 
+			if((timestamp & Const.SECOND_MASK) != 0)
+				return new PutRequest(tableName, row, family, qualifier, value, timestamp);
+			else
+				return new PutRequest(tableName, row, family, qualifier, value, timestamp * 1000);
+		else
+			return new PutRequest(tableName, row, family, qualifier, value);
+	}
+
+	public static AppendRequest buildAppendRequest(Config config, byte[] tableName, byte[] row, byte[] family, byte[] qualifier, byte[] value, long timestamp) {
+		
+		if(config.use_otsdb_timestamp())
+			if((timestamp & Const.SECOND_MASK) != 0)
+				return new AppendRequest(tableName, row, family, qualifier, value, timestamp);
+			else
+				return new AppendRequest(tableName, row, family, qualifier, value, timestamp * 1000);
+		else
+			return new AppendRequest(tableName, row, family, qualifier, value);
+	}
+
+}

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -988,12 +988,12 @@ public final class TSDB {
         Deferred<Object> result = null;
         if (config.enable_appends()) {
           final AppendDataPoints kv = new AppendDataPoints(qualifier, value);
-          final AppendRequest point = new AppendRequest(table, row, FAMILY, 
-              AppendDataPoints.APPEND_COLUMN_QUALIFIER, kv.getBytes());
+          final AppendRequest point = RequestBuilder.buildAppendRequest(config, table, row, FAMILY, 
+              AppendDataPoints.APPEND_COLUMN_QUALIFIER, kv.getBytes(), timestamp);
           result = client.append(point);
         } else {
           scheduleForCompaction(row, (int) base_time);
-          final PutRequest point = new PutRequest(table, row, FAMILY, qualifier, value);
+          final PutRequest point = RequestBuilder.buildPutRequest(config, table, row, FAMILY, qualifier, value, timestamp);
           result = client.put(point);
         }
 
@@ -1592,8 +1592,9 @@ public final class TSDB {
   /** Puts the given value into the data table. */
   final Deferred<Object> put(final byte[] key,
                              final byte[] qualifier,
-                             final byte[] value) {
-    return client.put(new PutRequest(table, key, FAMILY, qualifier, value));
+                             final byte[] value,
+                             long timestamp) {
+    return client.put(RequestBuilder.buildPutRequest(config, table, key, FAMILY, qualifier, value, timestamp));
   }
 
   /** Deletes the given cells from the data table. */

--- a/src/core/TsdbQuery.java
+++ b/src/core/TsdbQuery.java
@@ -24,15 +24,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.eclipse.jetty.util.log.Log;
 import org.hbase.async.Bytes;
+import org.hbase.async.Bytes.ByteMap;
 import org.hbase.async.DeleteRequest;
 import org.hbase.async.HBaseException;
 import org.hbase.async.KeyValue;
 import org.hbase.async.Scanner;
-import org.hbase.async.Bytes.ByteMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.stumbleupon.async.Callback;
@@ -1056,7 +1055,6 @@ final class TsdbQuery implements Query {
     if(tsdb.getConfig().use_otsdb_timestamp()) {
     	long stTime = (getScanStartTimeSeconds() * 1000);
     	long endTime = end_time == UNSET ? -1 : (getScanEndTimeSeconds() * 1000);
-    	Log.debug("Set scanner timestamp filter from: "+ stTime + "  to: " + endTime + " " + getStartTime() + " " + getEndTime());
     	scanner.setTimeRange(stTime, endTime);
     }
     if (tsuids != null && !tsuids.isEmpty()) {

--- a/src/meta/Annotation.java
+++ b/src/meta/Annotation.java
@@ -189,6 +189,7 @@ public final class Annotation implements Comparable<Annotation> {
             getRowKey(start_time, tsuid_byte), FAMILY, 
             getQualifier(start_time), 
             Annotation.this.getStorageJSON(), start_time);
+        System.out.println("PUT: " + put.toString());
         return tsdb.getClient().compareAndSet(put, original_note);
       }
       
@@ -276,7 +277,7 @@ public final class Annotation implements Comparable<Annotation> {
         if (row == null || row.isEmpty()) {
           return Deferred.fromResult(null);
         }
-        
+        System.out.println("GET RESULT: " + row);
         Annotation note = JSON.parseToObject(row.get(0).value(),
             Annotation.class);
         return Deferred.fromResult(note);
@@ -288,6 +289,7 @@ public final class Annotation implements Comparable<Annotation> {
         getRowKey(start_time, tsuid));
     get.family(FAMILY);
     get.qualifier(getQualifier(start_time));
+    System.out.println("GET: " + get.toString());
     return tsdb.getClient().get(get).addCallbackDeferring(new GetCB());    
   }
   

--- a/src/meta/Annotation.java
+++ b/src/meta/Annotation.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import net.opentsdb.core.Const;
 import net.opentsdb.core.Internal;
+import net.opentsdb.core.RequestBuilder;
 import net.opentsdb.core.RowKey;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.uid.UniqueId;
@@ -184,10 +185,10 @@ public final class Annotation implements Comparable<Annotation> {
         
         final byte[] tsuid_byte = tsuid != null && !tsuid.isEmpty() ? 
             UniqueId.stringToUid(tsuid) : null;
-        final PutRequest put = new PutRequest(tsdb.dataTable(), 
+        final PutRequest put = RequestBuilder.buildPutRequest(tsdb.getConfig(), tsdb.dataTable(), 
             getRowKey(start_time, tsuid_byte), FAMILY, 
             getQualifier(start_time), 
-            Annotation.this.getStorageJSON());
+            Annotation.this.getStorageJSON(), start_time);
         return tsdb.getClient().compareAndSet(put, original_note);
       }
       

--- a/src/tools/CliOptions.java
+++ b/src/tools/CliOptions.java
@@ -152,7 +152,9 @@ final class CliOptions {
         config.overrideConfig("tsd.network.async_io", entry.getValue());
       } else if (entry.getKey().toLowerCase().equals("--worker-threads")) {
         config.overrideConfig("tsd.network.worker_threads", entry.getValue());
-      } 	  
+      } else if(entry.getKey().toLowerCase().equals("--use-otsdb-ts")) {
+    	config.overrideConfig("tsd.storage.use_otsdb_timestamp", "true");
+      }
     }
   }
   

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -106,6 +106,9 @@ public class Config {
   /** tsd.storage.hbase.scanner.maxNumRows */
   private int scanner_max_num_rows = 128;
   
+  /** tsd.storage.use_otsdb_timestamp */
+  private boolean use_otsdb_timestamp = true;
+  
   /**
    * The list of properties configured to their defaults or modified by users
    */
@@ -251,6 +254,10 @@ public class Config {
   /** @return whether or not to process new or updated TSMetas through trees */
   public boolean enable_tree_processing() {
     return enable_tree_processing;
+  }
+  
+  public boolean use_otsdb_timestamp() {
+	  return use_otsdb_timestamp;
   }
   
   /**
@@ -542,6 +549,7 @@ public class Config {
       + "Content-Type, Accept, Origin, User-Agent, DNT, Cache-Control, "
       + "X-Mx-ReqToken, Keep-Alive, X-Requested-With, If-Modified-Since");
     default_map.put("tsd.query.timeout", "0");
+    default_map.put("tsd.storage.use_otsdb_timestamp", "true");
 
     for (Map.Entry<String, String> entry : default_map.entrySet()) {
       if (!properties.containsKey(entry.getKey()))
@@ -655,6 +663,7 @@ public class Config {
     enable_tree_processing = this.getBoolean("tsd.core.tree.enable_processing");
     fix_duplicates = this.getBoolean("tsd.storage.fix_duplicates");
     scanner_max_num_rows = this.getInt("tsd.storage.hbase.scanner.maxNumRows");
+    use_otsdb_timestamp = this.getBoolean("tsd.storage.use_otsdb_timestamp");
   }
   
   /**

--- a/test/core/TestTsdbQuery.java
+++ b/test/core/TestTsdbQuery.java
@@ -24,21 +24,25 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.hbase.async.HBaseClient;
+import org.hbase.async.Scanner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.internal.util.MockUtil;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.stumbleupon.async.DeferredGroupException;
+
 import net.opentsdb.core.TsdbQuery.ForTesting;
 import net.opentsdb.query.filter.TagVFilter;
 import net.opentsdb.query.filter.TagVWildcardFilter;
 import net.opentsdb.storage.MockBase;
 import net.opentsdb.uid.NoSuchUniqueName;
 import net.opentsdb.utils.DateTime;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
-import com.stumbleupon.async.DeferredGroupException;
 
 /**
  * This class is for unit testing the TsdbQuery class. Pretty much making sure
@@ -236,6 +240,7 @@ public final class TestTsdbQuery extends BaseTsdbTest {
   
   @Test
   public void configureFromQueryNoTags() throws Exception {
+	  
     setDataPointStorage();
     final TSQuery ts_query = getTSQuery();
     ts_query.getQueries().get(0).setTags(Collections.EMPTY_MAP);

--- a/test/core/TestTsdbTSConfig.java
+++ b/test/core/TestTsdbTSConfig.java
@@ -1,0 +1,192 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2015  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hbase.async.HBaseClient;
+import org.hbase.async.Scanner;
+import org.jboss.netty.util.HashedWheelTimer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.storage.MockBase;
+import net.opentsdb.uid.UniqueId;
+import net.opentsdb.utils.Config;
+
+/**
+ * Sets up a real TSDB with mocked client, compaction queue and timer along
+ * with mocked UID assignment, fetches for common unit tests.
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.management.*", "javax.xml.*",
+  "ch.qos.*", "org.slf4j.*",
+  "com.sum.*", "org.xml.*"})
+@PrepareForTest({TSDB.class, Config.class, UniqueId.class, HBaseClient.class, 
+  HashedWheelTimer.class, Scanner.class, Const.class })
+public class TestTsdbTSConfig {
+  /** A list of UIDs from A to Z for unit testing UIDs values */
+  public static final Map<String, byte[]> METRIC_UIDS = 
+      new HashMap<String, byte[]>(26);
+  public static final Map<String, byte[]> TAGK_UIDS = 
+      new HashMap<String, byte[]>(26);
+  public static final Map<String, byte[]> TAGV_UIDS = 
+      new HashMap<String, byte[]>(26);
+  static {
+    char letter = 'A';
+    int uid = 10;
+    for (int i = 0; i < 26; i++) {
+      METRIC_UIDS.put(Character.toString(letter), 
+          UniqueId.longToUID(uid, TSDB.metrics_width()));
+      TAGK_UIDS.put(Character.toString(letter), 
+          UniqueId.longToUID(uid, TSDB.tagk_width()));
+      TAGV_UIDS.put(Character.toString(letter++), 
+          UniqueId.longToUID(uid++, TSDB.tagv_width()));
+    }
+  }
+  
+  public static final String METRIC_STRING = "sys.cpu.user";
+  public static final byte[] METRIC_BYTES = new byte[] { 0, 0, 1 };
+  
+  public static final String TAGK_STRING = "host";
+  public static final byte[] TAGK_BYTES = new byte[] { 0, 0, 1 };
+  
+  public static final String TAGV_STRING = "web01";
+  public static final byte[] TAGV_BYTES = new byte[] { 0, 0, 1 };
+
+  protected HashedWheelTimer timer;
+  protected Config config;
+  protected TSDB tsdb;
+  protected HBaseClient client = mock(HBaseClient.class);
+  protected UniqueId metrics = mock(UniqueId.class);
+  protected UniqueId tag_names = mock(UniqueId.class);
+  protected UniqueId tag_values = mock(UniqueId.class);
+  protected Map<String, String> tags = new HashMap<String, String>(1);
+  protected MockBase storage;
+  
+  @Before
+  public void before() throws Exception {
+    timer = mock(HashedWheelTimer.class);
+
+    config = new Config(false);
+    config.overrideConfig("tsd.storage.enable_compaction", "false");
+    tsdb = PowerMockito.spy(new TSDB(config));
+
+    config.setAutoMetric(true);
+    
+    Whitebox.setInternalState(tsdb, "metrics", metrics);
+    Whitebox.setInternalState(tsdb, "tag_names", tag_names);
+    Whitebox.setInternalState(tsdb, "tag_values", tag_values);
+
+    setupMetricMaps();
+    setupTagkMaps();
+    setupTagvMaps();
+    
+    when(metrics.width()).thenReturn((short)3);
+    when(tag_names.width()).thenReturn((short)3);
+    when(tag_values.width()).thenReturn((short)3);
+    
+    tags.put(TAGK_STRING, TAGV_STRING);
+  }
+  
+  /** Adds the static UIDs to the metrics UID mock object */
+  void setupMetricMaps() {
+    when(metrics.getId(METRIC_STRING)).thenReturn(METRIC_BYTES);
+    when(metrics.getIdAsync(METRIC_STRING))
+      .thenAnswer(new Answer<Deferred<byte[]>>() {
+          @Override
+          public Deferred<byte[]> answer(InvocationOnMock invocation)
+              throws Throwable {
+            return Deferred.fromResult(METRIC_BYTES);
+          }
+      });
+    when(metrics.getOrCreateId(METRIC_STRING))
+      .thenReturn(METRIC_BYTES);
+  }
+  
+  /** Adds the static UIDs to the tag keys UID mock object */
+  void setupTagkMaps() {
+    when(tag_names.getId(TAGK_STRING)).thenReturn(TAGK_BYTES);
+    when(tag_names.getOrCreateId(TAGK_STRING)).thenReturn(TAGK_BYTES);
+    when(tag_names.getIdAsync(TAGK_STRING))
+      .thenAnswer(new Answer<Deferred<byte[]>>() {
+            @Override
+            public Deferred<byte[]> answer(InvocationOnMock invocation)
+                throws Throwable {
+              return Deferred.fromResult(TAGK_BYTES);
+            }
+        });
+    when(tag_names.getOrCreateIdAsync(TAGK_STRING))
+      .thenReturn(Deferred.fromResult(TAGK_BYTES));
+    
+  }
+  
+  /** Adds the static UIDs to the tag values UID mock object */
+  void setupTagvMaps() {
+    when(tag_values.getId(TAGV_STRING)).thenReturn(TAGV_BYTES);
+    when(tag_values.getOrCreateId(TAGV_STRING)).thenReturn(TAGV_BYTES);
+    when(tag_values.getIdAsync(TAGV_STRING))
+      .thenAnswer(new Answer<Deferred<byte[]>>() {
+          @Override
+          public Deferred<byte[]> answer(InvocationOnMock invocation)
+              throws Throwable {
+            return Deferred.fromResult(TAGV_BYTES);
+          }
+      });
+    when(tag_values.getOrCreateIdAsync(TAGV_STRING))
+      .thenReturn(Deferred.fromResult(TAGV_BYTES));
+  
+  }
+
+  @Test
+  public void scannerTimestampsEqualToQueryTimestamps() {
+	tsdb.getConfig().overrideConfig("tsd.storage.use_otsdb_timestamp", "true");
+    
+    TSQuery q = new TSQuery();
+    q.setStart("1h-ago");
+    
+    TSSubQuery subQuery = new TSSubQuery();
+    subQuery.setMetric(METRIC_STRING);
+    subQuery.setAggregator("none");
+    
+    ArrayList<TSSubQuery> list = new ArrayList<TSSubQuery>();
+    list.add(subQuery);
+    q.setQueries(list);
+    q.validateAndSetQuery();
+    
+    TsdbQuery query = new TsdbQuery(tsdb);
+    query.configureFromQuery(q, 0);
+    
+    Scanner scanner = query.getScanner();
+    long minTs = scanner.getMinTimestamp();
+    long maxTs = scanner.getMaxTimestamp();
+    // For 1h - ago, the TSDB will create a window of 2 hrs, For example if the current time is 2:45 PM, the window will be 1 PM to 3 PM
+    assert((maxTs - minTs) == (2 * 3600000));
+  }
+  
+}

--- a/test/meta/TestAnnotation.java
+++ b/test/meta/TestAnnotation.java
@@ -665,12 +665,12 @@ public final class TestAnnotation extends BaseTsdbTest {
         new byte[] { 1, 0, 0 }, 
         ("{\"startTime\":1328140800,\"endTime\":1328140801,\"description\":" + 
             "\"Description\",\"notes\":\"Notes\",\"custom\":{\"owner\":" + 
-            "\"ops\"}}").getBytes(MockBase.ASCII()));
+            "\"ops\"}}").getBytes(MockBase.ASCII()), 1328140799972L);
 
     storage.addColumn(global_row_key, 
         new byte[] { 1, 0, 1 }, 
         ("{\"startTime\":1328140801,\"endTime\":1328140803,\"description\":" + 
-            "\"Global 2\",\"notes\":\"Nothing\"}").getBytes(MockBase.ASCII()));
+            "\"Global 2\",\"notes\":\"Nothing\"}").getBytes(MockBase.ASCII()), 1328140799973L);
 
     // add a local
     storage.addColumn(tsuid_row_key, 
@@ -678,20 +678,20 @@ public final class TestAnnotation extends BaseTsdbTest {
         ("{\"tsuid\":\"000001000001000001\",\"startTime\":1388450562," +
             "\"endTime\":1419984000,\"description\":\"Hello!\",\"notes\":" + 
             "\"My Notes\",\"custom\":{\"owner\":\"ops\"}}")
-            .getBytes(MockBase.ASCII()));
+            .getBytes(MockBase.ASCII()), 1388448000003L);
     
     storage.addColumn(tsuid_row_key, 
         new byte[] { 1, 0x0A, 0x03 }, 
         ("{\"tsuid\":\"000001000001000001\",\"startTime\":1388450563," +
             "\"endTime\":1419984000,\"description\":\"Note2\",\"notes\":" + 
             "\"Nothing\"}")
-            .getBytes(MockBase.ASCII()));
+            .getBytes(MockBase.ASCII()), 1388448000004L);
     
     // add some data points too
     storage.addColumn(tsuid_row_key, 
-        new byte[] { 0x50, 0x10 }, new byte[] { 1 });
+        new byte[] { 0x50, 0x10 }, new byte[] { 1 }, 1388448000005L);
     
     storage.addColumn(tsuid_row_key, 
-        new byte[] { 0x50, 0x18 }, new byte[] { 2 });
+        new byte[] { 0x50, 0x18 }, new byte[] { 2 }, 1388448000006L);
   }
 }

--- a/test/tsd/TestAnnotationRpc.java
+++ b/test/tsd/TestAnnotationRpc.java
@@ -70,12 +70,12 @@ public final class TestAnnotationRpc {
         new byte[] { 1, 0, 0 }, 
         ("{\"startTime\":1328140800,\"endTime\":1328140801,\"description\":" + 
             "\"Description\",\"notes\":\"Notes\",\"custom\":{\"owner\":" + 
-            "\"ops\"}}").getBytes(MockBase.ASCII()));
+            "\"ops\"}}").getBytes(MockBase.ASCII()), 1328140799972L);
     
     storage.addColumn(global_row_key, 
         new byte[] { 1, 0, 1 }, 
         ("{\"startTime\":1328140801,\"endTime\":1328140803,\"description\":" + 
-            "\"Global 2\",\"notes\":\"Nothing\"}").getBytes(MockBase.ASCII()));
+            "\"Global 2\",\"notes\":\"Nothing\"}").getBytes(MockBase.ASCII()), 1328140799973L);
     
     // add a local
     storage.addColumn(tsuid_row_key, 
@@ -83,21 +83,21 @@ public final class TestAnnotationRpc {
         ("{\"tsuid\":\"000001000001000001\",\"startTime\":1388450562," +
             "\"endTime\":1419984000,\"description\":\"Hello!\",\"notes\":" + 
             "\"My Notes\",\"custom\":{\"owner\":\"ops\"}}")
-            .getBytes(MockBase.ASCII()));
+            .getBytes(MockBase.ASCII()), 1388448000003L);
     
     storage.addColumn(tsuid_row_key, 
         new byte[] { 1, 0x0A, 0x03 }, 
         ("{\"tsuid\":\"000001000001000001\",\"startTime\":1388450563," +
             "\"endTime\":1419984000,\"description\":\"Note2\",\"notes\":" + 
             "\"Nothing\"}")
-            .getBytes(MockBase.ASCII()));
+            .getBytes(MockBase.ASCII()), 1388448000004L);
     
     // add some data points too
     storage.addColumn(tsuid_row_key, 
-        new byte[] { 0x50, 0x10 }, new byte[] { 1 });
+        new byte[] { 0x50, 0x10 }, new byte[] { 1 }, 1388448000005L);
     
     storage.addColumn(tsuid_row_key, 
-        new byte[] { 0x50, 0x18 }, new byte[] { 2 });
+        new byte[] { 0x50, 0x18 }, new byte[] { 2 }, 1388448000006L);
   }
   
   @Test


### PR DESCRIPTION
Made corresponding code changes
1. Added OpenTSDB Timestamp as HBase Cell Timestamp while writing a metric
2. For OpenTSDB compaction, it will use the maximum Timestamp out of all the stamps being compacted and use it to write for HBase Cell Timestamp.
3. Adding TS to scanner.