### PR TITLE
Log query stats in case of Closed Channel also

### DIFF
--- a/src/tsd/AbstractHttpQuery.java
+++ b/src/tsd/AbstractHttpQuery.java
@@ -386,6 +386,9 @@ public abstract class AbstractHttpQuery {
    */
   public void sendStatusOnly(final HttpResponseStatus status) {
     if (!chan.isConnected()) {
+      if(stats != null) {
+        stats.markSendFailed();
+      }
       done();
       return;
     }
@@ -414,6 +417,9 @@ public abstract class AbstractHttpQuery {
                           final ChannelBuffer buf,
                           final String contentType) {
     if (!chan.isConnected()) {
+      if(stats != null) {
+        stats.markSendFailed();
+      }
       done();
       return;
     }
@@ -442,7 +448,10 @@ public abstract class AbstractHttpQuery {
   private class SendSuccess implements ChannelFutureListener {
     @Override
     public void operationComplete(final ChannelFuture future) throws Exception {
-      stats.markSent();
+      if(future.isSuccess()) {
+        stats.markSent();}
+      else
+        stats.markSendFailed();
     }
   }
   


### PR DESCRIPTION
PR for https://github.com/OpenTSDB/opentsdb/issues/979
We need to change the SuccessHandler also because channel might have been closed after the 
isConnectedCheck we made.