### PR TITLE
Fix #962 Allow OpenTSDB to take advantage of DateTieredCompaction

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -193,7 +193,8 @@ tsdb_SRC := \
 	src/utils/JSONException.java	\
 	src/utils/Pair.java	\
 	src/utils/PluginLoader.java	\
-	src/utils/Threads.java
+	src/utils/Threads.java \
+	src/core/RequestBuilder.java
 
 tsdb_DEPS = \
 	$(COMMONS_LOGGING)	\
@@ -270,6 +271,7 @@ test_SRC := \
 	test/core/TestTsdbQuerySaltedAppend.java	\
 	test/core/TestTSQuery.java	\
 	test/core/TestTSSubQuery.java	\
+	test/core/TestTsdbTSConfig.java \
 	test/plugin/DummyPlugin.java \
 	test/meta/TestAnnotation.java	\
 	test/meta/TestTSMeta.java	\

--- a/src/core/AppendDataPoints.java
+++ b/src/core/AppendDataPoints.java
@@ -227,8 +227,8 @@ public class AppendDataPoints {
       
     if (repair && needs_repair) {
       LOG.debug("Repairing appended data column " + kv);
-      final PutRequest put = new PutRequest(tsdb.table, kv.key(),  
-          TSDB.FAMILY(), kv.qualifier(), healed_cell);
+      final PutRequest put = RequestBuilder.buildPutRequest(tsdb.getConfig(), tsdb.table, kv.key(),
+          TSDB.FAMILY(), kv.qualifier(), healed_cell, kv.timestamp());
       repaired_deferred = tsdb.getClient().put(put);
     }
     

--- a/src/core/BatchedDataPoints.java
+++ b/src/core/BatchedDataPoints.java
@@ -138,7 +138,7 @@ final class BatchedDataPoints implements WritableDataPoints {
     final byte[] v = Arrays.copyOfRange(batched_value, 0, value_index);
     final byte[] r = Arrays.copyOfRange(row_key, 0, row_key.length);
     reset();
-    return tsdb.put(r, q, v);
+    return tsdb.put(r, q, v, base_time);
   }
 
   @Override

--- a/src/core/CompactionQueue.java
+++ b/src/core/CompactionQueue.java
@@ -35,6 +35,7 @@ import org.hbase.async.PleaseThrottleException;
 import net.opentsdb.meta.Annotation;
 import net.opentsdb.stats.StatsCollector;
 import net.opentsdb.utils.JSON;
+import net.opentsdb.utils.Pair;
 
 /**
  * "Queue" of rows to compact.
@@ -99,6 +100,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
     min_flush_threshold = tsdb.config.getInt("tsd.storage.compaction.min_flush_threshold");
     max_concurrent_flushes = tsdb.config.getInt("tsd.storage.compaction.max_concurrent_flushes");
     flush_speed = tsdb.config.getInt("tsd.storage.compaction.flush_speed");
+
     if (tsdb.config.enable_compactions()) {
       startCompactionThread();
     }
@@ -178,7 +180,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
       if (seed == row.hashCode() % 3) {
         continue;
       }
-      final long base_time = Bytes.getUnsignedInt(row, 
+      final long base_time = Bytes.getUnsignedInt(row,
           Const.SALT_WIDTH() + metric_width);
       if (base_time > cut_off) {
         break;
@@ -258,7 +260,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
    * Maintains state for a single compaction; exists to break the steps down into manageable
    * pieces without having to worry about returning multiple values and passing many parameters
    * around.
-   * 
+   *
    * @since 2.1
    */
   private class Compaction {
@@ -267,6 +269,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
     private final ArrayList<KeyValue> row;
     private final KeyValue[] compacted;
     private final List<Annotation> annotations;
+    private long compactedKVTimestamp;
 
     private final int nkvs;
 
@@ -285,7 +288,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
     // KeyValue containing the longest qualifier for the datapoint, used to optimize
     // checking if the compacted qualifier already exists.
     private KeyValue longest;
-    
+
     // the latest append column. If set then we don't want to re-write the row
     // and if we only had a single column with a single value, we return this.
     private KeyValue last_append_column;
@@ -296,6 +299,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
       this.compacted = compacted;
       this.annotations = annotations;
       to_delete = new ArrayList<KeyValue>(nkvs);
+      compactedKVTimestamp = Long.MIN_VALUE;
     }
 
     /**
@@ -336,6 +340,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
         return null;
       }
 
+      compactedKVTimestamp = Long.MIN_VALUE;
       // go through all the columns, process annotations, and
       heap = new PriorityQueue<ColumnDatapointIterator>(nkvs);
       int tot_values = buildHeapProcessAnnotations();
@@ -367,7 +372,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
 
       if (compacted != null) {  // Caller is interested in the compacted form.
         compacted[0] = compact;
-        final long base_time = Bytes.getUnsignedInt(compact.key(), 
+        final long base_time = Bytes.getUnsignedInt(compact.key(),
             Const.SALT_WIDTH() + metric_width);
         final long cut_off = System.currentTimeMillis() / 1000
             - Const.MAX_TIMESPAN - 1;
@@ -385,7 +390,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
       deleted_cells.addAndGet(to_delete.size());  // We're going to delete this.
       if (write) {
         written_cells.incrementAndGet();
-        Deferred<Object> deferred = tsdb.put(key, compact.qualifier(), compact.value());
+        Deferred<Object> deferred = tsdb.put(key, compact.qualifier(), compact.value(), compactedKVTimestamp);
         if (!to_delete.isEmpty()) {
           deferred = deferred.addCallbacks(new DeleteCompactedCB(to_delete), handle_write_error);
         }
@@ -426,6 +431,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
      */
     private int buildHeapProcessAnnotations() {
       int tot_values = 0;
+
       for (final KeyValue kv : row) {
         byte[] qual = kv.qualifier();
         int len = qual.length;
@@ -434,15 +440,16 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
           if (qual[0] == Annotation.PREFIX()) {
             annotations.add(JSON.parseToObject(kv.value(), Annotation.class));
           } else if (qual[0] == AppendDataPoints.APPEND_COLUMN_PREFIX){
+            compactedKVTimestamp = Math.max(compactedKVTimestamp, kv.timestamp());
             final AppendDataPoints adp = new AppendDataPoints();
             tot_values += adp.parseKeyValue(tsdb, kv).size();
-            last_append_column = new KeyValue(kv.key(), kv.family(), 
+            last_append_column = new KeyValue(kv.key(), kv.family(),
                 adp.qualifier(), kv.timestamp(), adp.value());
-            if (longest == null || 
+            if (longest == null ||
                 longest.qualifier().length < last_append_column.qualifier().length) {
               longest = last_append_column;
             }
-            final ColumnDatapointIterator col = 
+            final ColumnDatapointIterator col =
                 new ColumnDatapointIterator(last_append_column);
             if (col.hasMoreData()) {
               heap.add(col);
@@ -461,6 +468,7 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
           longest = kv;
         }
         ColumnDatapointIterator col = new ColumnDatapointIterator(kv);
+        compactedKVTimestamp = Math.max(compactedKVTimestamp, kv.timestamp());
         if (col.hasMoreData()) {
           heap.add(col);
         }
@@ -476,8 +484,59 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
      * @param compacted_qual qualifiers for sorted datapoints
      * @param compacted_val values for sorted datapoints
      */
-    private void mergeDatapoints(ByteBufferList compacted_qual, 
+
+    private void mergeDatapoints(ByteBufferList compacted_qual,
         ByteBufferList compacted_val) {
+      if (tsdb.getConfig().use_otsdb_timestamp()) {
+        dtcsMergeDataPoints(compacted_qual, compacted_val);
+      } else {
+        defaultMergeDataPoints(compacted_qual, compacted_val);
+      }
+    }
+
+    private void dtcsMergeDataPoints(ByteBufferList compacted_qual, ByteBufferList compacted_val) {
+      // Compare timestamps for two KeyValues at the same time, if they are same compare their values
+      // Return maximum or minimum value depending upon tsd.storage.use_max_value parameter
+      // This function is called once for every RowKey, so we only care about comparing offsets, which
+      // are a part of column qualifier
+      ColumnDatapointIterator col1 = null;
+      ColumnDatapointIterator col2 = null;
+      while (!heap.isEmpty()) {
+        col1 = heap.remove();
+        Pair<Integer, Integer> offsets = col1.getOffsets();
+        Pair<Integer, Integer> offsetLengths = col1.getOffsetLengths();
+        int ts1 = col1.getTimestampOffsetMs();
+        double val1 = col1.getCellValueAsDouble();
+        if (col1.advance()) {
+          heap.add(col1);
+        }
+        int ts2 = ts1;
+        while (ts1 == ts2) {
+          col2 = heap.peek();
+          ts2 = col2 != null ? col2.getTimestampOffsetMs() : ts2;
+          if (col2 == null || ts1 != ts2)
+            break;
+          double val2 = col2.getCellValueAsDouble();
+          if ((tsdb.config.use_max_value() && val2 > val1) || (!tsdb.config.use_max_value() && val1 > val2)) {
+            // Reduce copying of byte arrays by just using col1 variable to reference to either max or min KeyValue
+            col1 = col2;
+            val1 = val2;
+            offsets = col2.getOffsets();
+            offsetLengths = col2.getOffsetLengths();
+          }
+          heap.remove();
+          if (col2.advance()) {
+            heap.add(col2);
+          }
+        }
+        col1.writeToBuffersFromOffset(compacted_qual, compacted_val, offsets, offsetLengths);
+        ms_in_row |= col1.isMilliseconds();
+        s_in_row |= !col1.isMilliseconds();
+      }
+    }
+
+    private void defaultMergeDataPoints(ByteBufferList compacted_qual,
+            ByteBufferList compacted_val) {
       int prevTs = -1;
       while (!heap.isEmpty()) {
         final ColumnDatapointIterator col = heap.remove();
@@ -512,7 +571,6 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
         }
       }
     }
-
     /**
      * Build the compacted column from the list of byte buffers that were
      * merged together.
@@ -539,7 +597,11 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
       }
 
       final KeyValue first = row.get(0);
-      return new KeyValue(first.key(), first.family(), cq, cv);
+      if(tsdb.getConfig().getBoolean("tsd.storage.use_otsdb_timestamp")) {
+        return new KeyValue(first.key(), first.family(), cq, compactedKVTimestamp, cv);
+      } else {
+        return new KeyValue(first.key(), first.family(), cq, cv);
+      }
     }
 
     /**
@@ -553,11 +615,11 @@ final class CompactionQueue extends ConcurrentSkipListMap<byte[], Boolean> {
      */
     private boolean updateDeletesCheckForWrite(KeyValue compact) {
       if (last_append_column != null) {
-        // TODO appends are involved so we may want to squash dps into the 
-        // append or vice-versa. 
+        // TODO appends are involved so we may want to squash dps into the
+        // append or vice-versa.
         return false;
       }
-      
+
       // if the longest entry isn't as long as the compacted one, obviously the compacted
       // one can't have already existed
       if (longest != null && longest.qualifier().length >= compact.qualifier().length) {

--- a/src/core/IncomingDataPoints.java
+++ b/src/core/IncomingDataPoints.java
@@ -342,12 +342,12 @@ final class IncomingDataPoints implements WritableDataPoints {
         if (tsdb.getConfig().enable_appends()) {
           final AppendDataPoints kv = new AppendDataPoints(qualifier, value);
           final AppendRequest point = new AppendRequest(tsdb.table, row, TSDB.FAMILY, 
-              AppendDataPoints.APPEND_COLUMN_QUALIFIER, kv.getBytes());
+                  AppendDataPoints.APPEND_COLUMN_QUALIFIER, kv.getBytes());
           point.setDurable(!batch_import);
           return tsdb.client.append(point);/* .addBoth(cb) */
         } else {
-          final PutRequest point = new PutRequest(tsdb.table, row, TSDB.FAMILY, 
-              qualifier, value);
+          final PutRequest point = RequestBuilder.buildPutRequest(tsdb.getConfig(), tsdb.table, row, TSDB.FAMILY,
+              qualifier, value, timestamp);
           point.setDurable(!batch_import);
           return tsdb.client.put(point)/* .addBoth(cb) */;
         }

--- a/src/core/RequestBuilder.java
+++ b/src/core/RequestBuilder.java
@@ -1,0 +1,22 @@
+package net.opentsdb.core;
+
+import org.hbase.async.AppendRequest;
+import org.hbase.async.HBaseRpc;
+import org.hbase.async.PutRequest;
+
+import net.opentsdb.utils.Config;
+
+public class RequestBuilder {
+    
+    public static PutRequest buildPutRequest(Config config, byte[] tableName, byte[] row, byte[] family, byte[] qualifier, byte[] value, long timestamp) {
+        
+        if(config.use_otsdb_timestamp()) 
+            if((timestamp & Const.SECOND_MASK) != 0)
+                return new PutRequest(tableName, row, family, qualifier, value, timestamp);
+            else
+                return new PutRequest(tableName, row, family, qualifier, value, timestamp * 1000);
+        else
+            return new PutRequest(tableName, row, family, qualifier, value);
+    }
+
+}

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -75,7 +75,7 @@ import net.opentsdb.stats.StatsCollector;
  */
 public final class TSDB {
   private static final Logger LOG = LoggerFactory.getLogger(TSDB.class);
-  
+
   static final byte[] FAMILY = { 't' };
 
   /** Charset used to convert Strings to byte arrays and back. */
@@ -111,7 +111,7 @@ public final class TSDB {
 
   /** Timer used for various tasks such as idle timeouts or query timeouts */
   private final HashedWheelTimer timer;
-  
+
   /**
    * Row keys that need to be compacted.
    * Whenever we write a new data point to a row, we add the row key to this
@@ -128,23 +128,23 @@ public final class TSDB {
 
   /** Optional real time pulblisher plugin to use if configured */
   private RTPublisher rt_publisher = null;
-  
+
   /** Optional plugin for handling meta data caching and updating */
   private MetaDataCache meta_cache = null;
-  
+
   /** Plugin for dealing with data points that can't be stored */
   private StorageExceptionHandler storage_exception_handler = null;
 
   /** A filter plugin for allowing or blocking time series */
   private WriteableDataPointFilterPlugin ts_filter;
-  
+
   /** A filter plugin for allowing or blocking UIDs */
   private UniqueIdFilterPlugin uid_filter;
-  
-  /** Writes rejected by the filter */ 
+
+  /** Writes rejected by the filter */
   private final AtomicLong rejected_dps = new AtomicLong();
   private final AtomicLong rejected_aggregate_dps = new AtomicLong();
-  
+
   /** Datapoints Added */
   private static final AtomicLong datapoints_added = new AtomicLong();
 
@@ -162,23 +162,23 @@ public final class TSDB {
         try {
           async_config = new org.hbase.async.Config(config.configLocation());
         } catch (final IOException e) {
-          throw new RuntimeException("Failed to read the config file: " + 
+          throw new RuntimeException("Failed to read the config file: " +
               config.configLocation(), e);
         }
       } else {
         async_config = new org.hbase.async.Config();
       }
-      async_config.overrideConfig("hbase.zookeeper.znode.parent", 
+      async_config.overrideConfig("hbase.zookeeper.znode.parent",
           config.getString("tsd.storage.hbase.zk_basedir"));
-      async_config.overrideConfig("hbase.zookeeper.quorum", 
+      async_config.overrideConfig("hbase.zookeeper.quorum",
           config.getString("tsd.storage.hbase.zk_quorum"));
       this.client = new HBaseClient(async_config);
     } else {
       this.client = client;
     }
-    
+
     // SALT AND UID WIDTHS
-    // Users really wanted this to be set via config instead of having to 
+    // Users really wanted this to be set via config instead of having to
     // compile. Hopefully they know NOT to change these after writing data.
     if (config.hasProperty("tsd.storage.uid.width.metric")) {
       METRICS_WIDTH = config.getShort("tsd.storage.uid.width.metric");
@@ -198,7 +198,7 @@ public final class TSDB {
     if (config.hasProperty("tsd.storage.salt.width")) {
       Const.setSaltWidth(config.getInt("tsd.storage.salt.width"));
     }
-    
+
     table = config.getString("tsd.storage.hbase.data_table").getBytes(CHARSET);
     uidtable = config.getString("tsd.storage.hbase.uid_table").getBytes(CHARSET);
     treetable = config.getString("tsd.storage.hbase.tree_table").getBytes(CHARSET);
@@ -212,16 +212,16 @@ public final class TSDB {
     tag_names = new UniqueId(this, uidtable, TAG_NAME_QUAL, TAG_NAME_WIDTH, false);
     tag_values = new UniqueId(this, uidtable, TAG_VALUE_QUAL, TAG_VALUE_WIDTH, false);
     compactionq = new CompactionQueue(this);
-    
+
     if (config.hasProperty("tsd.core.timezone")) {
       DateTime.setDefaultTimezone(config.getString("tsd.core.timezone"));
     }
-    
+
     timer = Threads.newTimer("TSDB Timer");
-    
+
     QueryStats.setEnableDuplicates(
         config.getBoolean("tsd.query.allow_simultaneous_duplicates"));
-    
+
     if (config.getBoolean("tsd.core.preload_uid_cache")) {
       final ByteMap<UniqueId> uid_cache_map = new ByteMap<UniqueId>();
       uid_cache_map.put(METRICS_QUAL.getBytes(CHARSET), metrics);
@@ -229,20 +229,20 @@ public final class TSDB {
       uid_cache_map.put(TAG_VALUE_QUAL.getBytes(CHARSET), tag_values);
       UniqueId.preloadUidCache(this, uid_cache_map);
     }
-    
+
     if (config.getString("tsd.core.tag.allow_specialchars") != null) {
       Tags.setAllowSpecialChars(config.getString("tsd.core.tag.allow_specialchars"));
     }
-    
+
     // load up the functions that require the TSDB object
     ExpressionFactory.addTSDBFunctions(this);
-    
+
     // set any extra tags from the config for stats
     StatsCollector.setGlobalTags(config);
-    
+
     LOG.debug(config.dumpConfiguration());
   }
-  
+
   /**
    * Constructor
    * @param config An initialized configuration object
@@ -251,7 +251,7 @@ public final class TSDB {
   public TSDB(final Config config) {
     this(null, config);
   }
-  
+
   /** @return The data point column family name */
   public static byte[] FAMILY() {
     return FAMILY;
@@ -311,7 +311,7 @@ public final class TSDB {
       search = PluginLoader.loadSpecificPlugin(
           config.getString("tsd.search.plugin"), SearchPlugin.class);
       if (search == null) {
-        throw new IllegalArgumentException("Unable to locate search plugin: " + 
+        throw new IllegalArgumentException("Unable to locate search plugin: " +
             config.getString("tsd.search.plugin"));
       }
       try {
@@ -319,20 +319,20 @@ public final class TSDB {
       } catch (Exception e) {
         throw new RuntimeException("Failed to initialize search plugin", e);
       }
-      LOG.info("Successfully initialized search plugin [" + 
-          search.getClass().getCanonicalName() + "] version: " 
+      LOG.info("Successfully initialized search plugin [" +
+          search.getClass().getCanonicalName() + "] version: "
           + search.version());
     } else {
       search = null;
     }
-    
+
     // load the real time publisher plugin if enabled
     if (config.getBoolean("tsd.rtpublisher.enable")) {
       rt_publisher = PluginLoader.loadSpecificPlugin(
           config.getString("tsd.rtpublisher.plugin"), RTPublisher.class);
       if (rt_publisher == null) {
         throw new IllegalArgumentException(
-            "Unable to locate real time publisher plugin: " + 
+            "Unable to locate real time publisher plugin: " +
             config.getString("tsd.rtpublisher.plugin"));
       }
       try {
@@ -341,20 +341,20 @@ public final class TSDB {
         throw new RuntimeException(
             "Failed to initialize real time publisher plugin", e);
       }
-      LOG.info("Successfully initialized real time publisher plugin [" + 
-          rt_publisher.getClass().getCanonicalName() + "] version: " 
+      LOG.info("Successfully initialized real time publisher plugin [" +
+          rt_publisher.getClass().getCanonicalName() + "] version: "
           + rt_publisher.version());
     } else {
       rt_publisher = null;
     }
-    
+
     // load the meta cache plugin if enabled
     if (config.getBoolean("tsd.core.meta.cache.enable")) {
       meta_cache = PluginLoader.loadSpecificPlugin(
           config.getString("tsd.core.meta.cache.plugin"), MetaDataCache.class);
       if (meta_cache == null) {
         throw new IllegalArgumentException(
-            "Unable to locate meta cache plugin: " + 
+            "Unable to locate meta cache plugin: " +
             config.getString("tsd.core.meta.cache.plugin"));
       }
       try {
@@ -363,19 +363,19 @@ public final class TSDB {
         throw new RuntimeException(
             "Failed to initialize meta cache plugin", e);
       }
-      LOG.info("Successfully initialized meta cache plugin [" + 
-          meta_cache.getClass().getCanonicalName() + "] version: " 
+      LOG.info("Successfully initialized meta cache plugin [" +
+          meta_cache.getClass().getCanonicalName() + "] version: "
           + meta_cache.version());
     }
-    
+
     // load the storage exception plugin if enabled
     if (config.getBoolean("tsd.core.storage_exception_handler.enable")) {
       storage_exception_handler = PluginLoader.loadSpecificPlugin(
-          config.getString("tsd.core.storage_exception_handler.plugin"), 
+          config.getString("tsd.core.storage_exception_handler.plugin"),
           StorageExceptionHandler.class);
       if (storage_exception_handler == null) {
         throw new IllegalArgumentException(
-            "Unable to locate storage exception handler plugin: " + 
+            "Unable to locate storage exception handler plugin: " +
             config.getString("tsd.core.storage_exception_handler.plugin"));
       }
       try {
@@ -384,19 +384,19 @@ public final class TSDB {
         throw new RuntimeException(
             "Failed to initialize storage exception handler plugin", e);
       }
-      LOG.info("Successfully initialized storage exception handler plugin [" + 
-          storage_exception_handler.getClass().getCanonicalName() + "] version: " 
+      LOG.info("Successfully initialized storage exception handler plugin [" +
+          storage_exception_handler.getClass().getCanonicalName() + "] version: "
           + storage_exception_handler.version());
     }
-    
+
     // Writeable Data Point Filter
     if (config.getBoolean("tsd.timeseriesfilter.enable")) {
       ts_filter = PluginLoader.loadSpecificPlugin(
-          config.getString("tsd.timeseriesfilter.plugin"), 
+          config.getString("tsd.timeseriesfilter.plugin"),
           WriteableDataPointFilterPlugin.class);
       if (ts_filter == null) {
         throw new IllegalArgumentException(
-            "Unable to locate time series filter plugin plugin: " + 
+            "Unable to locate time series filter plugin plugin: " +
             config.getString("tsd.timeseriesfilter.plugin"));
       }
       try {
@@ -405,19 +405,19 @@ public final class TSDB {
         throw new RuntimeException(
             "Failed to initialize time series filter plugin", e);
       }
-      LOG.info("Successfully initialized time series filter plugin [" + 
-          ts_filter.getClass().getCanonicalName() + "] version: " 
+      LOG.info("Successfully initialized time series filter plugin [" +
+          ts_filter.getClass().getCanonicalName() + "] version: "
           + ts_filter.version());
     }
-    
+
     // UID Filter
     if (config.getBoolean("tsd.uidfilter.enable")) {
       uid_filter = PluginLoader.loadSpecificPlugin(
-          config.getString("tsd.uidfilter.plugin"), 
+          config.getString("tsd.uidfilter.plugin"),
           UniqueIdFilterPlugin.class);
       if (uid_filter == null) {
         throw new IllegalArgumentException(
-            "Unable to locate UID filter plugin plugin: " + 
+            "Unable to locate UID filter plugin plugin: " +
             config.getString("tsd.uidfilter.plugin"));
       }
       try {
@@ -426,50 +426,50 @@ public final class TSDB {
         throw new RuntimeException(
             "Failed to initialize UID filter plugin", e);
       }
-      LOG.info("Successfully initialized UID filter plugin [" + 
-          uid_filter.getClass().getCanonicalName() + "] version: " 
+      LOG.info("Successfully initialized UID filter plugin [" +
+          uid_filter.getClass().getCanonicalName() + "] version: "
           + uid_filter.version());
     }
   }
-  
-  /** 
-   * Returns the configured HBase client 
+
+  /**
+   * Returns the configured HBase client
    * @return The HBase client
-   * @since 2.0 
+   * @since 2.0
    */
   public final HBaseClient getClient() {
     return this.client;
   }
 
   /**
-   * Sets the startup plugin so that it can be shutdown properly. 
-   * Note that this method will not initialize or call any other methods 
+   * Sets the startup plugin so that it can be shutdown properly.
+   * Note that this method will not initialize or call any other methods
    * belonging to the plugin's implementation.
-   * @param plugin The startup plugin that was used. 
+   * @param plugin The startup plugin that was used.
    * @since 2.3
    */
-  public final void setStartupPlugin(final StartupPlugin plugin) { 
-    startup = plugin; 
+  public final void setStartupPlugin(final StartupPlugin plugin) {
+    startup = plugin;
   }
-  
+
   /**
    * Getter that returns the startup plugin object.
    * @return The StartupPlugin object or null if the plugin was not set.
    * @since 2.3
    */
-  public final StartupPlugin getStartupPlugin() { 
-    return startup; 
+  public final StartupPlugin getStartupPlugin() {
+    return startup;
   }
 
   /**
    * Getter that returns the configuration object
    * @return The configuration object
-   * @since 2.0 
+   * @since 2.0
    */
   public final Config getConfig() {
     return this.config;
   }
-  
+
   /**
    * Returns the storage exception handler. May be null if not enabled
    * @return The storage exception handler
@@ -486,15 +486,15 @@ public final class TSDB {
   public WriteableDataPointFilterPlugin getTSfilter() {
     return ts_filter;
   }
-  
-  /** 
-   * @return The UID filter object, may be null. 
-   * @since 2.3 
+
+  /**
+   * @return The UID filter object, may be null.
+   * @since 2.3
    */
   public UniqueIdFilterPlugin getUidFilter() {
     return uid_filter;
   }
-  
+
   /**
    * Attempts to find the name for a unique identifier given a type
    * @param type The type of UID
@@ -520,7 +520,7 @@ public final class TSDB {
         throw new IllegalArgumentException("Unrecognized UID type");
     }
   }
-  
+
   /**
    * Attempts to find the UID matching a given name
    * @param type The type of UID
@@ -541,7 +541,7 @@ public final class TSDB {
       throw new RuntimeException(e);
     }
   }
-  
+
   /**
    * Attempts to find the UID matching a given name
    * @param type The type of UID
@@ -565,7 +565,7 @@ public final class TSDB {
         throw new IllegalArgumentException("Unrecognized UID type");
     }
   }
-  
+
   /**
    * Verifies that the data and UID tables exist in HBase and optionally the
    * tree and meta data tables if the user has enabled meta tracking or tree
@@ -575,7 +575,7 @@ public final class TSDB {
    * @since 2.0
    */
   public Deferred<ArrayList<Object>> checkNecessaryTablesExist() {
-    final ArrayList<Deferred<Object>> checks = 
+    final ArrayList<Deferred<Object>> checks =
       new ArrayList<Deferred<Object>>(2);
     checks.add(client.ensureTableExists(
         config.getString("tsd.storage.hbase.data_table")));
@@ -585,14 +585,14 @@ public final class TSDB {
       checks.add(client.ensureTableExists(
           config.getString("tsd.storage.hbase.tree_table")));
     }
-    if (config.enable_realtime_ts() || config.enable_realtime_uid() || 
+    if (config.enable_realtime_ts() || config.enable_realtime_uid() ||
         config.enable_tsuid_incrementing()) {
       checks.add(client.ensureTableExists(
           config.getString("tsd.storage.hbase.meta_table")));
     }
     return Deferred.group(checks);
   }
-  
+
   /** Number of cache hits during lookups involving UIDs. */
   public int uidCacheHits() {
     return (metrics.cacheHits() + tag_names.cacheHits()
@@ -616,48 +616,48 @@ public final class TSDB {
    * @param collector The collector to use.
    */
   public void collectStats(final StatsCollector collector) {
-    final byte[][] kinds = { 
-        METRICS_QUAL.getBytes(CHARSET), 
-        TAG_NAME_QUAL.getBytes(CHARSET), 
-        TAG_VALUE_QUAL.getBytes(CHARSET) 
+    final byte[][] kinds = {
+        METRICS_QUAL.getBytes(CHARSET),
+        TAG_NAME_QUAL.getBytes(CHARSET),
+        TAG_VALUE_QUAL.getBytes(CHARSET)
       };
     try {
       final Map<String, Long> used_uids = UniqueId.getUsedUIDs(this, kinds)
         .joinUninterruptibly();
-      
+
       collectUidStats(metrics, collector);
       if (config.getBoolean("tsd.core.uid.random_metrics")) {
         collector.record("uid.ids-used", 0, "kind=" + METRICS_QUAL);
         collector.record("uid.ids-available", 0, "kind=" + METRICS_QUAL);
       } else {
-        collector.record("uid.ids-used", used_uids.get(METRICS_QUAL), 
+        collector.record("uid.ids-used", used_uids.get(METRICS_QUAL),
             "kind=" + METRICS_QUAL);
-        collector.record("uid.ids-available", 
-            (Internal.getMaxUnsignedValueOnBytes(metrics.width()) - 
+        collector.record("uid.ids-available",
+            (Internal.getMaxUnsignedValueOnBytes(metrics.width()) -
                 used_uids.get(METRICS_QUAL)), "kind=" + METRICS_QUAL);
       }
-      
+
       collectUidStats(tag_names, collector);
-      collector.record("uid.ids-used", used_uids.get(TAG_NAME_QUAL), 
+      collector.record("uid.ids-used", used_uids.get(TAG_NAME_QUAL),
           "kind=" + TAG_NAME_QUAL);
-      collector.record("uid.ids-available", 
-          (Internal.getMaxUnsignedValueOnBytes(tag_names.width()) - 
-              used_uids.get(TAG_NAME_QUAL)), 
+      collector.record("uid.ids-available",
+          (Internal.getMaxUnsignedValueOnBytes(tag_names.width()) -
+              used_uids.get(TAG_NAME_QUAL)),
           "kind=" + TAG_NAME_QUAL);
-      
+
       collectUidStats(tag_values, collector);
-      collector.record("uid.ids-used", used_uids.get(TAG_VALUE_QUAL), 
+      collector.record("uid.ids-used", used_uids.get(TAG_VALUE_QUAL),
           "kind=" + TAG_VALUE_QUAL);
-      collector.record("uid.ids-available", 
-          (Internal.getMaxUnsignedValueOnBytes(tag_values.width()) - 
+      collector.record("uid.ids-available",
+          (Internal.getMaxUnsignedValueOnBytes(tag_values.width()) -
               used_uids.get(TAG_VALUE_QUAL)), "kind=" + TAG_VALUE_QUAL);
-      
+
     } catch (Exception e) {
       throw new RuntimeException("Shouldn't be here", e);
     }
-    
+
     collector.record("uid.filter.rejected", rejected_dps.get(), "kind=raw");
-    collector.record("uid.filter.rejected", rejected_aggregate_dps.get(), 
+    collector.record("uid.filter.rejected", rejected_aggregate_dps.get(),
         "kind=aggregate");
 
     {
@@ -729,7 +729,7 @@ public final class TSDB {
         rt_publisher.collectStats(collector);
       } finally {
         collector.clearExtraTag("plugin");
-      }                        
+      }
     }
     if (search != null) {
       try {
@@ -737,7 +737,7 @@ public final class TSDB {
         search.collectStats(collector);
       } finally {
         collector.clearExtraTag("plugin");
-      }                        
+      }
     }
     if (storage_exception_handler != null) {
       try {
@@ -785,9 +785,9 @@ public final class TSDB {
     collector.record("uid.cache-hit", uid.cacheHits(), "kind=" + uid.kind());
     collector.record("uid.cache-miss", uid.cacheMisses(), "kind=" + uid.kind());
     collector.record("uid.cache-size", uid.cacheSize(), "kind=" + uid.kind());
-    collector.record("uid.random-collisions", uid.randomIdCollisions(), 
+    collector.record("uid.random-collisions", uid.randomIdCollisions(),
         "kind=" + uid.kind());
-    collector.record("uid.rejected-assignments", uid.rejectedAssignments(), 
+    collector.record("uid.rejected-assignments", uid.rejectedAssignments(),
         "kind=" + uid.kind());
   }
 
@@ -795,17 +795,17 @@ public final class TSDB {
   public static short metrics_width() {
     return METRICS_WIDTH;
   }
-  
+
   /** @return the width, in bytes, of tagk UIDs */
   public static short tagk_width() {
     return TAG_NAME_WIDTH;
   }
-  
+
   /** @return the width, in bytes, of tagv UIDs */
   public static short tagv_width() {
     return TAG_VALUE_WIDTH;
   }
-  
+
   /**
    * Returns a new {@link Query} instance suitable for this TSDB.
    */
@@ -825,7 +825,7 @@ public final class TSDB {
 
   /**
    * Returns a new {@link BatchedDataPoints} instance suitable for this TSDB.
-   * 
+   *
    * @param metric Every data point that gets appended must be associated to this metric.
    * @param tags The associated tags for all data points being added.
    * @return data structure which can have data points appended.
@@ -952,7 +952,7 @@ public final class TSDB {
                                             final Map<String, String> tags,
                                             final short flags) {
     // we only accept positive unix epoch timestamps in seconds or milliseconds
-    if (timestamp < 0 || ((timestamp & Const.SECOND_MASK) != 0 && 
+    if (timestamp < 0 || ((timestamp & Const.SECOND_MASK) != 0 &&
         timestamp > 9999999999999L)) {
       throw new IllegalArgumentException((timestamp < 0 ? "negative " : "bad")
           + " timestamp=" + timestamp
@@ -963,15 +963,15 @@ public final class TSDB {
     final byte[] row = IncomingDataPoints.rowKeyTemplate(this, metric, tags);
     final long base_time;
     final byte[] qualifier = Internal.buildQualifier(timestamp, flags);
-    
+
     if ((timestamp & Const.SECOND_MASK) != 0) {
       // drop the ms timestamp to seconds to calculate the base timestamp
-      base_time = ((timestamp / 1000) - 
+      base_time = ((timestamp / 1000) -
           ((timestamp / 1000) % Const.MAX_TIMESPAN));
     } else {
       base_time = (timestamp - (timestamp % Const.MAX_TIMESPAN));
     }
-    
+
     /** Callback executed for chaining filter calls to see if the value
      * should be written or not. */
     final class WriteCB implements Callback<Deferred<Object>, Boolean> {
@@ -981,19 +981,22 @@ public final class TSDB {
           rejected_dps.incrementAndGet();
           return Deferred.fromResult(null);
         }
-        
+
         Bytes.setInt(row, (int) base_time, metrics.width() + Const.SALT_WIDTH());
         RowKey.prefixKeyWithSalt(row);
 
         Deferred<Object> result = null;
         if (config.enable_appends()) {
+          if(config.use_otsdb_timestamp()) {
+              LOG.error("Cannot use Date Tiered Compaction with AppendPoints. Please turn off either of them.");
+          }
           final AppendDataPoints kv = new AppendDataPoints(qualifier, value);
-          final AppendRequest point = new AppendRequest(table, row, FAMILY, 
-              AppendDataPoints.APPEND_COLUMN_QUALIFIER, kv.getBytes());
+          final AppendRequest point = new AppendRequest(table, row, FAMILY,
+                  AppendDataPoints.APPEND_COLUMN_QUALIFIER, kv.getBytes());
           result = client.append(point);
         } else {
           scheduleForCompaction(row, (int) base_time);
-          final PutRequest point = new PutRequest(table, row, FAMILY, qualifier, value);
+          final PutRequest point = RequestBuilder.buildPutRequest(config, table, row, FAMILY, qualifier, value, timestamp);
           result = client.put(point);
         }
 
@@ -1003,15 +1006,15 @@ public final class TSDB {
 
         // TODO(tsuna): Add a callback to time the latency of HBase and store the
         // timing in a moving Histogram (once we have a class for this).
-        
-        if (!config.enable_realtime_ts() && !config.enable_tsuid_incrementing() && 
+
+        if (!config.enable_realtime_ts() && !config.enable_tsuid_incrementing() &&
             !config.enable_tsuid_tracking() && rt_publisher == null) {
           return result;
         }
-        
-        final byte[] tsuid = UniqueId.getTSUIDFromKey(row, METRICS_WIDTH, 
+
+        final byte[] tsuid = UniqueId.getTSUIDFromKey(row, METRICS_WIDTH,
             Const.TIMESTAMP_BYTES);
-        
+
         // if the meta cache plugin is instantiated then tracking goes through it
         if (meta_cache != null) {
           meta_cache.increment(tsuid);
@@ -1024,7 +1027,7 @@ public final class TSDB {
                 TSMeta.storeIfNecessary(TSDB.this, tsuid);
               }
             } else {
-              final PutRequest tracking = new PutRequest(meta_table, tsuid, 
+              final PutRequest tracking = new PutRequest(meta_table, tsuid,
                   TSMeta.FAMILY(), TSMeta.COUNTER_QUALIFIER(), Bytes.fromLong(1));
               client.put(tracking);
             }
@@ -1041,7 +1044,7 @@ public final class TSDB {
         return "addPointInternal Write Callback";
       }
     }
-    
+
     if (ts_filter != null && ts_filter.filterDataPoints()) {
       return ts_filter.allowDataPoint(metric, timestamp, value, tags, flags)
           .addCallbackDeferring(new WriteCB());
@@ -1050,7 +1053,7 @@ public final class TSDB {
   }
 
   /**
-   * Forces a flush of any un-committed in memory data including left over 
+   * Forces a flush of any un-committed in memory data including left over
    * compactions.
    * <p>
    * For instance, any data point not persisted will be sent to HBase.
@@ -1064,10 +1067,10 @@ public final class TSDB {
    */
   public Deferred<Object> flush() throws HBaseException {
     final class HClientFlush implements Callback<Object, ArrayList<Object>> {
-      public Object call(final ArrayList<Object> args) {
+	public Object call(final ArrayList<Object> args) {
         return client.flush();
       }
-      public String toString() {
+	public String toString() {
         return "flush HBase client";
       }
     }
@@ -1092,9 +1095,9 @@ public final class TSDB {
    * recoverable by retrying, some are not.
    */
   public Deferred<Object> shutdown() {
-    final ArrayList<Deferred<Object>> deferreds = 
+    final ArrayList<Deferred<Object>> deferreds =
       new ArrayList<Deferred<Object>>();
-    
+
     final class FinalShutdown implements Callback<Object, Object> {
       @Override
       public Object call(Object result) throws Exception {
@@ -1110,14 +1113,14 @@ public final class TSDB {
         return Deferred.fromResult(null);
       }
     }
-    
+
     final class SEHShutdown implements Callback<Object, Object> {
       @Override
       public Object call(Object result) throws Exception {
         if (result instanceof Exception) {
           LOG.error("Shutdown of the HBase client failed", (Exception)result);
         }
-        LOG.info("Shutting down storage exception handler plugin: " + 
+        LOG.info("Shutting down storage exception handler plugin: " +
             storage_exception_handler.getClass().getCanonicalName());
         return storage_exception_handler.shutdown().addBoth(new FinalShutdown());
       }
@@ -1126,21 +1129,21 @@ public final class TSDB {
         return "SEHShutdown";
       }
     }
-    
+
     final class HClientShutdown implements Callback<Deferred<Object>, ArrayList<Object>> {
-      public Deferred<Object> call(final ArrayList<Object> args) {
+	public Deferred<Object> call(final ArrayList<Object> args) {
         if (storage_exception_handler != null) {
           return client.shutdown().addBoth(new SEHShutdown());
         }
         return client.shutdown().addBoth(new FinalShutdown());
       }
-      public String toString() {
+	public String toString() {
         return "shutdown HBase client";
       }
     }
-    
+
     final class ShutdownErrback implements Callback<Object, Exception> {
-      public Object call(final Exception e) {
+	public Object call(final Exception e) {
         final Logger LOG = LoggerFactory.getLogger(ShutdownErrback.class);
         if (e instanceof DeferredGroupException) {
           final DeferredGroupException ge = (DeferredGroupException) e;
@@ -1154,17 +1157,17 @@ public final class TSDB {
         }
         return new HClientShutdown().call(null);
       }
-      public String toString() {
+	public String toString() {
         return "shutdown HBase client after error";
       }
     }
-    
+
     final class CompactCB implements Callback<Object, ArrayList<Object>> {
-      public Object call(ArrayList<Object> compactions) throws Exception {
+	public Object call(ArrayList<Object> compactions) throws Exception {
         return null;
       }
     }
-    
+
     if (config.enable_compactions()) {
       LOG.info("Flushing compaction queue");
       deferreds.add(compactionq.flush().addCallback(new CompactCB()));
@@ -1175,36 +1178,36 @@ public final class TSDB {
       deferreds.add(startup.shutdown());
     }
     if (search != null) {
-      LOG.info("Shutting down search plugin: " + 
+      LOG.info("Shutting down search plugin: " +
           search.getClass().getCanonicalName());
       deferreds.add(search.shutdown());
     }
     if (rt_publisher != null) {
-      LOG.info("Shutting down RT plugin: " + 
+      LOG.info("Shutting down RT plugin: " +
           rt_publisher.getClass().getCanonicalName());
       deferreds.add(rt_publisher.shutdown());
     }
     if (meta_cache != null) {
-      LOG.info("Shutting down meta cache plugin: " + 
+      LOG.info("Shutting down meta cache plugin: " +
           meta_cache.getClass().getCanonicalName());
       deferreds.add(meta_cache.shutdown());
     }
     if (storage_exception_handler != null) {
-      LOG.info("Shutting down storage exception handler plugin: " + 
+      LOG.info("Shutting down storage exception handler plugin: " +
           storage_exception_handler.getClass().getCanonicalName());
       deferreds.add(storage_exception_handler.shutdown());
     }
     if (ts_filter != null) {
-      LOG.info("Shutting down time series filter plugin: " + 
+      LOG.info("Shutting down time series filter plugin: " +
           ts_filter.getClass().getCanonicalName());
       deferreds.add(ts_filter.shutdown());
     }
     if (uid_filter != null) {
-      LOG.info("Shutting down UID filter plugin: " + 
+      LOG.info("Shutting down UID filter plugin: " +
           uid_filter.getClass().getCanonicalName());
       deferreds.add(uid_filter.shutdown());
     }
-    
+
     // wait for plugins to shutdown before we close the client
     return deferreds.size() > 0
       ? Deferred.group(deferreds).addCallbackDeferring(new HClientShutdown())
@@ -1219,14 +1222,14 @@ public final class TSDB {
   public List<String> suggestMetrics(final String search) {
     return metrics.suggest(search);
   }
-  
+
   /**
    * Given a prefix search, returns matching metric names.
    * @param search A prefix to search.
    * @param max_results Maximum number of results to return.
    * @since 2.0
    */
-  public List<String> suggestMetrics(final String search, 
+  public List<String> suggestMetrics(final String search,
       final int max_results) {
     return metrics.suggest(search, max_results);
   }
@@ -1238,14 +1241,14 @@ public final class TSDB {
   public List<String> suggestTagNames(final String search) {
     return tag_names.suggest(search);
   }
-  
+
   /**
    * Given a prefix search, returns matching tagk names.
    * @param search A prefix to search.
    * @param max_results Maximum number of results to return.
    * @since 2.0
    */
-  public List<String> suggestTagNames(final String search, 
+  public List<String> suggestTagNames(final String search,
       final int max_results) {
     return tag_names.suggest(search, max_results);
   }
@@ -1257,14 +1260,14 @@ public final class TSDB {
   public List<String> suggestTagValues(final String search) {
     return tag_values.suggest(search);
   }
-  
+
   /**
    * Given a prefix search, returns matching tag values.
    * @param search A prefix to search.
    * @param max_results Maximum number of results to return.
    * @since 2.0
    */
-  public List<String> suggestTagValues(final String search, 
+  public List<String> suggestTagValues(final String search,
       final int max_results) {
     return tag_values.suggest(search, max_results);
   }
@@ -1281,14 +1284,14 @@ public final class TSDB {
 
   /**
    * Attempts to assign a UID to a name for the given type
-   * Used by the UniqueIdRpc call to generate IDs for new metrics, tagks or 
+   * Used by the UniqueIdRpc call to generate IDs for new metrics, tagks or
    * tagvs. The name must pass validation and if it's already assigned a UID,
    * this method will throw an error with the proper UID. Otherwise if it can
    * create the UID, it will be returned
    * @param type The type of uid to assign, metric, tagk or tagv
    * @param name The name of the uid object
    * @return A byte array with the UID if the assignment was successful
-   * @throws IllegalArgumentException if the name is invalid or it already 
+   * @throws IllegalArgumentException if the name is invalid or it already
    * exists
    * @since 2.0
    */
@@ -1323,7 +1326,7 @@ public final class TSDB {
       throw new IllegalArgumentException("Unknown type name");
     }
   }
-  
+
   /**
    * Attempts to delete the given UID name mapping from the storage table as
    * well as the local cache.
@@ -1343,10 +1346,10 @@ public final class TSDB {
     case TAGV:
       return tag_values.deleteAsync(name);
     default:
-      throw new IllegalArgumentException("Unrecognized UID type: " + uid_type); 
+      throw new IllegalArgumentException("Unrecognized UID type: " + uid_type);
     }
   }
-  
+
   /**
    * Attempts to rename a UID from existing name to the given name
    * Used by the UniqueIdRpc call to rename name of existing metrics, tagks or
@@ -1397,17 +1400,17 @@ public final class TSDB {
   public byte[] uidTable() {
     return this.uidtable;
   }
-  
+
   /** @return the name of the data table as a byte array for client requests */
   public byte[] dataTable() {
     return this.table;
   }
-  
+
   /** @return the name of the tree table as a byte array for client requests */
   public byte[] treeTable() {
     return this.treetable;
   }
-  
+
   /** @return the name of the meta table as a byte array for client requests */
   public byte[] metaTable() {
     return this.meta_table;
@@ -1423,7 +1426,7 @@ public final class TSDB {
       search.indexTSMeta(meta).addErrback(new PluginError());
     }
   }
-  
+
   /**
    * Delete the timeseries meta object from the search index
    * @param tsuid The TSUID to delete
@@ -1434,7 +1437,7 @@ public final class TSDB {
       search.deleteTSMeta(tsuid).addErrback(new PluginError());
     }
   }
-  
+
   /**
    * Index the given UID meta object via the configured search plugin
    * @param meta The meta data object to index
@@ -1445,7 +1448,7 @@ public final class TSDB {
       search.indexUIDMeta(meta).addErrback(new PluginError());
     }
   }
-  
+
   /**
    * Delete the UID meta object from the search index
    * @param meta The UID meta object to delete
@@ -1456,7 +1459,7 @@ public final class TSDB {
       search.deleteUIDMeta(meta).addErrback(new PluginError());
     }
   }
-  
+
   /**
    * Index the given Annotation object via the configured search plugin
    * @param note The annotation object to index
@@ -1470,7 +1473,7 @@ public final class TSDB {
     	rt_publisher.publishAnnotation(note);
     }
   }
-  
+
   /**
    * Delete the annotation object from the search index
    * @param note The annotation object to delete
@@ -1481,7 +1484,7 @@ public final class TSDB {
       search.deleteAnnotation(note).addErrback(new PluginError());
     }
   }
-  
+
   /**
    * Processes the TSMeta through all of the trees if configured to do so
    * @param meta The meta data to process
@@ -1493,7 +1496,7 @@ public final class TSDB {
     }
     return Deferred.fromResult(false);
   }
-  
+
   /**
    * Executes a search query using the search plugin
    * @param query The query to execute
@@ -1507,13 +1510,13 @@ public final class TSDB {
       throw new IllegalStateException(
           "Searching has not been enabled on this TSD");
     }
-    
+
     return search.executeQuery(query);
   }
-  
+
   /**
-   * Simply logs plugin errors when they're thrown by attaching as an errorback. 
-   * Without this, exceptions will just disappear (unless logged by the plugin) 
+   * Simply logs plugin errors when they're thrown by attaching as an errorback.
+   * Without this, exceptions will just disappear (unless logged by the plugin)
    * since we don't wait for a result.
    */
   final class PluginError implements Callback<Object, Exception> {
@@ -1523,10 +1526,10 @@ public final class TSDB {
       return null;
     }
   }
-  
+
   /**
    * Blocks while pre-fetching meta data from the data and uid tables
-   * so that performance improves, particularly with a large number of 
+   * so that performance improves, particularly with a large number of
    * regions and region servers.
    * @since 2.2
    */
@@ -1536,12 +1539,12 @@ public final class TSDB {
     final ArrayList<Deferred<Object>> deferreds = new ArrayList<Deferred<Object>>();
     deferreds.add(client.prefetchMeta(table));
     deferreds.add(client.prefetchMeta(uidtable));
-    
+
     // TODO(cl) - meta, tree, etc
-    
+
     try {
       Deferred.group(deferreds).join();
-      LOG.info("Fetched meta data for tables in " + 
+      LOG.info("Fetched meta data for tables in " +
           (System.currentTimeMillis() - start) + "ms");
     } catch (InterruptedException e) {
       LOG.error("Interrupted", e);
@@ -1551,17 +1554,17 @@ public final class TSDB {
       LOG.error("Failed to prefetch meta for our tables", e);
     }
   }
-  
+
   /** @return the timer used for various house keeping functions */
   public Timer getTimer() {
     return timer;
   }
-  
+
   // ------------------ //
   // Compaction helpers //
   // ------------------ //
 
-  final KeyValue compact(final ArrayList<KeyValue> row, 
+  final KeyValue compact(final ArrayList<KeyValue> row,
       List<Annotation> annotations) {
     return compactionq.compact(row, annotations);
   }
@@ -1592,8 +1595,9 @@ public final class TSDB {
   /** Puts the given value into the data table. */
   final Deferred<Object> put(final byte[] key,
                              final byte[] qualifier,
-                             final byte[] value) {
-    return client.put(new PutRequest(table, key, FAMILY, qualifier, value));
+                             final byte[] value,
+                             long timestamp) {
+    return client.put(RequestBuilder.buildPutRequest(config, table, key, FAMILY, qualifier, value, timestamp));
   }
 
   /** Deletes the given cells from the data table. */

--- a/src/core/TsdbQuery.java
+++ b/src/core/TsdbQuery.java
@@ -1052,6 +1052,11 @@ final class TsdbQuery implements Query {
         (int) getScanStartTimeSeconds(), end_time == UNSET
         ? -1  // Will scan until the end (0xFFF...).
         : (int) getScanEndTimeSeconds(), tsdb.table, TSDB.FAMILY());
+    if(tsdb.getConfig().use_otsdb_timestamp()) {
+      long stTime = (getScanStartTimeSeconds() * 1000);
+      long endTime = end_time == UNSET ? -1 : (getScanEndTimeSeconds() * 1000);
+      scanner.setTimeRange(stTime, endTime);
+    }
     if (tsuids != null && !tsuids.isEmpty()) {
       createAndSetTSUIDFilter(scanner);
     } else if (filters.size() > 0) {

--- a/src/meta/Annotation.java
+++ b/src/meta/Annotation.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import net.opentsdb.core.Const;
 import net.opentsdb.core.Internal;
+import net.opentsdb.core.RequestBuilder;
 import net.opentsdb.core.RowKey;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.uid.UniqueId;
@@ -184,10 +185,10 @@ public final class Annotation implements Comparable<Annotation> {
         
         final byte[] tsuid_byte = tsuid != null && !tsuid.isEmpty() ? 
             UniqueId.stringToUid(tsuid) : null;
-        final PutRequest put = new PutRequest(tsdb.dataTable(), 
+        final PutRequest put = RequestBuilder.buildPutRequest(tsdb.getConfig(), tsdb.dataTable(),
             getRowKey(start_time, tsuid_byte), FAMILY, 
             getQualifier(start_time), 
-            Annotation.this.getStorageJSON());
+            Annotation.this.getStorageJSON(), start_time);
         return tsdb.getClient().compareAndSet(put, original_note);
       }
       
@@ -275,7 +276,6 @@ public final class Annotation implements Comparable<Annotation> {
         if (row == null || row.isEmpty()) {
           return Deferred.fromResult(null);
         }
-        
         Annotation note = JSON.parseToObject(row.get(0).value(),
             Annotation.class);
         return Deferred.fromResult(note);

--- a/src/tools/CliOptions.java
+++ b/src/tools/CliOptions.java
@@ -107,7 +107,7 @@ final class CliOptions {
     config.setAutoMetric(config.getBoolean("tsd.core.auto_create_metrics"));
     return config;
   }
-  
+
   /**
    * Copies the parsed command line options to the {@link Config} class
    * @param config Configuration instance to override
@@ -152,10 +152,12 @@ final class CliOptions {
         config.overrideConfig("tsd.network.async_io", entry.getValue());
       } else if (entry.getKey().toLowerCase().equals("--worker-threads")) {
         config.overrideConfig("tsd.network.worker_threads", entry.getValue());
-      } 	  
+      } else if(entry.getKey().toLowerCase().equals("--use-otsdb-ts")) {
+        config.overrideConfig("tsd.storage.use_otsdb_timestamp", "true");
+      }
     }
   }
-  
+
   /** Changes the log level to 'WARN' unless --verbose is passed.  */
   private static void honorVerboseFlag(final ArgP argp) {
     if (argp.optionExists("--verbose") && !argp.has("--verbose")

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -28,18 +28,18 @@ import com.google.common.collect.ImmutableMap;
 
 /**
  * OpenTSDB Configuration Class
- * 
+ *
  * This handles all of the user configurable variables for a TSD. On
  * initialization default values are configured for all variables. Then
  * implementations should call the {@link #loadConfig()} methods to search for a
  * default configuration or try to load one provided by the user.
- * 
+ *
  * To add a configuration, simply set a default value in {@link #setDefaults()}.
  * Wherever you need to access the config value, use the proper helper to fetch
  * the value, accounting for exceptions that may be thrown if necessary.
- * 
+ *
  * The get<type> number helpers will return NumberFormatExceptions if the
- * requested property is null or unparseable. The {@link #getString(String)} 
+ * requested property is null or unparseable. The {@link #getString(String)}
  * helper will return a NullPointerException if the property isn't found.
  * <p>
  * Plugins can extend this class and copy the properties from the main
@@ -53,11 +53,11 @@ public class Config {
   private static final Logger LOG = LoggerFactory.getLogger(Config.class);
 
   /** Flag to determine if we're running under Windows or not */
-  public static final boolean IS_WINDOWS = 
+  public static final boolean IS_WINDOWS =
       System.getProperty("os.name", "").contains("Windows");
-  
+
   // These are accessed often so need a set address for fast access (faster
-  // than accessing the map. Their value will be changed when the config is 
+  // than accessing the map. Their value will be changed when the config is
   // loaded
   // NOTE: edit the setDefaults() method if you add a public field
 
@@ -66,56 +66,65 @@ public class Config {
 
   /** tsd.core.auto_create_tagk */
   private boolean auto_tagk = true;
-  
+
   /** tsd.core.auto_create_tagv */
   private boolean auto_tagv = true;
-  
+
   /** tsd.storage.enable_compaction */
   private boolean enable_compactions = true;
-  
+
   /** tsd.storage.enable_appends */
   private boolean enable_appends = false;
-  
+
   /** tsd.storage.repair_appends */
   private boolean repair_appends = false;
-  
+
   /** tsd.core.meta.enable_realtime_ts */
   private boolean enable_realtime_ts = false;
-  
+
   /** tsd.core.meta.enable_realtime_uid */
   private boolean enable_realtime_uid = false;
-  
+
   /** tsd.core.meta.enable_tsuid_incrementing */
   private boolean enable_tsuid_incrementing = false;
-  
+
   /** tsd.core.meta.enable_tsuid_tracking */
   private boolean enable_tsuid_tracking = false;
-  
+
   /** tsd.http.request.enable_chunked */
   private boolean enable_chunked_requests = false;
-  
+
   /** tsd.storage.fix_duplicates */
   private boolean fix_duplicates = false;
 
   /** tsd.http.request.max_chunk */
-  private int max_chunked_requests = 4096; 
-  
+  private int max_chunked_requests = 4096;
+
   /** tsd.core.tree.enable_processing */
   private boolean enable_tree_processing = false;
 
   /** tsd.storage.hbase.scanner.maxNumRows */
   private int scanner_max_num_rows = 128;
-  
+
+  /** tsd.storage.use_otsdb_timestamp */
+  /** Sets the HBase cell timestamp equal to metric timestamp */
+  private boolean use_otsdb_timestamp = true;
+
+  /** tsd.storage.use_max_value */
+  /** Used for resolving between data coming in at same timestamp */
+  /** If set to true, the maximum value will be returned, minimum */
+  private boolean use_max_value = true;
+
   /**
    * The list of properties configured to their defaults or modified by users
    */
-  protected final HashMap<String, String> properties = 
+  protected final HashMap<String, String> properties =
     new HashMap<String, String>();
 
   /** Holds default values for the config */
-  protected static final HashMap<String, String> default_map = 
+  protected static final HashMap<String, String> default_map =
     new HashMap<String, String>();
-  
+
   /** Tracks the location of the file that was actually loaded */
   protected String config_location;
 
@@ -148,7 +157,7 @@ public class Config {
   /**
    * Constructor for plugins or overloaders who want a copy of the parent
    * properties but without the ability to modify them
-   * 
+   *
    * This constructor will not re-read the file, but it will copy the location
    * so if a child wants to reload the properties periodically, they may do so
    * @param parent Parent configuration object to load from
@@ -164,60 +173,60 @@ public class Config {
   public String configLocation() {
     return config_location;
   }
-  
+
   /** @return the auto_metric value */
   public boolean auto_metric() {
     return auto_metric;
   }
-  
+
   /** @return the auto_tagk value */
   public boolean auto_tagk() {
     return auto_tagk;
   }
-  
+
   /** @return the auto_tagv value */
   public boolean auto_tagv() {
     return auto_tagv;
   }
-  
+
   /** @param auto_metric whether or not to auto create metrics */
   public void setAutoMetric(boolean auto_metric) {
     this.auto_metric = auto_metric;
-    properties.put("tsd.core.auto_create_metrics", 
+    properties.put("tsd.core.auto_create_metrics",
         Boolean.toString(auto_metric));
   }
-  
+
   /** @return the enable_compaction value */
   public boolean enable_compactions() {
     return enable_compactions;
   }
-  
+
   /** @return whether or not to write data in the append format */
   public boolean enable_appends() {
     return enable_appends;
   }
-  
+
   /** @return whether or not to re-write appends with duplicates or out of order
    * data when queried. */
   public boolean repair_appends() {
     return repair_appends;
   }
-  
+
   /** @return whether or not to record new TSMeta objects in real time */
-  public boolean enable_realtime_ts() { 
+  public boolean enable_realtime_ts() {
     return enable_realtime_ts;
   }
-  
+
   /** @return whether or not record new UIDMeta objects in real time */
-  public boolean enable_realtime_uid() { 
+  public boolean enable_realtime_uid() {
     return enable_realtime_uid;
   }
-  
+
   /** @return whether or not to increment TSUID counters */
-  public boolean enable_tsuid_incrementing() { 
+  public boolean enable_tsuid_incrementing() {
     return enable_tsuid_incrementing;
   }
-  
+
   /** @return whether or not to record a 1 for every TSUID */
   public boolean enable_tsuid_tracking() {
     return enable_tsuid_tracking;
@@ -227,17 +236,17 @@ public class Config {
   public int scanner_maxNumRows() {
     return scanner_max_num_rows;
   }
-  
+
   /** @return whether or not chunked requests are supported */
   public boolean enable_chunked_requests() {
     return enable_chunked_requests;
   }
-  
+
   /** @return max incoming chunk size in bytes */
   public int max_chunked_requests() {
     return max_chunked_requests;
   }
-  
+
   /** @return true if duplicate values should be fixed */
   public boolean fix_duplicates() {
     return fix_duplicates;
@@ -252,14 +261,22 @@ public class Config {
   public boolean enable_tree_processing() {
     return enable_tree_processing;
   }
-  
+
+  public boolean use_otsdb_timestamp() {
+	  return use_otsdb_timestamp;
+  }
+
+  public boolean use_max_value() {
+	  return use_max_value;
+  }
+
   /**
    * Allows for modifying properties after creation or loading.
-   * 
-   * WARNING: This should only be used on initialization and is meant for 
-   * command line overrides. Also note that it will reset all static config 
+   *
+   * WARNING: This should only be used on initialization and is meant for
+   * command line overrides. Also note that it will reset all static config
    * variables when called.
-   * 
+   *
    * @param property The name of the property to override
    * @param value The value to store
    */
@@ -290,10 +307,10 @@ public class Config {
   }
 
   /**
-   * Returns the given string trimed or null if is null 
-   * @param string The string be trimmed of 
+   * Returns the given string trimed or null if is null
+   * @param string The string be trimmed of
    * @return The string trimed or null
-  */  
+  */
   private final String sanitize(final String string) {
     if (string == null) {
       return null;
@@ -348,12 +365,12 @@ public class Config {
 
   /**
    * Returns the given property as a boolean
-   * 
+   *
    * Property values are case insensitive and the following values will result
    * in a True return value: - 1 - True - Yes
-   * 
+   *
    * Any other values, including an empty string, will result in a False
-   * 
+   *
    * @param property The property to load
    * @return A parsed boolean
    * @throws NullPointerException if the property was not found
@@ -383,7 +400,7 @@ public class Config {
     if (IS_WINDOWS) {
       // Windows swings both ways. If a forward slash was already used, we'll
       // add one at the end if missing. Otherwise use the windows default of \
-      if (directory.charAt(directory.length() - 1) == '\\' || 
+      if (directory.charAt(directory.length() - 1) == '\\' ||
           directory.charAt(directory.length() - 1) == '/') {
         return directory;
       }
@@ -396,17 +413,17 @@ public class Config {
       throw new IllegalArgumentException(
           "Unix path names cannot contain a back slash");
     }
-    
+
     if (directory == null || directory.isEmpty()){
     	return null;
     }
-    
+
     if (directory.charAt(directory.length() - 1) == '/') {
       return directory;
     }
     return directory + "/";
   }
-  
+
   /**
    * Determines if the given propery is in the map
    * @param property The property to search for
@@ -466,10 +483,10 @@ public class Config {
   public final void disableCompactions() {
     this.enable_compactions = false;
   }
-  
+
   /**
    * Loads default entries that were not provided by a file or command line
-   * 
+   *
    * This should be called in the constructor
    */
   protected void setDefaults() {
@@ -532,7 +549,7 @@ public class Config {
     default_map.put("tsd.storage.compaction.flush_speed", "2");
     default_map.put("tsd.timeseriesfilter.enable", "false");
     default_map.put("tsd.uidfilter.enable", "false");
-    default_map.put("tsd.core.stats_with_port", "false");    
+    default_map.put("tsd.core.stats_with_port", "false");
     default_map.put("tsd.http.show_stack_trace", "true");
     default_map.put("tsd.http.query.allow_delete", "false");
     default_map.put("tsd.http.request.enable_chunked", "false");
@@ -542,6 +559,8 @@ public class Config {
       + "Content-Type, Accept, Origin, User-Agent, DNT, Cache-Control, "
       + "X-Mx-ReqToken, Keep-Alive, X-Requested-With, If-Modified-Since");
     default_map.put("tsd.query.timeout", "0");
+    default_map.put("tsd.storage.use_otsdb_timestamp", "true");
+    default_map.put("tsd.storage.use_max_value", "true");
 
     for (Map.Entry<String, String> entry : default_map.entrySet()) {
       if (!properties.containsKey(entry.getKey()))
@@ -553,14 +572,14 @@ public class Config {
 
   /**
    * Searches a list of locations for a valid opentsdb.conf file
-   * 
+   *
    * The config file must be a standard JAVA properties formatted file. If none
    * of the locations have a config file, then the defaults or command line
    * arguments will be used for the configuration
-   * 
+   *
    * Defaults for Linux based systems are: ./opentsdb.conf /etc/opentsdb.conf
    * /etc/opentsdb/opentdsb.conf /opt/opentsdb/opentsdb.conf
-   * 
+   *
    * @throws IOException Thrown if there was an issue reading a file
    */
   protected void loadConfig() throws IOException {
@@ -589,9 +608,9 @@ public class Config {
         FileInputStream file_stream = new FileInputStream(file);
         Properties props = new Properties();
         props.load(file_stream);
-        
+
         // load the hash map
-        loadHashMap(props);        
+        loadHashMap(props);
       } catch (Exception e) {
         // don't do anything, the file may be missing and that's fine
         LOG.debug("Unable to find or load " + file, e);
@@ -619,10 +638,10 @@ public class Config {
     try {
       final Properties props = new Properties();
       props.load(file_stream);
-  
+
       // load the hash map
       loadHashMap(props);
-  
+
       // no exceptions thrown, so save the valid path and exit
       LOG.info("Successfully loaded configuration file: " + file);
       config_location = file;
@@ -645,9 +664,9 @@ public class Config {
     enable_chunked_requests = this.getBoolean("tsd.http.request.enable_chunked");
     enable_realtime_ts = this.getBoolean("tsd.core.meta.enable_realtime_ts");
     enable_realtime_uid = this.getBoolean("tsd.core.meta.enable_realtime_uid");
-    enable_tsuid_incrementing = 
+    enable_tsuid_incrementing =
       this.getBoolean("tsd.core.meta.enable_tsuid_incrementing");
-    enable_tsuid_tracking = 
+    enable_tsuid_tracking =
       this.getBoolean("tsd.core.meta.enable_tsuid_tracking");
     if (this.hasProperty("tsd.http.request.max_chunk")) {
       max_chunked_requests = this.getInt("tsd.http.request.max_chunk");
@@ -655,18 +674,20 @@ public class Config {
     enable_tree_processing = this.getBoolean("tsd.core.tree.enable_processing");
     fix_duplicates = this.getBoolean("tsd.storage.fix_duplicates");
     scanner_max_num_rows = this.getInt("tsd.storage.hbase.scanner.maxNumRows");
+    use_otsdb_timestamp = this.getBoolean("tsd.storage.use_otsdb_timestamp");
+    use_max_value = this.getBoolean("tsd.storage.use_max_value");
   }
-  
+
   /**
    * Called from {@link #loadConfig} to copy the properties into the hash map
    * Tsuna points out that the Properties class is much slower than a hash
    * map so if we'll be looking up config values more than once, a hash map
-   * is the way to go 
+   * is the way to go
    * @param props The loaded Properties object to copy
    */
   private void loadHashMap(final Properties props) {
     properties.clear();
-    
+
     @SuppressWarnings("rawtypes")
     Enumeration e = props.propertyNames();
     while (e.hasMoreElements()) {

--- a/test/core/TestCompactionQueue.java
+++ b/test/core/TestCompactionQueue.java
@@ -24,6 +24,8 @@ import com.stumbleupon.async.Deferred;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
 import org.hbase.async.Bytes;
 import org.hbase.async.KeyValue;
 
@@ -47,6 +49,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.anyLong;
 
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -72,9 +75,9 @@ public final class TestCompactionQueue {
   private static final byte[] FAMILY = { 't' };
   private static final byte[] ZERO = { 0 };
   private static final byte[] MIXED_FLAG = { Const.MS_MIXED_COMPACT };
-  private static final String annotation = 
-      "{\"tsuid\":\"ABCD\",\"description\":\"Description\"," + 
-      "\"notes\":\"Notes\",\"custom\":null,\"endTime\":1328140801,\"startTime" + 
+  private static final String annotation =
+      "{\"tsuid\":\"ABCD\",\"description\":\"Description\"," +
+      "\"notes\":\"Notes\",\"custom\":null,\"endTime\":1328140801,\"startTime" +
       "\":1328140800}";
   private static final byte[] note = annotation.getBytes(Charset.forName("UTF-8"));
   private static final byte[] note_qual = { 1, 0, 0 };
@@ -96,10 +99,34 @@ public final class TestCompactionQueue {
     PowerMockito.when(config.fix_duplicates()).thenReturn(true);
     compactionq = new CompactionQueue(tsdb);
 
-    when(tsdb.put(anyBytes(), anyBytes(), anyBytes()))
+    when(tsdb.put(anyBytes(), anyBytes(), anyBytes(), anyLong()))
       .thenAnswer(newDeferred());
     when(tsdb.delete(anyBytes(), any(byte[][].class)))
       .thenAnswer(newDeferred());
+  }
+
+  @Test
+  public void useMaxTsWhileCompacting() throws Exception {
+	    ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(2);
+	    ArrayList<Annotation> annotations = new ArrayList<Annotation>(0);
+	    long ts1 = Math.abs(ThreadLocalRandom.current().nextLong());
+	    final byte[] qual1 = { (byte) 0xF0, 0x00, 0x00, 0x07 };
+	    final byte[] val1 = Bytes.fromLong(4L);
+	    kvs.add(makekvWithTs(qual1, ts1, val1));
+	    long ts2 = Math.abs(ThreadLocalRandom.current().nextLong());
+	    final byte[] qual2 = { (byte) 0xF0, 0x00, 0x01, 0x07 };
+	    final byte[] val2 = Bytes.fromLong(5L);
+	    kvs.add(makekvWithTs(qual2, ts2, val2));
+	    long ts3 = Math.abs(ThreadLocalRandom.current().nextLong());
+	    final byte[] qual3 = { (byte) 0xF0, 0x00, 0x02, 0x07 };
+	    final byte[] val3 = Bytes.fromLong(2L);
+	    kvs.add(makekvWithTs(qual3, ts3, val3));
+
+	    when(tsdb.getConfig().getBoolean("tsd.storage.use_otsdb_timestamp")).thenReturn(true);
+	    final KeyValue kv = compactionq.compact(kvs, annotations);
+	    assertArrayEquals(MockBase.concatByteArrays(qual1, qual2, qual3), kv.qualifier());
+	    assertArrayEquals(MockBase.concatByteArrays(val1, val2, val3, ZERO), kv.value());
+	    assert(kv.timestamp() == Math.max(ts1, Math.max(ts2, ts3)));
   }
 
   @Test
@@ -108,10 +135,10 @@ public final class TestCompactionQueue {
     ArrayList<Annotation> annotations = new ArrayList<Annotation>(0);
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertNull(kv);
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
@@ -126,33 +153,33 @@ public final class TestCompactionQueue {
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(qual, kv.qualifier());
     assertArrayEquals(val, kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void oneCellAppend() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
     ArrayList<Annotation> annotations = new ArrayList<Annotation>(0);
     final byte[] qual = { 0x00, 0x07 };
     final byte[] val = Bytes.fromLong(42L);
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual, val)));
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(qual, kv.qualifier());
     assertArrayEquals(val, kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void oneCellRowWAnnotation() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -165,14 +192,14 @@ public final class TestCompactionQueue {
     assertArrayEquals(qual, kv.qualifier());
     assertArrayEquals(val, kv.value());
     assertEquals(1, annotations.size());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void oneCellAppendWAnnotiation() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -180,20 +207,20 @@ public final class TestCompactionQueue {
     kvs.add(makekv(note_qual, note));
     final byte[] qual = { 0x00, 0x07 };
     final byte[] val = Bytes.fromLong(42L);
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual, val)));
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(qual, kv.qualifier());
     assertArrayEquals(val, kv.value());
     assertEquals(1, annotations.size());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void oneCellRowWAnnotationMS() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -206,10 +233,10 @@ public final class TestCompactionQueue {
     assertArrayEquals(qual, kv.qualifier());
     assertArrayEquals(val, kv.value());
     assertEquals(1, annotations.size());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
@@ -227,7 +254,7 @@ public final class TestCompactionQueue {
     assertArrayEquals(val, kv.value());
 
     // The old one needed the length fixed up, so verify that we wrote the new one
-    verify(tsdb, times(1)).put(KEY, cqual, val);
+    verify(tsdb, times(1)).put(KEY, cqual, val, kvCount - 1);
     // ... and deleted the old one
     verify(tsdb, times(1)).delete(KEY, new byte[][] { qual });
   }
@@ -242,10 +269,10 @@ public final class TestCompactionQueue {
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(qual, kv.qualifier());
     assertArrayEquals(val, kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
@@ -264,14 +291,14 @@ public final class TestCompactionQueue {
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(MockBase.concatByteArrays(qual1, qual2), kv.qualifier());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, ZERO), kv.value());
-    
+
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual1, qual2),
-                               MockBase.concatByteArrays(val1, val2, ZERO));
+                               MockBase.concatByteArrays(val1, val2, ZERO), kvCount - 1);
     // And we had to delete individual cells.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1, qual2 }));
   }
-  
+
   @Test
   public void twoCellAppend() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -280,19 +307,19 @@ public final class TestCompactionQueue {
     final byte[] val = Bytes.fromLong(42L);
     final byte[] qual2 = { 0x00, 0x17 };
     final byte[] val2 = Bytes.fromLong(5L);
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual, val, qual2, val2)));
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(MockBase.concatByteArrays(qual, qual2), kv.qualifier());
     assertArrayEquals(MockBase.concatByteArrays(val, val2, ZERO), kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void twoCellRowWAnnotation() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(2);
@@ -309,10 +336,10 @@ public final class TestCompactionQueue {
     assertArrayEquals(MockBase.concatByteArrays(qual1, qual2), kv.qualifier());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, ZERO), kv.value());
     assertEquals(1, annotations.size());
-    
+
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual1, qual2),
-                               MockBase.concatByteArrays(val1, val2, ZERO));
+                               MockBase.concatByteArrays(val1, val2, ZERO), kvCount - 1);
     // And we had to delete individual cells.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1, qual2 }));
   }
@@ -326,32 +353,32 @@ public final class TestCompactionQueue {
     final byte[] val = Bytes.fromLong(42L);
     final byte[] qual2 = { 0x00, 0x17 };
     final byte[] val2 = Bytes.fromLong(5L);
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual, val, qual2, val2)));
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(MockBase.concatByteArrays(qual, qual2), kv.qualifier());
     assertArrayEquals(MockBase.concatByteArrays(val, val2, ZERO), kv.value());
     assertEquals(1, annotations.size());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void fullRowSeconds() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(3600);
     ArrayList<Annotation> annotations = new ArrayList<Annotation>(0);
-    
+
     byte[] qualifiers = new byte[] {};
     byte[] values = new byte[] {};
-    
+
     for (int i = 0; i < 3600; i++) {
       final short qualifier = (short) (i << Const.FLAG_BITS | 0x07);
       kvs.add(makekv(Bytes.fromShort(qualifier), Bytes.fromLong(i)));
-      qualifiers = MockBase.concatByteArrays(qualifiers, 
+      qualifiers = MockBase.concatByteArrays(qualifiers,
           Bytes.fromShort(qualifier));
       values = MockBase.concatByteArrays(values, Bytes.fromLong(i));
     }
@@ -359,14 +386,14 @@ public final class TestCompactionQueue {
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(MockBase.concatByteArrays(qualifiers), kv.qualifier());
     assertArrayEquals(MockBase.concatByteArrays(values, ZERO), kv.value());
-    
+
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, qualifiers,
-                               MockBase.concatByteArrays(values, ZERO));
+                               MockBase.concatByteArrays(values, ZERO), kvCount - 1);
     // And we had to delete individual cells.
     verify(tsdb, times(1)).delete((byte[])any(), (byte[][])any());
   }
-  
+
   @Test
   public void bigRowMs() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(3599999);
@@ -377,7 +404,7 @@ public final class TestCompactionQueue {
     for (int i = 0; i < 3599999; i++) {
       final int qualifier = (((i << Const.MS_FLAG_BITS ) | 0x07) | 0xF0000000);
       kvs.add(makekv(Bytes.fromInt(qualifier), Bytes.fromLong(i)));
-      qualifiers = MockBase.concatByteArrays(qualifiers, 
+      qualifiers = MockBase.concatByteArrays(qualifiers,
           Bytes.fromInt(qualifier));
       values = MockBase.concatByteArrays(values, Bytes.fromLong(i));
       i += 100;
@@ -385,14 +412,14 @@ public final class TestCompactionQueue {
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(MockBase.concatByteArrays(qualifiers), kv.qualifier());
     assertArrayEquals(MockBase.concatByteArrays(values, ZERO), kv.value());
-    
+
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, qualifiers,
-        MockBase.concatByteArrays(values, ZERO));
+        MockBase.concatByteArrays(values, ZERO), kvCount - 1);
     // And we had to delete individual cells.
     verify(tsdb, times(1)).delete((byte[])any(), (byte[][])any());
   }
-  
+
   @Test
   public void twoCellRowMS() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(2);
@@ -407,14 +434,14 @@ public final class TestCompactionQueue {
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(MockBase.concatByteArrays(qual1, qual2), kv.qualifier());
     assertArrayEquals(MockBase.concatByteArrays(val1, val2, ZERO), kv.value());
-    
+
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual1, qual2),
-                               MockBase.concatByteArrays(val1, val2, ZERO));
+                               MockBase.concatByteArrays(val1, val2, ZERO), kvCount - 1);
     // And we had to delete individual cells.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1, qual2 }));
   }
-  
+
   @Test
   public void sortMsAndS() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(2);
@@ -428,21 +455,21 @@ public final class TestCompactionQueue {
     final byte[] qual3 = { (byte) 0xF0, 0x00, 0x01, 0x07 };
     final byte[] val3 = Bytes.fromLong(5L);
     kvs.add(makekv(qual3, val3));
-    
+
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2), 
+    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2, 
+    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2,
         new byte[] { 1 }), kv.value());
 
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual1, qual3, qual2),
-         MockBase.concatByteArrays(val1, val3, val2, new byte[] { 1 }));
+         MockBase.concatByteArrays(val1, val3, val2, new byte[] { 1 }), kvCount - 1);
     // And we had to delete individual cells.
-    verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1, 
+    verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1,
         qual2, qual3 }));
   }
-  
+
   @Test
   public void secondsOutOfOrder() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(3);
@@ -458,22 +485,22 @@ public final class TestCompactionQueue {
     kvs.add(makekv(qual3, val3));
 
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual2, qual3, qual1), 
+    assertArrayEquals(MockBase.concatByteArrays(qual2, qual3, qual1),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val2, val3, val1, ZERO), 
+    assertArrayEquals(MockBase.concatByteArrays(val2, val3, val1, ZERO),
         kv.value());
 
     // We compacted all columns to one, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual2, qual3, qual1),
-        MockBase.concatByteArrays(val2, val3, val1, ZERO));
+        MockBase.concatByteArrays(val2, val3, val1, ZERO), kvCount - 1);
     // And we had to delete individual cells.
-    verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1, 
+    verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1,
         qual2, qual3 }));
   }
-  
+
   @Test
   public void msOutOfOrder() throws Exception {
-    // all rows with an ms qualifier will go through the compaction 
+    // all rows with an ms qualifier will go through the compaction
     // process and they'll be sorted
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(3);
     ArrayList<Annotation> annotations = new ArrayList<Annotation>(0);
@@ -488,18 +515,18 @@ public final class TestCompactionQueue {
     kvs.add(makekv(qual3, val3));
 
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual2, qual3, qual1), 
+    assertArrayEquals(MockBase.concatByteArrays(qual2, qual3, qual1),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val2, val3, val1, ZERO), 
+    assertArrayEquals(MockBase.concatByteArrays(val2, val3, val1, ZERO),
         kv.value());
 
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual2, qual3, qual1),
-                               MockBase.concatByteArrays(val2, val3, val1, ZERO));
+                               MockBase.concatByteArrays(val2, val3, val1, ZERO), kvCount - 1);
     // And we had to delete individual cells.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1, qual2, qual3 }));
   }
-  
+
   @Test
   public void secondAndMs() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(2);
@@ -513,16 +540,16 @@ public final class TestCompactionQueue {
 
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(MockBase.concatByteArrays(qual1, qual2), kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 1 }), 
+    assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 1 }),
         kv.value());
 
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual1, qual2),
-         MockBase.concatByteArrays(val1, val2, new byte[] { 1 }));
+         MockBase.concatByteArrays(val1, val2, new byte[] { 1 }), kvCount - 1);
     // And we had to delete individual cells.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1, qual2 }));
   }
-  
+
   @Test
   public void secondAndMsWAnnotation() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(2);
@@ -537,13 +564,13 @@ public final class TestCompactionQueue {
 
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(MockBase.concatByteArrays(qual1, qual2), kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 1 }), 
+    assertArrayEquals(MockBase.concatByteArrays(val1, val2, new byte[] { 1 }),
         kv.value());
     assertEquals(1, annotations.size());
 
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual1, qual2),
-         MockBase.concatByteArrays(val1, val2, new byte[] { 1 }));
+         MockBase.concatByteArrays(val1, val2, new byte[] { 1 }), kvCount - 1);
     // And we had to delete individual cells.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1, qual2 }));
   }
@@ -577,13 +604,13 @@ public final class TestCompactionQueue {
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(qual2, kv.qualifier());
     assertArrayEquals(val2, kv.value());
-    
+
     // no compacted row
-    verify(tsdb, never()).put(KEY, qual2, val2);
+    verify(tsdb, never()).put(KEY, qual2, val2, kvCount - 1);
     // And we had to delete the earlier entry.
     verify(tsdb, times(1)).delete(KEY, new byte[][] {qual1});
   }
-  
+
   @Test
   public void fixQualifierFlags() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(2);
@@ -604,7 +631,7 @@ public final class TestCompactionQueue {
 
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(cqual1, qual2),
-                               MockBase.concatByteArrays(val1, val2, ZERO));
+                               MockBase.concatByteArrays(val1, val2, ZERO), kvCount - 1);
     // And we had to delete individual cells.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1, qual2 }));
   }
@@ -628,10 +655,10 @@ public final class TestCompactionQueue {
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(MockBase.concatByteArrays(qual1, qual2), kv.qualifier());
     assertArrayEquals(MockBase.concatByteArrays(val1, cval2, ZERO), kv.value());
-    
+
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual1, qual2),
-                               MockBase.concatByteArrays(val1, cval2, ZERO));
+                               MockBase.concatByteArrays(val1, cval2, ZERO), kvCount - 1);
     // And we had to delete individual cells.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1, qual2, }));
   }
@@ -651,7 +678,7 @@ public final class TestCompactionQueue {
 
     compactionq.compact(kvs, annotations);
   }
-  
+
   @Test
   public void overlappingDataPointsFix() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(2);
@@ -669,7 +696,7 @@ public final class TestCompactionQueue {
     assertArrayEquals(val2, kv.value());
 
     // We didn't have anything to write.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // We had to delete the first entry as it was older.
     verify(tsdb, times(1)).delete(KEY, new byte[][] {qual1});
   }
@@ -694,9 +721,9 @@ public final class TestCompactionQueue {
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(qualcompact, kv.qualifier());
     assertArrayEquals(valcompact, kv.value());
-    
+
     // We didn't have anything to write.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // We had to delete stuff in 1 row.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1, qual2 }));
   }
@@ -712,11 +739,11 @@ public final class TestCompactionQueue {
     assertEquals(1, annotations.size());
 
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void annotationsOnly() throws Exception {
     // Two annotations in a row only (the value of the second isn't parsed at
@@ -731,11 +758,11 @@ public final class TestCompactionQueue {
     assertEquals(2, annotations.size());
 
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void secondCompact() throws Exception {
     // In this test the row has already been compacted, and another data
@@ -756,18 +783,18 @@ public final class TestCompactionQueue {
     kvs.add(makekv(qual3, val3));
 
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2), 
+    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2, ZERO), 
+    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2, ZERO),
         kv.value());
 
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual1, qual3, qual2),
-                               MockBase.concatByteArrays(val1, val3, val2, ZERO));
+                               MockBase.concatByteArrays(val1, val3, val2, ZERO), kvCount - 1);
     // And we had to delete the individual cell + pre-existing compacted cell.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual12, qual3 }));
   }
-  
+
   @Test
   public void secondCompactWAnnotation() throws Exception {
     // In this test the row has already been compacted, and another data
@@ -789,15 +816,15 @@ public final class TestCompactionQueue {
     kvs.add(makekv(qual3, val3));
 
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2), 
+    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2, ZERO), 
+    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2, ZERO),
         kv.value());
     assertEquals(1, annotations.size());
 
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual1, qual3, qual2),
-                               MockBase.concatByteArrays(val1, val3, val2, ZERO));
+                               MockBase.concatByteArrays(val1, val3, val2, ZERO), kvCount - 1);
     // And we had to delete the individual cell + pre-existing compacted cell.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual12, qual3 }));
   }
@@ -822,18 +849,18 @@ public final class TestCompactionQueue {
     kvs.add(makekv(qual3, val3));
 
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2), 
+    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2, ZERO), 
+    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2, ZERO),
         kv.value());
-    
+
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual1, qual3, qual2),
-                               MockBase.concatByteArrays(val1, val3, val2, ZERO));
+                               MockBase.concatByteArrays(val1, val3, val2, ZERO), kvCount - 1);
     // And we had to delete the individual cell + pre-existing compacted cell.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual12, qual3 }));
   }
-  
+
   @Test
   public void secondCompactMixedSecond() throws Exception {
     // In this test the row has already been compacted, and another data
@@ -846,7 +873,7 @@ public final class TestCompactionQueue {
     final byte[] qual2 = { (byte) 0xF0, 0x0A, 0x41, 0x07 };
     final byte[] val2 = Bytes.fromLong(5L);
     final byte[] qual12 = MockBase.concatByteArrays(qual1, qual2);
-    kvs.add(makekv(qual12, MockBase.concatByteArrays(val1, val2, 
+    kvs.add(makekv(qual12, MockBase.concatByteArrays(val1, val2,
         new byte[] { 1 })));
     // This data point came late.  Note that its time delta falls in between
     // that of the two data points above.
@@ -855,19 +882,19 @@ public final class TestCompactionQueue {
     kvs.add(makekv(qual3, val3));
 
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2), 
+    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2, 
+    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2,
         new byte[] { 1 }), kv.value());
-    
+
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual1, qual3, qual2),
-                               MockBase.concatByteArrays(val1, val3, val2, 
-                                   new byte[] { 1 }));
+                               MockBase.concatByteArrays(val1, val3, val2,
+                                   new byte[] { 1 }), kvCount - 1);
     // And we had to delete the individual cell + pre-existing compacted cell.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual12, qual3 }));
   }
-  
+
   @Test
   public void secondCompactMixedMS() throws Exception {
     // In this test the row has already been compacted, and another data
@@ -880,7 +907,7 @@ public final class TestCompactionQueue {
     final byte[] qual2 = { (byte) 0xF0, 0x0A, 0x41, 0x07 };
     final byte[] val2 = Bytes.fromLong(5L);
     final byte[] qual12 = MockBase.concatByteArrays(qual1, qual2);
-    kvs.add(makekv(qual12, MockBase.concatByteArrays(val1, val2, 
+    kvs.add(makekv(qual12, MockBase.concatByteArrays(val1, val2,
         new byte[] { 1 })));
     // This data point came late.  Note that its time delta falls in between
     // that of the two data points above.
@@ -889,19 +916,19 @@ public final class TestCompactionQueue {
     kvs.add(makekv(qual3, val3));
 
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2), 
+    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2, 
+    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2,
         new byte[] { 1 }), kv.value());
-    
+
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual1, qual3, qual2),
-                               MockBase.concatByteArrays(val1, val3, val2, 
-                                   new byte[] { 1 }));
+                               MockBase.concatByteArrays(val1, val3, val2,
+                                   new byte[] { 1 }), kvCount - 1);
     // And we had to delete the individual cell + pre-existing compacted cell.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual12, qual3 }));
   }
-  
+
   @Test
   public void secondCompactMixedMSAndS() throws Exception {
     // In this test the row has already been compacted with a ms flag as the
@@ -915,7 +942,7 @@ public final class TestCompactionQueue {
     final byte[] qual2 = { 0x00, (byte) 0xF7 };
     final byte[] val2 = Bytes.fromLong(5L);
     final byte[] qual12 = MockBase.concatByteArrays(qual1, qual2);
-    kvs.add(makekv(qual12, MockBase.concatByteArrays(val1, val2, 
+    kvs.add(makekv(qual12, MockBase.concatByteArrays(val1, val2,
         new byte[] { 1 })));
     // This data point came late.  Note that its time delta falls in between
     // that of the two data points above.
@@ -924,19 +951,19 @@ public final class TestCompactionQueue {
     kvs.add(makekv(qual3, val3));
 
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual3, qual1, qual2), 
+    assertArrayEquals(MockBase.concatByteArrays(qual3, qual1, qual2),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val3, val1, val2, 
+    assertArrayEquals(MockBase.concatByteArrays(val3, val1, val2,
         new byte[] { 1 }), kv.value());
-    
+
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual3, qual1, qual2),
-                               MockBase.concatByteArrays(val3, val1, val2, 
-                                   new byte[] { 1 }));
+                               MockBase.concatByteArrays(val3, val1, val2,
+                                   new byte[] { 1 }), kvCount - 1);
     // And we had to delete the individual cell + pre-existing compacted cell.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual12, qual3 }));
   }
-  
+
   @Test (expected = IllegalDataException.class)
   public void secondCompactOverwrite() throws Exception {
     PowerMockito.when(config.fix_duplicates()).thenReturn(false);
@@ -959,7 +986,7 @@ public final class TestCompactionQueue {
 
     compactionq.compact(kvs, annotations);
   }
-  
+
   @Test
   public void secondCompactOverwriteFix() throws Exception {
     // In this test the row has already been compacted, and a new value for an
@@ -980,19 +1007,19 @@ public final class TestCompactionQueue {
     kvs.add(makekv(qual3, val3));
 
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual3, qual2), 
+    assertArrayEquals(MockBase.concatByteArrays(qual3, qual2),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val3, val2, new byte[] { 0 }), 
+    assertArrayEquals(MockBase.concatByteArrays(val3, val2, new byte[] { 0 }),
         kv.value());
-    
+
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual3, qual2),
-        MockBase.concatByteArrays(val3, val2, new byte[] { 0 }));
+        MockBase.concatByteArrays(val3, val2, new byte[] { 0 }), kvCount - 1);
     // And we had to delete the individual cell, but we overwrite the pre-existing compacted cell
     // rather than delete it.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] {qual3}));
   }
-  
+
   @Test
   public void doubleFailedCompactNoop() throws Exception {
     // In this test the row has already been compacted once, but we didn't
@@ -1021,15 +1048,15 @@ public final class TestCompactionQueue {
 
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(qual132, kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2, ZERO), 
+    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2, ZERO),
         kv.value());
-    
+
     // We didn't have anything to write, the last cell is already the correct
     // compacted version of the row.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // And we had to delete the 3 individual cells + the first pre-existing
     // compacted cell.
-    verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1, 
+    verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1,
         qual12, qual3, qual2 }));
   }
 
@@ -1058,14 +1085,14 @@ public final class TestCompactionQueue {
     kvs.add(makekv(qual2, val2));
 
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2), 
+    assertArrayEquals(MockBase.concatByteArrays(qual1, qual3, qual2),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2, ZERO), 
+    assertArrayEquals(MockBase.concatByteArrays(val1, val3, val2, ZERO),
         kv.value());
-    
+
     // We had one row to compact, so one put to do.
     verify(tsdb, times(1)).put(KEY, MockBase.concatByteArrays(qual1, qual3, qual2),
-                               MockBase.concatByteArrays(val1, val3, val2, ZERO));
+                               MockBase.concatByteArrays(val1, val3, val2, ZERO), kvCount - 1);
     // And we had to delete the 3 individual cells + 2 pre-existing
     // compacted cells.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual1, qual12, qual13, qual3, qual2 }));
@@ -1103,17 +1130,17 @@ public final class TestCompactionQueue {
     assertArrayEquals(
         MockBase.concatByteArrays(qual12, qual34, qual56), kv.qualifier());
     assertArrayEquals(
-        MockBase.concatByteArrays(val1, val2, val3, val4, val5, val6, ZERO), 
+        MockBase.concatByteArrays(val1, val2, val3, val4, val5, val6, ZERO),
         kv.value());
 
     // We wrote only the combined column.
-    verify(tsdb, times(1)).put(KEY, 
+    verify(tsdb, times(1)).put(KEY,
         MockBase.concatByteArrays(qual1, qual2, qual3, qual4, qual5, qual6),
-        MockBase.concatByteArrays(val1, val2, val3, val4, val5, val6, ZERO));
+        MockBase.concatByteArrays(val1, val2, val3, val4, val5, val6, ZERO), kvCount - 1);
     // And we had to delete the 3 partially compacted columns.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual12, qual34, qual56 }));
   }
-  
+
   @Test
   public void tripleCompactedOutOfOrder() throws Exception {
     // Here we have a row with #kvs > scanner.maxNumKeyValues and the result
@@ -1146,17 +1173,17 @@ public final class TestCompactionQueue {
     assertArrayEquals(
         MockBase.concatByteArrays(qual12, qual34, qual56), kv.qualifier());
     assertArrayEquals(
-        MockBase.concatByteArrays(val1, val2, val3, val4, val5, val6, ZERO), 
-        kv.value());    
-    
+        MockBase.concatByteArrays(val1, val2, val3, val4, val5, val6, ZERO),
+        kv.value());
+
     // We wrote only the combined column.
-    verify(tsdb, times(1)).put(KEY, 
+    verify(tsdb, times(1)).put(KEY,
         MockBase.concatByteArrays(qual1, qual2, qual3, qual4, qual5, qual6),
-        MockBase.concatByteArrays(val1, val2, val3, val4, val5, val6, ZERO));
+        MockBase.concatByteArrays(val1, val2, val3, val4, val5, val6, ZERO), kvCount - 1);
     // And we had to delete the 3 partially compacted columns.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual12, qual56, qual34 }));
   }
-  
+
   @Test
   public void tripleCompactedSecondsAndMs() throws Exception {
     // Here we have a row with #kvs > scanner.maxNumKeyValues and the result
@@ -1195,13 +1222,13 @@ public final class TestCompactionQueue {
         kv.value());
 
     // We wrote only the combined column.
-    verify(tsdb, times(1)).put(KEY, 
+    verify(tsdb, times(1)).put(KEY,
         MockBase.concatByteArrays(qual1, qual2, qual3, qual4, qual5, qual6),
-        MockBase.concatByteArrays(val1, val2, val3, val4, val5, val6, MIXED_FLAG));
+        MockBase.concatByteArrays(val1, val2, val3, val4, val5, val6, MIXED_FLAG), kvCount - 1);
     // And we had to delete the 3 partially compacted columns.
     verify(tsdb, times(1)).delete(eq(KEY), eqAnyOrder(new byte[][] { qual12, qual34, qual56 }));
   }
-  
+
   @Test
   public void appendsAndLaterPuts() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -1214,23 +1241,23 @@ public final class TestCompactionQueue {
     final byte[] val3 = Bytes.fromLong(3L);
     final byte[] qual4 = { 0x00, 0x37 };
     final byte[] val4 = Bytes.fromLong(2L);
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual, val, qual2, val2)));
     kvs.add(makekv(qual3, val3));
     kvs.add(makekv(qual4, val4));
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual, qual2, qual3, qual4), 
+    assertArrayEquals(MockBase.concatByteArrays(qual, qual2, qual3, qual4),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val, val2, val3, val4, ZERO), 
+    assertArrayEquals(MockBase.concatByteArrays(val, val2, val3, val4, ZERO),
         kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void appendsAndEarlierPuts() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -1245,21 +1272,21 @@ public final class TestCompactionQueue {
     final byte[] val4 = Bytes.fromLong(2L);
     kvs.add(makekv(qual, val));
     kvs.add(makekv(qual2, val2));
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual3, val3, qual4, val4)));
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual, qual2, qual3, qual4), 
+    assertArrayEquals(MockBase.concatByteArrays(qual, qual2, qual3, qual4),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val, val2, val3, val4, ZERO), 
+    assertArrayEquals(MockBase.concatByteArrays(val, val2, val3, val4, ZERO),
         kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void appendsAndInterspersedPuts() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -1274,21 +1301,21 @@ public final class TestCompactionQueue {
     final byte[] val4 = Bytes.fromLong(2L);
     kvs.add(makekv(qual, val));
     kvs.add(makekv(qual3, val3));
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual2, val2, qual4, val4)));
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual, qual2, qual3, qual4), 
+    assertArrayEquals(MockBase.concatByteArrays(qual, qual2, qual3, qual4),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val, val2, val3, val4, ZERO), 
+    assertArrayEquals(MockBase.concatByteArrays(val, val2, val3, val4, ZERO),
         kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void doubleAppends() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -1301,23 +1328,23 @@ public final class TestCompactionQueue {
     final byte[] val3 = Bytes.fromLong(3L);
     final byte[] qual4 = { 0x00, 0x37 };
     final byte[] val4 = Bytes.fromLong(2L);
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual, val, qual2, val2)));
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual3, val3, qual4, val4)));
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual, qual2, qual3, qual4), 
+    assertArrayEquals(MockBase.concatByteArrays(qual, qual2, qual3, qual4),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val, val2, val3, val4, ZERO), 
+    assertArrayEquals(MockBase.concatByteArrays(val, val2, val3, val4, ZERO),
         kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void tripleAppends() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -1334,25 +1361,25 @@ public final class TestCompactionQueue {
     final byte[] val5 = Bytes.fromLong(1L);
     final byte[] qual6 = { 0x00, 0x57 };
     final byte[] val6 = Bytes.fromLong(0L);
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual, val, qual2, val2)));
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual3, val3, qual4, val4)));
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual5, val5, qual6, val6)));
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(MockBase.concatByteArrays(
         qual, qual2, qual3, qual4, qual5, qual6), kv.qualifier());
     assertArrayEquals(MockBase.concatByteArrays(
         val, val2, val3, val4, val5, val6, ZERO), kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void doubleAppendsAndPuts() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -1369,25 +1396,25 @@ public final class TestCompactionQueue {
     final byte[] val5 = Bytes.fromLong(1L);
     final byte[] qual6 = { 0x00, 0x57 };
     final byte[] val6 = Bytes.fromLong(0L);
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual, val, qual2, val2)));
     kvs.add(makekv(qual3, val3));
     kvs.add(makekv(qual4, val4));
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual5, val5, qual6, val6)));
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(MockBase.concatByteArrays(
         qual, qual2, qual3, qual4, qual5, qual6), kv.qualifier());
     assertArrayEquals(MockBase.concatByteArrays(
         val, val2, val3, val4, val5, val6, ZERO), kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void appendsAndCompacted() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -1400,23 +1427,23 @@ public final class TestCompactionQueue {
     final byte[] val3 = Bytes.fromLong(3L);
     final byte[] qual4 = { 0x00, 0x37 };
     final byte[] val4 = Bytes.fromLong(2L);
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual, val, qual2, val2)));
-    kvs.add(makekv(MockBase.concatByteArrays(qual3, qual4), 
+    kvs.add(makekv(MockBase.concatByteArrays(qual3, qual4),
         MockBase.concatByteArrays(val3, val4, ZERO)));
     final KeyValue kv = compactionq.compact(kvs, annotations);
-    assertArrayEquals(MockBase.concatByteArrays(qual, qual2, qual3, qual4), 
+    assertArrayEquals(MockBase.concatByteArrays(qual, qual2, qual3, qual4),
         kv.qualifier());
-    assertArrayEquals(MockBase.concatByteArrays(val, val2, val3, val4, ZERO), 
+    assertArrayEquals(MockBase.concatByteArrays(val, val2, val3, val4, ZERO),
         kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void appendsAndCompactedAndPuts() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -1433,9 +1460,9 @@ public final class TestCompactionQueue {
     final byte[] val5 = Bytes.fromLong(1L);
     final byte[] qual6 = { 0x00, 0x57 };
     final byte[] val6 = Bytes.fromLong(0L);
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual, val, qual2, val2)));
-    kvs.add(makekv(MockBase.concatByteArrays(qual3, qual4), 
+    kvs.add(makekv(MockBase.concatByteArrays(qual3, qual4),
         MockBase.concatByteArrays(val3, val4, ZERO)));
     kvs.add(makekv(qual5, val5));
     kvs.add(makekv(qual6, val6));
@@ -1444,14 +1471,14 @@ public final class TestCompactionQueue {
         qual, qual2, qual3, qual4, qual5, qual6), kv.qualifier());
     assertArrayEquals(MockBase.concatByteArrays(
         val, val2, val3, val4, val5, val6, ZERO), kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void appendsDuplicatePuts() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -1460,21 +1487,21 @@ public final class TestCompactionQueue {
     final byte[] val = Bytes.fromLong(42L);
     final byte[] qual2 = { 0x00, 0x17 };
     final byte[] val2 = Bytes.fromLong(5L);
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual, val, qual2, val2)));
     kvs.add(makekv(qual, val));
     kvs.add(makekv(qual2, val2));
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(MockBase.concatByteArrays(qual, qual2), kv.qualifier());
     assertArrayEquals(MockBase.concatByteArrays(val, val2, ZERO), kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   @Test
   public void appendsDuplicateCompacted() throws Exception {
     ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
@@ -1483,21 +1510,21 @@ public final class TestCompactionQueue {
     final byte[] val = Bytes.fromLong(42L);
     final byte[] qual2 = { 0x00, 0x17 };
     final byte[] val2 = Bytes.fromLong(5L);
-    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER, 
+    kvs.add(makekv(AppendDataPoints.APPEND_COLUMN_QUALIFIER,
         MockBase.concatByteArrays(qual, val, qual2, val2)));
-    kvs.add(makekv(MockBase.concatByteArrays(qual, qual2), 
+    kvs.add(makekv(MockBase.concatByteArrays(qual, qual2),
         MockBase.concatByteArrays(val, val2, ZERO)));
     final KeyValue kv = compactionq.compact(kvs, annotations);
     assertArrayEquals(MockBase.concatByteArrays(qual, qual2), kv.qualifier());
     assertArrayEquals(MockBase.concatByteArrays(val, val2, ZERO), kv.value());
-    
+
     // We had nothing to do so...
     // ... verify there were no put.
-    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes());
+    verify(tsdb, never()).put(anyBytes(), anyBytes(), anyBytes(), anyLong());
     // ... verify there were no delete.
     verify(tsdb, never()).delete(anyBytes(), any(byte[][].class));
   }
-  
+
   // ----------------- //
   // Helper functions. //
   // ----------------- //
@@ -1508,6 +1535,10 @@ public final class TestCompactionQueue {
   /** Shorthand to create a {@link KeyValue}.  */
   private static KeyValue makekv(final byte[] qualifier, final byte[] value) {
     return new KeyValue(KEY, FAMILY, qualifier, kvCount++, value);
+  }
+
+  private static KeyValue makekvWithTs(final byte[] qualifier, long ts, final byte[] value) {
+    return new KeyValue(KEY, FAMILY, qualifier, ts, value);
   }
 
   private static byte[] anyBytes() {

--- a/test/core/TestTSDBAddPoint.java
+++ b/test/core/TestTSDBAddPoint.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.TreeMap;
 
 import org.hbase.async.Bytes;
 import org.junit.Before;
@@ -44,149 +46,177 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
   public void beforeLocal() throws Exception {
     setDataPointStorage();
   }
-  
+
   @Test
   public void addPointLong1Byte() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
     assertNotNull(value);
     assertEquals(42, value[0]);
   }
-  
+
+  @Test
+  public void addPointWithOTSDBTimeStamp() throws Exception {
+    long ts = 1356998400;
+    tsdb.getConfig().overrideConfig("tsd.storage.use_otsdb_timestamp", "true");
+    tsdb.addPoint(METRIC_STRING, ts, 42, tags).joinUninterruptibly();
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 0, 0, 1, 0, 0, 1 };
+    TreeMap<Long, byte[]> result = storage.getFullColumn(tsdb.dataTable(), row, tsdb.FAMILY(), new byte[] { 0, 0 });
+    assert (result != null);
+    for (Entry<Long, byte[]> e : result.entrySet()) {
+      long retrievedTs = e.getKey();
+      assert ((ts * 1000) == retrievedTs);
+    }
+  }
+
+  @Test
+  public void addPointWithoutOTSDBTimeStamp() throws Exception {
+	long ts = 1356998400;
+	tsdb.getConfig().overrideConfig("tsd.storage.use_otsdb_timestamp", "false");
+	tsdb.addPoint(METRIC_STRING, ts, 42, tags).joinUninterruptibly();
+	final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 0, 0, 1, 0, 0, 1 };
+	TreeMap<Long, byte[]> result = storage.getFullColumn(tsdb.dataTable(), row, tsdb.FAMILY(), new byte[] { 0, 0 });
+	assert(result != null);
+	for (Entry<Long, byte[]> e : result.entrySet()) {
+	  long retrievedTs = e.getKey();
+	  assert((ts * 1000) != retrievedTs);
+	}
+  }
+
   @Test
   public void addPointLong1ByteNegative() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400, -42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
     assertNotNull(value);
     assertEquals(-42, value[0]);
   }
-  
+
   @Test
   public void addPointLong2Bytes() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400, 257, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 1 });
     assertNotNull(value);
     assertEquals(257, Bytes.getShort(value));
   }
-  
+
   @Test
   public void addPointLong2BytesNegative() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400, -257, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 1 });
     assertNotNull(value);
     assertEquals(-257, Bytes.getShort(value));
   }
-  
+
   @Test
   public void addPointLong4Bytes() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400, 65537, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 3 });
     assertNotNull(value);
     assertEquals(65537, Bytes.getInt(value));
   }
-  
+
   @Test
   public void addPointLong4BytesNegative() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400, -65537, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 3 });
     assertNotNull(value);
     assertEquals(-65537, Bytes.getInt(value));
   }
-  
+
   @Test
   public void addPointLong8Bytes() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400, 4294967296L, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 7 });
     assertNotNull(value);
     assertEquals(4294967296L, Bytes.getLong(value));
   }
-  
+
   @Test
   public void addPointLong8BytesNegative() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400, -4294967296L, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 7 });
     assertNotNull(value);
     assertEquals(-4294967296L, Bytes.getLong(value));
   }
-  
+
   @Test
   public void addPointLongMs() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400500L, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, 
+    final byte[] value = storage.getColumn(row,
         new byte[] { (byte) 0xF0, 0, 0x7D, 0 });
     assertNotNull(value);
     assertEquals(42, value[0]);
   }
-  
+
   @Test
   public void addPointLongMany() throws Exception {
     long timestamp = 1356998400;
     for (int i = 1; i <= 50; i++) {
       tsdb.addPoint(METRIC_STRING, timestamp++, i, tags).joinUninterruptibly();
     }
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
     assertNotNull(value);
     assertEquals(1, value[0]);
     assertEquals(50, storage.numColumns(row));
   }
-  
+
   @Test
   public void addPointLongManyMs() throws Exception {
     long timestamp = 1356998400500L;
     for (int i = 1; i <= 50; i++) {
       tsdb.addPoint(METRIC_STRING, timestamp++, i, tags).joinUninterruptibly();
     }
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, 
+    final byte[] value = storage.getColumn(row,
         new byte[] { (byte) 0xF0, 0, 0x7D, 0 });
     assertNotNull(value);
     assertEquals(1, value[0]);
     assertEquals(50, storage.numColumns(row));
   }
-  
+
   @Test
   public void addPointLongEndOfRow() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1357001999, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, new byte[] { (byte) 0xE0, 
+    final byte[] value = storage.getColumn(row, new byte[] { (byte) 0xE0,
         (byte) 0xF0 });
     assertNotNull(value);
     assertEquals(42, value[0]);
   }
-  
+
   @Test
   public void addPointLongOverwrite() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998400, 24, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
     assertNotNull(value);
     assertEquals(24, value[0]);
   }
-  
+
   @Test (expected = NoSuchUniqueName.class)
   public void addPointNoAutoMetric() throws Exception {
     tsdb.addPoint(NSUN_METRIC, 1356998400, 42, tags).joinUninterruptibly();
@@ -201,7 +231,7 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     assertNotNull(value);
     assertEquals(42, value[0]);
   }
-  
+
   @Test
   public void addPointSecondOne() throws Exception {
     // hey, it's valid *shrug* Thu, 01 Jan 1970 00:00:01 GMT
@@ -211,25 +241,25 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     assertNotNull(value);
     assertEquals(42, value[0]);
   }
-  
+
   @Test
   public void addPointSecond2106() throws Exception {
     // Sun, 07 Feb 2106 06:28:15 GMT
     tsdb.addPoint(METRIC_STRING, 4294967295L, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, (byte) 0xFF, (byte) 0xFF, (byte) 0xF9, 
+    final byte[] row = new byte[] { 0, 0, 1, (byte) 0xFF, (byte) 0xFF, (byte) 0xF9,
         0x60, 0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0x69, (byte) 0xF0 });
     assertNotNull(value);
     assertEquals(42, value[0]);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void addPointSecondNegative() throws Exception {
     // Fri, 13 Dec 1901 20:45:52 GMT
     // may support in the future, but 1.0 didn't
     tsdb.addPoint(METRIC_STRING, -2147483648, 42, tags).joinUninterruptibly();
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void emptyTagValue() throws Exception {
     tags.put(TAGK_STRING, "");
@@ -243,44 +273,44 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     // Base time is 4294800 which is Thu, 19 Feb 1970 17:00:00 GMT
     // offset = F0A36000 or 167296 ms
     tsdb.addPoint(METRIC_STRING, 4294967296L, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0, (byte) 0x41, (byte) 0x88, 
+    final byte[] row = new byte[] { 0, 0, 1, 0, (byte) 0x41, (byte) 0x88,
         (byte) 0x90, 0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, new byte[] { (byte) 0xF0, 
+    final byte[] value = storage.getColumn(row, new byte[] { (byte) 0xF0,
         (byte) 0xA3, 0x60, 0});
     assertNotNull(value);
     assertEquals(42, value[0]);
   }
-  
+
   @Test
   public void addPointMS2106() throws Exception {
     // Sun, 07 Feb 2106 06:28:15.000 GMT
     tsdb.addPoint(METRIC_STRING, 4294967295000L, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, (byte) 0xFF, (byte) 0xFF, (byte) 0xF9, 
+    final byte[] row = new byte[] { 0, 0, 1, (byte) 0xFF, (byte) 0xFF, (byte) 0xF9,
         0x60, 0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, new byte[] { (byte) 0xF6, 
+    final byte[] value = storage.getColumn(row, new byte[] { (byte) 0xF6,
         (byte) 0x77, 0x46, 0 });
     assertNotNull(value);
     assertEquals(42, value[0]);
   }
-  
+
   @Test
   public void addPointMS2286() throws Exception {
     // It's an artificial limit and more thought needs to be put into it
     tsdb.addPoint(METRIC_STRING, 9999999999999L, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, (byte) 0x54, (byte) 0x0B, (byte) 0xD9, 
+    final byte[] row = new byte[] { 0, 0, 1, (byte) 0x54, (byte) 0x0B, (byte) 0xD9,
         0x10, 0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, new byte[] { (byte) 0xFA, 
+    final byte[] value = storage.getColumn(row, new byte[] { (byte) 0xFA,
         (byte) 0xAE, 0x5F, (byte) 0xC0 });
     assertNotNull(value);
     assertEquals(42, value[0]);
   }
-  
+
   @Test  (expected = IllegalArgumentException.class)
   public void addPointMSTooLarge() throws Exception {
     // It's an artificial limit and more thought needs to be put into it
     tsdb.addPoint(METRIC_STRING, 10000000000000L, 42, tags).joinUninterruptibly();
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void addPointMSNegative() throws Exception {
     // Fri, 13 Dec 1901 20:45:52 GMT
@@ -293,85 +323,85 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
   @Test
   public void addPointFloat() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400, 42.5F, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 11 });
     assertNotNull(value);
     // should have 7 digits of precision
     assertEquals(42.5F, Float.intBitsToFloat(Bytes.getInt(value)), 0.0000001);
   }
-  
+
   @Test
   public void addPointFloatNegative() throws Exception {
     HashMap<String, String> tags = new HashMap<String, String>(1);
     tags.put("host", "web01");
     tsdb.addPoint(METRIC_STRING, 1356998400, -42.5F, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 11 });
     assertNotNull(value);
     // should have 7 digits of precision
     assertEquals(-42.5F, Float.intBitsToFloat(Bytes.getInt(value)), 0.0000001);
   }
-  
+
   @Test
   public void addPointFloatMs() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400500L, 42.5F, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, 
+    final byte[] value = storage.getColumn(row,
         new byte[] { (byte) 0xF0, 0, 0x7D, 11 });
     assertNotNull(value);
     // should have 7 digits of precision
     assertEquals(42.5F, Float.intBitsToFloat(Bytes.getInt(value)), 0.0000001);
   }
-  
+
   @Test
   public void addPointFloatEndOfRow() throws Exception {
     HashMap<String, String> tags = new HashMap<String, String>(1);
     tags.put("host", "web01");
     tsdb.addPoint(METRIC_STRING, 1357001999, 42.5F, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, new byte[] { (byte) 0xE0, 
+    final byte[] value = storage.getColumn(row, new byte[] { (byte) 0xE0,
         (byte) 0xFB });
     assertNotNull(value);
     // should have 7 digits of precision
     assertEquals(42.5F, Float.intBitsToFloat(Bytes.getInt(value)), 0.0000001);
   }
-  
+
   @Test
   public void addPointFloatPrecision() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400, 42.5123459999F, tags)
       .joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 11 });
     assertNotNull(value);
     // should have 7 digits of precision
     assertEquals(42.512345F, Float.intBitsToFloat(Bytes.getInt(value)), 0.0000001);
   }
-  
+
   @Test
   public void addPointFloatOverwrite() throws Exception {
     tsdb.addPoint(METRIC_STRING, 1356998400, 42.5F, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998400, 25.4F, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 11 });
     assertNotNull(value);
     // should have 7 digits of precision
     assertEquals(25.4F, Float.intBitsToFloat(Bytes.getInt(value)), 0.0000001);
   }
-  
+
   @Test
   public void addPointBothSameTimeIntAndFloat() throws Exception {
     // this is an odd situation that can occur if the user puts an int and then
     // a float (or vice-versa) with the same timestamp. What happens in the
-    // aggregators when this occurs? 
+    // aggregators when this occurs?
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998400, 42.5F, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
     assertEquals(2, storage.numColumns(row));
@@ -382,15 +412,15 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     // should have 7 digits of precision
     assertEquals(42.5F, Float.intBitsToFloat(Bytes.getInt(value)), 0.0000001);
   }
-  
+
   @Test
   public void addPointBothSameTimeIntAndFloatMs() throws Exception {
     // this is an odd situation that can occur if the user puts an int and then
     // a float (or vice-versa) with the same timestamp. What happens in the
-    // aggregators when this occurs? 
+    // aggregators when this occurs?
     tsdb.addPoint(METRIC_STRING, 1356998400500L, 42, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998400500L, 42.5F, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     byte[] value = storage.getColumn(row, new byte[] { (byte) 0xF0, 0, 0x7D, 0 });
     assertEquals(2, storage.numColumns(row));
@@ -401,14 +431,14 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     // should have 7 digits of precision
     assertEquals(42.5F, Float.intBitsToFloat(Bytes.getInt(value)), 0.0000001);
   }
-  
+
   @Test
   public void addPointBothSameTimeSecondAndMs() throws Exception {
     // this can happen if a second and an ms data point are stored for the same
     // timestamp.
     tsdb.addPoint(METRIC_STRING, 1356998400L, 42, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998400000L, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
     assertEquals(2, storage.numColumns(row));
@@ -419,7 +449,7 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     // should have 7 digits of precision
     assertEquals(42, value[0]);
   }
-  
+
   @Test
   public void addPointWithSalt() throws Exception {
     PowerMockito.mockStatic(Const.class);
@@ -428,7 +458,7 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     PowerMockito.when(Const.MAX_NUM_TAGS()).thenReturn((short) 8);
 
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 8, 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 8, 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
     assertNotNull(value);
@@ -445,13 +475,13 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     tags.put(TAGK_STRING, TAGV_B_STRING);
 
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 9, 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 9, 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 2};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
     assertNotNull(value);
     assertEquals(42, value[0]);
   }
-  
+
   @Test
   public void addPointWithSaltDifferentTime() throws Exception {
     PowerMockito.mockStatic(Const.class);
@@ -460,37 +490,37 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     PowerMockito.when(Const.MAX_NUM_TAGS()).thenReturn((short) 8);
 
     tsdb.addPoint(METRIC_STRING, 1359680400, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 8, 0, 0, 1, 0x51, (byte) 0x0B, 0x13, 
+    final byte[] row = new byte[] { 8, 0, 0, 1, 0x51, (byte) 0x0B, 0x13,
         (byte) 0x90, 0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
     assertNotNull(value);
     assertEquals(42, value[0]);
   }
-  
+
   @Test
   public void addPointAppend() throws Exception {
     Whitebox.setInternalState(config, "enable_appends", true);
 
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, 
+    final byte[] value = storage.getColumn(row,
         AppendDataPoints.APPEND_COLUMN_QUALIFIER);
     assertArrayEquals(new byte[] { 0, 0, 42 }, value);
   }
-  
+
   @Test
   public void addPointAppendWithOffset() throws Exception {
     Whitebox.setInternalState(config, "enable_appends", true);
-    
+
     tsdb.addPoint(METRIC_STRING, 1356998430, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, 
+    final byte[] value = storage.getColumn(row,
         AppendDataPoints.APPEND_COLUMN_QUALIFIER);
     assertArrayEquals(new byte[] { 1, -32, 42 }, value);
   }
-  
+
   @Test
   public void addPointAppendAppending() throws Exception {
     Whitebox.setInternalState(config, "enable_appends", true);
@@ -498,13 +528,13 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998430, 24, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998460, 1, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, 
+    final byte[] value = storage.getColumn(row,
         AppendDataPoints.APPEND_COLUMN_QUALIFIER);
     assertArrayEquals(new byte[] { 0, 0, 42, 1, -32, 24, 3, -64, 1 }, value);
   }
-  
+
   @Test
   public void addPointAppendAppendingOutOfOrder() throws Exception {
     Whitebox.setInternalState(config, "enable_appends", true);
@@ -513,13 +543,13 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, 1356998460, 1, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998430, 24, tags).joinUninterruptibly();
 
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, 
+    final byte[] value = storage.getColumn(row,
         AppendDataPoints.APPEND_COLUMN_QUALIFIER);
     assertArrayEquals(new byte[] { 0, 0, 42, 3, -64, 1, 1, -32, 24 }, value);
   }
-  
+
   @Test
   public void addPointAppendAppendingDuplicates() throws Exception {
     Whitebox.setInternalState(config, "enable_appends", true);
@@ -527,25 +557,25 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998430, 24, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998430, 1, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, 
+    final byte[] value = storage.getColumn(row,
         AppendDataPoints.APPEND_COLUMN_QUALIFIER);
     assertArrayEquals(new byte[] { 0, 0, 42, 1, -32, 24, 1, -32, 1 }, value);
   }
-  
+
   @Test
   public void addPointAppendMS() throws Exception {
     Whitebox.setInternalState(config, "enable_appends", true);
 
     tsdb.addPoint(METRIC_STRING, 1356998400050L, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, 
+    final byte[] value = storage.getColumn(row,
         AppendDataPoints.APPEND_COLUMN_QUALIFIER);
     assertArrayEquals(new byte[] { (byte) 0xF0, 0, 12, -128, 42 }, value);
   }
-  
+
   @Test
   public void addPointAppendAppendingMixMS() throws Exception {
     Whitebox.setInternalState(config, "enable_appends", true);
@@ -553,14 +583,14 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998400050L, 1, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998430, 24, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, 
+    final byte[] value = storage.getColumn(row,
         AppendDataPoints.APPEND_COLUMN_QUALIFIER);
-    assertArrayEquals(new byte[] { 
+    assertArrayEquals(new byte[] {
         0, 0, 42, (byte) 0xF0, 0, 12, -128, 1, 1, -32, 24 }, value);
   }
-  
+
   @Test
   public void addPointAppendWithSalt() throws Exception {
     PowerMockito.mockStatic(Const.class);
@@ -570,13 +600,13 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     Whitebox.setInternalState(config, "enable_appends", true);
 
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 8, 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 8, 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, 
+    final byte[] value = storage.getColumn(row,
         AppendDataPoints.APPEND_COLUMN_QUALIFIER);
     assertArrayEquals(new byte[] { 0, 0, 42 }, value);
   }
-  
+
   @Test
   public void addPointAppendAppendingWithSalt() throws Exception {
     PowerMockito.mockStatic(Const.class);
@@ -588,103 +618,103 @@ public class TestTSDBAddPoint extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998430, 24, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, 1356998460, 1, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 8, 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 8, 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
-    final byte[] value = storage.getColumn(row, 
+    final byte[] value = storage.getColumn(row,
         AppendDataPoints.APPEND_COLUMN_QUALIFIER);
     assertArrayEquals(new byte[] { 0, 0, 42, 1, -32, 24, 3, -64, 1 }, value);
   }
-  
+
   @Test
   public void dpFilterOK() throws Exception {
-    final WriteableDataPointFilterPlugin filter = 
+    final WriteableDataPointFilterPlugin filter =
         mock(WriteableDataPointFilterPlugin.class);
     when(filter.filterDataPoints()).thenReturn(true);
-    when(filter.allowDataPoint(eq(METRIC_STRING), anyLong(), 
+    when(filter.allowDataPoint(eq(METRIC_STRING), anyLong(),
         any(byte[].class), eq(tags), anyShort()))
       .thenReturn(Deferred.<Boolean>fromResult(true));
     Whitebox.setInternalState(tsdb, "ts_filter", filter);
-    
+
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
     assertNotNull(value);
     assertEquals(42, value[0]);
-    
+
     verify(filter, times(1)).filterDataPoints();
-    verify(filter, times(1)).allowDataPoint(eq(METRIC_STRING), anyLong(), 
+    verify(filter, times(1)).allowDataPoint(eq(METRIC_STRING), anyLong(),
         any(byte[].class), eq(tags), anyShort());
   }
-  
+
   @Test
   public void dpFilterBlocked() throws Exception {
-    final WriteableDataPointFilterPlugin filter = 
+    final WriteableDataPointFilterPlugin filter =
         mock(WriteableDataPointFilterPlugin.class);
     when(filter.filterDataPoints()).thenReturn(true);
-    when(filter.allowDataPoint(eq(METRIC_STRING), anyLong(), 
+    when(filter.allowDataPoint(eq(METRIC_STRING), anyLong(),
         any(byte[].class), eq(tags), anyShort()))
       .thenReturn(Deferred.<Boolean>fromResult(false));
     Whitebox.setInternalState(tsdb, "ts_filter", filter);
-    
+
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
     assertNull(value);
-    
+
     verify(filter, times(1)).filterDataPoints();
-    verify(filter, times(1)).allowDataPoint(eq(METRIC_STRING), anyLong(), 
+    verify(filter, times(1)).allowDataPoint(eq(METRIC_STRING), anyLong(),
         any(byte[].class), eq(tags), anyShort());
   }
-  
+
   @Test
   public void dpFilterReturnsException() throws Exception {
-    final WriteableDataPointFilterPlugin filter = 
+    final WriteableDataPointFilterPlugin filter =
         mock(WriteableDataPointFilterPlugin.class);
     when(filter.filterDataPoints()).thenReturn(true);
-    when(filter.allowDataPoint(eq(METRIC_STRING), anyLong(), 
+    when(filter.allowDataPoint(eq(METRIC_STRING), anyLong(),
         any(byte[].class), eq(tags), anyShort()))
       .thenReturn(Deferred.<Boolean>fromError(new UnitTestException("Boo!")));
     Whitebox.setInternalState(tsdb, "ts_filter", filter);
-    
-    final Deferred<Object> deferred = 
+
+    final Deferred<Object> deferred =
         tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags);
     try {
       deferred.join();
       fail("Expected an UnitTestException");
     } catch (UnitTestException e) { };
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
     assertNull(value);
-    
+
     verify(filter, times(1)).filterDataPoints();
-    verify(filter, times(1)).allowDataPoint(eq(METRIC_STRING), anyLong(), 
+    verify(filter, times(1)).allowDataPoint(eq(METRIC_STRING), anyLong(),
         any(byte[].class), eq(tags), anyShort());
   }
-  
+
   @Test
   public void uidFilterThrowsException() throws Exception {
-    final WriteableDataPointFilterPlugin filter = 
+    final WriteableDataPointFilterPlugin filter =
         mock(WriteableDataPointFilterPlugin.class);
     when(filter.filterDataPoints()).thenReturn(true);
-    when(filter.allowDataPoint(eq(METRIC_STRING), anyLong(), 
+    when(filter.allowDataPoint(eq(METRIC_STRING), anyLong(),
         any(byte[].class), eq(tags), anyShort()))
       .thenThrow(new UnitTestException("Boo!"));
     Whitebox.setInternalState(tsdb, "ts_filter", filter);
-    
+
     try {
       tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags);
       fail("Expected an UnitTestException");
     } catch (UnitTestException e) { };
-    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0, 
+    final byte[] row = new byte[] { 0, 0, 1, 0x50, (byte) 0xE2, 0x27, 0,
         0, 0, 1, 0, 0, 1};
     final byte[] value = storage.getColumn(row, new byte[] { 0, 0 });
     assertNull(value);
-    
+
     verify(filter, times(1)).filterDataPoints();
-    verify(filter, times(1)).allowDataPoint(eq(METRIC_STRING), anyLong(), 
+    verify(filter, times(1)).allowDataPoint(eq(METRIC_STRING), anyLong(),
         any(byte[].class), eq(tags), anyShort());
   }
 }

--- a/test/core/TestTsdbQuery.java
+++ b/test/core/TestTsdbQuery.java
@@ -43,7 +43,7 @@ import com.stumbleupon.async.DeferredGroupException;
 /**
  * This class is for unit testing the TsdbQuery class. Pretty much making sure
  * the various ctors and methods function as expected. For actually running the
- * queries and validating the group by and aggregation logic, see 
+ * queries and validating the group by and aggregation logic, see
  * {@link TestTsdbQueryQueries}
  */
 @RunWith(PowerMockRunner.class)
@@ -55,80 +55,80 @@ public final class TestTsdbQuery extends BaseTsdbTest {
   public void beforeLocal() throws Exception {
     query = new TsdbQuery(tsdb);
   }
-  
+
   @Test
   public void setStartTime() throws Exception {
     query.setStartTime(1356998400L);
     assertEquals(1356998400L, query.getStartTime());
   }
-  
+
   @Test
   public void setStartTimeZero() throws Exception {
     query.setStartTime(0L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setStartTimeInvalidNegative() throws Exception {
     query.setStartTime(-1L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setStartTimeInvalidTooBig() throws Exception {
     query.setStartTime(17592186044416L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setStartTimeEqualtoEndTime() throws Exception {
     query.setEndTime(1356998400L);
     query.setStartTime(1356998400L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setStartTimeGreaterThanEndTime() throws Exception {
     query.setEndTime(1356998400L);
     query.setStartTime(1356998460L);
   }
-  
+
   @Test
   public void setEndTime() throws Exception {
     query.setEndTime(1356998400L);
     assertEquals(1356998400L, query.getEndTime());
   }
-  
+
   @Test (expected = IllegalStateException.class)
   public void getStartTimeNotSet() throws Exception {
     query.getStartTime();
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setEndTimeInvalidNegative() throws Exception {
     query.setEndTime(-1L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setEndTimeInvalidTooBig() throws Exception {
     query.setEndTime(17592186044416L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setEndTimeEqualtoEndTime() throws Exception {
     query.setStartTime(1356998400L);
     query.setEndTime(1356998400L);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setEndTimeGreaterThanEndTime() throws Exception {
     query.setStartTime(1356998460L);
     query.setEndTime(1356998400L);
   }
-  
+
   @Test
   public void getEndTimeNotSet() throws Exception {
     PowerMockito.mockStatic(DateTime.class);
     PowerMockito.when(DateTime.currentTimeMillis()).thenReturn(1357300800000L);
     assertEquals(1357300800000L, query.getEndTime());
   }
-  
+
   @Test
   public void setTimeSeries() throws Exception {
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
@@ -139,34 +139,34 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     assertArrayEquals(TAGK_BYTES, ForTesting.getGroupBys(query).get(0));
     assertEquals(1, ForTesting.getRowKeyLiterals(query).size());
     assertEquals(1, ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES).length);
-    assertArrayEquals(TAGV_BYTES, 
+    assertArrayEquals(TAGV_BYTES,
         ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES)[0]);
   }
-  
+
   @Test (expected = NullPointerException.class)
   public void setTimeSeriesNullTags() throws Exception {
     query.setTimeSeries(METRIC_STRING, null, Aggregators.SUM, false);
   }
-  
+
   @Test
   public void setTimeSeriesEmptyTags() throws Exception {
     tags.clear();
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     assertNotNull(query);
   }
-  
+
   @Test (expected = NoSuchUniqueName.class)
   public void setTimeSeriesNosuchMetric() throws Exception {
     query.setTimeSeries(NSUN_METRIC, tags, Aggregators.SUM, false);
   }
-  
+
   @Test (expected = NoSuchUniqueName.class)
   public void setTimeSeriesNosuchTagk() throws Exception {
     tags.clear();
     tags.put(NSUN_TAGK, TAGV_STRING);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
   }
-  
+
   @Test (expected = NoSuchUniqueName.class)
   public void setTimeSeriesNosuchTagv() throws Exception {
     tags.put(TAGK_STRING, NSUN_TAGV);
@@ -181,18 +181,18 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
     assertNotNull(query);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setTimeSeriesTSNullList() throws Exception {
     query.setTimeSeries(null, Aggregators.SUM, false);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setTimeSeriesTSEmptyList() throws Exception {
     final List<String> tsuids = new ArrayList<String>();
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void setTimeSeriesTSDifferentMetrics() throws Exception {
     final List<String> tsuids = new ArrayList<String>(2);
@@ -200,7 +200,7 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     tsuids.add("000002000001000002");
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
   }
-  
+
   @Test
   public void configureFromQuery() throws Exception {
     setDataPointStorage();
@@ -208,14 +208,14 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     ts_query.validateAndSetQuery();
     query = new TsdbQuery(tsdb);
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertArrayEquals(TAGK_BYTES, ForTesting.getGroupBys(query).get(0));
     assertEquals(1, ForTesting.getGroupBys(query).size());
     assertNotNull(ForTesting.getRateOptions(query));
   }
-  
+
   @Test
   public void configureFromQueryWithRate() throws Exception {
     setDataPointStorage();
@@ -226,29 +226,30 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     ts_query.validateAndSetQuery();
     query = new TsdbQuery(tsdb);
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertArrayEquals(TAGK_BYTES, ForTesting.getGroupBys(query).get(0));
     assertEquals(1, ForTesting.getGroupBys(query).size());
     assertTrue(rate_options == ForTesting.getRateOptions(query));
   }
-  
+
   @Test
   public void configureFromQueryNoTags() throws Exception {
+
     setDataPointStorage();
     final TSQuery ts_query = getTSQuery();
     ts_query.getQueries().get(0).setTags(Collections.EMPTY_MAP);
     ts_query.validateAndSetQuery();
     query = new TsdbQuery(tsdb);
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(0, ForTesting.getFilters(query).size());
     assertNull(ForTesting.getGroupBys(query));
     assertNull(ForTesting.getRowKeyLiterals(query));
   }
-  
+
   @Test
   public void configureFromQueryGroupByAll() throws Exception {
     setDataPointStorage();
@@ -259,16 +260,16 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     ts_query.validateAndSetQuery();
     query = new TsdbQuery(tsdb);
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertEquals(1, ForTesting.getGroupBys(query).size());
-    assertArrayEquals(TAGK_BYTES, 
+    assertArrayEquals(TAGK_BYTES,
         ForTesting.getGroupBys(query).get(0));
     assertEquals(1, ForTesting.getRowKeyLiterals(query).size());
     assertNull(ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES));
   }
-  
+
   @Test
   public void configureFromQueryGroupByPipe() throws Exception {
     setDataPointStorage();
@@ -279,19 +280,19 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     ts_query.validateAndSetQuery();
     query = new TsdbQuery(tsdb);
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertEquals(1, ForTesting.getGroupBys(query).size());
     assertArrayEquals(TAGK_BYTES, ForTesting.getGroupBys(query).get(0));
     assertEquals(1, ForTesting.getRowKeyLiterals(query).size());
     assertEquals(2, ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES).length);
-    assertArrayEquals(TAGV_BYTES, 
+    assertArrayEquals(TAGV_BYTES,
         ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES)[0]);
-    assertArrayEquals(TAGV_B_BYTES, 
+    assertArrayEquals(TAGV_B_BYTES,
         ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES)[1]);
   }
-  
+
   @Test
   public void configureFromQueryWithGroupByFilter() throws Exception {
     setDataPointStorage();
@@ -302,7 +303,7 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     ts_query.validateAndSetQuery();
     query = new TsdbQuery(tsdb);
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertEquals(1, ForTesting.getGroupBys(query).size());
@@ -322,7 +323,7 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     ts_query.validateAndSetQuery();
     query = new TsdbQuery(tsdb);
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertNull(ForTesting.getGroupBys(query));
@@ -330,7 +331,7 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     assertNull(ForTesting.getRowKeyLiterals(query).get(TAGV_BYTES));
     assertNotNull(ForTesting.getRateOptions(query));
   }
-  
+
   @Test
   public void configureFromQueryWithGroupByAndRegularFilters() throws Exception {
     setDataPointStorage();
@@ -352,32 +353,32 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     assertNull(ForTesting.getRowKeyLiterals(query).get(TAGK_BYTES));
     assertNotNull(ForTesting.getRateOptions(query));
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void configureFromQueryNullSubs() throws Exception {
     final TSQuery ts_query = new TSQuery();
     new TsdbQuery(tsdb).configureFromQuery(ts_query, 0);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void configureFromQueryEmptySubs() throws Exception {
     final TSQuery ts_query = new TSQuery();
     ts_query.setQueries(new ArrayList<TSSubQuery>(0));
     new TsdbQuery(tsdb).configureFromQuery(ts_query, 0);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void configureFromQueryNegativeIndex() throws Exception {
     final TSQuery ts_query = getTSQuery();
     new TsdbQuery(tsdb).configureFromQuery(ts_query, -1);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void configureFromQueryIndexOutOfBounds() throws Exception {
     final TSQuery ts_query = getTSQuery();
     new TsdbQuery(tsdb).configureFromQuery(ts_query, 2);
   }
-  
+
   @Test (expected = NoSuchUniqueName.class)
   public void configureFromQueryNSUMetric() throws Exception {
     setDataPointStorage();
@@ -387,7 +388,7 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     query = new TsdbQuery(tsdb);
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
   }
-  
+
   @Test (expected = DeferredGroupException.class)
   public void configureFromQueryNSUTagk() throws Exception {
     setDataPointStorage();
@@ -399,7 +400,7 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     query = new TsdbQuery(tsdb);
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
   }
-  
+
   @Test (expected = DeferredGroupException.class)
   public void configureFromQueryNSUTagv() throws Exception {
     setDataPointStorage();
@@ -411,7 +412,7 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     query = new TsdbQuery(tsdb);
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
   }
-  
+
   @Test (expected = DeferredGroupException.class)
   public void configureFromQueryGroupByPipeNSUTagk() throws Exception {
     setDataPointStorage();
@@ -423,7 +424,7 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     query = new TsdbQuery(tsdb);
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
   }
-  
+
   @Test (expected = DeferredGroupException.class)
   public void configureFromQueryGroupByPipeNSUTagv() throws Exception {
     setDataPointStorage();
@@ -435,9 +436,9 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     query = new TsdbQuery(tsdb);
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
   }
-  
+
   @Test
-  public void configureFromQueryGroupByPipeNSUTagvSkipUnresolved() 
+  public void configureFromQueryGroupByPipeNSUTagvSkipUnresolved()
       throws Exception {
     config.overrideConfig("tsd.query.skip_unresolved_tagvs", "true");
     setDataPointStorage();
@@ -448,22 +449,22 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     ts_query.validateAndSetQuery();
     query = new TsdbQuery(tsdb);
     query.configureFromQuery(ts_query, 0).joinUninterruptibly();
-    
+
     assertArrayEquals(METRIC_BYTES, ForTesting.getMetric(query));
     assertEquals(1, ForTesting.getFilters(query).size());
     assertEquals(1, ForTesting.getGroupBys(query).size());
-    assertArrayEquals(TAGK_BYTES, 
+    assertArrayEquals(TAGK_BYTES,
         ForTesting.getGroupBys(query).get(0));
   }
-  
+
   @Test
   public void deleteDatapoints() throws Exception {
     setDataPointStorage();
-    
+
     tsdb.addPoint(METRIC_STRING, 1356998400, 42, tags).joinUninterruptibly();
     query.setStartTime(1356998400);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     query.setDelete(true);
     final DataPoints[] dps1 = query.run();
     assertEquals(1, dps1.length);
@@ -471,14 +472,14 @@ public final class TestTsdbQuery extends BaseTsdbTest {
     final DataPoints[] dps2 = query.run();
     assertEquals(0, dps2.length);
   }
-  
+
   @Test
   public void scannerException() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
     final RuntimeException ex = new RuntimeException("Boo!");
     storage.throwException(MockBase.stringToBytes(
         "00000150E22700000001000001"), ex, true);
-    
+
     storage.dumpToSystemOut();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
@@ -490,21 +491,21 @@ public final class TestTsdbQuery extends BaseTsdbTest {
       assertSame(ex, e);
     }
   }
-  
+
   /** @return a simple TSQuery object for testing */
   private TSQuery getTSQuery() {
     final TSQuery ts_query = new TSQuery();
     ts_query.setStart("1356998400");
-    
+
     final TSSubQuery sub_query = new TSSubQuery();
     sub_query.setMetric(METRIC_STRING);
     sub_query.setAggregator("sum");
 
     sub_query.setTags(tags);
-    
+
     final ArrayList<TSSubQuery> sub_queries = new ArrayList<TSSubQuery>(1);
     sub_queries.add(sub_query);
-    
+
     ts_query.setQueries(sub_queries);
     return ts_query;
   }

--- a/test/core/TestTsdbQueryQueries.java
+++ b/test/core/TestTsdbQueryQueries.java
@@ -29,11 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import net.opentsdb.storage.MockBase;
-import net.opentsdb.storage.MockBase.MockScanner;
-import net.opentsdb.uid.NoSuchUniqueId;
-import net.opentsdb.utils.Config;
-
 import org.hbase.async.Bytes;
 import org.hbase.async.FilterList;
 import org.hbase.async.Scanner;
@@ -45,9 +40,14 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.stumbleupon.async.Deferred;
 
+import net.opentsdb.storage.MockBase;
+import net.opentsdb.storage.MockBase.MockScanner;
+import net.opentsdb.uid.NoSuchUniqueId;
+import net.opentsdb.utils.Config;
+
 /**
  * An integration test class that makes sure our query path is up to snuff.
- * This class should have tests for different data point types, rates, 
+ * This class should have tests for different data point types, rates,
  * compactions, etc. Other files can cover salting, aggregation and downsampling.
  */
 @RunWith(PowerMockRunner.class)
@@ -59,7 +59,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
   public void beforeLocal() throws Exception {
     query = new TsdbQuery(tsdb);
   }
-  
+
   @Test
   public void runLongSingleTS() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
@@ -70,7 +70,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     verify(tag_values, times(1)).getNameAsync(TAGV_BYTES);
@@ -94,7 +94,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998400500L;
     for (DataPoint dp : dps[0]) {
@@ -105,7 +105,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].aggregatedSize());
   }
-  
+
   @Test
   public void runLongSingleTSNoData() throws Exception {
     setDataPointStorage();
@@ -113,24 +113,24 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertNotNull(dps);
     assertEquals(0, dps.length);
   }
-  
+
   @Test
   public void runLongTwoAggSum() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400L);
     query.setEndTime(1357041600L);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(301, dp.longValue());
@@ -139,19 +139,19 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runLongTwoAggSumMs() throws Exception {
     storeLongTimeSeriesMs();
-    
+
     tags.clear();
     query.setStartTime(1356998400L);
     query.setEndTime(1357041600L);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long timestamp = 1356998400500L;
     for (DataPoint dp : dps[0]) {
       assertEquals(301, dp.longValue());
@@ -160,22 +160,22 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runLongTwoGroup() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
-    
+
     tags.clear();
     tags.put(TAGK_STRING , "*");
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
     assertMeta(dps, 1, false);
     assertEquals(2, dps.length);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -185,7 +185,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       timestamp += 30000;
     }
     assertEquals(300, dps[0].size());
-    
+
     value = 300;
     timestamp = 1356998430000L;
     for (DataPoint dp : dps[1]) {
@@ -196,7 +196,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[1].size());
   }
-  
+
   @Test
   public void runLongSingleTSRate() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
@@ -204,10 +204,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, true);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998460000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(0.033F, dp.doubleValue(), 0.001);
@@ -216,7 +216,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(299, dps[0].size());
   }
-  
+
   @Test
   public void runLongSingleTSRateMs() throws Exception {
     storeLongTimeSeriesMs();
@@ -224,10 +224,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, true);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998401000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(2.0F, dp.doubleValue(), 0.001);
@@ -244,10 +244,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     double value = 1.25D;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -258,7 +258,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runFloatSingleTSMs() throws Exception {
     storeFloatTimeSeriesMs();
@@ -266,10 +266,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     double value = 1.25D;
     long timestamp = 1356998400500L;
     for (DataPoint dp : dps[0]) {
@@ -280,19 +280,19 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runFloatTwoAggSum() throws Exception {
     storeFloatTimeSeriesSeconds(true, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(76.25, dp.doubleValue(), 0.00001);
@@ -301,16 +301,16 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runFloatTwoAggNoneAgg() throws Exception {
     storeFloatTimeSeriesSeconds(true, false);
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.NONE, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
     assertMeta(dps, 1, false);
@@ -325,7 +325,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       timestamp += 30000;
     }
     assertEquals(300, dps[0].size());
-    
+
     value = 75D;
     timestamp = 1356998430000L;
     for (DataPoint dp : dps[1]) {
@@ -336,7 +336,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[1].size());
   }
-  
+
   @Test
   public void runFloatTwoAggSumMs() throws Exception {
     storeFloatTimeSeriesMs();
@@ -345,10 +345,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long timestamp = 1356998400500L;
     for (DataPoint dp : dps[0]) {
       assertEquals(76.25, dp.doubleValue(), 0.00001);
@@ -357,7 +357,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runFloatTwoGroup() throws Exception {
     storeFloatTimeSeriesSeconds(true, false);
@@ -366,7 +366,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
     assertMeta(dps, 1, false);
@@ -381,7 +381,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       timestamp += 30000;
     }
     assertEquals(300, dps[0].size());
-    
+
     value = 75D;
     timestamp = 1356998430000L;
     for (DataPoint dp : dps[1]) {
@@ -392,7 +392,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[1].size());
   }
-  
+
   @Test
   public void runFloatSingleTSRate() throws Exception {
     storeFloatTimeSeriesSeconds(true, false);
@@ -400,10 +400,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, true);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998460000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(0.00833F, dp.doubleValue(), 0.00001);
@@ -412,7 +412,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(299, dps[0].size());
   }
-  
+
   @Test
   public void runFloatSingleTSRateMs() throws Exception {
     storeFloatTimeSeriesMs();
@@ -420,10 +420,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, true);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998401000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(0.5F, dp.doubleValue(), 0.00001);
@@ -441,10 +441,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998430000L;
     double value = 1.25D;
     for (DataPoint dp : dps[0]) {
@@ -455,7 +455,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMixedSingleTS() throws Exception {
     storeMixedTimeSeriesSeconds();
@@ -463,10 +463,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.AVG, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998430000L;
     double float_value = 1.25D;
     int int_value = 76;
@@ -487,7 +487,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMixedSingleTSMsAndS() throws Exception {
     storeMixedTimeSeriesMsAndS();
@@ -495,10 +495,10 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.AVG, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998400500L;
     double float_value = 1.25D;
     int int_value = 76;
@@ -519,11 +519,11 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runMixedSingleTSPostCompaction() throws Exception {
     storeMixedTimeSeriesSeconds();
-    
+
     final Field compact = Config.class.getDeclaredField("enable_compactions");
     compact.setAccessible(true);
     compact.set(config, true);
@@ -534,24 +534,24 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     // this should only compact the rows for the time series that we fetched and
     // leave the others alone
-    
-    final byte[] key = 
+
+    final byte[] key =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key);
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key, 
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key));
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key, 
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key));
-    System.arraycopy(Bytes.fromInt(1357005600), 0, key, 
+    System.arraycopy(Bytes.fromInt(1357005600), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key));
 
     // run it again to verify the compacted data uncompacts properly
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     long timestamp = 1356998430000L;
     double float_value = 1.25D;
     int int_value = 76;
@@ -572,7 +572,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
- 
+
   @Test
   public void runEndTime() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
@@ -582,7 +582,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -593,11 +593,11 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(119, dps[0].size());
   }
-  
+
   @Test
   public void runCompactPostQuery() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
-    
+
     final Field compact = Config.class.getDeclaredField("enable_compactions");
     compact.setAccessible(true);
     compact.set(config, true);
@@ -607,47 +607,47 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-  
+
     // this should only compact the rows for the time series that we fetched and
     // leave the others alone
-    final byte[] key_a = 
+    final byte[] key_a =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key_a);
     final Map<String, String> tags_copy = new HashMap<String, String>(tags);
     tags_copy.put(TAGK_STRING, TAGV_B_STRING);
-    final byte[] key_b = 
+    final byte[] key_b =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags_copy);
     RowKey.prefixKeyWithSalt(key_b);
-    
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key_a, 
+
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key_a,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key_a));
-    
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key_b, 
+
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key_b,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     if (config.enable_appends()) {
       assertEquals(1, storage.numColumns(key_b));
     } else {
       assertEquals(119, storage.numColumns(key_b));
     }
-    
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key_a, 
+
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key_a,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key_a));
-    
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key_b, 
+
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key_b,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     if (config.enable_appends()) {
       assertEquals(1, storage.numColumns(key_b));
     } else {
       assertEquals(120, storage.numColumns(key_b));
     }
-    
-    System.arraycopy(Bytes.fromInt(1357005600), 0, key_a, 
+
+    System.arraycopy(Bytes.fromInt(1357005600), 0, key_a,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key_a));
-    
-    System.arraycopy(Bytes.fromInt(1357005600), 0, key_b, 
+
+    System.arraycopy(Bytes.fromInt(1357005600), 0, key_b,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     if (config.enable_appends()) {
       assertEquals(1, storage.numColumns(key_b));
@@ -658,7 +658,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     // run it again to verify the compacted data uncompacts properly
     dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -669,7 +669,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test (expected = IllegalStateException.class)
   public void runStartNotSet() throws Exception {
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
@@ -678,21 +678,25 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
   @Test
   public void runFloatAndIntSameTSNoFix() throws Exception {
+    tsdb.config.overrideConfig("tsd.storage.use_otsdb_timestamp", "true");
     // if a row has an integer and a float for the same timestamp, there will be
-    // two different qualifiers that will resolve to the same offset. This no
-    // will throw the IllegalDataException as querytime fixes are disabled by
-    // default
+    // two different qualifiers that will resolve to the same offset. With DTCS enabled
+	// the conflicts are auto resolved i.e. either the maximum or the minimum value of
+	// data is returned depending on the configuration tsd.storage.use_max_value
+	// If DTCS is disabled, it will fall throw the exception.
+	// DTCS -> Date Tiered Compaction Strategy (tsd.storage.use_otsdb_timestamp config parameter)
+
     storeLongTimeSeriesSeconds(true, false);
 
     tsdb.addPoint(METRIC_STRING, 1356998430, 42.5F, tags).joinUninterruptibly();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
-    if (config.enable_appends()) {
+
+    if (config.enable_appends() || config.use_otsdb_timestamp()) {
       DataPoints[] dps = query.run();
       assertMeta(dps, 0, false, false);
-      
+
       int value = 1;
       long timestamp = 1356998430000L;
       for (DataPoint dp : dps[0]) {
@@ -707,29 +711,33 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
         timestamp += 30000;
       }
       assertEquals(300, dps[0].size());
-    } else {
-      try {
+    }
+
+    tsdb.config.overrideConfig("tsd.storage.use_otsdb_timestamp", "false");
+    try {
         query.run();
         fail("Expected an IllegalDataException");
       } catch (IllegalDataException ide) { }
-    }
+
   }
-  
+
   @Test
   public void runFloatAndIntSameTSFix() throws Exception {
     config.setFixDuplicates(true);
     // if a row has an integer and a float for the same timestamp, there will be
-    // two different qualifiers that will resolve to the same offset. This no
-    // longer tosses an exception, and keeps the last value
+    // two different qualifiers that owill resolve to the same offset. This no
+    // longer tosses an exception, and keeps the maximum of all values
+    // This can also be configured via tsdb.storage.use_max_value config
     storeLongTimeSeriesSeconds(true, false);
 
     tsdb.addPoint(METRIC_STRING, 1356998430, 42.5F, tags).joinUninterruptibly();
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -744,7 +752,61 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].aggregatedSize());
   }
-  
+
+  @Test
+  public void multipleValuesAtSameTimestampShouldReturnMaxValueDefault() throws Exception {
+    tsdb.config.overrideConfig("tsd.storage.use_otsdb_timestamp", "true");
+    config.setFixDuplicates(true);
+    // if a row has an integer and a float for the same timestamp, there will be
+    // two different qualifiers that will resolve to the same offset. This no
+    // longer tosses an exception, and keeps the maximum of all values
+    // This can also be configured via tsdb.storage.use_max_value config
+    setDataPointStorage();
+
+    tsdb.addPoint(METRIC_STRING, 1356998430, 69755263, tags).joinUninterruptibly();
+    tsdb.addPoint(METRIC_STRING, 1356998430, 62500.52F, tags).joinUninterruptibly();
+    tsdb.addPoint(METRIC_STRING, 1356998430, 2533, tags).joinUninterruptibly();
+    query.setStartTime(1356998400);
+    query.setEndTime(1357041600);
+    query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
+    final DataPoints[] dps = query.run();
+    assertMeta(dps, 0, false);
+
+    long timestamp = 1356998430000L;
+    for (DataPoint dp : dps[0]) {
+      assertEquals(69755263, dp.longValue());
+      assertEquals(timestamp, dp.timestamp());
+    }
+    assertEquals(1, dps[0].aggregatedSize());
+  }
+
+  @Test
+  public void multipleValuesAtSameTimestampShouldReturnMinValueIfConfigured() throws Exception {
+    tsdb.config.overrideConfig("tsd.storage.use_otsdb_timestamp", "true");
+	// This test explicitly configures the use_max_value as false thus when different data type values
+	// are written at same timestamp, the minimum of all will be provided in output
+	tsdb.getConfig().overrideConfig("tsd.storage.use_max_value", "false");
+    config.setFixDuplicates(true);
+    setDataPointStorage();
+
+    tsdb.addPoint(METRIC_STRING, 1356998430, 69755263, tags).joinUninterruptibly();
+    tsdb.addPoint(METRIC_STRING, 1356998430, 62500.52F, tags).joinUninterruptibly();
+    tsdb.addPoint(METRIC_STRING, 1356998430, 2533, tags).joinUninterruptibly();
+    query.setStartTime(1356998400);
+    query.setEndTime(1357041600);
+    query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
+    final DataPoints[] dps = query.run();
+    assertMeta(dps, 0, false);
+
+    long timestamp = 1356998430000L;
+    for (DataPoint dp : dps[0]) {
+      assertEquals(2533, dp.longValue());
+      assertEquals(timestamp, dp.timestamp());
+    }
+    assertEquals(1, dps[0].aggregatedSize());
+  }
+
+
   @Test
   public void runWithAnnotation() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
@@ -756,7 +818,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false, true);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -767,7 +829,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runWithAnnotationPostCompact() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
@@ -785,32 +847,32 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     // this should only compact the rows for the time series that we fetched and
     // leave the others alone
-    final byte[] key_a = 
+    final byte[] key_a =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key_a);
     final Map<String, String> tags_copy = new HashMap<String, String>(tags);
     tags_copy.put(TAGK_STRING, TAGV_B_STRING);
-    final byte[] key_b = 
+    final byte[] key_b =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags_copy);
     RowKey.prefixKeyWithSalt(key_b);
 
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key_a, 
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key_a,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(2, storage.numColumns(key_a));
-    
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key_b, 
+
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key_b,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     if (config.enable_appends()) {
       assertEquals(1, storage.numColumns(key_b));
     } else {
       assertEquals(119, storage.numColumns(key_b));
     }
-    
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key_a, 
+
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key_a,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key_a));
-    
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key_b, 
+
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key_b,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     if (config.enable_appends()) {
       assertEquals(1, storage.numColumns(key_b));
@@ -818,21 +880,21 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       assertEquals(120, storage.numColumns(key_b));
     }
 
-    System.arraycopy(Bytes.fromInt(1357005600), 0, key_a, 
+    System.arraycopy(Bytes.fromInt(1357005600), 0, key_a,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     assertEquals(1, storage.numColumns(key_a));
-    
-    System.arraycopy(Bytes.fromInt(1357005600), 0, key_b, 
+
+    System.arraycopy(Bytes.fromInt(1357005600), 0, key_b,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     if (config.enable_appends()) {
       assertEquals(1, storage.numColumns(key_b));
     } else {
       assertEquals(61, storage.numColumns(key_b));
     }
-    
+
     dps = query.run();
     assertMeta(dps, 0, false, true);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -850,15 +912,15 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     // verifies that we can pickup an annotation stored all by it's lonesome
     // in a row without any data
-    final byte[] key = 
+    final byte[] key =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key);
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key, 
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     storage.flushRow(key);
-    
+
     storeAnnotation(1357002090);
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
@@ -891,13 +953,13 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     // verifies that we can pickup an annotation stored all by it's lonesome
     // in a row without any data
-    final byte[] key = 
+    final byte[] key =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key);
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key, 
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     storage.flushRow(key);
-    
+
     storeAnnotation(1357002090);
 
     query.setStartTime(1356998400);
@@ -905,7 +967,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
 
     final DataPoints[] dps = query.run();
-    // TODO - apparently if you only fetch annotations, the metric and tags 
+    // TODO - apparently if you only fetch annotations, the metric and tags
     // may not be set. Check this
     //assertMeta(dps, 0, false, true);
     assertEquals(1, dps[0].getAnnotations().size());
@@ -920,14 +982,14 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     setDataPointStorage();
     long timestamp = 1356998410;
     tsdb.addPoint(METRIC_STRING, timestamp, 42, tags).joinUninterruptibly();
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     storage.dumpToSystemOut();
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     assertEquals(1, dps[0].size());
     assertEquals(42, dps[0].longValue(0));
     assertEquals(1356998410000L, dps[0].timestamp(0));
@@ -938,23 +1000,23 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     setDataPointStorage();
     long timestamp = 1356998410;
     tsdb.addPoint(METRIC_STRING, timestamp, 42, tags).joinUninterruptibly();
-    
-    final byte[] key = 
+
+    final byte[] key =
         IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key);
-    System.arraycopy(Bytes.fromInt(1357002000), 0, key, 
+    System.arraycopy(Bytes.fromInt(1357002000), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
     storage.flushRow(key);
-    
+
     storeAnnotation(1357002090);
 
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false, true);
-    
+
     assertEquals(1, dps[0].size());
     assertEquals(42, dps[0].longValue(0));
     assertEquals(1356998410000L, dps[0].timestamp(0));
@@ -963,16 +1025,16 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
   @Test
   public void runTSUIDQuery() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     final List<String> tsuids = new ArrayList<String>(1);
     tsuids.add("000001000001000001");
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
@@ -983,21 +1045,21 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].aggregatedSize());
   }
-  
+
   @Test
   public void runTSUIDsAggSum() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     final List<String> tsuids = new ArrayList<String>(1);
     tsuids.add("000001000001000001");
     tsuids.add("000001000001000002");
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long timestamp = 1356998430000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(301, dp.longValue());
@@ -1006,57 +1068,57 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].size());
   }
-  
+
   @Test
   public void runTSUIDQueryNoData() throws Exception {
     setDataPointStorage();
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
-    
+
     final List<String> tsuids = new ArrayList<String>(1);
     tsuids.add("000001000001000001");
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertNotNull(dps);
     assertEquals(0, dps.length);
   }
-  
+
   @Test
   public void runTSUIDQueryNoDataForTSUID() throws Exception {
     // this doesn't throw an exception since the UIDs are only looked for when
     // the query completes.
     setDataPointStorage();
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     final List<String> tsuids = new ArrayList<String>(1);
     tsuids.add("000001000001000005");
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertNotNull(dps);
     assertEquals(0, dps.length);
   }
-  
+
   @Test (expected = NoSuchUniqueId.class)
   public void runTSUIDQueryNSU() throws Exception {
     when(metrics.getNameAsync(new byte[] { 0, 0, 1 }))
       .thenThrow(new NoSuchUniqueId("metrics", new byte[] { 0, 0, 1 }));
     storeLongTimeSeriesSeconds(true, false);
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     final List<String> tsuids = new ArrayList<String>(1);
     tsuids.add("000001000001000001");
     query.setTimeSeries(tsuids, Aggregators.SUM, false);
-    
+
     final DataPoints[] dps = query.run();
     assertNotNull(dps);
     dps[0].metricName();
   }
-  
+
   @Test
   public void runRateCounterDefault() throws Exception {
     setDataPointStorage();
@@ -1066,14 +1128,14 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, timestamp += 30, Long.MAX_VALUE - 25, tags)
       .joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 5, tags).joinUninterruptibly();
-    
+
     final RateOptions ro = new RateOptions(true, Long.MAX_VALUE, 0);
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, true, ro);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     timestamp = 1356998460000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(1.0, dp.doubleValue(), 0.001);
@@ -1082,7 +1144,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(2, dps[0].size());
   }
-  
+
   @Test
   public void runRateCounterDefaultNoOp() throws Exception {
     setDataPointStorage();
@@ -1090,14 +1152,14 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 30, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 60, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 90, tags).joinUninterruptibly();
-    
+
     final RateOptions ro = new RateOptions(true, Long.MAX_VALUE, 0);
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, true, ro);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     timestamp = 1356998460000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(1.0, dp.doubleValue(), 0.001);
@@ -1106,7 +1168,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(2, dps[0].size());
   }
-  
+
   @Test
   public void runRateCounterMaxSet() throws Exception {
     setDataPointStorage();
@@ -1114,7 +1176,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 45, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 75, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 5, tags).joinUninterruptibly();
-    
+
     final RateOptions ro = new RateOptions(true, 100, 0);
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
@@ -1130,7 +1192,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(2, dps[0].size());
   }
-  
+
   @Test
   public void runRateCounterAnomally() throws Exception {
     setDataPointStorage();
@@ -1138,7 +1200,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 45, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 75, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 25, tags).joinUninterruptibly();
-    
+
     final RateOptions ro = new RateOptions(true, 10000, 35);
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
@@ -1161,7 +1223,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 75, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 25, tags).joinUninterruptibly();
     tsdb.addPoint(METRIC_STRING, timestamp += 30, 55, tags).joinUninterruptibly();
-    
+
     final RateOptions ro = new RateOptions(true, 10000, 35, true);
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
@@ -1175,7 +1237,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     assertEquals(1356998520000L, dps[0].timestamp(1));
     assertEquals(2, dps[0].size());
   }
-  
+
   @Test
   public void runMultiCompact() throws Exception {
     final byte[] qual1 = { 0x00, 0x17 };
@@ -1197,20 +1259,20 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     final byte[] key = IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key);
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key, 
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
-    
+
     setDataPointStorage();
-    storage.addColumn(key, 
-        MockBase.concatByteArrays(qual1, qual2), 
+    storage.addColumn(key,
+        MockBase.concatByteArrays(qual1, qual2),
         MockBase.concatByteArrays(val1, val2, new byte[] { 0 }));
-    storage.addColumn(key, 
-        MockBase.concatByteArrays(qual3, qual4), 
+    storage.addColumn(key,
+        MockBase.concatByteArrays(qual3, qual4),
         MockBase.concatByteArrays(val3, val4, new byte[] { 0 }));
-    storage.addColumn(key, 
-        MockBase.concatByteArrays(qual5, qual6), 
+    storage.addColumn(key,
+        MockBase.concatByteArrays(qual5, qual6),
         MockBase.concatByteArrays(val5, val6, new byte[] { 0 }));
-    
+
     HashMap<String, String> tags = new HashMap<String, String>(1);
     tags.put(TAGK_STRING , TAGV_STRING );
     query.setStartTime(1356998400);
@@ -1219,7 +1281,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998401000L;
     for (DataPoint dp : dps[0]) {
@@ -1252,26 +1314,26 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
 
     final byte[] key = IncomingDataPoints.rowKeyTemplate(tsdb, METRIC_STRING, tags);
     RowKey.prefixKeyWithSalt(key);
-    System.arraycopy(Bytes.fromInt(1356998400), 0, key, 
+    System.arraycopy(Bytes.fromInt(1356998400), 0, key,
         Const.SALT_WIDTH() + TSDB.metrics_width(), Const.TIMESTAMP_BYTES);
-    
+
     setDataPointStorage();
-    storage.addColumn(key, 
-        MockBase.concatByteArrays(qual1, qual2), 
+    storage.addColumn(key,
+        MockBase.concatByteArrays(qual1, qual2),
         MockBase.concatByteArrays(val1, val2, new byte[] { 0 }));
     storage.addColumn(key, qual3, val3);
     storage.addColumn(key, qual4, val4);
-    storage.addColumn(key, 
-        MockBase.concatByteArrays(qual5, qual6), 
+    storage.addColumn(key,
+        MockBase.concatByteArrays(qual5, qual6),
         MockBase.concatByteArrays(val5, val6, new byte[] { 0 }));
-    
+
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
 
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, false);
-    
+
     int value = 1;
     long timestamp = 1356998401000L;
     for (DataPoint dp : dps[0]) {
@@ -1282,7 +1344,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(6, dps[0].aggregatedSize());
   }
-  
+
   @Test
   public void runInterpolationSeconds() throws Exception {
     setDataPointStorage();
@@ -1298,21 +1360,21 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       tsdb.addPoint(METRIC_STRING, timestamp += 30, i, tags)
         .joinUninterruptibly();
     }
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v = 1;
     long ts = 1356998430000L;
     for (DataPoint dp : dps[0]) {
       assertEquals(ts, dp.timestamp());
       ts += 15000;
       assertEquals(v, dp.longValue());
-      
+
       if (dp.timestamp() == 1357007400000L) {
         v = 1;
       } else if (v == 1 || v == 302) {
@@ -1323,7 +1385,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runInterpolationMs() throws Exception {
     setDataPointStorage();
@@ -1339,21 +1401,21 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       tsdb.addPoint(METRIC_STRING, timestamp += 500, i, tags)
         .joinUninterruptibly();
     }
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
-    
+
     long v = 1;
     long ts = 1356998400500L;
     for (DataPoint dp : dps[0]) {
       assertEquals(ts, dp.timestamp());
       ts += 250;
       assertEquals(v, dp.longValue());
-      
+
       if (dp.timestamp() == 1356998550000L) {
         v = 1;
       } else if (v == 1 || v == 302) {
@@ -1364,7 +1426,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(600, dps[0].size());
   }
-  
+
   @Test
   public void runInterpolationMsDownsampled() throws Exception {
     setDataPointStorage();
@@ -1387,7 +1449,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       tsdb.addPoint(METRIC_STRING, timestamp, i, tags)
         .joinUninterruptibly();
     }
-    
+
     // ts = 1356998400750, v = 300
     // ts = 1356998401250, v = 299
     // ts = 1356998401750, v = 298
@@ -1404,13 +1466,13 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       tsdb.addPoint(METRIC_STRING, timestamp += 500, i, tags)
         .joinUninterruptibly();
     }
-    
+
     tags.clear();
     query.setStartTime(1356998400);
     query.setEndTime(1357041600);
     query.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
     query.downsample(1000, Aggregators.SUM);
-    
+
     final DataPoints[] dps = query.run();
     assertMeta(dps, 0, true);
 
@@ -1471,7 +1533,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     }
     assertEquals(300, dps[0].aggregatedSize());
   }
-  
+
   @Test
   public void runRegexpNoMatch() throws Exception {
     storeLongTimeSeriesSeconds(true, false);
@@ -1500,13 +1562,13 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setTimeSeries("sys.cpu.user", tags, Aggregators.SUM, false);
 
     final DataPoints[] dps = query.run();
-    
+
     assertNotNull(dps);
     assertEquals("sys.cpu.user", dps[0].metricName());
     assertTrue(dps[0].getAggregatedTags().isEmpty());
     assertNull(dps[0].getAnnotations());
     assertEquals("web01", dps[0].getTags().get("host"));
-    
+
     int value = 1;
     for (DataPoint dp : dps[0]) {
       assertEquals(value, dp.longValue());
@@ -1518,7 +1580,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       assertTrue(scanner.getFilter() instanceof FilterList);
     }
   }
-  
+
   @Test
   public void filterExplicitTagsGroupByOK() throws Exception {
     tsdb.getConfig().overrideConfig("tsd.query.enable_fuzzy", "true");
@@ -1531,13 +1593,13 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setTimeSeries("sys.cpu.user", tags, Aggregators.SUM, false);
 
     final DataPoints[] dps = query.run();
-    
+
     assertNotNull(dps);
     assertEquals("sys.cpu.user", dps[0].metricName());
     assertTrue(dps[0].getAggregatedTags().isEmpty());
     assertNull(dps[0].getAnnotations());
     assertEquals("web01", dps[0].getTags().get("host"));
-    
+
     int value = 1;
     for (DataPoint dp : dps[0]) {
       assertEquals(value, dp.longValue());
@@ -1549,7 +1611,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       assertTrue(scanner.getFilter() instanceof FilterList);
     }
   }
-  
+
   @Test
   public void filterExplicitTagsMissing() throws Exception {
     tsdb.getConfig().overrideConfig("tsd.query.enable_fuzzy", "true");
@@ -1567,7 +1629,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     query.setTimeSeries("sys.cpu.user", tags, Aggregators.SUM, false);
 
     final DataPoints[] dps = query.run();
-    
+
     assertNotNull(dps);
     assertEquals(0, dps.length);
     // assert fuzzy
@@ -1575,5 +1637,5 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
       assertTrue(scanner.getFilter() instanceof FilterList);
     }
   }
-  
+
 }

--- a/test/core/TestTsdbTSConfig.java
+++ b/test/core/TestTsdbTSConfig.java
@@ -1,0 +1,189 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2015  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hbase.async.HBaseClient;
+import org.hbase.async.Scanner;
+import org.jboss.netty.util.HashedWheelTimer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.storage.MockBase;
+import net.opentsdb.uid.UniqueId;
+import net.opentsdb.utils.Config;
+
+/**
+ * Sets up a real TSDB with mocked client, compaction queue and timer along
+ * with mocked UID assignment, fetches for common unit tests.
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.management.*", "javax.xml.*",
+  "ch.qos.*", "org.slf4j.*",
+  "com.sum.*", "org.xml.*"})
+@PrepareForTest({TSDB.class, Config.class, UniqueId.class, HBaseClient.class,
+  HashedWheelTimer.class, Scanner.class, Const.class })
+public class TestTsdbTSConfig {
+  /** A list of UIDs from A to Z for unit testing UIDs values */
+  public static final Map<String, byte[]> METRIC_UIDS =
+      new HashMap<String, byte[]>(26);
+  public static final Map<String, byte[]> TAGK_UIDS =
+      new HashMap<String, byte[]>(26);
+  public static final Map<String, byte[]> TAGV_UIDS =
+      new HashMap<String, byte[]>(26);
+  static {
+    char letter = 'A';
+    int uid = 10;
+    for (int i = 0; i < 26; i++) {
+      METRIC_UIDS.put(Character.toString(letter),
+          UniqueId.longToUID(uid, TSDB.metrics_width()));
+      TAGK_UIDS.put(Character.toString(letter),
+          UniqueId.longToUID(uid, TSDB.tagk_width()));
+      TAGV_UIDS.put(Character.toString(letter++),
+          UniqueId.longToUID(uid++, TSDB.tagv_width()));
+    }
+  }
+
+  public static final String METRIC_STRING = "sys.cpu.user";
+  public static final byte[] METRIC_BYTES = new byte[] { 0, 0, 1 };
+
+  public static final String TAGK_STRING = "host";
+  public static final byte[] TAGK_BYTES = new byte[] { 0, 0, 1 };
+
+  public static final String TAGV_STRING = "web01";
+  public static final byte[] TAGV_BYTES = new byte[] { 0, 0, 1 };
+
+  protected Config config;
+  protected TSDB tsdb;
+  protected HBaseClient client = mock(HBaseClient.class);
+  protected UniqueId metrics = mock(UniqueId.class);
+  protected UniqueId tag_names = mock(UniqueId.class);
+  protected UniqueId tag_values = mock(UniqueId.class);
+  protected Map<String, String> tags = new HashMap<String, String>(1);
+  protected MockBase storage;
+
+  @Before
+  public void before() throws Exception {
+
+    config = new Config(false);
+    config.overrideConfig("tsd.storage.enable_compaction", "false");
+    tsdb = PowerMockito.spy(new TSDB(config));
+
+    config.setAutoMetric(true);
+
+    Whitebox.setInternalState(tsdb, "metrics", metrics);
+    Whitebox.setInternalState(tsdb, "tag_names", tag_names);
+    Whitebox.setInternalState(tsdb, "tag_values", tag_values);
+
+    setupMetricMaps();
+    setupTagkMaps();
+    setupTagvMaps();
+
+    when(metrics.width()).thenReturn((short)3);
+    when(tag_names.width()).thenReturn((short)3);
+    when(tag_values.width()).thenReturn((short)3);
+
+    tags.put(TAGK_STRING, TAGV_STRING);
+  }
+
+  /** Adds the static UIDs to the metrics UID mock object */
+  void setupMetricMaps() {
+    when(metrics.getId(METRIC_STRING)).thenReturn(METRIC_BYTES);
+    when(metrics.getIdAsync(METRIC_STRING))
+      .thenAnswer(new Answer<Deferred<byte[]>>() {
+          @Override
+          public Deferred<byte[]> answer(InvocationOnMock invocation)
+              throws Throwable {
+            return Deferred.fromResult(METRIC_BYTES);
+          }
+      });
+    when(metrics.getOrCreateId(METRIC_STRING))
+      .thenReturn(METRIC_BYTES);
+  }
+
+  /** Adds the static UIDs to the tag keys UID mock object */
+  void setupTagkMaps() {
+    when(tag_names.getId(TAGK_STRING)).thenReturn(TAGK_BYTES);
+    when(tag_names.getOrCreateId(TAGK_STRING)).thenReturn(TAGK_BYTES);
+    when(tag_names.getIdAsync(TAGK_STRING))
+      .thenAnswer(new Answer<Deferred<byte[]>>() {
+            @Override
+            public Deferred<byte[]> answer(InvocationOnMock invocation)
+                throws Throwable {
+              return Deferred.fromResult(TAGK_BYTES);
+            }
+        });
+    when(tag_names.getOrCreateIdAsync(TAGK_STRING))
+      .thenReturn(Deferred.fromResult(TAGK_BYTES));
+
+  }
+
+  /** Adds the static UIDs to the tag values UID mock object */
+  void setupTagvMaps() {
+    when(tag_values.getId(TAGV_STRING)).thenReturn(TAGV_BYTES);
+    when(tag_values.getOrCreateId(TAGV_STRING)).thenReturn(TAGV_BYTES);
+    when(tag_values.getIdAsync(TAGV_STRING))
+      .thenAnswer(new Answer<Deferred<byte[]>>() {
+          @Override
+          public Deferred<byte[]> answer(InvocationOnMock invocation)
+              throws Throwable {
+            return Deferred.fromResult(TAGV_BYTES);
+          }
+      });
+    when(tag_values.getOrCreateIdAsync(TAGV_STRING))
+      .thenReturn(Deferred.fromResult(TAGV_BYTES));
+
+  }
+
+  @Test
+  public void scannerTimestampsEqualToQueryTimestamps() {
+
+    TSQuery q = new TSQuery();
+    q.setStart("1h-ago");
+
+    TSSubQuery subQuery = new TSSubQuery();
+    subQuery.setMetric(METRIC_STRING);
+    subQuery.setAggregator("none");
+
+    ArrayList<TSSubQuery> list = new ArrayList<TSSubQuery>();
+    list.add(subQuery);
+    q.setQueries(list);
+    q.validateAndSetQuery();
+
+    TsdbQuery query = new TsdbQuery(tsdb);
+    query.configureFromQuery(q, 0);
+
+    Scanner scanner = query.getScanner();
+    long minTs = scanner.getMinTimestamp();
+    long maxTs = scanner.getMaxTimestamp();
+    // For 1h - ago, the TSDB will create a window of 2 hrs, For example if the current time is 2:45 PM, the window will be 1 PM to 3 PM
+    assert((maxTs - minTs) == (2 * 3600000));
+  }
+
+}

--- a/test/meta/TestAnnotation.java
+++ b/test/meta/TestAnnotation.java
@@ -665,12 +665,12 @@ public final class TestAnnotation extends BaseTsdbTest {
         new byte[] { 1, 0, 0 }, 
         ("{\"startTime\":1328140800,\"endTime\":1328140801,\"description\":" + 
             "\"Description\",\"notes\":\"Notes\",\"custom\":{\"owner\":" + 
-            "\"ops\"}}").getBytes(MockBase.ASCII()));
+            "\"ops\"}}").getBytes(MockBase.ASCII()), 1328140799972L);
 
     storage.addColumn(global_row_key, 
         new byte[] { 1, 0, 1 }, 
         ("{\"startTime\":1328140801,\"endTime\":1328140803,\"description\":" + 
-            "\"Global 2\",\"notes\":\"Nothing\"}").getBytes(MockBase.ASCII()));
+            "\"Global 2\",\"notes\":\"Nothing\"}").getBytes(MockBase.ASCII()), 1328140799973L);
 
     // add a local
     storage.addColumn(tsuid_row_key, 
@@ -678,20 +678,20 @@ public final class TestAnnotation extends BaseTsdbTest {
         ("{\"tsuid\":\"000001000001000001\",\"startTime\":1388450562," +
             "\"endTime\":1419984000,\"description\":\"Hello!\",\"notes\":" + 
             "\"My Notes\",\"custom\":{\"owner\":\"ops\"}}")
-            .getBytes(MockBase.ASCII()));
+            .getBytes(MockBase.ASCII()), 1388448000003L);
     
     storage.addColumn(tsuid_row_key, 
         new byte[] { 1, 0x0A, 0x03 }, 
         ("{\"tsuid\":\"000001000001000001\",\"startTime\":1388450563," +
             "\"endTime\":1419984000,\"description\":\"Note2\",\"notes\":" + 
             "\"Nothing\"}")
-            .getBytes(MockBase.ASCII()));
+            .getBytes(MockBase.ASCII()), 1388448000004L);
     
     // add some data points too
     storage.addColumn(tsuid_row_key, 
-        new byte[] { 0x50, 0x10 }, new byte[] { 1 });
+        new byte[] { 0x50, 0x10 }, new byte[] { 1 }, 1388448000005L);
     
     storage.addColumn(tsuid_row_key, 
-        new byte[] { 0x50, 0x18 }, new byte[] { 2 });
+        new byte[] { 0x50, 0x18 }, new byte[] { 2 }, 1388448000006L);
   }
 }

--- a/test/storage/MockBase.java
+++ b/test/storage/MockBase.java
@@ -60,23 +60,23 @@ import com.stumbleupon.async.Deferred;
 /**
  * Mock HBase implementation useful in testing calls to and from storage with
  * actual pretend data. The underlying data store is an incredibly ugly nesting
- * of ByteMaps from AsyncHbase so it stores and orders byte arrays similar to 
- * HBase. It supports tables and column families along with timestamps but 
+ * of ByteMaps from AsyncHbase so it stores and orders byte arrays similar to
+ * HBase. It supports tables and column families along with timestamps but
  * doesn't deal with TTLs or other features.
  * <p>
- * By default we configure the "'tsdb', {NAME => 't'}" and 
+ * By default we configure the "'tsdb', {NAME => 't'}" and
  * "'tsdb-uid', {NAME => 'id'}, {NAME => 'name'}" tables. If you need more, just
  * add em.
- * 
+ *
  * <p>
  * It's not a perfect mock but is useful for the majority of unit tests. Gets,
  * puts, cas, deletes and scans are currently supported. See notes for each
  * inner class below about what does and doesn't work.
  * <p>
- * Regarding timestamps, whenever you execute an RPC request, the 
+ * Regarding timestamps, whenever you execute an RPC request, the
  * {@code current_timestamp} will be incremented by one millisecond. By default
  * the timestamp starts at 1/1/2014 00:00:00 but you can set it to any value
- * at any time. If a PutRequest comes in with a specific time, that time will 
+ * at any time. If a PutRequest comes in with a specific time, that time will
  * be stored and the timestamp will not be incremented.
  * <p>
  * <b>Warning:</b> To use this class, you need to prepare the classes for testing
@@ -96,27 +96,27 @@ import com.stumbleupon.async.Deferred;
 public final class MockBase {
   private static final Charset ASCII = Charset.forName("ISO-8859-1");
   private TSDB tsdb;
-  
+
   /** Gross huh? <table, <cf, <row, <qual, <ts, value>>>>>
    * Why is CF before row? Because we want to throw exceptions if a CF hasn't
    * been "configured"
    */
-  private ByteMap<ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>>> 
+  private ByteMap<ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>>>
   storage = new ByteMap<ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>>>();
   private HashSet<MockScanner> scanners = new HashSet<MockScanner>(2);
-  
+
   /** The default family for shortcuts */
   private byte[] default_family;
-  
+
   /** The default table for shortcuts */
   private byte[] default_table;
-  
+
   /** Incremented every time a new value is stored (without a timestamp) */
   private long current_timestamp = 1388534400000L;
-  
+
   /** A list of exceptions that can be thrown when working with a row key */
   private ByteMap<Pair<RuntimeException, Boolean>> exceptions;
-  
+
   /**
    * Setups up mock intercepts for all of the calls. Depending on the given
    * flags, some mocks may not be enabled, allowing local unit tests to setup
@@ -132,7 +132,7 @@ public final class MockBase {
    */
   public MockBase(
       final TSDB tsdb, final HBaseClient client,
-      final boolean default_get, 
+      final boolean default_get,
       final boolean default_put,
       final boolean default_delete,
       final boolean default_scan) {
@@ -141,7 +141,7 @@ public final class MockBase {
     default_family = "t".getBytes(ASCII);
     default_table = "tsdb".getBytes(ASCII);
     setupDefaultTables();
-    
+
     // replace the "real" field objects with mocks
     Whitebox.setInternalState(tsdb, "client", client);
 
@@ -149,7 +149,7 @@ public final class MockBase {
     if (default_get) {
       when(client.get((GetRequest)any())).thenAnswer(new MockGet());
     }
-    
+
     // Default put answer will store the given values in the proper location.
     if (default_put) {
       when(client.put((PutRequest)any())).thenAnswer(new MockPut());
@@ -160,7 +160,7 @@ public final class MockBase {
     if (default_delete) {
       when(client.delete((DeleteRequest)any())).thenAnswer(new MockDelete());
     }
-    
+
     if (default_scan) {
       // to facilitate unit tests where more than one scanner is used (i.e. in a
       // callback chain) we have to provide a new mock scanner for each new
@@ -175,11 +175,11 @@ public final class MockBase {
           scanners.add(new MockScanner(scanner, table));
           return scanner;
         }
-        
-      });      
+
+      });
 
     }
-    
+
     when(client.atomicIncrement((AtomicIncrementRequest)any()))
       .then(new MockAtomicIncrement());
     when(client.bufferAtomicIncrement((AtomicIncrementRequest)any()))
@@ -205,7 +205,7 @@ public final class MockBase {
       }
     }
   }
-  
+
   /**
    * Pops the table out of the map
    * @param table The table to pop
@@ -214,45 +214,62 @@ public final class MockBase {
   public boolean deleteTable(final byte[] table) {
     return storage.remove(table) != null;
   }
-  
+
   /** @param family Sets the default family for calls that need it */
   public void setFamily(final byte[] family) {
     default_family = family;
   }
-  
+
   /** @param table Sets the default table for calls that need it */
   public void setDefaultTable(final byte[] table) {
     default_table = table;
   }
-  
+
   /** @param timestamp The timestamp to use for further storage increments */
   public void setCurrentTimestamp(final long timestamp) {
     this.current_timestamp = timestamp;
   }
-  
+
   /** @return the incrementing timestamp */
   public long getCurrentTimestamp() {
     return current_timestamp;
   }
-  
+
+
   /**
-   * Add a column to the hash table using the default column family. 
-   * The proper row will be created if it doesn't exist. If the column already 
+   * Add a column to the hash table using the default column family.
+   * The proper row will be created if it doesn't exist. If the column already
+   * exists, the original value will be overwritten with the new data.
+   * Uses the default table and family
+   * @param key The row key
+   * @param qualifier The qualifier
+   * @param value The value to store
+   * @param timestamp The timestamp of cell
+   */
+  public void addColumn(final byte[] key, final byte[] qualifier,
+      final byte[] value, final long timestamp) {
+    addColumn(default_table, key, default_family, qualifier, value,
+        timestamp);
+  }
+
+  /**
+   * Add a column to the hash table using the default column family.
+   * The proper row will be created if it doesn't exist. If the column already
    * exists, the original value will be overwritten with the new data.
    * Uses the default table and family
    * @param key The row key
    * @param qualifier The qualifier
    * @param value The value to store
    */
-  public void addColumn(final byte[] key, final byte[] qualifier, 
+  public void addColumn(final byte[] key, final byte[] qualifier,
       final byte[] value) {
-    addColumn(default_table, key, default_family, qualifier, value, 
+    addColumn(default_table, key, default_family, qualifier, value,
         current_timestamp++);
   }
-  
+
   /**
-   * Add a column to the hash table 
-   * The proper row will be created if it doesn't exist. If the column already 
+   * Add a column to the hash table
+   * The proper row will be created if it doesn't exist. If the column already
    * exists, the original value will be overwritten with the new data.
    * Uses the default table.
    * @param key The row key
@@ -260,14 +277,14 @@ public final class MockBase {
    * @param qualifier The qualifier
    * @param value The value to store
    */
-  public void addColumn(final byte[] key, final byte[] family, 
+  public void addColumn(final byte[] key, final byte[] family,
       final byte[] qualifier, final byte[] value) {
     addColumn(default_table, key, family, qualifier, value, current_timestamp++);
   }
-  
+
   /**
-   * Add a column to the hash table 
-   * The proper row will be created if it doesn't exist. If the column already 
+   * Add a column to the hash table
+   * The proper row will be created if it doesn't exist. If the column already
    * exists, the original value will be overwritten with the new data
    * @param table The table
    * @param key The row key
@@ -275,14 +292,14 @@ public final class MockBase {
    * @param qualifier The qualifier
    * @param value The value to store
    */
-  public void addColumn(final byte[] table, final byte[] key, final byte[] family, 
+  public void addColumn(final byte[] table, final byte[] key, final byte[] family,
       final byte[] qualifier, final byte[] value) {
     addColumn(table, key, family, qualifier, value, current_timestamp++);
   }
-  
+
   /**
-   * Add a column to the hash table 
-   * The proper row will be created if it doesn't exist. If the column already 
+   * Add a column to the hash table
+   * The proper row will be created if it doesn't exist. If the column already
    * exists, the original value will be overwritten with the new data
    * @param table The table
    * @param key The row key
@@ -291,7 +308,7 @@ public final class MockBase {
    * @param value The value to store
    * @param timestamp The timestamp to store
    */
-  public void addColumn(final byte[] table, final byte[] key, final byte[] family, 
+  public void addColumn(final byte[] table, final byte[] key, final byte[] family,
       final byte[] qualifier, final byte[] value, final long timestamp) {
     // AsyncHBase will throw an NPE if the user tries to write a NULL value
     // so we better do the same. An empty value is ok though, i.e. new byte[] {}
@@ -308,7 +325,7 @@ public final class MockBase {
       throw new RuntimeException(
           "No such CF " + Bytes.pretty(family));
     }
-    
+
     ByteMap<TreeMap<Long, byte[]>> row = cf.get(key);
     if (row == null) {
       row = new ByteMap<TreeMap<Long, byte[]>>();
@@ -323,7 +340,7 @@ public final class MockBase {
     }
     column.put(timestamp, value);
   }
-  
+
   /**
    * Stores an exception so that any operation on the given key will cause it
    * to be thrown.
@@ -333,7 +350,7 @@ public final class MockBase {
   public void throwException(final byte[] key, final RuntimeException exception) {
     throwException(key, exception, true);
   }
-  
+
   /**
    * Stores an exception so that any operation on the given key will cause it
    * to be thrown.
@@ -342,37 +359,37 @@ public final class MockBase {
    * @param as_result Whether or not to return the exception in the deferred
    * result or throw it outright.
    */
-  public void throwException(final byte[] key, final RuntimeException exception, 
+  public void throwException(final byte[] key, final RuntimeException exception,
       final boolean as_result) {
     if (exceptions == null) {
       exceptions = new ByteMap<Pair<RuntimeException, Boolean>>();
     }
     exceptions.put(key, new Pair<RuntimeException, Boolean>(exception, as_result));
   }
-  
+
   /** Removes all exceptions from the exception list */
   public void clearExceptions() {
     exceptions.clear();
   }
-  
-  /** @return Total number of unique rows in the default table. Returns 0 if the 
+
+  /** @return Total number of unique rows in the default table. Returns 0 if the
    * default table does not exist */
   public int numRows() {
     return numRows(default_table);
   }
-  
+
   /**
    * Total number of rows in the given table. Returns 0 if the table does not exit.
    * @param table The table to scan
    * @return The number of rows
    */
   public int numRows(final byte[] table) {
-    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
         storage.get(table);
     if (map == null) {
       return 0;
     }
-    final ByteMap<Void> unique_rows = new ByteMap<Void>(); 
+    final ByteMap<Void> unique_rows = new ByteMap<Void>();
     for (final ByteMap<ByteMap<TreeMap<Long, byte[]>>> cf : map.values()) {
       for (final byte[] key : cf.keySet()) {
         unique_rows.put(key, null);
@@ -380,26 +397,26 @@ public final class MockBase {
     }
     return unique_rows.size();
   }
-  
+
   /**
    * Return the total number of column families for the row in the default table
    * @param key The row to search for
-   * @return -1 if the table or row did not exist, otherwise the number of 
+   * @return -1 if the table or row did not exist, otherwise the number of
    * column families.
    */
   public int numColumnFamilies(final byte[] key) {
     return numColumnFamilies(default_table, key);
   }
-  
+
   /**
    * Return the number of column families for the given row key in the given table.
    * @param table The table to iterate over
-   * @param key The row to search for 
-   * @return -1 if the table or row did not exist, otherwise the number of 
+   * @param key The row to search for
+   * @return -1 if the table or row did not exist, otherwise the number of
    * column families.
    */
   public int numColumnFamilies(final byte[] table, final byte[] key) {
-    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
         storage.get(table);
     if (map == null) {
       return -1;
@@ -412,7 +429,7 @@ public final class MockBase {
     }
     return sum == 0 ? -1 : sum;
   }
-  
+
   /**
    * Total number of columns in the given row across all column families in the
    * default table
@@ -422,7 +439,7 @@ public final class MockBase {
   public long numColumns(final byte[] key) {
     return numColumns(default_table, key);
   }
-  
+
   /**
    * Total number of columns in the given row across all column families in the
    * default table
@@ -431,7 +448,7 @@ public final class MockBase {
    * @return -1 if the row did not exist, otherwise the number of columns.
    */
   public long numColumns(final byte[] table, final byte[] key) {
-    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
         storage.get(table);
     if (map == null) {
       return -1;
@@ -445,7 +462,7 @@ public final class MockBase {
     }
     return size == 0 ? -1 : size;
   }
-  
+
   /**
    * Return the total number of columns for a specific row and family in the
    * default table
@@ -456,16 +473,16 @@ public final class MockBase {
   public int numColumnsInFamily(final byte[] key, final byte[] family) {
     return numColumnsInFamily(default_table, key, family);
   }
-  
+
   /**
    * Return the total number of columns for a specific row and family
    * @param key The row to search for
    * @param family The column family to search for
    * @return -1 if the row did not exist, otherwise the number of columns.
    */
-  public int numColumnsInFamily(final byte[] table, final byte[] key, 
+  public int numColumnsInFamily(final byte[] table, final byte[] key,
       final byte[] family) {
-    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
         storage.get(table);
     if (map == null) {
       return -1;
@@ -487,7 +504,7 @@ public final class MockBase {
   public byte[] getColumn(final byte[] key, final byte[] qualifier) {
     return getColumn(default_table, key, default_family, qualifier);
   }
-  
+
   /**
    * Retrieve the most recent contents of a single column with the default table
    * @param key The row key of the column
@@ -495,11 +512,11 @@ public final class MockBase {
    * @param qualifier The column qualifier
    * @return The byte array of data or null if not found
    */
-  public byte[] getColumn(final byte[] key, final byte[] family, 
+  public byte[] getColumn(final byte[] key, final byte[] family,
       final byte[] qualifier) {
     return getColumn(default_table, key, family, qualifier);
   }
-  
+
   /**
    * Retrieve the most recent contents of a single column
    * @param table The table to fetch from
@@ -508,9 +525,9 @@ public final class MockBase {
    * @param qualifier The column qualifier
    * @return The byte array of data or null if not found
    */
-  public byte[] getColumn(final byte[] table, final byte[] key, 
+  public byte[] getColumn(final byte[] table, final byte[] key,
       final byte[] family, final byte[] qualifier) {
-    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
         storage.get(table);
     if (map == null) {
       return null;
@@ -531,17 +548,17 @@ public final class MockBase {
   }
 
   /**
-   * Retrieve the full map of timestamps and values of a single column with 
+   * Retrieve the full map of timestamps and values of a single column with
    * the default family and default table
    * @param key The row key of the column
    * @param qualifier The column qualifier
    * @return The byte array of data or null if not found
    */
-  public TreeMap<Long, byte[]> getFullColumn(final byte[] key, 
+  public TreeMap<Long, byte[]> getFullColumn(final byte[] key,
       final byte[] qualifier) {
     return getFullColumn(default_table, key, default_family, qualifier);
   }
-  
+
   /**
    * Retrieve the full map of timestamps and values of a single column
    * @param table The table to fetch from
@@ -550,9 +567,9 @@ public final class MockBase {
    * @param qualifier The column qualifier
    * @return The tree map of timestamps and values or null if not found
    */
-  public TreeMap<Long, byte[]> getFullColumn(final byte[] table, final byte[] key, 
+  public TreeMap<Long, byte[]> getFullColumn(final byte[] table, final byte[] key,
       final byte[] family, final byte[] qualifier) {
-    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
         storage.get(table);
     if (map == null) {
       return null;
@@ -567,7 +584,7 @@ public final class MockBase {
     }
     return row.get(qualifier);
   }
-  
+
   /**
    * Returns the most recent value from all columns for a given column family
    * in the default table
@@ -575,11 +592,11 @@ public final class MockBase {
    * @param family The column family ID
    * @return A map of columns if the CF was found, null if no such CF
    */
-  public ByteMap<byte[]> getColumnFamily(final byte[] key, 
+  public ByteMap<byte[]> getColumnFamily(final byte[] key,
       final byte[] family) {
     return getColumnFamily(default_table, key , family);
   }
-  
+
   /**
    * Returns the most recent value from all columns for a given column family
    * @param table The table to fetch from
@@ -587,9 +604,9 @@ public final class MockBase {
    * @param family The column family ID
    * @return A map of columns if the CF was found, null if no such CF
    */
-  public ByteMap<byte[]> getColumnFamily(final byte[] table, final byte[] key, 
+  public ByteMap<byte[]> getColumnFamily(final byte[] table, final byte[] key,
       final byte[] family) {
-    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
         storage.get(table);
     if (map == null) {
       return null;
@@ -610,24 +627,24 @@ public final class MockBase {
     }
     return columns;
   }
-  
+
   /** @return the list of keys stored in the default table for all CFs */
   public Set<byte[]> getKeys() {
     return getKeys(default_table);
   }
-  
+
   /**
    * Return the list of unique keys in the given table for all CFs
    * @param table The table to pull from
    * @return A list of keys. May be null if the table doesn't exist
    */
   public Set<byte[]> getKeys(final byte[] table) {
-    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
         storage.get(table);
     if (map == null) {
       return null;
     }
-    final ByteMap<Void> unique_rows = new ByteMap<Void>(); 
+    final ByteMap<Void> unique_rows = new ByteMap<Void>();
     for (final ByteMap<ByteMap<TreeMap<Long, byte[]>>> cf : map.values()) {
       for (final byte[] key : cf.keySet()) {
         unique_rows.put(key, null);
@@ -635,12 +652,12 @@ public final class MockBase {
     }
     return unique_rows.keySet();
   }
-  
+
   /** @return The set of scanners configured by the caller */
   public HashSet<MockScanner> getScanners() {
     return scanners;
   }
-  
+
   /**
    * Return the mocked TSDB object to use for HBaseClient access
    * @return
@@ -648,17 +665,17 @@ public final class MockBase {
   public TSDB getTSDB() {
     return tsdb;
   }
-  
+
   /**
-   * Runs through all rows in the "tsdb" table and compacts them by making a 
-   * call to the {@link TSDB.compact} method. It will delete any columns 
-   * that were compacted and leave others untouched, just as the normal 
+   * Runs through all rows in the "tsdb" table and compacts them by making a
+   * call to the {@link TSDB.compact} method. It will delete any columns
+   * that were compacted and leave others untouched, just as the normal
    * method does.
    * And only iterates over the 't' family.
    * @throws Exception if Whitebox couldn't access the compact method
    */
   public void tsdbCompactAllRows() throws Exception {
-    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+    final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
         storage.get("tsdb".getBytes(ASCII));
     if (map == null) {
       return;
@@ -667,16 +684,16 @@ public final class MockBase {
     if (cf == null) {
       return;
     }
-    
+
     for (Entry<byte[], ByteMap<TreeMap<Long, byte[]>>> entry : cf.entrySet()) {
       final byte[] key = entry.getKey();
-      
+
       final ByteMap<TreeMap<Long, byte[]>> row = entry.getValue();
       ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(row.size());
       final Set<byte[]> deletes = new HashSet<byte[]>();
       for (Map.Entry<byte[], TreeMap<Long, byte[]>> column : row.entrySet()) {
         if (column.getKey().length % 2 == 0) {
-          kvs.add(new KeyValue(key, default_family, column.getKey(), 
+          kvs.add(new KeyValue(key, default_family, column.getKey(),
               column.getValue().firstKey(),
               column.getValue().firstEntry().getValue()));
           deletes.add(column.getKey());
@@ -686,7 +703,7 @@ public final class MockBase {
         for (final byte[] k : deletes) {
           row.remove(k);
         }
-        final KeyValue compacted = 
+        final KeyValue compacted =
             Whitebox.invokeMethod(tsdb, "compact", kvs, Collections.EMPTY_LIST);
         final TreeMap<Long, byte[]> compacted_value = new TreeMap<Long, byte[]>();
         compacted_value.put(current_timestamp++, compacted.value());
@@ -694,12 +711,12 @@ public final class MockBase {
       }
     }
   }
-  
+
   /**
    * Clears out all rows from storage but doesn't delete the tables or families.
    */
   public void flushStorage() {
-    for (final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> table : 
+    for (final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> table :
       storage.values()) {
       for (final ByteMap<ByteMap<TreeMap<Long, byte[]>>> cf : table.values()) {
         cf.clear();
@@ -720,7 +737,7 @@ public final class MockBase {
       cf.clear();
     }
   }
-  
+
   /**
    * Removes the entire row from the default table for all column families
    * @param key The row to remove
@@ -728,7 +745,7 @@ public final class MockBase {
   public void flushRow(final byte[] key) {
     flushRow(default_table, key);
   }
-  
+
   /**
    * Removes the entire row from the table for all column families
    * @param table The table to purge
@@ -743,7 +760,7 @@ public final class MockBase {
       cf.remove(key);
     }
   }
-  
+
   /**
    * Removes all rows from the default table for the given column family
    * @param family The family to remove
@@ -751,7 +768,7 @@ public final class MockBase {
   public void flushFamily(final byte[] family) {
     flushFamily(default_table, family);
   }
-  
+
   /**
    * Removes all rows from the default table for the given column family
    * @param table The table to purge from
@@ -767,18 +784,18 @@ public final class MockBase {
       cf.clear();
     }
   }
-  
+
   /**
-   * Removes the given column from the default table 
+   * Removes the given column from the default table
    * @param key Row key
    * @param family Column family
    * @param qualifier Column qualifier
    */
-  public void flushColumn(final byte[] key, final byte[] family, 
+  public void flushColumn(final byte[] key, final byte[] family,
       final byte[] qualifier) {
     flushColumn(default_table, key, family, qualifier);
   }
-  
+
   /**
    * Removes the given column from the table
    * @param table The table to purge from
@@ -786,7 +803,7 @@ public final class MockBase {
    * @param family Column family
    * @param qualifier Column qualifier
    */
-  public void flushColumn(final byte[] table, final byte[] key, 
+  public void flushColumn(final byte[] table, final byte[] key,
       final byte[] family, final byte[] qualifier) {
     final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = storage.get(table);
     if (map == null) {
@@ -802,7 +819,7 @@ public final class MockBase {
     }
     row.remove(qualifier);
   }
-  
+
   /**
    * Dumps the entire storage hash to stdout in a sort of tree style format with
    * all byte arrays hex encoded
@@ -810,7 +827,7 @@ public final class MockBase {
   public void dumpToSystemOut() {
     dumpToSystemOut(false);
   }
-  
+
   /**
    * Dumps the entire storage hash to stdout in a sort of tree style format
    * @param ascii Whether or not the values should be converted to ascii
@@ -820,27 +837,27 @@ public final class MockBase {
       System.out.println("Storage is Empty");
       return;
     }
-    
-    for (Entry<byte[], ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>>> table : 
+
+    for (Entry<byte[], ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>>> table :
       storage.entrySet()) {
       System.out.println("[Table] " + new String(table.getKey(), ASCII));
-      
-      for (Entry<byte[], ByteMap<ByteMap<TreeMap<Long, byte[]>>>> cf : 
+
+      for (Entry<byte[], ByteMap<ByteMap<TreeMap<Long, byte[]>>>> cf :
         table.getValue().entrySet()) {
         System.out.println("  [CF] " + new String(cf.getKey(), ASCII));
 
-        for (Entry<byte[], ByteMap<TreeMap<Long, byte[]>>> row : 
+        for (Entry<byte[], ByteMap<TreeMap<Long, byte[]>>> row :
           cf.getValue().entrySet()) {
-          System.out.println("    [Row] " + (ascii ? 
+          System.out.println("    [Row] " + (ascii ?
               new String(row.getKey(), ASCII) : bytesToString(row.getKey())));
-          
+
           for (Map.Entry<byte[], TreeMap<Long, byte[]>> column : row.getValue().entrySet()) {
             System.out.println("      [Qual] " + (ascii ?
                 "\"" + new String(column.getKey(), ASCII) + "\""
                 : bytesToString(column.getKey())));
             for (Map.Entry<Long, byte[]> cell : column.getValue().entrySet()) {
-              System.out.println("        [TS] " + cell.getKey() + "  [Value] " + 
-                  (ascii ?  new String(cell.getValue(), ASCII) 
+              System.out.println("        [TS] " + cell.getKey() + "  [Value] " +
+                  (ascii ?  new String(cell.getValue(), ASCII)
                   : bytesToString(cell.getValue())));
             }
           }
@@ -848,7 +865,7 @@ public final class MockBase {
       }
     }
   }
-  
+
   /**
    * Helper to convert an array of bytes to a hexadecimal encoded string.
    * @param bytes The byte array to convert
@@ -857,7 +874,7 @@ public final class MockBase {
   public static String bytesToString(final byte[] bytes) {
     return DatatypeConverter.printHexBinary(bytes);
   }
-  
+
   /**
    * Helper to convert a hex encoded string into a byte array.
    * <b>Warning:</b> This method won't pad the string to make sure it's an
@@ -870,12 +887,12 @@ public final class MockBase {
   public static byte[] stringToBytes(final String bytes) {
     return DatatypeConverter.parseHexBinary(bytes);
   }
-  
+
   /** @return Returns the ASCII character set */
   public static Charset ASCII() {
     return ASCII;
   }
-  
+
   /**
    * Concatenates byte arrays into one big array
    * @param arrays Any number of arrays to concatenate
@@ -894,26 +911,26 @@ public final class MockBase {
     }
     return result;
   }
-  
+
   /** Creates the TSDB and UID tables */
   private void setupDefaultTables() {
     final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> tsdb =
         new ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>>();
     tsdb.put("t".getBytes(ASCII), new ByteMap<ByteMap<TreeMap<Long, byte[]>>>());
     storage.put("tsdb".getBytes(ASCII), tsdb);
-    
+
     final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> tsdb_uid =
         new ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>>();
-    tsdb_uid.put("name".getBytes(ASCII), 
+    tsdb_uid.put("name".getBytes(ASCII),
         new ByteMap<ByteMap<TreeMap<Long, byte[]>>>());
-    tsdb_uid.put("id".getBytes(ASCII), 
+    tsdb_uid.put("id".getBytes(ASCII),
         new ByteMap<ByteMap<TreeMap<Long, byte[]>>>());
     storage.put("tsdb-uid".getBytes(ASCII), tsdb_uid);
   }
-  
+
   /**
    * Gets one or more columns from a row. If the row does not exist, a null is
-   * returned. If no qualifiers are given, the entire row is returned. 
+   * returned. If no qualifiers are given, the entire row is returned.
    * NOTE: all timestamp, value pairs are returned.
    */
   private class MockGet implements Answer<Deferred<ArrayList<KeyValue>>> {
@@ -922,7 +939,7 @@ public final class MockBase {
         throws Throwable {
       final Object[] args = invocation.getArguments();
       final GetRequest get = (GetRequest)args[0];
-      
+
       if (exceptions != null) {
         final Pair<RuntimeException, Boolean> ex = exceptions.get(get.key());
         if (ex != null) {
@@ -933,40 +950,40 @@ public final class MockBase {
           }
         }
       }
-      
-      final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+
+      final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
           storage.get(get.table());
       if (map == null) {
         return Deferred.fromError(new RuntimeException(
           "No such table " + Bytes.pretty(get.table())));
       }
-      
+
       // compile a set of qualifiers to use as a filter if necessary
       final ByteMap<Object> qualifiers = new ByteMap<Object>();
-      if (get.qualifiers() != null && get.qualifiers().length > 0) { 
+      if (get.qualifiers() != null && get.qualifiers().length > 0) {
         for (byte[] q : get.qualifiers()) {
           qualifiers.put(q, null);
         }
       }
-      
+
       final ArrayList<KeyValue> kvs = new ArrayList<KeyValue>();
-      for (final Entry<byte[], ByteMap<ByteMap<TreeMap<Long, byte[]>>>> cf : 
+      for (final Entry<byte[], ByteMap<ByteMap<TreeMap<Long, byte[]>>>> cf :
           map.entrySet()) {
         if (get.family() != null && Bytes.memcmp(get.family(), cf.getKey()) != 0) {
           continue;
         }
-        
+
         final ByteMap<TreeMap<Long, byte[]>> row = cf.getValue().get(get.key());
         if (row == null) {
           continue;
         }
-        
+
         for (Entry<byte[], TreeMap<Long, byte[]>> column : row.entrySet()) {
           if (!qualifiers.isEmpty() && !qualifiers.containsKey(column.getKey())) {
             continue;
           }
-          
-          // TODO - if we want to support multiple values, iterate over the 
+
+          // TODO - if we want to support multiple values, iterate over the
           // tree map. Otherwise Get returns just the latest value.
           kvs.add(new KeyValue(get.key(), cf.getKey(), column.getKey(),
               column.getValue().firstKey(),
@@ -979,18 +996,18 @@ public final class MockBase {
       return Deferred.fromResult(kvs);
     }
   }
-  
+
   /**
    * Stores one or more columns in a row. If the row does not exist, it's
    * created.
    */
   private class MockPut implements Answer<Deferred<Boolean>> {
     @Override
-    public Deferred<Boolean> answer(final InvocationOnMock invocation) 
+    public Deferred<Boolean> answer(final InvocationOnMock invocation)
       throws Throwable {
       final Object[] args = invocation.getArguments();
       final PutRequest put = (PutRequest)args[0];
-      
+
       if (exceptions != null) {
         final Pair<RuntimeException, Boolean> ex = exceptions.get(put.key());
         if (ex != null) {
@@ -1001,20 +1018,20 @@ public final class MockBase {
           }
         }
       }
-      
-      final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+
+      final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
           storage.get(put.table());
       if (map == null) {
         return Deferred.fromError(new RuntimeException(
           "No such table " + Bytes.pretty(put.table())));
       }
-      
+
       final ByteMap<ByteMap<TreeMap<Long, byte[]>>> cf = map.get(put.family());
       if (cf == null) {
         return Deferred.fromError(new RuntimeException(
-            "No such CF " + Bytes.pretty(put.table()))); 
+            "No such CF " + Bytes.pretty(put.table())));
       }
-      
+
       ByteMap<TreeMap<Long, byte[]>> row = cf.get(put.key());
       if (row == null) {
         row = new ByteMap<TreeMap<Long, byte[]>>();
@@ -1026,23 +1043,31 @@ public final class MockBase {
         if (column == null) {
           column = new TreeMap<Long, byte[]>(Collections.reverseOrder());
           row.put(put.qualifiers()[i], column);
+        } else {
+          long storedTs = column.firstKey();
+		  if(put.timestamp() >= storedTs) {
+		    column.clear();
+		  } else {
+			continue;
+		  }
         }
-        
-        column.put(put.timestamp() != Long.MAX_VALUE ? put.timestamp() : 
+
+        column.put(put.timestamp() != Long.MAX_VALUE ? put.timestamp() :
           current_timestamp++, put.values()[i]);
+        assert column.size() == 1 : "Since max versions allowed is 1, there can never be two entries at similar timestamp. To resolve change the code to only keep the entry with higher timestamp";
       }
-      
+
       return Deferred.fromResult(true);
     }
   }
-  
+
   /**
    * Stores one or more columns in a row. If the row does not exist, it's
    * created.
    */
   private class MockAppend implements Answer<Deferred<Boolean>> {
     @Override
-    public Deferred<Boolean> answer(final InvocationOnMock invocation) 
+    public Deferred<Boolean> answer(final InvocationOnMock invocation)
       throws Throwable {
       final Object[] args = invocation.getArguments();
       final AppendRequest append = (AppendRequest)args[0];
@@ -1057,48 +1082,48 @@ public final class MockBase {
           }
         }
       }
-      
-      final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+
+      final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
           storage.get(append.table());
       if (map == null) {
         return Deferred.fromError(new RuntimeException(
           "No such table " + Bytes.pretty(append.table())));
       }
-      
+
       final ByteMap<ByteMap<TreeMap<Long, byte[]>>> cf = map.get(append.family());
       if (cf == null) {
         return Deferred.fromError(new RuntimeException(
-            "No such CF " + Bytes.pretty(append.table()))); 
+            "No such CF " + Bytes.pretty(append.table())));
       }
-      
+
       ByteMap<TreeMap<Long, byte[]>> row = cf.get(append.key());
       if (row == null) {
         row = new ByteMap<TreeMap<Long, byte[]>>();
         cf.put(append.key(), row);
       }
-      
+
       for (int i = 0; i < append.qualifiers().length; i++) {
         TreeMap<Long, byte[]> column = row.get(append.qualifiers()[i]);
         if (column == null) {
           column = new TreeMap<Long, byte[]>(Collections.reverseOrder());
           row.put(append.qualifiers()[i], column);
         }
-        
+
         final byte[] values;
         long column_timestamp = 0;
-        if (append.timestamp() != Long.MAX_VALUE) {
-          values = column.get(append.timestamp());
-          column_timestamp = append.timestamp();
-        } else {
-          if (column.isEmpty()) {
-            values = null;
-          } else {
-            values = column.firstEntry().getValue();
-            column_timestamp = column.firstKey();
-          }
-        }
-        if (column_timestamp == 0) {
+        /*
+         * If there is no Map for Timestamp -> Value, then we create one, add the value with current timestamp
+         * else we fetch the top most KeyValue from the column map and append the value in the request with the value
+         * already present. The timestamp is also updated. The larger of either current time or the first timestamp from
+         * the map is incremented by 1 and used for the updated KeyValue.
+         */
+
+        if (column.isEmpty()) {
+          values = null;
           column_timestamp = current_timestamp++;
+        } else {
+          values = column.firstEntry().getValue();
+          column_timestamp = current_timestamp > column.firstKey() ? current_timestamp++ : column.firstKey() + 1;
         }
 
         final int current_len = values != null ? values.length : 0;
@@ -1106,34 +1131,38 @@ public final class MockBase {
         if (current_len > 0) {
           System.arraycopy(values, 0, append_value, 0, values.length);
         }
-        
-        System.arraycopy(append.value(), 0, append_value, current_len, 
+
+        System.arraycopy(append.value(), 0, append_value, current_len,
             append.values()[i].length);
+        // Remove all the old KeyValues, if any, since we need to have only 1 version of data
+        // Column_timestamp will hold the new timestamp and append_value holds the corresponding new data
+        column.clear();
         column.put(column_timestamp, append_value);
+        assert column.size() == 1 : "MockBase is designed to store only a single version of cell since OpenTSDB table schema for HBase is designed in that manner";
       }
-      
+
       return Deferred.fromResult(true);
     }
   }
-  
+
   /**
    * Imitates the compareAndSet client call where a {@code PutRequest} is passed
    * along with a byte array to compared the stored value against. If the stored
-   * value doesn't match, the put is ignored and a "false" is returned. If the 
+   * value doesn't match, the put is ignored and a "false" is returned. If the
    * comparator matches, the new put is recorded.
    * <b>Warning:</b> While a put works on multiple qualifiers, CAS only works
    * with one. So if the put includes more than one qualifier, only the first
-   * one will be processed in this CAS call. 
+   * one will be processed in this CAS call.
    */
   private class MockCAS implements Answer<Deferred<Boolean>> {
-    
+
     @Override
-    public Deferred<Boolean> answer(final InvocationOnMock invocation) 
+    public Deferred<Boolean> answer(final InvocationOnMock invocation)
       throws Throwable {
       final Object[] args = invocation.getArguments();
       final PutRequest put = (PutRequest)args[0];
       final byte[] expected = (byte[])args[1];
-      
+
       if (exceptions != null) {
         final Pair<RuntimeException, Boolean> ex = exceptions.get(put.key());
         if (ex != null) {
@@ -1144,20 +1173,20 @@ public final class MockBase {
           }
         }
       }
-      
-      final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+
+      final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
           storage.get(put.table());
       if (map == null) {
         return Deferred.fromError(new RuntimeException(
           "No such table " + Bytes.pretty(put.table())));
       }
-      
+
       final ByteMap<ByteMap<TreeMap<Long, byte[]>>> cf = map.get(put.family());
       if (cf == null) {
         return Deferred.fromError(new RuntimeException(
-            "No such CF " + Bytes.pretty(put.table()))); 
+            "No such CF " + Bytes.pretty(put.table())));
       }
-      
+
       ByteMap<TreeMap<Long, byte[]>> row = cf.get(put.key());
       if (row == null) {
         if (expected != null && expected.length > 0) {
@@ -1166,53 +1195,65 @@ public final class MockBase {
         row = new ByteMap<TreeMap<Long, byte[]>>();
         cf.put(put.key(), row);
       }
-      
-      // CAS can only operate on one cell, so if the put request has more than 
+
+      // CAS can only operate on one cell, so if the put request has more than
       // one, we ignore any but the first
       TreeMap<Long, byte[]> column = row.get(put.qualifiers()[0]);
       if (column == null && (expected != null && expected.length > 0)) {
         return Deferred.fromResult(false);
       }
-      // if a timestamp was specified, maybe we're CASing against a specific 
-      // cell. Otherwise we deal with the latest value
-      final byte[] stored = column == null ? null : 
-        put.timestamp() != Long.MAX_VALUE ? column.get(put.timestamp()) :
-        column.firstEntry().getValue();
+
+      // HBase CAS doesn't use Timestamps for comparison
+      // Since OpenTSDB uses an HBase Table with single version, the final TreeMap 'column' should always
+      // contain a single entry, the one with higher timestamp
+
+      final byte[] stored = column == null ? null : column.firstEntry().getValue();
+
       if (stored == null && (expected != null && expected.length > 0)) {
         return Deferred.fromResult(false);
       }
       if (stored != null && (expected == null || expected.length < 1)) {
         return Deferred.fromResult(false);
       }
-      if (stored != null && expected != null && 
+      if (stored != null && expected != null &&
           Bytes.memcmp(stored, expected) != 0) {
         return Deferred.fromResult(false);
       }
-      
+
       // passed CAS!
       if (column == null) {
         column = new TreeMap<Long, byte[]>(Collections.reverseOrder());
         row.put(put.qualifiers()[0], column);
+      } else {
+        long storedTs = column.firstKey();
+        if(put.timestamp() >= storedTs) {
+          column.clear();
+    	} else {
+    	  return Deferred.fromResult(true);
+    	}
       }
-      column.put(put.timestamp() != Long.MAX_VALUE ? put.timestamp() : 
+
+      column.put(put.timestamp() != Long.MAX_VALUE ? put.timestamp() :
         current_timestamp++, put.value());
+
+      assert column.size() == 1 : "MockBase is designed to store only a single version of cell since OpenTSDB table schema for HBase is designed in that manner";
       return Deferred.fromResult(true);
     }
-    
+
   }
-  
+
   /**
    * Deletes one or more columns. If a row no longer has any valid columns, the
    * entire row will be removed.
    */
   private class MockDelete implements Answer<Deferred<Object>> {
-    
+
     @Override
     public Deferred<Object> answer(InvocationOnMock invocation)
         throws Throwable {
       final Object[] args = invocation.getArguments();
       final DeleteRequest delete = (DeleteRequest)args[0];
-      
+
       if (exceptions != null) {
         final Pair<RuntimeException, Boolean> ex = exceptions.get(delete.key());
         if (ex != null) {
@@ -1223,44 +1264,44 @@ public final class MockBase {
           }
         }
       }
-      
-      final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+
+      final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
           storage.get(delete.table());
       if (map == null) {
         return Deferred.fromError(new RuntimeException(
           "No such table " + Bytes.pretty(delete.table())));
       }
-      
+
       // if no qualifiers or family, then delete the row from all families
-      if ((delete.qualifiers() == null || delete.qualifiers().length < 1 || 
-          delete.qualifiers()[0].length < 1) && (delete.family() == null || 
+      if ((delete.qualifiers() == null || delete.qualifiers().length < 1 ||
+          delete.qualifiers()[0].length < 1) && (delete.family() == null ||
           delete.family().length < 1)) {
-        for (final Entry<byte[], ByteMap<ByteMap<TreeMap<Long, byte[]>>>> cf : 
+        for (final Entry<byte[], ByteMap<ByteMap<TreeMap<Long, byte[]>>>> cf :
           map.entrySet()) {
           cf.getValue().remove(delete.key());
         }
         return Deferred.fromResult(new Object());
       }
-      
+
       final byte[] family = delete.family();
       if (family != null && family.length > 0) {
         if (!map.containsKey(family)) {
           return Deferred.fromError(new RuntimeException(
-              "No such CF " + Bytes.pretty(family))); 
+              "No such CF " + Bytes.pretty(family)));
         }
       }
-      
+
       // compile a set of qualifiers
       ByteMap<Object> qualifiers = new ByteMap<Object>();
-      if (delete.qualifiers() != null || delete.qualifiers().length > 0) { 
+      if (delete.qualifiers() != null || delete.qualifiers().length > 0) {
         for (byte[] q : delete.qualifiers()) {
           qualifiers.put(q, null);
         }
       }
-      
+
       // TODO - validate the assumption that a delete with a row key and qual
       // but without a family would delete the columns in ALL families
-      
+
       // if the request only has a column family and no qualifiers, we delete
       // the row from the entire family
       if (family != null && qualifiers.isEmpty()) {
@@ -1269,27 +1310,27 @@ public final class MockBase {
         cf.remove(delete.key());
         return Deferred.fromResult(new Object());
       }
-      
-      for (final Entry<byte[], ByteMap<ByteMap<TreeMap<Long, byte[]>>>> cf : 
+
+      for (final Entry<byte[], ByteMap<ByteMap<TreeMap<Long, byte[]>>>> cf :
         map.entrySet()) {
-        
+
         // column family filter
-        if (family != null && family.length > 0 && 
+        if (family != null && family.length > 0 &&
             !Bytes.equals(family, cf.getKey())) {
           continue;
         }
-        
+
         ByteMap<TreeMap<Long, byte[]>> row = cf.getValue().get(delete.key());
         if (row == null) {
           continue;
         }
-        
+
         for (byte[] qualifier : qualifiers.keySet()) {
           final TreeMap<Long, byte[]> column = row.get(qualifier);
           if (column == null) {
             continue;
           }
-          
+
           // with this flag we delete a single timestamp
           if (delete.deleteAtTimestampOnly()) {
             if (column != null) {
@@ -1299,7 +1340,7 @@ public final class MockBase {
               }
             }
           } else {
-            // otherwise we delete everything less than or equal to the 
+            // otherwise we delete everything less than or equal to the
             // delete timestamp
             List<Long> column_removals = new ArrayList<Long>(column.size());
             for (Map.Entry<Long, byte[]> cell : column.entrySet()) {
@@ -1315,16 +1356,16 @@ public final class MockBase {
             }
           }
         }
-        
+
         if (row.isEmpty()) {
           cf.getValue().remove(delete.key());
         }
       }
       return Deferred.fromResult(new Object());
     }
-    
+
   }
-  
+
   /**
    * This is a limited implementation of the scanner object. The only fields
    * caputred and acted on are:
@@ -1338,10 +1379,10 @@ public final class MockBase {
    * call. The second {@code nextRows} call will always return null. Multiple
    * qualifiers are supported for matching.
    * <p>
-   * The KeyRegexp can be set and it will run against the hex value of the 
+   * The KeyRegexp can be set and it will run against the hex value of the
    * row key. In testing it seems to work nicely even with byte patterns.
    */
-  public class MockScanner implements 
+  public class MockScanner implements
     Answer<Deferred<ArrayList<ArrayList<KeyValue>>>> {
 
     private final Scanner mock_scanner;
@@ -1352,12 +1393,12 @@ public final class MockBase {
     private byte[] family = null;
     private ScanFilter filter = null;
     private int max_num_rows = Scanner.DEFAULT_MAX_NUM_ROWS;
-    private ByteMap<Iterator<Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>>> 
+    private ByteMap<Iterator<Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>>>
       cursors;
     private ByteMap<Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>> cf_rows;
     private byte[] last_row;
     private String rex; // TEMP
-    
+
     /**
      * Default ctor
      * @param mock_scanner The scanner we're using
@@ -1377,7 +1418,7 @@ public final class MockBase {
           return null;
         }
       }).when(mock_scanner).setKeyRegexp(anyString());
-      
+
       doAnswer(new Answer<Object>() {
         @Override
         public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -1387,7 +1428,7 @@ public final class MockBase {
           return null;
         }
       }).when(mock_scanner).setKeyRegexp(anyString(), (Charset)any());
-      
+
       doAnswer(new Answer<Object>() {
         @Override
         public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -1403,27 +1444,27 @@ public final class MockBase {
           final Object[] args = invocation.getArguments();
           start = (byte[])args[0];
           return null;
-        }      
+        }
       }).when(mock_scanner).setStartKey((byte[])any());
-      
+
       doAnswer(new Answer<Object>() {
         @Override
         public Object answer(InvocationOnMock invocation) throws Throwable {
           final Object[] args = invocation.getArguments();
           stop = (byte[])args[0];
           return null;
-        }      
+        }
       }).when(mock_scanner).setStopKey((byte[])any());
-      
+
       doAnswer(new Answer<Object>() {
         @Override
         public Object answer(InvocationOnMock invocation) throws Throwable {
           final Object[] args = invocation.getArguments();
           family = (byte[])args[0];
           return null;
-        }      
+        }
       }).when(mock_scanner).setFamily((byte[])any());
-      
+
       doAnswer(new Answer<Object>() {
         @Override
         public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -1431,9 +1472,9 @@ public final class MockBase {
           scnr_qualifiers = new HashSet<String>(1);
           scnr_qualifiers.add(bytesToString((byte[])args[0]));
           return null;
-        }      
+        }
       }).when(mock_scanner).setQualifier((byte[])any());
-      
+
       doAnswer(new Answer<Object>() {
         @Override
         public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -1444,39 +1485,39 @@ public final class MockBase {
             scnr_qualifiers.add(bytesToString(qualifier));
           }
           return null;
-        }      
+        }
       }).when(mock_scanner).setQualifiers((byte[][])any());
-      
+
       doAnswer(new Answer<byte[]>() {
         @Override
         public byte[] answer(InvocationOnMock invocation) throws Throwable {
           return start;
         }
       }).when(mock_scanner).getCurrentKey();
-      
+
       when(mock_scanner.nextRows()).thenAnswer(this);
-      
+
     }
-    
+
     @Override
     public Deferred<ArrayList<ArrayList<KeyValue>>> answer(
         final InvocationOnMock invocation) throws Throwable {
-      
+
       if (cursors == null) {
-        final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+        final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
             storage.get(table);
         if (map == null) {
           return Deferred.fromError( new RuntimeException(
               "No such table " + Bytes.pretty(table)));
         }
-        
-        cursors = new ByteMap<Iterator<Entry<byte[], 
+
+        cursors = new ByteMap<Iterator<Entry<byte[],
             ByteMap<TreeMap<Long, byte[]>>>>>();
         cf_rows = new ByteMap<Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>>();
-        
+
         if (family == null || family.length < 1) {
           for (final Entry<byte[], ByteMap<ByteMap<TreeMap<Long, byte[]>>>> cf : map) {
-            final Iterator<Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>> 
+            final Iterator<Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>>
             cursor = cf.getValue().iterator();
             cursors.put(cf.getKey(), cursor);
             cf_rows.put(cf.getKey(), null);
@@ -1487,21 +1528,21 @@ public final class MockBase {
             return Deferred.fromError(new RuntimeException(
             "No such CF " + Bytes.pretty(family)));
           }
-          final Iterator<Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>> 
+          final Iterator<Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>>
             cursor = cf.iterator();
           cursors.put(family, cursor);
           cf_rows.put(family, null);
         }
       }
 
-      // If we're out of rows to scan, then you HAVE to return null as the 
+      // If we're out of rows to scan, then you HAVE to return null as the
       // HBase client does.
       if (!hasNext()) {
         return Deferred.fromResult(null);
       }
-      
+
       // TODO - fuzzy filter support
-      // TODO - fix the regex comparator 
+      // TODO - fix the regex comparator
       Pattern pattern = null;
       if (rex != null) {
         if (!rex.isEmpty()) {
@@ -1509,11 +1550,11 @@ public final class MockBase {
         }
       } else if (filter != null) {
         KeyRegexpFilter regex_filter = null;
-        
+
         if (filter instanceof KeyRegexpFilter) {
           regex_filter = (KeyRegexpFilter)filter;
         } else if (filter instanceof FilterList) {
-          final List<ScanFilter> filters = 
+          final List<ScanFilter> filters =
               Whitebox.getInternalState(filter, "filters");
           for (final ScanFilter f : filters) {
             if (f instanceof KeyRegexpFilter) {
@@ -1521,11 +1562,11 @@ public final class MockBase {
             }
           }
         }
-        
+
         if (regex_filter != null) {
           try {
             final String regexp = new String(
-                (byte[])Whitebox.getInternalState(regex_filter, "regexp"), 
+                (byte[])Whitebox.getInternalState(regex_filter, "regexp"),
                 Charset.forName(new String(
                     (byte[])Whitebox.getInternalState(regex_filter, "charset"))));
             if (!regexp.isEmpty()) {
@@ -1537,14 +1578,14 @@ public final class MockBase {
           }
         }
       }
-      
+
       // return all matches
-      final ArrayList<ArrayList<KeyValue>> results = 
+      final ArrayList<ArrayList<KeyValue>> results =
         new ArrayList<ArrayList<KeyValue>>();
       int rows_read = 0;
       while (hasNext()) {
         advance();
-        
+
         // if it's before the start row, after the end row or doesn't
         // match the given regex, continue on to the next row
         if (start != null && Bytes.memcmp(last_row, start) < 0) {
@@ -1552,11 +1593,11 @@ public final class MockBase {
         }
         // asynchbase Scanner's logic:
         // - start_key is inclusive, stop key is exclusive
-        // - when start key is equal to the stop key, 
+        // - when start key is equal to the stop key,
         //   include the key in scan result
         // - if stop key is empty, scan till the end
-        if (stop != null && stop.length > 0 && 
-            Bytes.memcmp(last_row, stop) >= 0 && 
+        if (stop != null && stop.length > 0 &&
+            Bytes.memcmp(last_row, stop) >= 0 &&
             Bytes.memcmp(start, stop) != 0) {
           continue;
         }
@@ -1566,7 +1607,7 @@ public final class MockBase {
             continue;
           }
         }
-        
+
         // throws AFTER we match on a row key
         if (exceptions != null) {
           final Pair<RuntimeException, Boolean> ex = exceptions.get(last_row);
@@ -1581,47 +1622,47 @@ public final class MockBase {
 
         // loop over the column family rows to see if they match
         final ArrayList<KeyValue> kvs = new ArrayList<KeyValue>();
-        for (final Entry<byte[], Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>> row : 
+        for (final Entry<byte[], Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>> row :
           cf_rows.entrySet()) {
-          if (row.getValue() == null || 
+          if (row.getValue() == null ||
               Bytes.memcmp(last_row, row.getValue().getKey()) != 0) {
             continue;
           }
-          
-          for (final Entry<byte[], TreeMap<Long, byte[]>> column : 
+
+          for (final Entry<byte[], TreeMap<Long, byte[]>> column :
             row.getValue().getValue().entrySet()) {
             // if the qualifier isn't in the set, continue
-            if (scnr_qualifiers != null && 
+            if (scnr_qualifiers != null &&
                 !scnr_qualifiers.contains(bytesToString(column.getKey()))) {
               continue;
             }
-            
-            kvs.add(new KeyValue(row.getValue().getKey(), row.getKey(), 
+
+            kvs.add(new KeyValue(row.getValue().getKey(), row.getKey(),
                 column.getKey(), column.getValue().firstKey(),
                 column.getValue().firstEntry().getValue()));
           }
         }
-        
+
         if (!kvs.isEmpty()) {
           results.add(kvs);
         }
         rows_read++;
-        
+
         if (rows_read >= max_num_rows) {
           Thread.sleep(10); // this is here for time based unit tests
           break;
         }
       }
-      
+
       if (results.isEmpty()) {
         return Deferred.fromResult(null);
       }
       return Deferred.fromResult(results);
     }
-    
+
     /** @return Returns true if any of the CF iterators have another value */
     private boolean hasNext() {
-      for (final Iterator<Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>> cursor : 
+      for (final Iterator<Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>> cursor :
           cursors.values()) {
         if (cursor.hasNext()) {
           return true;
@@ -1629,15 +1670,15 @@ public final class MockBase {
       }
       return false;
     }
-  
+
     /** Insanely inefficient and ugly way of advancing the cursors */
     private void advance() {
       // first time to get the ceiling
       if (last_row == null) {
-        for (final Entry<byte[], 
-            Iterator<Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>>> iterator : 
+        for (final Entry<byte[],
+            Iterator<Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>>> iterator :
           cursors.entrySet()) {
-          final Entry<byte[], ByteMap<TreeMap<Long, byte[]>>> row = 
+          final Entry<byte[], ByteMap<TreeMap<Long, byte[]>>> row =
               iterator.getValue().hasNext() ? iterator.getValue().next() : null;
           cf_rows.put(iterator.getKey(), row);
           if (last_row == null) {
@@ -1650,14 +1691,14 @@ public final class MockBase {
         }
         return;
       }
-      
-      for (final Entry<byte[], Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>> cf : 
+
+      for (final Entry<byte[], Entry<byte[], ByteMap<TreeMap<Long, byte[]>>>> cf :
         cf_rows.entrySet()) {
         final Entry<byte[], ByteMap<TreeMap<Long, byte[]>>> row = cf.getValue();
         if (row == null) {
           continue;
         }
-        
+
         if (Bytes.memcmp(last_row, row.getKey()) == 0) {
           if (!cursors.get(cf.getKey()).hasNext()) {
             cf_rows.put(cf.getKey(), null); // EX?
@@ -1666,14 +1707,14 @@ public final class MockBase {
           }
         }
       }
-      
+
       last_row = null;
-      for (final Entry<byte[], ByteMap<TreeMap<Long, byte[]>>> row : 
+      for (final Entry<byte[], ByteMap<TreeMap<Long, byte[]>>> row :
         cf_rows.values()) {
         if (row == null) {
           continue;
         }
-        
+
         if (last_row == null) {
           last_row = row.getKey();
         } else {
@@ -1683,18 +1724,18 @@ public final class MockBase {
         }
       }
     }
-    
+
     /** @return The scanner for this mock */
     public Scanner getScanner() {
       return mock_scanner;
     }
-  
+
     /** @return The filter for this mock */
     public ScanFilter getFilter() {
       return filter;
     }
   }
-  
+
   /**
    * Creates or increments (possibly decrements) a Long in the hash table at the
    * given location.
@@ -1707,7 +1748,7 @@ public final class MockBase {
       final Object[] args = invocation.getArguments();
       final AtomicIncrementRequest air = (AtomicIncrementRequest)args[0];
       final long amount = air.getAmount();
-      
+
       if (exceptions != null) {
         final Pair<RuntimeException, Boolean> ex = exceptions.get(air.key());
         if (ex != null) {
@@ -1718,26 +1759,26 @@ public final class MockBase {
           }
         }
       }
-      
-      final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map = 
+
+      final ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>> map =
           storage.get(air.table());
       if (map == null) {
         return Deferred.fromError(new RuntimeException(
           "No such table " + Bytes.pretty(air.table())));
       }
-      
+
       final ByteMap<ByteMap<TreeMap<Long, byte[]>>> cf = map.get(air.family());
       if (cf == null) {
         return Deferred.fromError(new RuntimeException(
-            "No such CF " + Bytes.pretty(air.table()))); 
+            "No such CF " + Bytes.pretty(air.table())));
       }
-      
+
       ByteMap<TreeMap<Long, byte[]>> row = cf.get(air.key());
       if (row == null) {
         row = new ByteMap<TreeMap<Long, byte[]>>();
         cf.put(air.key(), row);
       }
-      
+
       TreeMap<Long, byte[]> column = row.get(air.qualifier());
       if (column == null) {
         column = new TreeMap<Long, byte[]>(Collections.reverseOrder());
@@ -1745,13 +1786,13 @@ public final class MockBase {
         column.put(current_timestamp++, Bytes.fromLong(amount));
         return Deferred.fromResult(amount);
       }
-      
+
       long incremented_value = Bytes.getLong(column.firstEntry().getValue());
       incremented_value += amount;
       column.put(column.firstKey(), Bytes.fromLong(incremented_value));
       return Deferred.fromResult(incremented_value);
     }
-    
+
   }
 
 }

--- a/test/tsd/TestAnnotationRpc.java
+++ b/test/tsd/TestAnnotationRpc.java
@@ -70,12 +70,12 @@ public final class TestAnnotationRpc {
         new byte[] { 1, 0, 0 }, 
         ("{\"startTime\":1328140800,\"endTime\":1328140801,\"description\":" + 
             "\"Description\",\"notes\":\"Notes\",\"custom\":{\"owner\":" + 
-            "\"ops\"}}").getBytes(MockBase.ASCII()));
+            "\"ops\"}}").getBytes(MockBase.ASCII()), 1328140799972L);
     
     storage.addColumn(global_row_key, 
         new byte[] { 1, 0, 1 }, 
         ("{\"startTime\":1328140801,\"endTime\":1328140803,\"description\":" + 
-            "\"Global 2\",\"notes\":\"Nothing\"}").getBytes(MockBase.ASCII()));
+            "\"Global 2\",\"notes\":\"Nothing\"}").getBytes(MockBase.ASCII()), 1328140799973L);
     
     // add a local
     storage.addColumn(tsuid_row_key, 
@@ -83,21 +83,21 @@ public final class TestAnnotationRpc {
         ("{\"tsuid\":\"000001000001000001\",\"startTime\":1388450562," +
             "\"endTime\":1419984000,\"description\":\"Hello!\",\"notes\":" + 
             "\"My Notes\",\"custom\":{\"owner\":\"ops\"}}")
-            .getBytes(MockBase.ASCII()));
+            .getBytes(MockBase.ASCII()), 1388448000003L);
     
     storage.addColumn(tsuid_row_key, 
         new byte[] { 1, 0x0A, 0x03 }, 
         ("{\"tsuid\":\"000001000001000001\",\"startTime\":1388450563," +
             "\"endTime\":1419984000,\"description\":\"Note2\",\"notes\":" + 
             "\"Nothing\"}")
-            .getBytes(MockBase.ASCII()));
+            .getBytes(MockBase.ASCII()), 1388448000004L);
     
     // add some data points too
     storage.addColumn(tsuid_row_key, 
-        new byte[] { 0x50, 0x10 }, new byte[] { 1 });
+        new byte[] { 0x50, 0x10 }, new byte[] { 1 }, 1388448000005L);
     
     storage.addColumn(tsuid_row_key, 
-        new byte[] { 0x50, 0x18 }, new byte[] { 2 });
+        new byte[] { 0x50, 0x18 }, new byte[] { 2 }, 1388448000006L);
   }
   
   @Test


### PR DESCRIPTION
Following changes are done
1. RequestBuilder class added to create new PutRequest based on user parameters and configurations.
2. MockHBase functionality modified to make it equivalent to HBase.
3. Refactored and added new tests to verify the functionality
4. compactedKVTimestamp variable is now thread safe.
5. New function for merging various data points when DTCS is enabled. More details added as comments inside the code.
6. Query Scanners to use timerange based scans.