### PR TITLE
Tolerate session_objects being null

### DIFF
--- a/core/src/main/java/net/opentsdb/query/context/QueryContext.java
+++ b/core/src/main/java/net/opentsdb/query/context/QueryContext.java
@@ -741,7 +741,10 @@ public abstract class QueryContext {
     if (Strings.isNullOrEmpty(key)) {
       throw new IllegalArgumentException("Key cannot be null.");
     }
-    return session_objects.get(key);
+    if (session_objects != null) {
+      return session_objects.get(key);
+    }
+    return null;
   }
   
   /**

--- a/core/src/test/java/net/opentsdb/query/context/TestQueryContext.java
+++ b/core/src/test/java/net/opentsdb/query/context/TestQueryContext.java
@@ -1136,6 +1136,9 @@ public class TestQueryContext {
     final Object obj_b = new Object();
    
     final MockContext context = new MockContext(tsdb, executor_graph);
+    assertNull(context.getSessionObject("obj_a"));
+    assertNull(context.getSessionObject("obj_b"));
+
     context.addSessionObject("obj_a", obj_a);
     assertSame(obj_a, context.getSessionObject("obj_a"));
     context.addSessionObject("obj_b", obj_b);


### PR DESCRIPTION
As encountered while using new V3 query engine:

```
Caused by: java.lang.NullPointerException
        at net.opentsdb.query.context.QueryContext.getSessionObject(QueryContext.java:744)
        at net.opentsdb.query.execution.HttpQueryV2Executor$Execution.execute(HttpQueryV2Executor.java:399)
        at net.opentsdb.query.execution.HttpQueryV2Executor.executeQuery(HttpQueryV2Executor.java:131)
        at net.opentsdb.query.execution.MultiClusterQueryExecutor$QueryToClusterSplitter.executeQuery(MultiClusterQueryExecutor.java:297)
        ... 24 more
```