### PR TITLE
Fix session-headers NPE

### DIFF
--- a/executors/http/src/test/java/net/opentsdb/query/execution/TestHttpQueryV2Executor.java
+++ b/executors/http/src/test/java/net/opentsdb/query/execution/TestHttpQueryV2Executor.java
@@ -297,6 +297,20 @@ public class TestHttpQueryV2Executor extends BaseExecutorTest {
     assertTrue(executor.outstandingRequests().isEmpty());
     verify(client, times(1)).close();
   }
+
+  @Test (expected = IllegalStateException.class)
+  public void executeQueryNonMapSessionHeaders() throws Exception {
+    final HttpQueryV2Executor executor = new HttpQueryV2Executor(node);
+    setupQuery();
+
+    final Object notMap = new Object();
+    when(context.getSessionObject(HttpQueryV2Executor.SESSION_HEADERS_KEY))
+      .thenReturn(notMap);
+
+    QueryExecution<IteratorGroups> exec =
+      executor.executeQuery(context, query, span);
+    exec.deferred().join();
+  }
   
   @Test (expected = IllegalArgumentException.class)
   public void executeQueryNullQuery() throws Exception {


### PR DESCRIPTION
Encountered in system-testing:

```
Caused by: java.lang.NullPointerException
        at net.opentsdb.query.execution.HttpQueryV2Executor$Execution.execute(HttpQueryV2Executor.java:403)
        at net.opentsdb.query.execution.HttpQueryV2Executor.executeQuery(HttpQueryV2Executor.java:131)
        at net.opentsdb.query.execution.MultiClusterQueryExecutor$QueryToClusterSplitter.executeQuery(MultiClusterQueryExecutor.java:297)
        ... 32 more
```