### PR TITLE
Add the TimeBasedRoutingExecutor that's the first stab at a time based

### DIFF
--- a/core/src/main/java/net/opentsdb/query/execution/TimeBasedRoutingExecutor.java
+++ b/core/src/main/java/net/opentsdb/query/execution/TimeBasedRoutingExecutor.java
@@ -1,0 +1,758 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2017  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.query.execution;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.Objects;
+import com.google.common.base.Strings;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Ordering;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+
+import io.opentracing.Span;
+import net.opentsdb.core.Const;
+import net.opentsdb.data.iterators.DefaultIteratorGroups;
+import net.opentsdb.exceptions.QueryExecutionCanceled;
+import net.opentsdb.query.context.QueryContext;
+import net.opentsdb.query.execution.graph.ExecutionGraphNode;
+import net.opentsdb.query.plan.QueryPlanner;
+import net.opentsdb.query.plan.QueryPlannnerFactory;
+import net.opentsdb.query.plan.TimeSlicedQueryPlanner;
+import net.opentsdb.query.pojo.TimeSeriesQuery;
+import net.opentsdb.query.pojo.Timespan;
+import net.opentsdb.stats.TsdbTrace;
+import net.opentsdb.utils.DateTime;
+import net.opentsdb.utils.JSON;
+
+/**
+ * An executor that manages slicing and routing queries across multiple sources
+ * over configurable time ranges. For example, if the time series storage system
+ * has a 24h in-memory cache (e.g. Facebook's Beringei) and there's a long-term
+ * storage layer, the router will send querys for the current 24h of data to the
+ * cache and longer and/or older queries to the long-term store.
+ * <p> 
+ * Additionally the long-term layer can be sharded across tables or data stores.
+ * For example, if a TSD runs out of UIDs and users need more, they can create
+ * a new set of tables with a larger UID size. The router will then split queries
+ * at the appropriate date and merge the results.
+ * <p>
+ * Configuration is performed via {@link TimeRange}s. Two types of sources are
+ * allowed at this time:
+ * <ul>
+ * <li><b>Cache</b> - These are denoted by {@link TimeRange}s that only have 
+ * their {@link TimeRange#end} values configured with a relative timestamp, e.g.
+ * "24h-ago". This indicates the cache has rolling data from "now" until 24 hours
+ * in the past. More than one cache *can* be configured but they MUST overlap,
+ * e.g. if there is a "24h-ago" cache and a "48h-ago" cache, the 48 hour cache
+ * MUST have all of the data from "now" until 48 hours ago. (Eventually we can 
+ * try sharding).</li>
+ * <li><b>TSDB</b> - These are standard long-term stores that hold data from 
+ * "now" until the last {@link TimeRange#end} timestamp. {@link TimeRange#start}
+ * and {@link TimeRange#end} times must be absolute timestamps, e.g. 
+ * "2016/07/31-00:00:00". For the "now" slice, the start time can be null and 
+ * the end some time in the past like "1979/01/01-00:00:00". If more than one
+ * TSDB is configured, it's start and end times must be the same as adjacent
+ * time ranges.</li> 
+ * </ul>
+ * 
+ * <b>Notes:</b>
+ * If the end time of a query is beyond the end time of the final cache or TSDB
+ * then the query will always respond with an empty data set.
+ * 
+ * TODO - Eventually we could shard across cache and tsdbs, right now it's 
+ * either or. Either the fully query must be served from cache or it's sharded
+ * across the TSDs.
+ * 
+ * TODO - Need to implement fallback options if the cache is empty.
+ *
+ * @param <T> The type of data returned by the executor.
+ * 
+ * @since 3.0
+ */
+public class TimeBasedRoutingExecutor<T> extends QueryExecutor<T> {
+  private static final Logger LOG = LoggerFactory.getLogger(
+      TimeBasedRoutingExecutor.class);
+  
+  /** The map of time ranges to executors. */
+  private Map<String, QueryExecutor<T>> executors;
+  
+  /** The sorted list of caches. */
+  private List<TimeRange> caches;
+  
+  /** The sorted list of tsdbs. */
+  private List<TimeRange> tsds;
+  
+  /**
+   * Default ctor.
+   * @param node A non-null node with a default configuration.
+   */
+  public TimeBasedRoutingExecutor(final ExecutionGraphNode node) {
+    super(node);
+    if (node.getDefaultConfig() == null) {
+      throw new IllegalArgumentException("Default config cannot be null.");
+    }
+    if (node.graph() == null) {
+      throw new IllegalStateException("Execution graph cannot be null.");
+    }
+    if (Strings.isNullOrEmpty(((Config) node.getDefaultConfig()).getPlannerId())) {
+      throw new IllegalArgumentException("Default planner ID must be non-empty.");
+    }
+    executors = Maps.newHashMapWithExpectedSize(
+        ((Config) node.getDefaultConfig()).times.size());
+    for (final TimeRange range : ((Config) node.getDefaultConfig()).times) {
+      @SuppressWarnings("unchecked")
+      final QueryExecutor<T> executor = (QueryExecutor<T>) 
+          node.graph().getDownstreamExecutor(range.executorId);
+      if (executor == null) {
+        throw new IllegalStateException("No downstram executor found for ID " 
+            + range.executorId);
+      }
+      executors.put(range.executorId, executor);
+      registerDownstreamExecutor(executor);
+    }
+    
+    caches = ((Config) node.getDefaultConfig()).caches;
+    tsds = ((Config) node.getDefaultConfig()).tsds;
+  }
+
+  @Override
+  public QueryExecution<T> executeQuery(final QueryContext context,
+                                        final TimeSeriesQuery query, 
+                                        final Span upstream_span) {
+    final LocalExecution execution = 
+        new LocalExecution(context, query, upstream_span);
+    execution.execute();
+    return execution;
+  }
+
+  /**
+   * Method that searches the caches and tsdbs for the proper combination of
+   * downstream executors to run the query against.
+   * @param query A non-null query to pull the start and end times from.
+   * @return A list of 1 or more time ranges with execution IDs to run against.
+   * If no ranges would satisfy the query, the response is null.
+   */
+  List<TimeRange> getSources(final TimeSeriesQuery query) {
+    if (caches != null) {
+      long now = DateTime.currentTimeMillis();
+      for (final TimeRange range : caches) {
+        if (query.getTime().startTime().msEpoch() >= now - range.end_long) {
+          return Lists.newArrayList(range);
+        }
+      }
+    }
+    
+    if (tsds == null) {
+      return null;
+    }
+    
+    // TODO - check range inclusion
+    final List<TimeRange> sources = Lists.newArrayListWithCapacity(1);
+    for (final TimeRange range : tsds) {
+      if (query.getTime().endTime().msEpoch() < range.end_long) {
+        continue;
+      }
+      if (query.getTime().startTime().msEpoch() >= range.end_long) {
+        sources.add(range);
+        return sources;
+      }
+      if (query.getTime().startTime().msEpoch() < range.end_long) {
+        sources.add(range);
+      }
+    }
+    return sources;
+  }
+    
+  /**
+   * The local execution that computes the downstream executors to fire the 
+   * queries against.
+   */
+  class LocalExecution extends QueryExecution<T> {
+    
+    /** The query context. */
+    private final QueryContext context;
+    
+    /** The time ranges detected that we should use for the query. */
+    private final List<TimeRange> ranges;
+    
+    /** Outstanding executions fired downstream. Used for cancelation. */
+    private final QueryExecution<T>[] executions;
+    
+    /** The query planner used to merge tsd slices. */
+    private TimeSlicedQueryPlanner<T> planner;
+    
+    /**
+     * Default ctor.
+     * @param context The non-null query context.
+     * @param query The non-null query to parse.
+     * @param upstream_span An optional upstream span for tracing.
+     */
+    @SuppressWarnings("unchecked")
+    public LocalExecution(final QueryContext context,
+                          final TimeSeriesQuery query,
+                          final Span upstream_span) {
+      super(query);
+      this.context = context;
+      outstanding_executions.add(this);
+      
+      if (context.getTracer() != null) {
+        setSpan(context, 
+            TimeBasedRoutingExecutor.this.getClass().getSimpleName(),
+            upstream_span,
+            TsdbTrace.addTags(
+                "order", Integer.toString(query.getOrder()),
+                "query", JSON.serializeToString(query),
+                "startThread", Thread.currentThread().getName()));
+      }
+      
+      ranges = getSources(query);
+      executions = ranges != null ? new QueryExecution[ranges.size()] : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    void execute() {
+      try {
+        if (ranges == null || ranges.isEmpty()) {
+          // ------------------------------------------------------------
+          // no ranges matched, e.g. maybe there's a short ttl
+          callback(new DefaultIteratorGroups(),
+              TsdbTrace.successfulTags("downstreams", "null"));
+          outstanding_executions.remove(LocalExecution.this);
+          return;
+        } else if (ranges.size() == 1) {
+          // ------------------------------------------------------------
+          // only querying a single host so foward and attach the callback
+          final QueryExecutor<T> downstream = 
+              executors.get(ranges.get(0).executorId);
+          if (downstream == null) {
+            final IllegalStateException ex = new IllegalStateException(
+                "No executor found for executor ID: " 
+                    + ranges.get(0).executorId);
+            callback(ex,
+              TsdbTrace.exceptionTags(ex),
+              TsdbTrace.exceptionAnnotation(ex));
+            outstanding_executions.remove(LocalExecution.this);
+            return;
+          }
+          
+          final QueryExecution<T> execution = 
+              downstream.executeQuery(context, query, tracer_span);
+          executions[0] = execution;
+          
+          /** The success callback that just passes results upstream and logs
+           * the span. */
+          class DSSuccessCB implements Callback<Object, T> {
+            @Override
+            public Object call(final T results) throws Exception {
+              callback(results, 
+                  TsdbTrace.successfulTags("downstreams", 
+                      ranges.get(0).executorId));
+              outstanding_executions.remove(LocalExecution.this);
+              return null;
+            }
+          }
+          
+          /** The error callback returning the exception upstream and completing 
+           * the span. */
+          class DSErrorCB implements Callback<Object, Exception> {
+            @Override
+            public Object call(final Exception e) throws Exception {
+              try {
+                callback(e, 
+                    TsdbTrace.exceptionTags(e),
+                    TsdbTrace.exceptionAnnotation(e));
+              } catch (IllegalStateException ex) { 
+                // Safe to ignore as it's already been called.
+              } catch (Exception ex) {
+                LOG.error("Unexpected exception when handling exception for " 
+                    + this, ex);
+              }
+              outstanding_executions.remove(LocalExecution.this);
+              return null;
+            }
+          }
+          
+          execution.deferred()
+            .addCallback(new DSSuccessCB())
+            .addErrback(new DSErrorCB());
+          return;
+        }
+        
+        // ------------------------------------------------------------
+        // fall through means we need to query 2 or more tsds.
+        final QueryExecutorConfig override = 
+            context.getConfigOverride(node.getExecutorId());
+        final Config config;
+        if (override != null) {
+          config = (Config) override;
+        } else {
+          config = (Config) node.getDefaultConfig();
+        }
+        
+        final String plan_id = Strings.isNullOrEmpty(config.getPlannerId()) ? 
+            ((Config) node.getDefaultConfig()).getPlannerId() : config.getPlannerId();
+        final QueryPlannnerFactory<?> plan_factory = context.getTSDB().getRegistry()
+            .getQueryPlanner(plan_id);
+        if (plan_factory == null) {
+          throw new IllegalArgumentException("No such query plan factory: " 
+              + config.getPlannerId());
+        }
+        final QueryPlanner<?> temp_planner = plan_factory.newPlanner(query);
+        if (temp_planner == null) {
+          throw new IllegalStateException("Plan factory returned a null planner: " 
+              + plan_factory);
+        }
+        if (!(temp_planner instanceof TimeSlicedQueryPlanner)) {
+          throw new IllegalStateException("Planner was of the wrong type: " 
+              + temp_planner.getClass().getCanonicalName() + " while it must be "
+                  + "a TimeSlicedQueryPlanner.");
+        }
+        planner = (TimeSlicedQueryPlanner<T>) temp_planner;
+        
+        int i = 0;
+        final List<Deferred<T>> deferreds = Lists.newArrayListWithCapacity(ranges.size());
+        for (final TimeRange range : ranges) {
+          final Timespan.Builder builder = Timespan.newBuilder(query.getTime());
+          if (query.getTime().endTime().msEpoch() <= range.start_long) {
+            builder.setEnd(Long.toString(query.getTime().endTime().msEpoch()));
+          } else {
+            builder.setEnd(range.start);
+          }
+          
+          if (query.getTime().startTime().msEpoch() > range.end_long) {
+            builder.setStart(Long.toString(query.getTime().startTime().msEpoch()));
+          } else {
+            builder.setStart(range.end);
+          }
+          
+          final QueryExecutor<T> executor = executors.get(range.executorId);
+          if (executor == null) {
+            // TODO - WTF!?!?!
+          }
+          
+          executions[i] = executor.executeQuery(context, 
+              TimeSeriesQuery.newBuilder(query)
+                .setTime(builder)
+                .build(), 
+              tracer_span);
+          deferreds.add(executions[i].deferred());
+          // TODO - fail-fast and/or/failover
+          i++;
+        }
+        
+        Deferred.group(deferreds)
+          .addCallback(new CompletedCB())
+          .addErrback(new ErrorCB());
+      } catch (Exception e) {
+        try {
+          callback(e, 
+              TsdbTrace.exceptionTags(e),
+              TsdbTrace.exceptionAnnotation(e));
+        } catch (IllegalStateException ex) { 
+          // Safe to ignore as it's already been called.
+        } catch (Exception ex) {
+          LOG.error("Unexpected exception when handling exception for " + this, ex);
+        }
+        outstanding_executions.remove(LocalExecution.this);
+      }
+    }
+    
+    /**
+     * Overall callback used when we need to hit 2 or more executors. Merges
+     * the results using the configured planner.
+     */
+    class CompletedCB implements Callback<Object, ArrayList<T>> {
+
+      @Override
+      public Object call(ArrayList<T> results) throws Exception {
+        try {
+          // Note: The merge expects series to be in ascending order but the
+          // way we sort tsds is descending so we need to flip the order.
+          Collections.reverse(results);
+          final T merged = planner.mergeSlicedResults(results);
+          
+          final StringBuilder buf = new StringBuilder();
+          for (int i = 0; i < ranges.size(); i++) {
+            if (i > 0) {
+              buf.append(",");
+            }
+            buf.append(ranges.get(i).executorId);
+          }
+          callback(merged,
+              TsdbTrace.successfulTags("downstreams", buf.toString()));
+        } catch (Exception e) {
+          try {
+            callback(e, 
+                TsdbTrace.exceptionTags(e),
+                TsdbTrace.exceptionAnnotation(e));
+          } catch (IllegalStateException ex) { 
+            // Safe to ignore as it's already been called.
+          } catch (Exception ex) {
+            LOG.error("Unexpected exception handling success callback for " 
+                + this, ex);
+          }
+        } finally {
+          outstanding_executions.remove(LocalExecution.this);
+        }
+        return null;
+      }
+      
+    }
+    
+    /**
+     * Error handler for the grouped downstreams.
+     */
+    class ErrorCB implements Callback<Object, Exception> {
+      @Override
+      public Object call(final Exception e) throws Exception {
+        try {
+          callback(e, 
+              TsdbTrace.exceptionTags(e),
+              TsdbTrace.exceptionAnnotation(e));
+        } catch (IllegalStateException ex) { 
+          // Safe to ignore as it's already been called.
+        } catch (Exception ex) {
+          LOG.error("Unexpected exception when handling exception for " + this, ex);
+        }
+        outstanding_executions.remove(LocalExecution.this);
+        return null;
+      }
+    }
+    
+    @Override
+    public void cancel() {
+      if (!completed.get()) {
+        try {
+          final Exception e = new QueryExecutionCanceled(
+              "Query was cancelled upstream: " + this, 400, query.getOrder());
+          callback(e, TsdbTrace.canceledTags(e));
+        } catch (IllegalArgumentException ex) {
+          // lost race, no prob.
+        } catch (Exception ex) {
+          LOG.warn("Failed to complete callback due to unexepcted "
+              + "exception: " + this, ex);
+        }
+      }
+      outstanding_executions.remove(LocalExecution.this);
+      
+      if (executions != null) {
+        for (final QueryExecution<T> execution : executions) {
+          try {
+            execution.cancel();
+          } catch (Exception e) {
+            LOG.warn("Failed canceling execution: " + execution, e);
+          }
+        }
+      }
+    }
+    
+  }
+  
+  /** The configuration class for this executor. */
+  @JsonInclude(Include.NON_NULL)
+  @JsonDeserialize(builder = Config.Builder.class)
+  public static class Config extends QueryExecutorConfig {
+    private List<TimeRange> times;
+    private String planner_id;
+    private List<TimeRange> caches;
+    private List<TimeRange> tsds;
+    
+    protected Config(Builder builder) {
+      super(builder);
+      times = builder.times;
+      planner_id = builder.plannerId;
+      if (Strings.isNullOrEmpty(planner_id)) {
+        throw new IllegalArgumentException("Cannot have an empty planner ID.");
+      }
+      if (times == null || times.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Time settings cannot be null or empty.");
+      }
+      
+      for (final TimeRange range : times) {
+        if (range.is_relative) {
+          if (caches == null) {
+            caches = Lists.newArrayListWithCapacity(1);
+          }
+          caches.add(range);
+        } else {
+          if (tsds == null) {
+            tsds = Lists.newArrayListWithCapacity(1);
+          }
+          tsds.add(range);
+        }
+      }
+      
+      if (caches != null) {
+        Collections.sort(caches, new TimeRange.TimeSorting());
+      }
+      if (tsds != null) {
+        Collections.sort(tsds, new TimeRange.TimeSorting());
+      }
+      // TODO - validation of overlaps
+    }
+    
+    /** @return The list of time ranges. */
+    public List<TimeRange> getTimes() {
+      return Collections.unmodifiableList(times);
+    }
+
+    /** @return The planner ID. */
+    public String getPlannerId() {
+      return planner_id;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final Config config = (Config) o;
+      return Objects.equal(executor_id, config.executor_id)
+          && Objects.equal(executor_type, config.executor_type)
+          && Objects.equal(planner_id, config.planner_id)
+          && Objects.equal(times, config.times);
+    }
+
+    @Override
+    public int hashCode() {
+      return buildHashCode().asInt();
+    }
+
+    @Override
+    public HashCode buildHashCode() {
+      final List<HashCode> hashes = Lists.newArrayListWithCapacity(
+          times.size() + 1);
+      hashes.add(Const.HASH_FUNCTION().newHasher()
+        .putString(Strings.nullToEmpty(executor_id), Const.UTF8_CHARSET)
+        .putString(Strings.nullToEmpty(executor_type), Const.UTF8_CHARSET)
+        .putString(Strings.nullToEmpty(planner_id), Const.UTF8_CHARSET)
+        .hash());
+      for (final TimeRange range : times) {
+        hashes.add(range.buildHashCode());
+      }
+      return Hashing.combineOrdered(hashes);
+    }
+
+    @Override
+    public int compareTo(QueryExecutorConfig config) {
+      return ComparisonChain.start()
+          .compare(executor_id, config.executor_id, 
+              Ordering.natural().nullsFirst())
+          .compare(executor_type, config.executor_type, 
+              Ordering.natural().nullsFirst())
+          .compare(planner_id, ((Config) config).planner_id, 
+              Ordering.natural().nullsFirst())
+          .compare(times, ((Config) config).times,
+              Ordering.<TimeRange>natural().lexicographical().nullsFirst())
+          .result();
+    }
+    
+    public static Builder newBuilder() {
+      return new Builder();
+    }
+    
+    public static class Builder extends QueryExecutorConfig.Builder {
+      @JsonProperty
+      private List<TimeRange> times;
+      @JsonProperty
+      private String plannerId = "IteratorGroupsSlicePlanner";
+      
+      /** @param times The non-null and non-empty list of time ranges. */
+      public Builder setTimes(final List<TimeRange> times) {
+        this.times = times;
+        if (times != null) {
+          Collections.sort(this.times);
+        }
+        return this;
+      }
+      
+      /** @param plannerId The non-null and non-empty planner ID */ 
+      public Builder setPlannerId(final String plannerId) {
+        this.plannerId = plannerId;
+        return this;
+      }
+      
+      @Override
+      public Config build() {
+        return new Config(this);
+      }
+      
+    }
+    
+  }
+  
+  /** A single time range object. It's validated on build. */
+  @JsonInclude(Include.NON_NULL)
+  @JsonDeserialize(builder = TimeRange.Builder.class)
+  public static class TimeRange implements Comparable<TimeRange> {
+    private String start;
+    private String end;
+    private String executorId;
+    private boolean is_relative;
+    private long start_long;
+    private long end_long;
+    
+    protected TimeRange(final Builder builder) {
+      start = Strings.isNullOrEmpty(builder.start) ? null : builder.start;
+      end = Strings.isNullOrEmpty(builder.end) ? null : builder.end;
+      if (Strings.isNullOrEmpty(builder.executorId)) {
+        throw new IllegalArgumentException("Executor ID is missing.");
+      }
+      executorId = builder.executorId;
+      if (start == null && end == null) {
+        throw new IllegalArgumentException("Start and/or end must be provided.");
+      }
+      if (DateTime.isRelativeDate(end)) {
+        end_long = DateTime.parseDuration(
+            end.substring(0, end.length() - "-ago".length()));
+        is_relative = true;
+      } else {
+        end_long = DateTime.parseDateTimeString(end, null);
+      }
+      
+      if (start != null) {
+        if (is_relative) {
+          throw new IllegalArgumentException("Start time cannot be given in "
+              + "relative ranges.");
+        }
+        start_long = DateTime.parseDateTimeString(start, null);
+      } 
+    }
+    
+    /** @return The start time as given by the user. May be null. */
+    public String getStart() {
+      return start;
+    }
+    
+    /** @return The end time as given by the user. May be null. */
+    public String getEnd() {
+      return end;
+    }
+    
+    /** @return The executor ID to use downstream. */
+    public String getExecutorId() {
+      return executorId;
+    }
+    
+    /** Helper used for sorting caches vs tsdbs. */
+    static class TimeSorting implements Comparator<TimeRange> {
+
+      @Override
+      public int compare(final TimeRange o1, final TimeRange o2) {
+        long diff = o1.is_relative ?
+            o1.end_long - o2.end_long :
+            o2.end_long - o1.end_long;
+          if (diff == 0) {
+            return 0;
+          } else if (diff < 1) {
+            return -1;
+          }
+          return 1;
+      }
+      
+    }
+    
+    @Override
+    public int compareTo(final TimeRange o) {
+      return ComparisonChain.start()
+          .compare(executorId, o.executorId, Ordering.natural().nullsFirst())
+          .compare(start, o.start, Ordering.natural().nullsFirst())
+          .compare(end, o.end, Ordering.natural().nullsFirst())
+          .result();
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final TimeRange range = (TimeRange) o;
+      return Objects.equal(start, range.start)
+          && Objects.equal(end, range.end)
+          && Objects.equal(executorId, range.executorId);
+    }
+
+    @Override
+    public int hashCode() {
+      return buildHashCode().asInt();
+    }
+    
+    public HashCode buildHashCode() {
+      return Const.HASH_FUNCTION().newHasher()
+          .putString(Strings.nullToEmpty(start), Const.UTF8_CHARSET)
+          .putString(Strings.nullToEmpty(end), Const.UTF8_CHARSET)
+          .putString(executorId, Const.UTF8_CHARSET)
+          .hash();
+    }
+    
+    public static Builder newBuilder() {
+      return new Builder();
+    }
+    
+    public static class Builder {
+      @JsonProperty
+      private String start;
+      @JsonProperty
+      private String end;
+      @JsonProperty
+      private String executorId;
+      
+      /** @param start The start time. May be null or an absolute timestamp. */
+      public Builder setStart(final String start) {
+        this.start = start;
+        return this;
+      }
+      
+      /** @param end The end time. May be null or an absolute or relative timestamp. */
+      public Builder setEnd(final String end) {
+        this.end = end;
+        return this;
+      }
+      
+      /** param executorId The name of the downstream executor. */
+      public Builder setExecutorId(final String executorId) {
+        this.executorId = executorId;
+        return this;
+      }
+      
+      public TimeRange build() {
+        return new TimeRange(this);
+      }
+    }
+    
+  }
+}

--- a/core/src/test/java/net/opentsdb/data/iterators/IteratorTestUtils.java
+++ b/core/src/test/java/net/opentsdb/data/iterators/IteratorTestUtils.java
@@ -12,6 +12,9 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.data.iterators;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
 import org.junit.Ignore;
 
 import net.opentsdb.data.MillisecondTimeStamp;
@@ -19,7 +22,9 @@ import net.opentsdb.data.SimpleStringGroupId;
 import net.opentsdb.data.SimpleStringTimeSeriesId;
 import net.opentsdb.data.TimeSeriesGroupId;
 import net.opentsdb.data.TimeSeriesId;
+import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.types.numeric.NumericMillisecondShard;
+import net.opentsdb.data.types.numeric.NumericType;
 
 /**
  * A helper class with static utilities for working with iterators in unit
@@ -72,5 +77,86 @@ public class IteratorTestUtils {
     groups.addIterator(GROUP_B, shard.getShallowCopy(null));
     
     return groups;
+  }
+
+  @SuppressWarnings("unchecked")
+  public static void validateData(final IteratorGroups results, 
+                                  final long start, final long end,  
+                                  final int order, 
+                                  final long interval) {
+    assertEquals(4, results.flattenedIterators().size());
+    IteratorGroup group = results.group(IteratorTestUtils.GROUP_A);
+    assertEquals(2, group.flattenedIterators().size());
+    assertSame(IteratorTestUtils.ID_A, group.flattenedIterators().get(0).id());
+    assertSame(IteratorTestUtils.ID_B, group.flattenedIterators().get(1).id());
+    
+    TimeSeriesIterator<NumericType> iterator = 
+        (TimeSeriesIterator<NumericType>) group.flattenedIterators().get(0);
+    assertEquals(start, iterator.startTime().msEpoch());
+    assertEquals(end, iterator.endTime().msEpoch());
+    long ts = start;
+    int count = 0;
+    while (iterator.status() == IteratorStatus.HAS_DATA) {
+      TimeSeriesValue<NumericType> v = iterator.next();
+      assertEquals(ts, v.timestamp().msEpoch());
+      assertEquals(ts, v.value().longValue());
+      assertEquals(1, v.realCount());
+      ts += interval;
+      ++count;
+    }
+    assertEquals(((end - start) / interval) + 1, count);
+    
+    iterator = 
+        (TimeSeriesIterator<NumericType>) group.flattenedIterators().get(1);
+    assertEquals(start, iterator.startTime().msEpoch());
+    assertEquals(end, iterator.endTime().msEpoch());
+    ts = start;
+    count = 0;
+    while (iterator.status() == IteratorStatus.HAS_DATA) {
+      TimeSeriesValue<NumericType> v = iterator.next();
+      assertEquals(ts, v.timestamp().msEpoch());
+      assertEquals(ts, v.value().longValue());
+      assertEquals(1, v.realCount());
+      ts += interval;
+      ++count;
+    }
+    assertEquals(((end - start) / interval) + 1, count);
+    
+    group = results.group(IteratorTestUtils.GROUP_B);
+    assertEquals(2, group.flattenedIterators().size());
+    assertSame(IteratorTestUtils.ID_A, group.flattenedIterators().get(0).id());
+    assertSame(IteratorTestUtils.ID_B, group.flattenedIterators().get(1).id());
+    
+    iterator = 
+        (TimeSeriesIterator<NumericType>) group.flattenedIterators().get(0);
+    assertEquals(start, iterator.startTime().msEpoch());
+    assertEquals(end, iterator.endTime().msEpoch());
+    ts = start;
+    count = 0;
+    while (iterator.status() == IteratorStatus.HAS_DATA) {
+      TimeSeriesValue<NumericType> v = iterator.next();
+      assertEquals(ts, v.timestamp().msEpoch());
+      assertEquals(ts, v.value().longValue());
+      assertEquals(1, v.realCount());
+      ts += interval;
+      ++count;
+    }
+    assertEquals(((end - start) / interval) + 1, count);
+    
+    iterator = 
+        (TimeSeriesIterator<NumericType>) group.flattenedIterators().get(1);
+    assertEquals(start, iterator.startTime().msEpoch());
+    assertEquals(end, iterator.endTime().msEpoch());
+    ts = start;
+    count = 0;
+    while (iterator.status() == IteratorStatus.HAS_DATA) {
+      TimeSeriesValue<NumericType> v = iterator.next();
+      assertEquals(ts, v.timestamp().msEpoch());
+      assertEquals(ts, v.value().longValue());
+      assertEquals(1, v.realCount());
+      ts += interval;
+      ++count;
+    }
+    assertEquals(((end - start) / interval) + 1, count);
   }
 }

--- a/core/src/test/java/net/opentsdb/query/execution/TestTimeBasedRoutingExecutor.java
+++ b/core/src/test/java/net/opentsdb/query/execution/TestTimeBasedRoutingExecutor.java
@@ -1,0 +1,1105 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2017  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.query.execution;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.stumbleupon.async.Deferred;
+import com.stumbleupon.async.DeferredGroupException;
+import com.stumbleupon.async.TimeoutException;
+
+import io.opentracing.Span;
+import net.opentsdb.data.iterators.DefaultIteratorGroups;
+import net.opentsdb.data.iterators.IteratorGroups;
+import net.opentsdb.data.iterators.IteratorTestUtils;
+import net.opentsdb.exceptions.QueryExecutionCanceled;
+import net.opentsdb.query.context.QueryContext;
+import net.opentsdb.query.execution.TestQueryExecutor.MockDownstream;
+import net.opentsdb.query.execution.TimeBasedRoutingExecutor.Config;
+import net.opentsdb.query.execution.TimeBasedRoutingExecutor.TimeRange;
+import net.opentsdb.query.execution.graph.ExecutionGraphNode;
+import net.opentsdb.query.plan.IteratorGroupsSlicePlanner;
+import net.opentsdb.query.plan.QueryPlannnerFactory;
+import net.opentsdb.query.pojo.Metric;
+import net.opentsdb.query.pojo.TimeSeriesQuery;
+import net.opentsdb.query.pojo.Timespan;
+import net.opentsdb.utils.DateTime;
+import net.opentsdb.utils.JSON;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ DateTime.class, TimeBasedRoutingExecutor.class })
+public class TestTimeBasedRoutingExecutor extends BaseExecutorTest {
+  
+  private Map<String, QueryExecutor<IteratorGroups>> executors;
+  private Map<String, MockDownstream<IteratorGroups>> downstream_executions;
+  private List<TimeRange> ranges;
+  private Config config;
+  private Set<String> executor_ids;
+  private IteratorGroupsSlicePlanner planner;
+  private QueryPlannnerFactory<IteratorGroups> plan_factory;
+  
+  @SuppressWarnings("unchecked")
+  @Before
+  public void beforeLocal() throws Exception {
+    PowerMockito.mockStatic(DateTime.class);
+    PowerMockito.when(DateTime.isRelativeDate(anyString())).thenCallRealMethod();
+    PowerMockito.when(DateTime.parseDuration(anyString())).thenCallRealMethod();
+    PowerMockito.when(DateTime.parseDateTimeString(anyString(), anyString())).thenCallRealMethod();
+  
+    executor_ids = Sets.newHashSet("cache1", "cache2", "tsdb1", "tsdb2", "tsdb3");
+    node = mock(ExecutionGraphNode.class);
+    ranges = Lists.newArrayList(
+        TimeRange.newBuilder()
+          .setExecutorId("cache1")
+          .setEnd("24h-ago")
+          .build(),
+        TimeRange.newBuilder()
+          .setExecutorId("cache2")
+          .setEnd("48h-ago")
+          .build(),
+        TimeRange.newBuilder()
+          .setExecutorId("tsdb3")
+          .setEnd("2017/01/01-00:00:00")
+          .build(),
+        TimeRange.newBuilder()
+          .setExecutorId("tsdb2")
+          .setStart("2017/01/01-00:00:00")
+          .setEnd("2016/07/31-00:00:00")
+          .build(),
+        TimeRange.newBuilder()
+          .setExecutorId("tsdb1")
+          .setStart("2016/07/31-00:00:00")
+          .setEnd("2015/01/01-00:00:00")
+          .build());
+    config = (Config) Config.newBuilder()
+        .setTimes(ranges)
+        .setExecutorId("Router")
+        .setExecutorType("TimeBasedRoutingExecutor")
+        .build();
+    executors = Maps.newHashMap();
+    downstream_executions = Maps.newHashMap();
+    plan_factory = mock(QueryPlannnerFactory.class);
+        
+    when(tsdb.getConfig()).thenReturn(new net.opentsdb.utils.Config(false));
+    when(node.graph()).thenReturn(graph);
+    when(node.getDefaultConfig()).thenReturn(config);
+    when(graph.getDownstreamExecutor(anyString()))
+      .thenAnswer(new Answer<QueryExecutor<?>>() {
+      @Override
+      public QueryExecutor<?> answer(InvocationOnMock invocation)
+          throws Throwable {
+        final String executor_id = (String) invocation.getArguments()[0];
+        if (executor_ids.contains(executor_id)) {
+          final QueryExecutor<IteratorGroups> mock_executor = 
+              mock(QueryExecutor.class);
+          executors.put(executor_id, mock_executor);
+          
+          // nesting answers, woot!
+          when(mock_executor.executeQuery(any(QueryContext.class), 
+              any(TimeSeriesQuery.class), any(Span.class)))
+          .thenAnswer(new Answer<QueryExecution<?>>() {
+
+            @Override
+            public QueryExecution<?> answer(InvocationOnMock invocation) 
+                throws Throwable {
+              final TimeSeriesQuery q = (TimeSeriesQuery) invocation.getArguments()[1];
+              final MockDownstream<IteratorGroups> execution = 
+                  new MockDownstream<IteratorGroups>(q);
+              downstream_executions.put(executor_id, execution);
+              return execution;
+            }
+            
+          });
+          
+          when(mock_executor.close())
+            .thenReturn(Deferred.<Object>fromResult(null));
+          
+          return mock_executor;
+        }
+        return null;
+      }
+    });
+    when(registry.getQueryPlanner(anyString()))
+      .thenAnswer(new Answer<QueryPlannnerFactory<?>>() {
+      @Override
+      public QueryPlannnerFactory<?> answer(InvocationOnMock invocation)
+          throws Throwable {
+        return plan_factory;
+      }
+    });
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart("1483488000")
+            .setEnd("1483491600"))
+        .addMetric(Metric.newBuilder()
+            .setMetric("system.cpu.user"))
+        .build();
+    planner = spy(new IteratorGroupsSlicePlanner(query));
+    when(plan_factory.newPlanner(any(TimeSeriesQuery.class)))
+      .thenReturn(planner);
+  }
+  
+  @Test
+  public void ctor() throws Exception {
+    TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    assertEquals(5, executor.downstreamExecutors().size());
+    assertNotNull(executors.get("cache1"));
+    assertNotNull(executors.get("cache2"));
+    assertNotNull(executors.get("tsdb1"));
+    assertNotNull(executors.get("tsdb2"));
+    assertNotNull(executors.get("tsdb3"));
+    
+    try {
+      new TimeBasedRoutingExecutor<IteratorGroups>(null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    when(node.getDefaultConfig()).thenReturn(null);
+    try {
+      new TimeBasedRoutingExecutor<IteratorGroups>(node);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    ranges = Lists.newArrayList(
+        TimeRange.newBuilder()
+          .setExecutorId("cache4")
+          .setEnd("24h-ago")
+          .build(),
+        TimeRange.newBuilder()
+          .setExecutorId("cache5")
+          .setEnd("48h-ago")
+          .build());
+    config = (Config) Config.newBuilder()
+        .setTimes(ranges)
+        .setExecutorId("Router")
+        .setExecutorType("TimeBasedRoutingExecutor")
+        .build();
+    when(node.getDefaultConfig()).thenReturn(config);
+    
+    // same as query end time so start time falls within the first cache bucket
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+        
+    try {
+      new TimeBasedRoutingExecutor<IteratorGroups>(node);
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException e) { }
+  }
+  
+  @Test
+  public void executeCache1() throws Exception {
+    // same as query end time so start time falls within the first cache bucket
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(1, downstream_executions.size());
+    assertNotNull(downstream_executions.get("cache1"));
+    
+    final IteratorGroups data = 
+        IteratorTestUtils.generateData(1483488000000L, 1483491600000L, 0, 300000);
+    downstream_executions.get("cache1").callback(data);
+    final IteratorGroups results = exec.deferred().join(1);
+    IteratorTestUtils.validateData(results, 1483488000000L, 1483491600000L, 0, 300000);
+    assertFalse(executor.outstandingRequests().contains(exec));
+  }
+  
+  @Test
+  public void executeCache1EndOfInterval() throws Exception {
+    // start of query begins at tail of first bucket.
+    when(DateTime.currentTimeMillis()).thenReturn(1483405200000L);
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(1, downstream_executions.size());
+    assertNotNull(downstream_executions.get("cache1"));
+    
+    final IteratorGroups data = 
+        IteratorTestUtils.generateData(1483488000000L, 1483491600000L, 0, 300000);
+    downstream_executions.get("cache1").callback(data);
+    final IteratorGroups results = exec.deferred().join(1);
+    IteratorTestUtils.validateData(results, 1483488000000L, 1483491600000L, 0, 300000);
+    assertFalse(executor.outstandingRequests().contains(exec));
+  }
+  
+  @Test
+  public void executeCacheException() throws Exception {
+    // same as query end time so start time falls within the first cache bucket
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(1, downstream_executions.size());
+    assertNotNull(downstream_executions.get("cache1"));
+    
+    downstream_executions.get("cache1").callback(new IllegalStateException("Boo!"));
+    try {
+      exec.deferred().join(1);
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException e) { }
+    assertFalse(executor.outstandingRequests().contains(exec));
+  }
+  
+  @Test
+  public void executeCache2() throws Exception {
+    // the end of the query is at 24h-ago so it falls completely in bucket 2
+    when(DateTime.currentTimeMillis()).thenReturn(1483578000000L);
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(1, downstream_executions.size());
+    assertNotNull(downstream_executions.get("cache2"));
+    
+    final IteratorGroups data = 
+        IteratorTestUtils.generateData(1483488000000L, 1483491600000L, 0, 300000);
+    downstream_executions.get("cache2").callback(data);
+    final IteratorGroups results = exec.deferred().join(1);
+    IteratorTestUtils.validateData(results, 1483488000000L, 1483491600000L, 0, 300000);
+    assertFalse(executor.outstandingRequests().contains(exec));
+  }
+  
+  @Test
+  public void executeCache2SpansBuckets() throws Exception {
+    // start time is 25h-ago so it overlaps the first cache, meaning entirety
+    // is served from the second bucket.
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart("1483401600")
+            .setEnd("1483491600"))
+        .addMetric(Metric.newBuilder()
+            .setMetric("system.cpu.user"))
+        .build();
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(1, downstream_executions.size());
+    assertNotNull(downstream_executions.get("cache2"));
+    
+    final IteratorGroups data = 
+        IteratorTestUtils.generateData(1483488000000L, 1483491600000L, 0, 300000);
+    downstream_executions.get("cache2").callback(data);
+    final IteratorGroups results = exec.deferred().join(1);
+    IteratorTestUtils.validateData(results, 1483488000000L, 1483491600000L, 0, 300000);
+    assertFalse(executor.outstandingRequests().contains(exec));
+  }
+  
+  @Test
+  public void executeBeyondCache() throws Exception {
+    // end time is 48h ago so outside of the cache and only 1 hour so only hits
+    // one TSD.
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart("1483315200")
+            .setEnd("1483318800"))
+        .addMetric(Metric.newBuilder()
+            .setMetric("system.cpu.user"))
+        .build();
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(1, downstream_executions.size());
+    assertNotNull(downstream_executions.get("tsdb3"));
+    
+    final IteratorGroups data = 
+        IteratorTestUtils.generateData(1483488000000L, 1483491600000L, 0, 300000);
+    downstream_executions.get("tsdb3").callback(data);
+    final IteratorGroups results = exec.deferred().join(1);
+    IteratorTestUtils.validateData(results, 1483488000000L, 1483491600000L, 0, 300000);
+    assertFalse(executor.outstandingRequests().contains(exec));
+  }
+  
+  @Test
+  public void executeTsdb2() throws Exception {
+    // end time is Jan 1 of 17 so outside of the cache and tsdb3, only 1 hour 
+    // so only hits one TSD.
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart("1483225200")
+            .setEnd("1483228800"))
+        .addMetric(Metric.newBuilder()
+            .setMetric("system.cpu.user"))
+        .build();
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(1, downstream_executions.size());
+    assertNotNull(downstream_executions.get("tsdb2"));
+    
+    final IteratorGroups data = 
+        IteratorTestUtils.generateData(1483488000000L, 1483491600000L, 0, 300000);
+    downstream_executions.get("tsdb2").callback(data);
+    final IteratorGroups results = exec.deferred().join(1);
+    IteratorTestUtils.validateData(results, 1483488000000L, 1483491600000L, 0, 300000);
+    assertFalse(executor.outstandingRequests().contains(exec));
+  }
+  
+  @Test
+  public void executeTsd1() throws Exception {
+    // end time is July 4 of 16 so outside of the cache and tsdb3 and 2, only 1 hour 
+    // so only hits one TSD.
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart("1467586800")
+            .setEnd("1467590400"))
+        .addMetric(Metric.newBuilder()
+            .setMetric("system.cpu.user"))
+        .build();
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(1, downstream_executions.size());
+    assertNotNull(downstream_executions.get("tsdb1"));
+    
+    final IteratorGroups data = 
+        IteratorTestUtils.generateData(1483488000000L, 1483491600000L, 0, 300000);
+    downstream_executions.get("tsdb1").callback(data);
+    final IteratorGroups results = exec.deferred().join(1);
+    IteratorTestUtils.validateData(results, 1483488000000L, 1483491600000L, 0, 300000);
+    assertFalse(executor.outstandingRequests().contains(exec));
+  }
+  
+  @Test
+  public void executeBeyond1() throws Exception {
+    // end time is Dec 31 of 15 so outside of everything.
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart("1419980400")
+            .setEnd("1419984000"))
+        .addMetric(Metric.newBuilder()
+            .setMetric("system.cpu.user"))
+        .build();
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    
+    final IteratorGroups data = exec.deferred().join(1);
+    
+    assertTrue(data.flattenedIterators().isEmpty());
+    assertFalse(executor.outstandingRequests().contains(exec));
+    assertEquals(0, downstream_executions.size());
+  }
+  
+  @Test
+  public void executeSplit3and2() throws Exception {
+    // Dec 31st 2016 for the start time so it's outside of the cache 2 range
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart("1483146000")
+            .setEnd("1483491600"))
+        .addMetric(Metric.newBuilder()
+            .setMetric("system.cpu.user"))
+        .build();
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(2, downstream_executions.size());
+    assertNotNull(downstream_executions.get("tsdb3"));
+    assertNotNull(downstream_executions.get("tsdb2"));
+    
+    IteratorGroups data = 
+        IteratorTestUtils.generateData(1483318800000L, 1483491600000L, 0, 300000);
+    downstream_executions.get("tsdb3").callback(data);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    data = 
+        IteratorTestUtils.generateData(1483146000000L, 1483318800000L, 0, 300000);
+    downstream_executions.get("tsdb2").callback(data);
+    
+    final IteratorGroups results = exec.deferred().join(1);
+    IteratorTestUtils.validateData(results, 1483146000000L, 1483491600000L, 0, 300000);
+    assertFalse(executor.outstandingRequests().contains(exec));
+  }
+  
+  @Test
+  public void executeSplit321() throws Exception {
+    // Dec 31st 2014 for the start time so it encompasses all tsds
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart("1419984000")
+            .setEnd("1483491600"))
+        .addMetric(Metric.newBuilder()
+            .setMetric("system.cpu.user"))
+        .build();
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(3, downstream_executions.size());
+    assertNotNull(downstream_executions.get("tsdb3"));
+    assertNotNull(downstream_executions.get("tsdb2"));
+    assertNotNull(downstream_executions.get("tsdb1"));
+    
+    IteratorGroups data = 
+        IteratorTestUtils.generateData(1483318800000L, 1483491600000L, 0, 300000);
+    downstream_executions.get("tsdb3").callback(data);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    data = 
+        IteratorTestUtils.generateData(1483146000000L, 1483318800000L, 0, 300000);
+    downstream_executions.get("tsdb2").callback(data);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    data = 
+        IteratorTestUtils.generateData(1483059600000L, 1483146000000L, 0, 300000);
+    downstream_executions.get("tsdb1").callback(data);
+    
+    final IteratorGroups results = exec.deferred().join(1);
+    IteratorTestUtils.validateData(results, 1483059600000L, 1483491600000L, 0, 300000);
+    assertFalse(executor.outstandingRequests().contains(exec));
+  }
+  
+  @Test
+  public void executeSplit321EmptyMiddle() throws Exception {
+    // Dec 31st 2014 for the start time so it encompasses all tsds
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart("1419984000")
+            .setEnd("1483491600"))
+        .addMetric(Metric.newBuilder()
+            .setMetric("system.cpu.user"))
+        .build();
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(3, downstream_executions.size());
+    assertNotNull(downstream_executions.get("tsdb3"));
+    assertNotNull(downstream_executions.get("tsdb2"));
+    assertNotNull(downstream_executions.get("tsdb1"));
+    
+    IteratorGroups data = 
+        IteratorTestUtils.generateData(1483318800000L, 1483491600000L, 0, 300000);
+    downstream_executions.get("tsdb3").callback(data);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    downstream_executions.get("tsdb2").callback(new DefaultIteratorGroups());
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    data = 
+        IteratorTestUtils.generateData(1483059600000L, 1483146000000L, 0, 300000);
+    downstream_executions.get("tsdb1").callback(data);
+    
+    final IteratorGroups results = exec.deferred().join(1);
+    assertEquals(4, results.flattenedIterators().size());
+    // TODO - maybe verify the gap, otherwise we should be ok.
+    assertFalse(executor.outstandingRequests().contains(exec));
+  }
+  
+  @Test
+  public void executeSplitException() throws Exception {
+    // Dec 31st 2016 for the start time so it's outside of the cache 2 range
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart("1483146000")
+            .setEnd("1483491600"))
+        .addMetric(Metric.newBuilder()
+            .setMetric("system.cpu.user"))
+        .build();
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(2, downstream_executions.size());
+    assertNotNull(downstream_executions.get("tsdb3"));
+    assertNotNull(downstream_executions.get("tsdb2"));
+    
+    downstream_executions.get("tsdb3").callback(new IllegalStateException("Boo!"));
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    final IteratorGroups data = 
+        IteratorTestUtils.generateData(1483146000000L, 1483318800000L, 0, 300000);
+    downstream_executions.get("tsdb2").callback(data);
+    
+    try {
+      exec.deferred().join(1);
+      fail("Expected DeferredGroupException");
+    } catch (DeferredGroupException e) {
+      assertTrue(e.getCause() instanceof IllegalStateException);
+    }
+  }
+  
+  @Test
+  public void executeThrowsException() throws Exception {
+    // same as query end time so start time falls within the first cache bucket
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    executors.put("cache1", mock(QueryExecutor.class));
+    
+    when(graph.getDownstreamExecutor(anyString()))
+      .thenAnswer(new Answer<QueryExecutor<?>>() {
+      @Override
+      public QueryExecutor<?> answer(InvocationOnMock invocation)
+          throws Throwable {
+        return executors.get("cache1");
+      }
+    });
+    when(executors.get("cache1").executeQuery(any(QueryContext.class), 
+        any(TimeSeriesQuery.class), any(Span.class)))
+      .thenThrow(new IllegalStateException("Boo!"));
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException e) { }
+    assertFalse(executor.outstandingRequests().contains(exec));
+  }
+  
+  @Test
+  public void executeMergeException() throws Exception {
+    when(planner.mergeSlicedResults(anyList()))
+      .thenThrow(new IllegalArgumentException("Boo!"));
+    
+    // Dec 31st 2016 for the start time so it's outside of the cache 2 range
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart("1483146000")
+            .setEnd("1483491600"))
+        .addMetric(Metric.newBuilder()
+            .setMetric("system.cpu.user"))
+        .build();
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(2, downstream_executions.size());
+    assertNotNull(downstream_executions.get("tsdb3"));
+    assertNotNull(downstream_executions.get("tsdb2"));
+    
+    IteratorGroups data = 
+        IteratorTestUtils.generateData(1483318800000L, 1483491600000L, 0, 300000);
+    downstream_executions.get("tsdb3").callback(data);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    data = 
+        IteratorTestUtils.generateData(1483146000000L, 1483318800000L, 0, 300000);
+    downstream_executions.get("tsdb2").callback(data);
+    
+    try {
+      exec.deferred().join(1);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    assertFalse(executor.outstandingRequests().contains(exec));
+  }
+  
+  @Test
+  public void executeCancelSingle() throws Exception {
+    // same as query end time so start time falls within the first cache bucket
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(1, downstream_executions.size());
+    assertNotNull(downstream_executions.get("cache1"));
+    
+    exec.cancel();
+    
+    try {
+      exec.deferred().join(1);
+      fail("Expected QueryExecutionCanceled");
+    } catch (QueryExecutionCanceled e) { }
+    assertFalse(executor.outstandingRequests().contains(exec));
+    assertTrue(downstream_executions.get("cache1").cancelled);
+  }
+  
+  @Test
+  public void executeCancelMulti() throws Exception {
+    // Dec 31st 2014 for the start time so it encompasses all tsds
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart("1419984000")
+            .setEnd("1483491600"))
+        .addMetric(Metric.newBuilder()
+            .setMetric("system.cpu.user"))
+        .build();
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(3, downstream_executions.size());
+    assertNotNull(downstream_executions.get("tsdb3"));
+    assertNotNull(downstream_executions.get("tsdb2"));
+    assertNotNull(downstream_executions.get("tsdb1"));
+    
+    IteratorGroups data = 
+        IteratorTestUtils.generateData(1483318800000L, 1483491600000L, 0, 300000);
+    downstream_executions.get("tsdb3").callback(data);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    exec.cancel();
+    try {
+      exec.deferred().join(1);
+      fail("Expected QueryExecutionCanceled");
+    } catch (QueryExecutionCanceled e) { }
+    assertFalse(executor.outstandingRequests().contains(exec));
+    assertTrue(downstream_executions.get("tsdb3").cancelled); // called anyway
+    assertTrue(downstream_executions.get("tsdb2").cancelled);
+    assertTrue(downstream_executions.get("tsdb1").cancelled);
+  }
+
+  @Test
+  public void executeClose() throws Exception {
+    // same as query end time so start time falls within the first cache bucket
+    when(DateTime.currentTimeMillis()).thenReturn(1483491600000L);
+    
+    final TimeBasedRoutingExecutor<IteratorGroups> executor =
+        new TimeBasedRoutingExecutor<IteratorGroups>(node);
+    final QueryExecution<IteratorGroups> exec = 
+        executor.executeQuery(context, query, span);
+    try {
+      exec.deferred().join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertTrue(executor.outstandingRequests().contains(exec));
+    assertEquals(1, downstream_executions.size());
+    assertNotNull(downstream_executions.get("cache1"));
+    
+    executor.close().join();
+    
+    try {
+      exec.deferred().join(1);
+      fail("Expected QueryExecutionCanceled");
+    } catch (QueryExecutionCanceled e) { }
+    assertFalse(executor.outstandingRequests().contains(exec));
+    assertTrue(downstream_executions.get("cache1").cancelled);
+  }
+
+  @Test
+  public void builder() throws Exception {
+    String json = JSON.serializeToString(config);
+    assertTrue(json.contains("\"executorType\":\"TimeBasedRoutingExecutor\""));
+    assertTrue(json.contains("\"executorId\":\"Router\""));
+    assertTrue(json.contains("\"plannerId\":\"IteratorGroupsSlicePlanner\""));
+    assertTrue(json.contains("\"end\":\"24h-ago\""));
+    assertTrue(json.contains("\"executorId\":\"cache1\""));
+    assertTrue(json.contains("\"end\":\"48h-ago\""));
+    assertTrue(json.contains("\"executorId\":\"cache2\""));
+    assertTrue(json.contains("\"end\":\"2017/01/01-00:00:00\""));
+    assertTrue(json.contains("\"executorId\":\"tsdb3\""));
+    assertTrue(json.contains("\"start\":\"2017/01/01-00:00:00\""));
+    assertTrue(json.contains("\"end\":\"2016/07/31-00:00:00\""));
+    assertTrue(json.contains("\"executorId\":\"tsdb2\""));
+    assertTrue(json.contains("\"start\":\"2016/07/31-00:00:00\""));
+    assertTrue(json.contains("\"end\":\"2015/01/01-00:00:00\""));
+    assertTrue(json.contains("\"executorId\":\"tsdb1\""));
+    
+    json = "{\"executorType\":\"TimeBasedRoutingExecutor\",\"times\":[{\"end\":"
+        + "\"2017/01/01-00:00:00\",\"executorId\":\"tsdb3\"},{\"start\":"
+        + "\"2017/01/01-00:00:00\",\"end\":\"2016/07/31-00:00:00\","
+        + "\"executorId\":\"tsdb2\"},{\"start\":\"2016/07/31-00:00:00\","
+        + "\"end\":\"2015/01/01-00:00:00\",\"executorId\":\"tsdb1\"},{\"end\":"
+        + "\"24h-ago\",\"executorId\":\"cache1\"},{\"end\":\"48h-ago\","
+        + "\"executorId\":\"cache2\"}],\"plannerId\":"
+        + "\"IteratorGroupsSlicePlanner\",\"executorId\":\"Router\"}";
+    config = JSON.parseToObject(json, Config.class);
+    assertEquals("TimeBasedRoutingExecutor", config.executorType());
+    assertEquals("Router", config.getExecutorId());
+    assertEquals("IteratorGroupsSlicePlanner", config.getPlannerId());
+    assertEquals(5, config.getTimes().size());
+    
+    assertNull(config.getTimes().get(0).getStart());
+    assertEquals("2017/01/01-00:00:00", config.getTimes().get(0).getEnd());
+    assertEquals("tsdb3", config.getTimes().get(0).getExecutorId());
+    assertEquals("2017/01/01-00:00:00", config.getTimes().get(1).getStart());
+    assertEquals("2016/07/31-00:00:00", config.getTimes().get(1).getEnd());
+    assertEquals("tsdb2", config.getTimes().get(1).getExecutorId());
+    assertEquals("2016/07/31-00:00:00", config.getTimes().get(2).getStart());
+    assertEquals("2015/01/01-00:00:00", config.getTimes().get(2).getEnd());
+    assertEquals("tsdb1", config.getTimes().get(2).getExecutorId());
+    assertNull(config.getTimes().get(3).getStart());
+    assertEquals("24h-ago", config.getTimes().get(3).getEnd());
+    assertEquals("cache1", config.getTimes().get(3).getExecutorId());
+    assertNull(config.getTimes().get(4).getStart());
+    assertEquals("48h-ago", config.getTimes().get(4).getEnd());
+    assertEquals("cache2", config.getTimes().get(4).getExecutorId());
+    
+    try {
+      TimeRange.newBuilder().build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      TimeRange.newBuilder()
+        .setStart("1y-ago")
+        .setEnd("1d-ago")
+        .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      TimeRange.newBuilder()
+        .setStart("blarg")
+        .setEnd("2015/01/01-00:00:00")
+        .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      Config.newBuilder()
+        .setExecutorId("Router")
+        .setExecutorType("TimeBasedRoutingExecutor")
+        .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void hashCodeEqualsCompareTo() throws Exception {
+    final Config c1 = (Config) Config.newBuilder()
+        .setTimes(Lists.newArrayList(TimeRange.newBuilder()
+            .setExecutorId("cache2")
+            .setEnd("48h-ago")
+            .build(),
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb3")
+            .setEnd("2017/01/01-00:00:00")
+            .build(),
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb2")
+            .setStart("2017/01/01-00:00:00")
+            .setEnd("2016/07/31-00:00:00")
+            .build()))
+        .setPlannerId("plannerA")
+        .setExecutorId("Router")
+        .setExecutorType("TimeBasedRoutingExecutor")
+        .build();
+    
+    Config c2 = (Config) Config.newBuilder()
+        .setTimes(Lists.newArrayList(TimeRange.newBuilder()
+            .setExecutorId("cache2")
+            .setEnd("48h-ago")
+            .build(),
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb3")
+            .setEnd("2017/01/01-00:00:00")
+            .build(),
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb2")
+            .setStart("2017/01/01-00:00:00")
+            .setEnd("2016/07/31-00:00:00")
+            .build()))
+        .setPlannerId("plannerA")
+        .setExecutorId("Router")
+        .setExecutorType("TimeBasedRoutingExecutor")
+        .build();
+    assertEquals(c1.hashCode(), c2.hashCode());
+    assertEquals(c1, c2);
+    assertEquals(0, c1.compareTo(c2));
+    
+    c2 = (Config) Config.newBuilder()
+        .setTimes(Lists.newArrayList(TimeRange.newBuilder()
+            .setExecutorId("cache4")  // <-- diff
+            .setEnd("48h-ago")
+            .build(),
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb3")
+            .setEnd("2017/01/01-00:00:00")
+            .build(),
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb2")
+            .setStart("2017/01/01-00:00:00")
+            .setEnd("2016/07/31-00:00:00")
+            .build()))
+        .setPlannerId("plannerA")
+        .setExecutorId("Router")
+        .setExecutorType("TimeBasedRoutingExecutor")
+        .build();
+    assertNotEquals(c1.hashCode(), c2.hashCode());
+    assertNotEquals(c1, c2);
+    assertEquals(-1, c1.compareTo(c2));
+    
+    c2 = (Config) Config.newBuilder()
+        .setTimes(Lists.newArrayList(TimeRange.newBuilder()
+            .setExecutorId("cache2")
+            .setEnd("46h-ago") // <-- diff
+            .build(),
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb3")
+            .setEnd("2017/01/01-00:00:00")
+            .build(),
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb2")
+            .setStart("2017/01/01-00:00:00")
+            .setEnd("2016/07/31-00:00:00")
+            .build()))
+        .setPlannerId("plannerA")
+        .setExecutorId("Router")
+        .setExecutorType("TimeBasedRoutingExecutor")
+        .build();
+    assertNotEquals(c1.hashCode(), c2.hashCode());
+    assertNotEquals(c1, c2);
+    assertEquals(1, c1.compareTo(c2));
+    
+    c2 = (Config) Config.newBuilder()
+        .setTimes(Lists.newArrayList(
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb3")
+            .setEnd("2017/01/01-00:00:00")
+            .build(),
+         TimeRange.newBuilder()  // <-- Diff ORDER is OK!!
+            .setExecutorId("cache2")
+            .setEnd("48h-ago")
+            .build(),
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb2")
+            .setStart("2017/01/01-00:00:00")
+            .setEnd("2016/07/31-00:00:00")
+            .build()))
+        .setPlannerId("plannerA")
+        .setExecutorId("Router")
+        .setExecutorType("TimeBasedRoutingExecutor")
+        .build();
+    assertEquals(c1.hashCode(), c2.hashCode());
+    assertEquals(c1, c2);
+    assertEquals(0, c1.compareTo(c2));
+    
+    c2 = (Config) Config.newBuilder()
+        .setTimes(Lists.newArrayList(TimeRange.newBuilder()
+            .setExecutorId("cache2")
+            .setEnd("48h-ago")
+            .build(),
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb3")
+            .setEnd("2017/01/01-00:00:00")
+            .build(),
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb2")
+            .setStart("2017/01/01-00:00:00")
+            .setEnd("2016/07/31-00:00:00")
+            .build()))
+        .setPlannerId("plannerB") // <-- Diff
+        .setExecutorId("Router")
+        .setExecutorType("TimeBasedRoutingExecutor")
+        .build();
+    assertNotEquals(c1.hashCode(), c2.hashCode());
+    assertNotEquals(c1, c2);
+    assertEquals(-1, c1.compareTo(c2));
+    
+    c2 = (Config) Config.newBuilder()
+        .setTimes(Lists.newArrayList(TimeRange.newBuilder()
+            .setExecutorId("cache2")
+            .setEnd("48h-ago")
+            .build(),
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb3")
+            .setEnd("2017/01/01-00:00:00")
+            .build(),
+          TimeRange.newBuilder()
+            .setExecutorId("tsdb2")
+            .setStart("2017/01/01-00:00:00")
+            .setEnd("2016/07/31-00:00:00")
+            .build()))
+        .setPlannerId("plannerA")
+        .setExecutorId("Nothername") // <-- Diff
+        .setExecutorType("TimeBasedRoutingExecutor")
+        .build();
+    assertNotEquals(c1.hashCode(), c2.hashCode());
+    assertNotEquals(c1, c2);
+    assertEquals(1, c1.compareTo(c2));
+  }
+}


### PR DESCRIPTION
router that allows TSDB to query a cache (e.g. Facebook's Beringei)
for short-term data or fall back to long-term storage (HBase) at
query time.