### PR TITLE
HighestCurrent may return wrong result

### DIFF
--- a/src/query/expression/HighestCurrent.java
+++ b/src/query/expression/HighestCurrent.java
@@ -92,10 +92,14 @@ public class HighestCurrent implements Expression {
               MutableDataPoint.ofLongValue(point.timestamp(), point.longValue())
             : MutableDataPoint.ofDoubleValue(point.timestamp(), point.doubleValue()));
         }
-        post_agg_results[ix++] = new PostAggregatedDataPoints(dps,
-                mutable_points.toArray(new DataPoint[mutable_points.size()]));
+        // Because of AggregationIterator.hasNextValue() will skip empty item.
+        if (mutable_points.size() > 0) {
+            post_agg_results[ix++] = new PostAggregatedDataPoints(dps,
+                    mutable_points.toArray(new DataPoint[mutable_points.size()]));
+        }
       }
     }
+    num_results = ix;
     
     final SeekableView[] views = new SeekableView[num_results];
     for (int i = 0; i < num_results; i++) {


### PR DESCRIPTION
Because of DataPoints maybe empty and AggregationIterator.hasNextValue() will skip empty item.