### PR TITLE
Adding QueryLimitOverride to the list of build files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -104,6 +104,7 @@ tsdb_SRC := \
 	src/meta/TSUIDQuery.java	\
 	src/meta/UIDMeta.java	\
 	src/query/QueryUtil.java	\
+	src/query/QueryLimitOverride.java	\
 	src/query/expression/Absolute.java	\
 	src/query/expression/Alias.java	\
 	src/query/expression/DiffSeries.java	\


### PR DESCRIPTION
### Change:
QueryLimitOverride.java seems to be missed out from the Makefile, causing the build to fail.

### Test:
 - Created an rpm package