### PR TITLE
Report epoch queryStart time for running queries

### DIFF
--- a/src/stats/QueryStats.java
+++ b/src/stats/QueryStats.java
@@ -411,7 +411,7 @@ public class QueryStats {
         obj.put("remote", stats.remote_address);
         obj.put("user", stats.user);
         obj.put("headers", stats.headers);;
-        obj.put("queryStart", DateTime.msFromNano(stats.query_start_ns));
+        obj.put("queryStart", stats.query_start_ms);
         obj.put("elapsed", DateTime.msFromNanoDiff(DateTime.nanoTime(), 
             stats.query_start_ns));
         running.add(obj);


### PR DESCRIPTION
The query start time returned for running queries from the opentsdb stats api are not wall clock time and do not correspond to the start times reported for completed queries at the same stats endpoint.

The problem is that OpenTSDB converts `query_start_ns` to milliseconds and returns that value as the `queryStart` value for running queries: <https://github.com/OpenTSDB/opentsdb/blob/v2.3.0/src/stats/QueryStats.java#L414>.

Internally OpenTSDB tracks query stats using a `QueryStats` class, which has internal variables
for both `query_start_ns` and `query_start_ms`. 

`query_start_ns` is initialized here: <https://github.com/OpenTSDB/opentsdb/blob/v2.3.0/src/stats/QueryStats.java#L250>
using a wrapped call to `System.nanoTime` found here: <https://github.com/OpenTSDB/opentsdb/blob/v2.3.0/src/utils/DateTime.java#L302>.

Based on this StackOverflow answer <https://stackoverflow.com/a/32444139> and confirmed in the
javadocs <https://docs.oracle.com/javase/7/docs/api/java/lang/System.html#nanoTime()> it is not possible to use `nanoTime` to measure wall clock time: "This method can only be used to measure elapsed time and is not related to any other notion of system or wall-clock time."

As such, anything referencing `query_start_ns` outside of the context of diffing with other nanoTime values will be inaccurate.

The solution is simply to return the `query_start_ms` value for running queries.