### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/configuration/Configuration.java
+++ b/common/src/main/java/net/opentsdb/configuration/Configuration.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -41,10 +42,13 @@ import net.opentsdb.configuration.provider.EnvironmentProvider;
 import net.opentsdb.configuration.provider.ProtocolProviderFactory;
 import net.opentsdb.configuration.provider.Provider;
 import net.opentsdb.configuration.provider.ProviderFactory;
+import net.opentsdb.configuration.provider.RuntimeOverrideProvider;
+import net.opentsdb.configuration.provider.RuntimeOverrideProvider.RuntimeOverride;
 import net.opentsdb.configuration.provider.SystemPropertiesProvider;
 import net.opentsdb.utils.ArgP;
 import net.opentsdb.utils.PluginLoader;
 import net.opentsdb.utils.StringUtils;
+import net.opentsdb.utils.Threads;
 
 /**
  * A configuration framework that provides overriding and flattening of
@@ -241,14 +245,14 @@ public class Configuration implements Closeable {
 
   /**
    * Helper to register a schema builder. 
-   * See {@link #registerSchema(ConfigurationEntrySchema)}
+   * See {@link #register(ConfigurationEntrySchema)}
    * @param builder A non-null builder.
    */
-  public void registerSchema(final ConfigurationEntrySchema.Builder builder) {
+  public void register(final ConfigurationEntrySchema.Builder builder) {
     if (builder == null) {
       throw new IllegalArgumentException("Builder cannot be null.");
     }
-    registerSchema(builder.build());
+    register(builder.build());
   }
   
   /**
@@ -264,7 +268,7 @@ public class Configuration implements Closeable {
    * @throws IllegalArgumentException if the given schema was null.
    * @throws ConfigurationException if the schema was already registered.
    */
-  public void registerSchema(final ConfigurationEntrySchema schema) {
+  public void register(final ConfigurationEntrySchema schema) {
     if (schema == null) {
       throw new IllegalArgumentException("Schema cannot be null.");
     }
@@ -292,6 +296,197 @@ public class Configuration implements Closeable {
   }
 
   /**
+   * Registers a configuration schema with the type {@link String} with
+   * the source set to the class name of the caller and the schema
+   * marked as nullable.
+   * 
+   * @param key A non-null and non-empty key.
+   * @param default_value A default value, may be null.
+   * @param is_dynamic Whether or not the value can be overridden.
+   * @param description A non-null and non-empty description.
+   * @throws IllegalArgumentException if the key or description was 
+   * null or empty.
+   * @throws ConfigurationException if the key was already registered. 
+   */
+  public void register(final String key, 
+                       final String default_value, 
+                       final boolean is_dynamic,
+                       final String description) {
+    if (Strings.isNullOrEmpty(key)) {
+      throw new IllegalArgumentException("Key cannot be null or empty.");
+    }
+    if (Strings.isNullOrEmpty(description)) {
+      throw new IllegalArgumentException("Description cannot be null or "
+          + "empty. Help the users!");
+    }
+    final ConfigurationEntrySchema.Builder builder = 
+        ConfigurationEntrySchema.newBuilder()
+        .setKey(key)
+        .setDefaultValue(default_value)
+        .setType(String.class)
+        .setSource(Threads.getCallerCallerClassName())
+        .isNullable()
+        .setDescription(description);
+    if (is_dynamic) {
+      builder.isDynamic();
+    }
+    
+    register(builder.build());
+  }
+  
+  /**
+   * Registers a configuration schema with the type {@link int} with
+   * the source set to the class name of the caller and the schema
+   * marked as not-nullable.
+   * 
+   * @param key A non-null and non-empty key.
+   * @param default_value A default value.
+   * @param is_dynamic Whether or not the value can be overridden.
+   * @param description A non-null and non-empty description.
+   * @throws IllegalArgumentException if the key or description was 
+   * null or empty.
+   * @throws ConfigurationException if the key was already registered. 
+   */
+  public void register(final String key, 
+                       final int default_value, 
+                       final boolean is_dynamic,
+                       final String description) {
+    if (Strings.isNullOrEmpty(key)) {
+      throw new IllegalArgumentException("Key cannot be null or empty.");
+    }
+    if (Strings.isNullOrEmpty(description)) {
+      throw new IllegalArgumentException("Description cannot be null or "
+          + "empty. Help the users!");
+    }
+    final ConfigurationEntrySchema.Builder builder = 
+        ConfigurationEntrySchema.newBuilder()
+        .setKey(key)
+        .setDefaultValue(default_value)
+        .setType(int.class)
+        .setSource(Threads.getCallerCallerClassName())
+        .setDescription(description);
+    if (is_dynamic) {
+      builder.isDynamic();
+    }
+    
+    register(builder.build());
+  }
+  
+  /**
+   * Registers a configuration schema with the type {@link long} with
+   * the source set to the class name of the caller and the schema
+   * marked as not-nullable.
+   * 
+   * @param key A non-null and non-empty key.
+   * @param default_value A default value.
+   * @param is_dynamic Whether or not the value can be overridden.
+   * @param description A non-null and non-empty description.
+   * @throws IllegalArgumentException if the key or description was 
+   * null or empty.
+   * @throws ConfigurationException if the key was already registered. 
+   */
+  public void register(final String key, 
+                       final long default_value, 
+                       final boolean is_dynamic,
+                       final String description) {
+    if (Strings.isNullOrEmpty(key)) {
+      throw new IllegalArgumentException("Key cannot be null or empty.");
+    }
+    if (Strings.isNullOrEmpty(description)) {
+      throw new IllegalArgumentException("Description cannot be null or "
+          + "empty. Help the users!");
+    }
+    final ConfigurationEntrySchema.Builder builder = 
+        ConfigurationEntrySchema.newBuilder()
+        .setKey(key)
+        .setDefaultValue(default_value)
+        .setType(long.class)
+        .setSource(Threads.getCallerCallerClassName())
+        .setDescription(description);
+    if (is_dynamic) {
+      builder.isDynamic();
+    }
+    
+    register(builder.build());
+  }
+  
+  /**
+   * Registers a configuration schema with the type {@link double} with
+   * the source set to the class name of the caller and the schema
+   * marked as not-nullable.
+   * 
+   * @param key A non-null and non-empty key.
+   * @param default_value A default value.
+   * @param is_dynamic Whether or not the value can be overridden.
+   * @param description A non-null and non-empty description.
+   * @throws IllegalArgumentException if the key or description was 
+   * null or empty.
+   * @throws ConfigurationException if the key was already registered. 
+   */
+  public void register(final String key, 
+                       final double default_value, 
+                       final boolean is_dynamic,
+                       final String description) {
+    if (Strings.isNullOrEmpty(key)) {
+      throw new IllegalArgumentException("Key cannot be null or empty.");
+    }
+    if (Strings.isNullOrEmpty(description)) {
+      throw new IllegalArgumentException("Description cannot be null or "
+          + "empty. Help the users!");
+    }
+    final ConfigurationEntrySchema.Builder builder = 
+        ConfigurationEntrySchema.newBuilder()
+        .setKey(key)
+        .setDefaultValue(default_value)
+        .setType(double.class)
+        .setSource(Threads.getCallerCallerClassName())
+        .setDescription(description);
+    if (is_dynamic) {
+      builder.isDynamic();
+    }
+    
+    register(builder.build());
+  }
+  
+  /**
+   * Registers a configuration schema with the type {@link boolean} with
+   * the source set to the class name of the caller and the schema
+   * marked as not-nullable.
+   * 
+   * @param key A non-null and non-empty key.
+   * @param default_value A default value.
+   * @param is_dynamic Whether or not the value can be overridden.
+   * @param description A non-null and non-empty description.
+   * @throws IllegalArgumentException if the key or description was 
+   * null or empty.
+   * @throws ConfigurationException if the key was already registered. 
+   */
+  public void register(final String key, 
+                       final boolean default_value, 
+                       final boolean is_dynamic,
+                       final String description) {
+    if (Strings.isNullOrEmpty(key)) {
+      throw new IllegalArgumentException("Key cannot be null or empty.");
+    }
+    if (Strings.isNullOrEmpty(description)) {
+      throw new IllegalArgumentException("Description cannot be null or "
+          + "empty. Help the users!");
+    }
+    final ConfigurationEntrySchema.Builder builder = 
+        ConfigurationEntrySchema.newBuilder()
+        .setKey(key)
+        .setDefaultValue(default_value)
+        .setType(boolean.class)
+        .setSource(Threads.getCallerCallerClassName())
+        .setDescription(description);
+    if (is_dynamic) {
+      builder.isDynamic();
+    }
+    
+    register(builder.build());
+  }
+  
+  /**
    * Helper to register an override builder. See 
    * {@link #addOverride(String, ConfigurationOverride)}.
    * 
@@ -314,6 +509,9 @@ public class Configuration implements Closeable {
    * or not the override passed validation or failed. On failure, the
    * override is NOT saved in the config. See 
    * {@link ValidationResult#isValid()}.
+   * <b>Note:</b> This should only be used by {@link Provider} 
+   * implementations on reloads. For runtime overrides, use 
+   * {@link #addOverride(String, Object)}.
    * 
    * @param key A non-null and non-empty key.
    * @param override A non-null setting.
@@ -337,6 +535,35 @@ public class Configuration implements Closeable {
           + "storing a schema.");
     }
     return entry.addOverride(override);
+  }
+  
+  /**
+   * Registers an override with the config as a {@link RuntimeOverrideProvider#SOURCE}.
+   * The response includes whether or not the override passed validation 
+   * or failed. On failure, the override is NOT saved in the config. See 
+   * {@link ValidationResult#isValid()}.
+   * 
+   * @param key A non-null and non-empty key.
+   * @param value The override. May be null when appropriate.
+   * IllegalArgumentException if the key was null or empty, or
+   * the setting was null.
+   * @throws ConfigurationException if no schema was present for the 
+   * given key.
+   */
+  public ValidationResult addOverride(final String key, 
+                                      final Object value) {
+    if (Strings.isNullOrEmpty(key)) {
+      throw new IllegalArgumentException("Key cannot be null or empty.");
+    }
+    final ConfigurationEntry entry = merged_config.get(key);
+    if (entry == null) {
+      throw new ConfigurationException("Cannot store a override before "
+          + "storing a schema.");
+    }
+    return entry.addOverride(ConfigurationOverride.newBuilder()
+        .setSource(RuntimeOverrideProvider.SOURCE)
+        .setValue(value)
+        .build());
   }
   
   /**
@@ -585,7 +812,7 @@ public class Configuration implements Closeable {
    * to read methods would throw an exception.
    * @throws IllegalArgumentException if the key was null or empty.
    */
-  public boolean hasKey(final String key) {
+  public boolean hasProperty(final String key) {
     if (Strings.isNullOrEmpty(key)) {
       throw new IllegalArgumentException("Key cannot be null or empty.");
     }
@@ -892,7 +1119,7 @@ public class Configuration implements Closeable {
         
       } else {
         if (CommandLine.class.getName().endsWith(source)) {
-          // this is the only outlier as it needs the cli args.
+          // this is an outlier as it needs the cli args.
           providers.add(new CommandLineProvider(new CommandLine(), 
                                                 this, 
                                                 timer, 
@@ -901,7 +1128,25 @@ public class Configuration implements Closeable {
           if (LOG.isDebugEnabled()) {
             LOG.debug("Instantiated the [CommandLine] provider.");
           }
-        } else {
+        } else if (RuntimeOverride.class.getName().endsWith(source)) {
+          // another outlier as unit tests that use Mockito or PowerMockito
+          // may fail as it will prevent the implementations from loading
+          // properly. Here we force instantiation.
+          providers.add(new RuntimeOverrideProvider(new CommandLine(), 
+                                                    this, 
+                                                    timer, 
+                                                    reload_keys));
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Instantiated the [CommandLine] provider.");
+          }
+        } else if (source.equals("UnitTest")) {
+          // another outlier for unit tests.
+          providers.add(new UnitTestConfiguration.UnitTest()
+              .newInstance(this, timer, reload_keys));
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Instantiated the [UnitTest] provider.");
+          }
+        } else if (factories != null && !factories.isEmpty()) {
           boolean matched = false;
           // plugin source so find the plugin
           for (final ProviderFactory factory : factories) {
@@ -927,6 +1172,9 @@ public class Configuration implements Closeable {
             throw new ConfigurationException("Unable to find a plugin "
                 + "factory for source: " + source);
           }
+        } else {
+          throw new ConfigurationException("Unable to find a plugin "
+              + "factory for source: " + source);
         }
       }
     }
@@ -949,7 +1197,7 @@ public class Configuration implements Closeable {
         .setDescription("How often to refresh reloadable configuration "
             + "providers in seconds.")
         .build();
-    registerSchema(schema);
+    register(schema);
     
     // start reloads for providers so configured.
     final long reload_interval = getTyped(CONFIG_RELOAD_INTERVAL_KEY, long.class);
@@ -978,19 +1226,33 @@ public class Configuration implements Closeable {
     }
   }
   
+  @VisibleForTesting
   List<Provider> sources() {
     return providers;
   }
 
+  @VisibleForTesting
   HashedWheelTimer timer() {
     return timer;
   }
 
+  @VisibleForTesting
   Set<String> reloadKeys() {
     return this.reloadKeys();
   }
   
+  @VisibleForTesting
   List<ProviderFactory> factories() {
     return factories;
+  }
+
+  @VisibleForTesting
+  List<Provider> providers() {
+    return providers;
+  }
+  
+  @VisibleForTesting
+  ConfigurationEntry getEntry(final String key) {
+    return merged_config.get(key);
   }
 }

--- a/common/src/main/java/net/opentsdb/configuration/UnitTestConfiguration.java
+++ b/common/src/main/java/net/opentsdb/configuration/UnitTestConfiguration.java
@@ -1,0 +1,142 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.configuration;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import io.netty.util.HashedWheelTimer;
+import net.opentsdb.configuration.provider.Provider;
+import net.opentsdb.configuration.provider.ProviderFactory;
+import net.opentsdb.configuration.provider.RuntimeOverrideProvider;
+
+/**
+ * A helper for use with Unit Testing Configuration consumers. The full
+ * Configuration class is instantiated but only one or two providers are
+ * given. So use this in a BeforeClass call.
+ * <p>
+ * To instantiate with default settings, use the {@link #getConfiguration(Map)}
+ * by providing the reference to a map.
+ * 
+ * @since 3.0
+ */
+public class UnitTestConfiguration {
+
+  /**
+   * Helper function that returns a Configuration instance with a dead
+   * timer and only the {@link RuntimeOverrideProvider} given.
+   * 
+   * @return A non-null config.
+   */
+  public static Configuration getConfiguration() {
+    final String[] providers = new String[] {
+        "--" + Configuration.CONFIG_PROVIDERS_KEY + "=RuntimeOverride"
+    };
+    return new Configuration(providers);
+  }
+  
+  /**
+   * Helper function that returns a Configuration instance with a dead
+   * timer and only the {@link RuntimeOverrideProvider} given. The map
+   * given must be a mutable reference.
+   * 
+   * @param settings A map of key values to load.
+   * @return A non-null config.
+   */
+  public static Configuration getConfiguration(
+      final Map<String, String> settings) {
+    final String[] providers = new String[] {
+        "--" + Configuration.CONFIG_PROVIDERS_KEY 
+        + "=UnitTest,RuntimeOverride"
+    };
+    final Configuration config = new Configuration(providers);
+    for (final Provider provider : config.providers()) {
+      if (provider instanceof UnitTestProvider) {
+        ((UnitTestProvider) provider).kvs = settings;
+      }
+    }
+    return config;
+  }
+
+  static class UnitTestProvider extends Provider {
+    private Map<String, String> kvs;
+    
+    public UnitTestProvider(final ProviderFactory factory, 
+                            final Configuration config,
+                            final HashedWheelTimer timer, 
+                            final Set<String> reload_keys) {
+      super(factory, config, timer, reload_keys);
+    }
+
+    @Override
+    public void close() throws IOException {
+      // no-op
+    }
+
+    @Override
+    public ConfigurationOverride getSetting(final String key) {
+      if (kvs != null && kvs.containsKey(key)) {
+        return ConfigurationOverride.newBuilder()
+            .setSource(source())
+            .setValue(kvs.get(key))
+            .build();
+      }
+      return null;
+    }
+
+    @Override
+    public String source() {
+      return getClass().getSimpleName();
+    }
+
+    @Override
+    public void reload() {
+      // no-op
+    }
+    
+  }
+  
+  static class UnitTest implements ProviderFactory {
+
+    @Override
+    public void close() throws IOException {
+      // no-op
+    }
+
+    @Override
+    public Provider newInstance(final Configuration config, 
+                                final HashedWheelTimer timer,
+                                final Set<String> reload_keys) {
+      return new UnitTestProvider(this, config, timer, reload_keys);
+    }
+
+    @Override
+    public boolean isReloadable() {
+      return false;
+    }
+
+    @Override
+    public String description() {
+      return "Only used for Unit Tests";
+    }
+
+    @Override
+    public String simpleName() {
+      return getClass().getSimpleName();
+    }
+    
+  }
+}

--- a/common/src/main/java/net/opentsdb/configuration/provider/Provider.java
+++ b/common/src/main/java/net/opentsdb/configuration/provider/Provider.java
@@ -91,7 +91,7 @@ public abstract class Provider implements Closeable, TimerTask {
   /**
    * Called by the {@link Configuration} class to load the current value for the
    * given key when a schema is registered via 
-   * {@link Configuration#registerSchema(net.opentsdb.configuration.ConfigurationEntrySchema)}.
+   * {@link Configuration#register(net.opentsdb.configuration.ConfigurationEntrySchema)}.
    * @param key A non-null and non-empty key.
    * @return A configuration override if the provider had data for the 
    * key (even if it was null) or null if the provider did not have any

--- a/common/src/main/java/net/opentsdb/core/TSDB.java
+++ b/common/src/main/java/net/opentsdb/core/TSDB.java
@@ -14,7 +14,7 @@
 // limitations under the License.
 package net.opentsdb.core;
 
-import net.opentsdb.utils.Config;
+import net.opentsdb.configuration.Configuration;
 
 /**
  * The core interface for an OpenTSDB client.
@@ -24,7 +24,7 @@ import net.opentsdb.utils.Config;
 public interface TSDB {
 
   /** @return The non-null OpenTSDB config repository. */
-  public Config getConfig();
+  public Configuration getConfig();
   
   /** @return The non-null registry for components. */
   public Registry getRegistry();

--- a/common/src/main/java/net/opentsdb/utils/Threads.java
+++ b/common/src/main/java/net/opentsdb/utils/Threads.java
@@ -60,4 +60,27 @@ public class Threads {
         ticks, MILLISECONDS, ticks_per_wheel);
   }
   
+  /**
+   * When used in a method, pulls the caller's class name from the 
+   * stack trace. Thanks to:
+   * https://stackoverflow.com/questions/11306811/how-to-get-the-caller-class-in-java
+   * 
+   * @return A non-null string.
+   */
+  public static String getCallerCallerClassName() { 
+    final StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+    String caller = null;
+    for (int i=1; i<stack.length; i++) {
+      final StackTraceElement ste = stack[i];
+      if (!ste.getClassName().equals(Threads.class.getName()) && 
+        ste.getClassName().indexOf("java.lang.Thread") != 0) {
+        if (caller==null) {
+          caller = ste.getClassName();
+        } else if (!caller.equals(ste.getClassName())) {
+          return ste.getClassName();
+        }
+      }
+    }
+    return null;
+ }
 }

--- a/core/src/main/java/net/opentsdb/core/DefaultRegistry.java
+++ b/core/src/main/java/net/opentsdb/core/DefaultRegistry.java
@@ -74,6 +74,11 @@ import net.opentsdb.utils.JSON;
 public class DefaultRegistry implements Registry {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultRegistry.class);
   
+  /** Configuration keys. */
+  public static final String PLUGIN_CONFIG_KEY = "tsd.plugin.config";
+  public static final String DEFAULT_CLUSTERS_KEY = "tsd.query.default_clusters";
+  public static final String DEFAULT_GRAPHS_KEY = "tsd.query.default_execution_graphs";
+  
   /** The TSDB to which this registry belongs. Used for reading the config. */
   private final TSDB tsdb;
   
@@ -116,6 +121,13 @@ public class DefaultRegistry implements Registry {
     if (tsdb == null) {
       throw new IllegalArgumentException("TSDB cannot be null.");
     }
+    
+    tsdb.getConfig().register(PLUGIN_CONFIG_KEY, null, false, 
+        "The path to a plugin configuration file.");
+    tsdb.getConfig().register(DEFAULT_CLUSTERS_KEY, null, false, 
+        "TODO");
+    tsdb.getConfig().register(DEFAULT_GRAPHS_KEY, null, false, "TODO");
+    
     this.tsdb = tsdb;
     data_mergers = 
         Maps.<String, DataMerger<?>>newHashMapWithExpectedSize(1);
@@ -431,7 +443,7 @@ public class DefaultRegistry implements Registry {
    * @return A deferred to wait on for results.
    */
   public Deferred<Object> loadPlugins() {
-    final String config = tsdb.getConfig().getString("tsd.plugin.config");
+    final String config = tsdb.getConfig().getString(PLUGIN_CONFIG_KEY);
     if (Strings.isNullOrEmpty(config)) {
       if (plugins == null) {
         LOG.info("No plugin config provided. Instantiating empty plugin config.");
@@ -546,7 +558,7 @@ public class DefaultRegistry implements Registry {
     try {
       // load default cluster BEFORE execution graphs as they may depend on
       // cluster configs.
-      String clusters = tsdb.getConfig().getString("tsd.query.default_clusters");
+      String clusters = tsdb.getConfig().getString(DEFAULT_CLUSTERS_KEY);
       if (!Strings.isNullOrEmpty(clusters)) {
         if (clusters.toLowerCase().endsWith(".json") ||
             clusters.toLowerCase().endsWith(".conf")) {
@@ -576,8 +588,7 @@ public class DefaultRegistry implements Registry {
       }
       
       // load default execution graphs
-      String exec_graphs = tsdb.getConfig().getString(
-          "tsd.query.default_execution_graphs");
+      String exec_graphs = tsdb.getConfig().getString(DEFAULT_GRAPHS_KEY);
       if (!Strings.isNullOrEmpty(exec_graphs)) {
         if (exec_graphs.toLowerCase().endsWith(".json") || 
             exec_graphs.toLowerCase().endsWith(".conf")) {

--- a/core/src/main/java/net/opentsdb/core/DefaultTSDB.java
+++ b/core/src/main/java/net/opentsdb/core/DefaultTSDB.java
@@ -61,6 +61,7 @@ import net.opentsdb.utils.Config;
 import net.opentsdb.utils.DateTime;
 import net.opentsdb.utils.PluginLoader;
 import net.opentsdb.utils.Threads;
+import net.opentsdb.configuration.Configuration;
 //import net.opentsdb.meta.Annotation;
 //import net.opentsdb.meta.MetaDataCache;
 //import net.opentsdb.meta.TSMeta;
@@ -117,7 +118,7 @@ public class DefaultTSDB implements TSDB {
 //  final UniqueId tag_values;
 
   /** Configuration object for all TSDB components */
-  final Config config;
+  final Configuration config;
   
   /** The plugin and object regsitry used by OpenTSDB. */
   final Registry registry;
@@ -309,9 +310,9 @@ public class DefaultTSDB implements TSDB {
   /**
    * Constructor
    * @param config An initialized configuration object
-   * @since 2.0
+   * @since 3.0
    */
-  public DefaultTSDB(final Config config) {
+  public DefaultTSDB(final Configuration config) {
     this.config = config;
     registry = new DefaultRegistry(this);
     timer = Threads.newTimer("MainTSDBTimer");
@@ -563,7 +564,7 @@ public class DefaultTSDB implements TSDB {
    * @return The configuration object
    * @since 2.0 
    */
-  public Config getConfig() {
+  public Configuration getConfig() {
     return config;
   }
   

--- a/core/src/main/java/net/opentsdb/core/PluginsConfig.java
+++ b/core/src/main/java/net/opentsdb/core/PluginsConfig.java
@@ -93,6 +93,9 @@ import net.opentsdb.utils.PluginLoader;
 public class PluginsConfig extends Validatable {
   private static final Logger LOG = LoggerFactory.getLogger(PluginsConfig.class);
   
+  /** The key used for finding the plugin directory. */
+  public static final String PLUGIN_PATH_KEY = "tsd.core.plugin_path";
+  
   /** The list of plugin configs. */
   private List<PluginConfig> configs;
   
@@ -240,8 +243,15 @@ public class PluginsConfig extends Validatable {
    */
   public Deferred<Object> initialize(final TSDB tsdb) {
     // backwards compatibility.
-    final String plugin_path = tsdb.getConfig()
-        .getDirectoryName("tsd.core.plugin_path");
+    if (!tsdb.getConfig().hasProperty(PLUGIN_PATH_KEY)) {
+      tsdb.getConfig().register(PLUGIN_PATH_KEY, null, false, 
+          "An optional directory that is checked for .JAR files "
+          + "containing plugin implementations. When found, the files "
+          + "are loaded so that plugins can be instantiated.");
+    }
+//    final String plugin_path = tsdb.getConfig()
+//        .getDirectoryName("tsd.core.plugin_path");
+    final String plugin_path = tsdb.getConfig().getString("tsd.core.plugin_path");
     if (plugin_locations == null && !Strings.isNullOrEmpty(plugin_path)) {
       plugin_locations = Lists.newArrayListWithCapacity(1);
       plugin_locations.add(plugin_path);

--- a/core/src/test/java/net/opentsdb/core/TestPluginsConfig.java
+++ b/core/src/test/java/net/opentsdb/core/TestPluginsConfig.java
@@ -37,12 +37,13 @@ import org.junit.Test;
 import com.google.common.collect.Lists;
 import com.stumbleupon.async.Deferred;
 
+import net.opentsdb.configuration.Configuration;
+import net.opentsdb.configuration.UnitTestConfiguration;
 import net.opentsdb.core.PluginsConfig.PluginConfig;
 import net.opentsdb.exceptions.PluginLoadException;
 import net.opentsdb.query.execution.cache.GuavaLRUCache;
 import net.opentsdb.query.execution.cache.QueryCachePlugin;
 import net.opentsdb.query.execution.cluster.ClusterConfigPlugin;
-import net.opentsdb.utils.Config;
 import net.opentsdb.utils.JSON;
 import net.opentsdb.utils.PluginLoader;
 
@@ -54,15 +55,14 @@ import net.opentsdb.utils.PluginLoader;
 public class TestPluginsConfig {
   private static int ORDER = 0;
   private TSDB tsdb;
-  private Config tsd_config;
+  private Configuration tsd_config;
   private PluginsConfig config;
   
   @Before
   public void before() throws Exception {
     ORDER = 0;
     tsdb = mock(TSDB.class);
-    tsd_config = new Config(false);
-    
+    tsd_config = UnitTestConfiguration.getConfiguration();
     when(tsdb.getConfig()).thenReturn(tsd_config);
     config = spy(new PluginsConfig());
   }

--- a/core/src/test/java/net/opentsdb/core/TestRegistry.java
+++ b/core/src/test/java/net/opentsdb/core/TestRegistry.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -31,24 +32,29 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.google.common.collect.Maps;
+
+import net.opentsdb.configuration.Configuration;
+import net.opentsdb.configuration.UnitTestConfiguration;
 import net.opentsdb.core.TestPluginsConfig.MockPluginBase;
 import net.opentsdb.query.execution.QueryExecutorFactory;
 import net.opentsdb.query.execution.cluster.ClusterConfig;
 import net.opentsdb.query.execution.graph.ExecutionGraph;
-import net.opentsdb.utils.Config;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ DefaultRegistry.class, Executors.class })
 public class TestRegistry {
 
   private DefaultTSDB tsdb;
-  private Config config;
+  private Map<String, String> config_map;
+  private Configuration config;
   private ExecutorService cleanup_pool;
   
   @Before
   public void before() throws Exception {
     tsdb = mock(DefaultTSDB.class);
-    config = new Config(false);
+    config_map = Maps.newHashMap();
+    config = UnitTestConfiguration.getConfiguration(config_map);
     cleanup_pool = mock(ExecutorService.class);
     
     when(tsdb.getConfig()).thenReturn(config);
@@ -229,7 +235,7 @@ public class TestRegistry {
         + "\"net.opentsdb.core.TestPluginsConfig$MockPluginBase\"}],"
         + "\"pluginLocations\": [],\"continueOnError\": false,"
         + "\"shutdownReverse\": true}";
-    config.overrideConfig("tsd.plugin.config", json);
+    config_map.put("tsd.plugin.config", json);
     
     final DefaultRegistry registry = new DefaultRegistry(tsdb);
     assertNull(registry.loadPlugins().join(1));

--- a/core/src/test/java/net/opentsdb/query/TestTSDBV2Pipeline.java
+++ b/core/src/test/java/net/opentsdb/query/TestTSDBV2Pipeline.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 import com.stumbleupon.async.Deferred;
 import com.stumbleupon.async.TimeoutException;
 
+import net.opentsdb.configuration.Configuration;
+import net.opentsdb.configuration.UnitTestConfiguration;
 import net.opentsdb.core.DefaultRegistry;
 import net.opentsdb.core.DefaultTSDB;
 import net.opentsdb.data.TimeSeries;
@@ -40,24 +42,23 @@ import net.opentsdb.query.pojo.Metric;
 import net.opentsdb.query.pojo.TimeSeriesQuery;
 import net.opentsdb.query.pojo.Timespan;
 import net.opentsdb.storage.MockDataStore;
-import net.opentsdb.utils.Config;
 
 public class TestTSDBV2Pipeline {
 
   private DefaultTSDB tsdb;
-  private Config config;
+  private Configuration config;
   private DefaultRegistry registry;
   private MockDataStore mds;
   
   @Before
   public void before() throws Exception {
     tsdb = mock(DefaultTSDB.class);
-    config = new Config(false);
+    config = UnitTestConfiguration.getConfiguration();
     registry = mock(DefaultRegistry.class);
     when(tsdb.getConfig()).thenReturn(config);
     when(tsdb.getRegistry()).thenReturn(registry);
     
-    config.overrideConfig("MockDataStore.timestamp", "1483228800000");
+    config.register("MockDataStore.timestamp", 1483228800000L, false, "UT");
     //config.overrideConfig("MockDataStore.threadpool.enable", "true");
     mds = new MockDataStore();
     mds.initialize(tsdb).join();

--- a/core/src/test/java/net/opentsdb/query/execution/TestCachingQueryExecutor.java
+++ b/core/src/test/java/net/opentsdb/query/execution/TestCachingQueryExecutor.java
@@ -41,6 +41,7 @@ import org.mockito.stubbing.Answer;
 import com.stumbleupon.async.Deferred;
 import com.stumbleupon.async.TimeoutException;
 import io.opentracing.Span;
+import net.opentsdb.configuration.Configuration;
 import net.opentsdb.data.iterators.DefaultIteratorGroups;
 import net.opentsdb.data.iterators.IteratorGroups;
 import net.opentsdb.exceptions.QueryExecutionException;
@@ -61,6 +62,7 @@ import net.opentsdb.utils.JSON;
 public class TestCachingQueryExecutor extends BaseExecutorTest {
   private QueryExecutor<IteratorGroups> executor;
   private MockDownstream<IteratorGroups> cache_execution;
+  private Configuration tsd_config;
   private Config config;
   private QueryCachePlugin plugin;
   private TimeSeriesSerdes serdes;
@@ -81,7 +83,10 @@ public class TestCachingQueryExecutor extends BaseExecutorTest {
         .setExecutorType("CachingQueryExecutor")
         .build();
     
-    when(tsdb.getConfig()).thenReturn(new net.opentsdb.utils.Config(false));
+    tsd_config = new Configuration(new String[] { 
+        "--" + Configuration.CONFIG_PROVIDERS_KEY + "=RuntimeOverride" });
+    
+    when(tsdb.getConfig()).thenReturn(tsd_config);
     key_generator = new DefaultTimeSeriesCacheKeyGenerator();
     key_generator.initialize(tsdb).join();
     when(node.graph()).thenReturn(graph);

--- a/core/src/test/java/net/opentsdb/query/execution/TestTimeBasedRoutingExecutor.java
+++ b/core/src/test/java/net/opentsdb/query/execution/TestTimeBasedRoutingExecutor.java
@@ -49,7 +49,7 @@ import com.stumbleupon.async.DeferredGroupException;
 import com.stumbleupon.async.TimeoutException;
 
 import io.opentracing.Span;
-import net.opentsdb.data.iterators.DefaultIteratorGroups;
+import net.opentsdb.configuration.Configuration;
 import net.opentsdb.data.iterators.IteratorGroups;
 import net.opentsdb.data.iterators.IteratorTestUtils;
 import net.opentsdb.exceptions.QueryExecutionCanceled;
@@ -73,6 +73,7 @@ public class TestTimeBasedRoutingExecutor extends BaseExecutorTest {
   private Map<String, QueryExecutor<IteratorGroups>> executors;
   private Map<String, MockDownstream<IteratorGroups>> downstream_executions;
   private List<TimeRange> ranges;
+  private Configuration tsd_config;
   private Config config;
   private Set<String> executor_ids;
   private IteratorGroupsSlicePlanner planner;
@@ -119,8 +120,10 @@ public class TestTimeBasedRoutingExecutor extends BaseExecutorTest {
     executors = Maps.newHashMap();
     downstream_executions = Maps.newHashMap();
     plan_factory = mock(QueryPlannnerFactory.class);
-        
-    when(tsdb.getConfig()).thenReturn(new net.opentsdb.utils.Config(false));
+    
+    tsd_config = new Configuration(new String[] { 
+        "--" + Configuration.CONFIG_PROVIDERS_KEY + "=RuntimeOverride" });
+    when(tsdb.getConfig()).thenReturn(tsd_config);
     when(node.graph()).thenReturn(graph);
     when(node.getDefaultConfig()).thenReturn(config);
     when(graph.getDownstreamExecutor(anyString()))

--- a/core/src/test/java/net/opentsdb/query/execution/TestTimeSlicedCachingExecutor.java
+++ b/core/src/test/java/net/opentsdb/query/execution/TestTimeSlicedCachingExecutor.java
@@ -49,6 +49,7 @@ import com.google.common.collect.Lists;
 import com.stumbleupon.async.Deferred;
 import com.stumbleupon.async.TimeoutException;
 import io.opentracing.Span;
+import net.opentsdb.configuration.Configuration;
 import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.iterators.IteratorGroup;
 import net.opentsdb.data.iterators.IteratorGroups;
@@ -81,6 +82,7 @@ public class TestTimeSlicedCachingExecutor extends BaseExecutorTest {
 
   private QueryExecutor<IteratorGroups> executor;
   private MockDownstream<IteratorGroups> cache_execution;
+  private Configuration tsd_config;
   private Config config;
   private QueryCachePlugin plugin;
   private TimeSeriesSerdes serdes;
@@ -113,7 +115,9 @@ public class TestTimeSlicedCachingExecutor extends BaseExecutorTest {
     
     plan_factory = mock(QueryPlannnerFactory.class);
     
-    when(tsdb.getConfig()).thenReturn(new net.opentsdb.utils.Config(false));
+    tsd_config = new Configuration(new String[] { 
+        "--" + Configuration.CONFIG_PROVIDERS_KEY + "=RuntimeOverride" });
+    when(tsdb.getConfig()).thenReturn(tsd_config);
     key_generator = new DefaultTimeSeriesCacheKeyGenerator();
     key_generator.initialize(tsdb).join();
     when(node.graph()).thenReturn(graph);

--- a/core/src/test/java/net/opentsdb/storage/TestMockDataStore.java
+++ b/core/src/test/java/net/opentsdb/storage/TestMockDataStore.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 
 import com.stumbleupon.async.Deferred;
 
+import net.opentsdb.configuration.Configuration;
+import net.opentsdb.configuration.UnitTestConfiguration;
 import net.opentsdb.core.DefaultRegistry;
 import net.opentsdb.core.DefaultTSDB;
 import net.opentsdb.data.MillisecondTimeStamp;
@@ -55,26 +57,25 @@ import net.opentsdb.utils.Config;
 public class TestMockDataStore {
 
   private DefaultTSDB tsdb;
-  private Config config;
+  private Configuration config;
   private DefaultRegistry registry;
   private MockDataStore mds;
   
   @Before
   public void before() throws Exception {
     tsdb = mock(DefaultTSDB.class);
-    config = new Config(false);
+    config = UnitTestConfiguration.getConfiguration();
     registry = mock(DefaultRegistry.class);
     when(tsdb.getConfig()).thenReturn(config);
     when(tsdb.getRegistry()).thenReturn(registry);
     
-    config.overrideConfig("MockDataStore.timestamp", "1483228800000");
-    config.overrideConfig("MockDataStore.threadpool.enable", "true");
-    config.overrideConfig("MockDataStore.sysout.enable", "true");
+    config.register("MockDataStore.timestamp", 1483228800000L, false, "UT");
+    config.register("MockDataStore.threadpool.enable", true, false, "UT");
+    config.register("MockDataStore.sysout.enable", true, false, "UT");
     mds = new MockDataStore();
     mds.initialize(tsdb).join();
     when(registry.getQueryNodeFactory(anyString())).thenReturn(mds);
   }
-
   
   @Test
   public void initialize() throws Exception {

--- a/implementation/redis/src/test/java/net/opentsdb/query/execution/cache/TestRedisClusterKeyGenerator.java
+++ b/implementation/redis/src/test/java/net/opentsdb/query/execution/cache/TestRedisClusterKeyGenerator.java
@@ -28,6 +28,8 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import net.opentsdb.configuration.Configuration;
+import net.opentsdb.configuration.UnitTestConfiguration;
 import net.opentsdb.core.DefaultTSDB;
 import net.opentsdb.data.MillisecondTimeStamp;
 import net.opentsdb.data.TimeStamp;
@@ -35,7 +37,6 @@ import net.opentsdb.query.pojo.Metric;
 import net.opentsdb.query.pojo.TimeSeriesQuery;
 import net.opentsdb.query.pojo.Timespan;
 import net.opentsdb.utils.Bytes;
-import net.opentsdb.utils.Config;
 import net.opentsdb.utils.DateTime;
 
 @RunWith(PowerMockRunner.class)
@@ -43,12 +44,12 @@ import net.opentsdb.utils.DateTime;
 public class TestRedisClusterKeyGenerator {
 
   private DefaultTSDB tsdb;
-  private Config config;
+  private Configuration config;
   
   @Before
   public void before() throws Exception {
     tsdb = mock(DefaultTSDB.class);
-    config = new Config(false);
+    config = UnitTestConfiguration.getConfiguration();
     when(tsdb.getConfig()).thenReturn(config);
   }
   

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/applications/OpenTSDBApplication.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/applications/OpenTSDBApplication.java
@@ -22,12 +22,12 @@ import org.glassfish.jersey.server.ResourceConfig;
 
 import com.google.common.collect.ImmutableMap;
 
+import net.opentsdb.configuration.Configuration;
 import net.opentsdb.core.DefaultTSDB;
 import net.opentsdb.servlet.exceptions.GenericExceptionMapper;
 import net.opentsdb.servlet.exceptions.QueryExecutionExceptionMapper;
 import net.opentsdb.servlet.resources.JMXResource;
 import net.opentsdb.servlet.resources.QueryRpc;
-import net.opentsdb.utils.Config;
 
 @ApplicationPath("/")
 public class OpenTSDBApplication extends ResourceConfig {
@@ -51,7 +51,7 @@ public class OpenTSDBApplication extends ResourceConfig {
       if (pre_instantiated_tsd != null && pre_instantiated_tsd instanceof DefaultTSDB) {
         tsdb = (DefaultTSDB) pre_instantiated_tsd;
       } else {
-        tsdb = new DefaultTSDB(new Config(true)); 
+        tsdb = new DefaultTSDB(new Configuration()); 
         servletConfig.getServletContext().setAttribute(TSD_ATTRIBUTE, tsdb);
         tsdb.initializeRegistry(true).join();
       }

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
@@ -250,7 +250,7 @@ final public class QueryRpc {
         // TODO - possible upstream headers
         .put("queryId", Bytes.byteArrayToString(query.buildHashCode().asBytes()))
         .put("queryHash", Bytes.byteArrayToString(query.buildTimelessHashCode().asBytes()))
-        .put("traceId", trace != null ? trace.traceId() : null)
+        .put("traceId", trace != null ? trace.traceId() : "")
         .put("query", ts_query)
         .build()));
     if (convert_span != null) {
@@ -304,7 +304,7 @@ final public class QueryRpc {
                   // TODO - possible upstream headers
                   .put("queryId", Bytes.byteArrayToString(query.buildHashCode().asBytes()))
                   .put("queryHash", Bytes.byteArrayToString(query.buildTimelessHashCode().asBytes()))
-                  .put("traceId", trace != null ? trace.traceId() : null)
+                  .put("traceId", trace != null ? trace.traceId() : "")
                   .put("query", ts_query)
                   .build()));
         }
@@ -527,7 +527,7 @@ final public class QueryRpc {
       // TODO - possible upstream headers
       .put("queryId", Bytes.byteArrayToString(query.buildHashCode().asBytes()))
       .put("queryHash", Bytes.byteArrayToString(query.buildTimelessHashCode().asBytes()))
-      .put("traceId", trace != null ? trace.traceId() : null)
+      .put("traceId", trace != null ? trace.traceId() : "")
       .put("status", Response.Status.OK)
       .put("query", request.getAttribute(V2_QUERY_KEY))
       .build()));
@@ -538,7 +538,7 @@ final public class QueryRpc {
       // TODO - possible upstream headers
       .put("queryId", Bytes.byteArrayToString(query.buildHashCode().asBytes()))
       .put("queryHash", Bytes.byteArrayToString(query.buildTimelessHashCode().asBytes()))
-      .put("traceId", trace != null ? trace.traceId() : null)
+      .put("traceId", trace != null ? trace.traceId() : "")
       .put("status", Response.Status.OK)
       //.put("trace", trace.serializeToString())
       .put("query", request.getAttribute(V2_QUERY_KEY))

--- a/implementation/servlet/src/test/java/net/opentsdb/servlet/resources/TestQueryRpc.java
+++ b/implementation/servlet/src/test/java/net/opentsdb/servlet/resources/TestQueryRpc.java
@@ -34,6 +34,8 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.WebApplicationException;
 
+import net.opentsdb.configuration.Configuration;
+import net.opentsdb.configuration.UnitTestConfiguration;
 import net.opentsdb.core.DefaultTSDB;
 import net.opentsdb.query.TSQuery;
 import net.opentsdb.query.filter.TagVLiteralOrFilter;
@@ -66,7 +68,7 @@ import com.stumbleupon.async.DeferredGroupException;
   Deferred.class, TSQuery.class, DateTime.class, DeferredGroupException.class })
 public final class TestQueryRpc {
   private DefaultTSDB tsdb;
-  private Config config;
+  private Configuration config;
   private QueryRpc rpc;
   private ServletConfig servlet_config;
   private ServletContext context;
@@ -80,7 +82,7 @@ public final class TestQueryRpc {
   @Before
   public void before() throws Exception {
     tsdb = PowerMockito.mock(DefaultTSDB.class);
-    config = new Config(false);
+    config = UnitTestConfiguration.getConfiguration();
 //    empty_query = mock(Query.class);
 //    query_result = mock(Query.class);
     rpc = new QueryRpc();

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/AsyncHBaseDataStore.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/AsyncHBaseDataStore.java
@@ -57,17 +57,7 @@ public class AsyncHBaseDataStore extends TimeSeriesDataStore {
   public Deferred<Object> initialize(final TSDB tsdb) {
     this.tsdb = tsdb;
     
-    final org.hbase.async.Config async_config;
-    if (tsdb.getConfig().configLocation() != null && !tsdb.getConfig().configLocation().isEmpty()) {
-      try {
-        async_config = new org.hbase.async.Config(tsdb.getConfig().configLocation());
-      } catch (final IOException e) {
-        throw new RuntimeException("Failed to read the config file: " + 
-            tsdb.getConfig().configLocation(), e);
-      }
-    } else {
-      async_config = new org.hbase.async.Config();
-    }
+    final org.hbase.async.Config async_config = new org.hbase.async.Config();
     if (Strings.isNullOrEmpty(
         async_config.getString("asynchbase.zk.base_path"))) {
       async_config.overrideConfig("asynchbase.zk.base_path", 


### PR DESCRIPTION
- Rename the RegisterSchema() methods to Register() and add some overloads that
allow for registering primitive values to avoid having to create complex
builders anytime you need to register in code.
- Rename hasKey() to hasProperty() so it's more compatible with the old
config class.
- Add a UnitTestConfiguration class to make it easier to use the configuration
object in unit tests.
- Explicitly load the UnitTest and RuntimeOverride providers for UTs that are
using Mockito or PowerMockito.
- Add a helper to Threads to get the calling class name two methods up so that
config registrations can capture the source.
- Return the new Configuration class from the TSDB interface.

CORE:
- Use the new Configuration class.

IMPLEMENTATIONs:
- Use the new Configuration class.
- Brave tracer will allow for changing endpoints. The new Config class allows
binding so there's a callback now that will attempt to kill and start a new
reporter.
- Fix QueryRpc null trace entries in the immutable map.