### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/uid/LRUUniqueId.java
+++ b/core/src/main/java/net/opentsdb/uid/LRUUniqueId.java
@@ -1,0 +1,538 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.uid;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Lists;
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.stats.Span;
+import net.opentsdb.storage.StorageException;
+import net.opentsdb.utils.Bytes;
+
+public class LRUUniqueId implements UniqueId {
+  private static final Logger LOG = LoggerFactory.getLogger(
+      LRUUniqueId.class);
+  
+  /** Cache for forward mappings (name to ID). */
+  private final Cache<String, byte[]> name_cache;
+  
+  /** Cache for backward mappings (ID to name).
+   * The ID in the key is a byte[] converted to a String to be Comparable. */
+  private final Cache<String, String> id_cache;
+  
+  private final UniqueIdStore store;
+  private final UniqueIdType type;
+  private final CacheMode mode;
+  private final String id;
+  
+  public LRUUniqueId(final TSDB tsdb, 
+                     final String id, 
+                     final UniqueIdType type, 
+                     final UniqueIdStore store) {
+    this.store = store;
+    this.id = id;
+    this.type = type;
+    
+    final String prefix = "tsd.uid." + id + "." + 
+        type.toString().toLowerCase(); 
+    
+    String key = prefix + ".mode";
+    if (!tsdb.getConfig().hasProperty(key)) {
+      tsdb.getConfig().register(key, "read_write", false, 
+          "The mode of the cache, i.e. if it caches both forward and "
+          + "reverse mappings or only one of those two. Values "
+          + "supported include 'write_only', 'read_only' and 'read_write'.");
+    }
+    mode = CacheMode.fromString(tsdb.getConfig().getString(key));
+    
+    // record_stats are global
+    key = "tsd.uid." + id + ".record_stats";
+    if (!tsdb.getConfig().hasProperty(key)) {
+      tsdb.getConfig().register(key, true, false, 
+          "Whether or not to track statistics about cache hits, misses, etc.");
+    }
+    final boolean record_stats = tsdb.getConfig().getBoolean(key);
+    
+    key = prefix + ".lru.name.size";
+    if (!tsdb.getConfig().hasProperty(key)) {
+      tsdb.getConfig().register(key, 1048576L, false, 
+          "Number of items to maintain in the name to UID cache.");
+    }
+    final long name_size = tsdb.getConfig().getLong(key);
+    
+    // id stats
+    key = prefix + ".lru.id.size";
+    if (!tsdb.getConfig().hasProperty(key)) {
+      tsdb.getConfig().register(key, 1048576L, false, 
+          "Number of items to maintain in the UID to name cache.");
+    }
+    final long id_size = tsdb.getConfig().getLong(key);
+    
+    // TODO - only one or the other depending on mode
+    @SuppressWarnings("rawtypes")
+    CacheBuilder builder = CacheBuilder.newBuilder()
+        .maximumSize(name_size);
+    if (record_stats) {
+      builder = builder.recordStats();
+    }
+    name_cache = builder.<String, byte[]>build();
+    
+    builder = CacheBuilder.newBuilder()
+        .maximumSize(id_size);
+    if (record_stats) {
+      builder = builder.recordStats();
+    }
+    id_cache = builder.<String, String>build();
+    
+    LOG.info("Initialized LRU UniqueId cache for [" + type 
+        + "] with a name limit of " + name_size 
+        + " and an Id limit of " + id_size + " and mode " + mode);
+  }
+
+  @Override
+  public UniqueIdType type() {
+    return type;
+  }
+  
+  @Override
+  public void dropCaches(final Span span) {
+    // TODO - only one or the other depending on mode
+    name_cache.invalidateAll();
+    id_cache.invalidateAll();
+  }
+  
+  @Override
+  public Deferred<String> getName(final byte[] id, final Span span) {
+    if (Bytes.isNullOrEmpty(id)) {
+      throw new IllegalArgumentException("The ID cannot be null or empty.");
+    }
+    
+    final Span child;
+    if (span != null && span.isDebug()) {
+      child = span.newChild(getClass().getName() + ".getName")
+          .withTag("type", type.toString())
+          .withTag("id", UniqueId.uidToString(id))
+          .start();
+    } else {
+      child = null;
+    }
+    
+    final String name = id_cache.getIfPresent(UniqueId.uidToString(id));
+    if (name != null) {
+      if (child != null) {
+        child.setSuccessTags()
+          .setTag("fromCache", "true")
+          .finish();
+      }
+      return Deferred.fromResult(name);
+    }
+    
+    class ErrorCB implements Callback<String, Exception> {
+      @Override
+      public String call(final Exception ex) throws Exception {
+        if (child != null) {
+          child.setErrorTags()
+            .log("Exception", ex)
+            .finish();
+        }
+        throw ex;
+      }
+    }
+    
+    class IdToString implements Callback<String, String> {
+      @Override
+      public String call(final String name) throws Exception {
+        switch (mode) {
+        case WRITE_ONLY:
+          break;
+        case READ_ONLY:
+          id_cache.put(UniqueId.uidToString(id), name);
+          break;
+        default:
+          id_cache.put(UniqueId.uidToString(id), name);
+          name_cache.put(name, id);
+        }
+        
+        if (child != null) {
+          child.setSuccessTags()
+          .setTag("fromCache", "false")
+          .finish();
+        }
+        return name;
+      }
+    }
+    
+    try {
+      return store.getName(type, id, child != null ? child : span)
+          .addCallbacks(new IdToString(), new ErrorCB());
+    } catch (Exception e) {
+      if (child != null) {
+        child.setErrorTags()
+          .log("Exception", e)
+          .finish();
+      }
+      return Deferred.fromError(new StorageException(
+          "Unexpected exception from UID storage", e));
+    }
+  }
+
+  @Override
+  public Deferred<List<String>> getNames(final List<byte[]> ids, 
+                                         final Span span) {
+    if (ids == null || ids.isEmpty()) {
+      throw new IllegalArgumentException("ID list cannot be null or empty.");
+    }
+    
+    final Span child;
+    if (span != null && span.isDebug()) {
+      child = span.newChild(getClass().getName() + ".getNames")
+          .withTag("type", type.toString())
+          .withTag("ids", ids.size())
+          .start();
+    } else {
+      child = null;
+    }
+    
+    // need the clone so we can dump cached copies
+    final List<byte[]> misses = Lists.newArrayListWithCapacity(ids.size());
+    final List<String> names = Lists.newArrayListWithCapacity(ids.size());
+
+    int resolved = 0;
+    for (int i = 0; i < ids.size(); i++) {
+      final String name = id_cache.getIfPresent(
+          UniqueId.uidToString(ids.get(i)));
+      if (name != null) {
+        names.add(name);
+        resolved++;
+      } else {
+        names.add(null);
+        misses.add(ids.get(i));
+      }
+    }
+    
+    // if it was a 100% cache hit, we're all done.
+    if (resolved == ids.size()) {
+      if (child != null) {
+        child.setSuccessTags()
+          .setTag("fromCache", "true")
+          .setTag("cached", ids.size())
+          .finish();
+      }
+      return Deferred.fromResult(names);
+    }
+    
+    class ErrorCB implements Callback<String, Exception> {
+      @Override
+      public String call(final Exception ex) throws Exception {
+        if (child != null) {
+          child.setErrorTags()
+            .log("Exception", ex)
+            .finish();
+        }
+        throw ex;
+      }
+    }
+    
+    class IdsToStrings implements Callback<List<String>, List<String>> {
+      @Override
+      public List<String> call(final List<String> store_names) throws Exception {
+        int ids_idx = 0;
+        for (int i = 0; i < misses.size(); i++) {
+          final String name = store_names.get(i);
+          if (name == null) {
+            continue;
+          }
+          
+          while (Bytes.memcmp(ids.get(ids_idx), misses.get(i)) != 0) {
+            ids_idx++;
+            if (ids_idx >= ids.size()) {
+              throw new IllegalStateException("WENT TOO FAR!");
+            }
+          }
+          
+          switch (mode) {
+          case WRITE_ONLY:
+            break;
+          case READ_ONLY:
+            id_cache.put(UniqueId.uidToString(misses.get(i)), name);
+            break;
+          default:
+            id_cache.put(UniqueId.uidToString(misses.get(i)), name);
+            name_cache.put(name, misses.get(i));
+          }
+          names.set(ids_idx, name);
+        }
+        
+        if (child != null) {
+          child.setSuccessTags()
+            .setTag("fromCache", "false")
+            .setTag("cached", ids.size() - misses.size())
+            .finish();
+        }
+        return names;
+      }
+    }
+    
+    try {
+      return store.getNames(type, misses, child != null ? child : span)
+          .addCallbacks(new IdsToStrings(), new ErrorCB());
+    } catch (Exception e) {
+      if (child != null) {
+        child.setErrorTags()
+          .log("Exception", e)
+          .finish();
+      }
+      return Deferred.fromError(new StorageException(
+          "Unexpected exception from UID storage", e));
+    }
+  }
+
+  @Override
+  public Deferred<byte[]> getId(final String name, final Span span) {
+    if (Strings.isNullOrEmpty(name)) {
+      throw new IllegalArgumentException("Name cannot be null or empty.");
+    }
+    
+    final Span child;
+    if (span != null && span.isDebug()) {
+      child = span.newChild(getClass().getName() + ".getId")
+          .withTag("type", type.toString())
+          .withTag("name", name)
+          .start();
+    } else {
+      child = null;
+    }
+    
+    final byte[] uid = name_cache.getIfPresent(name);
+    if (uid != null) {
+      if (child != null) {
+        child.setSuccessTags()
+          .setTag("fromCache", "true")
+          .finish();
+      }
+      return Deferred.fromResult(uid);
+    }
+    
+    class ErrorCB implements Callback<byte[], Exception> {
+      @Override
+      public byte[] call(final Exception ex) throws Exception {
+        if (child != null) {
+          child.setErrorTags()
+            .log("Exception", ex)
+            .finish();
+        }
+        throw ex;
+      }
+    }
+    
+    class StringToId implements Callback<byte[], byte[]> {
+      @Override
+      public byte[] call(final byte[] uid) throws Exception {
+        switch (mode) {
+        case WRITE_ONLY:
+          name_cache.put(name, uid);
+          break;
+        case READ_ONLY:
+          break;
+        default:
+          id_cache.put(UniqueId.uidToString(uid), name);
+          name_cache.put(name, uid);
+        }
+        
+        if (child != null) {
+          child.setSuccessTags()
+          .setTag("fromCache", "false")
+          .finish();
+        }
+        return uid;
+      }
+    }
+    
+    try {
+      return store.getId(type, name, child != null ? child : span)
+          .addCallbacks(new StringToId(), new ErrorCB());
+    } catch (Exception e) {
+      if (child != null) {
+        child.setErrorTags()
+          .log("Exception", e)
+          .finish();
+      }
+      return Deferred.fromError(new StorageException(
+          "Unexpected exception from UID storage", e));
+    }
+  }
+
+  @Override
+  public Deferred<List<byte[]>> getIds(final List<String> names, 
+                                       final Span span) {
+    if (names == null || names.isEmpty()) {
+      throw new IllegalArgumentException("Names cannot be null or empty.");
+    }
+    
+    final Span child;
+    if (span != null && span.isDebug()) {
+      child = span.newChild(getClass().getName() + ".getIds")
+          .withTag("type", type.toString())
+          .withTag("names", names.size())
+          .start();
+    } else {
+      child = null;
+    }
+    
+    // need the clone so we can dump cached copies
+    final List<String> misses = Lists.newArrayListWithCapacity(names.size());
+    final List<byte[]> uids = Lists.newArrayListWithCapacity(names.size());
+    int resolved = 0;
+    for (int i = 0; i < names.size(); i++) {
+      final byte[] uid = name_cache.getIfPresent(names.get(i));
+      if (uid != null) {
+        uids.add(uid);
+        resolved++;
+      } else {
+        uids.add(null);
+        misses.add(names.get(i));
+      }
+    }
+    
+    // if it was a 100% cache hit, we're all done.
+    if (resolved == names.size()) {
+      if (child != null) {
+        child.setSuccessTags()
+          .setTag("fromCache", "true")
+          .setTag("cached", uids.size())
+          .finish();
+      }
+      return Deferred.fromResult(uids);
+    }
+    
+    class ErrorCB implements Callback<String, Exception> {
+      @Override
+      public String call(final Exception ex) throws Exception {
+        if (child != null) {
+          child.setErrorTags()
+            .log("Exception", ex)
+            .finish();
+        }
+        throw ex;
+      }
+    }
+    
+    class StringsToIds implements Callback<List<byte[]>, List<byte[]>> {
+      @Override
+      public List<byte[]> call(final List<byte[]> store_uids) throws Exception {
+        int names_idx = 0;
+        for (int i = 0; i < misses.size(); i++) {
+          final byte[] id = store_uids.get(i);
+          if (id == null) {
+            continue;
+          }
+          
+          while (!names.get(names_idx).equals(misses.get(i))) {
+            names_idx++;
+            if (names_idx >= names.size()) {
+              throw new IllegalStateException("WENT TOO FAR!");
+            }
+          }
+          
+          switch (mode) {
+          case WRITE_ONLY:
+            name_cache.put(misses.get(i), id);
+            break;
+          case READ_ONLY:
+            break;
+          default:
+            name_cache.put(misses.get(i), id);
+            id_cache.put(UniqueId.uidToString(id), misses.get(i));
+          }
+          
+          uids.set(names_idx, id);
+        }
+        
+        if (child != null) {
+          child.setSuccessTags()
+            .setTag("fromCache", "false")
+            .setTag("cached", names.size() - misses.size())
+            .finish();
+        }
+        return uids;
+      }
+    }
+    
+    try {
+      return store.getIds(type, misses, child != null ? child : span)
+          .addCallbacks(new StringsToIds(), new ErrorCB());
+    } catch (Exception e) {
+      if (child != null) {
+        child.setErrorTags()
+          .log("Exception", e)
+          .finish();
+      }
+      return Deferred.fromError(new StorageException(
+          "Unexpected exception from UID storage", e));
+    }
+  }
+  
+  @Override
+  public Deferred<byte[]> getOrCreateId(final String name, final Span span) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+  
+  @Override
+  public Deferred<List<byte[]>> getOrCreateIds(final List<String> names, 
+      final Span span) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public Deferred<List<String>> suggest(String search, int max_results, final Span span) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public Deferred<Object> rename(String oldname, String newname, final Span span) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public Deferred<Object> delete(final String name, final Span span) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+  
+  @VisibleForTesting
+  Cache<String, byte[]> nameCache() {
+    return name_cache;
+  }
+  
+  @VisibleForTesting
+  Cache<String, String> idCache() {
+    return id_cache;
+  }
+}

--- a/core/src/main/java/net/opentsdb/uid/UniqueId.java
+++ b/core/src/main/java/net/opentsdb/uid/UniqueId.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import javax.xml.bind.DatatypeConverter;
 
+import com.google.common.base.Strings;
 import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.data.TimeSeriesStringId;
@@ -32,6 +33,59 @@ import net.opentsdb.utils.Bytes;
  */
 public interface UniqueId {
 
+  public static enum CacheMode {
+    /** Populate the string to UID cache only for writers. */
+    WRITE_ONLY("write_only"),
+    
+    /** Populate the UID to string cache only for readers. */
+    READ_ONLY("read_only"),
+    
+    /** Populate both forward and reverse caches. */
+    READ_WRITE("read_write");
+    
+    /** User friendly name of this enum. */
+    private final String name;
+    
+    /**
+     * Ctor package private for ^^.
+     * @param name A non-null and non-empty name.
+     */
+    CacheMode(final String name) {
+      this.name = name;
+    }
+    
+    /** @return The user friendly name of the cache mode. */
+    public String getName() {
+      return name;
+    }
+    
+    /**
+     * Converts a string to the proper cache mode. 
+     * @param name A non-null and non-empty name.
+     * @return The cache mode enum if found.
+     * @throws IllegalArgumentException if the name was null or empty or
+     * the string didn't match an existing mode.
+     */
+    public static CacheMode fromString(final String name) {
+      if (Strings.isNullOrEmpty(name)) {
+        throw new IllegalArgumentException("Cache mode cannot be null "
+            + "or empty.");
+      }
+      final String lc = name.trim().toLowerCase();
+      if (lc.equals("w") || lc.equals("write") || lc.equals("write_only")) {
+        return WRITE_ONLY;
+      } else if (lc.equals("r") || lc.equals("read") || 
+                 lc.equals("read_only")) {
+        return READ_ONLY;
+      } else if (lc.equals("rw") || lc.equals("wr") || 
+                 lc.equals("readwrite") || lc.equals("writeread") || 
+                 lc.equals("read_write") || lc.equals("write_read")) {
+        return READ_WRITE;
+      }
+      throw new IllegalArgumentException("Unrecognized cache mode name.");
+    }
+  }
+  
   /** 
    * @return The type of Unique ID this implementation works with.
    * @since 2.0 

--- a/core/src/main/java/net/opentsdb/uid/UniqueIdStore.java
+++ b/core/src/main/java/net/opentsdb/uid/UniqueIdStore.java
@@ -14,6 +14,7 @@
 // limitations under the License.
 package net.opentsdb.uid;
 
+import java.nio.charset.Charset;
 import java.util.List;
 
 import com.stumbleupon.async.Deferred;
@@ -142,4 +143,6 @@ public interface UniqueIdStore {
                                          final List<byte[]> ids,
                                          final Span span);
   
+  /** @return The non-null characterset used for en/decoding. */
+  public Charset characterSet();
 }

--- a/core/src/test/java/net/opentsdb/uid/TestLRUUniqueId.java
+++ b/core/src/test/java/net/opentsdb/uid/TestLRUUniqueId.java
@@ -1,0 +1,819 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.uid;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.configuration.Configuration;
+import net.opentsdb.configuration.UnitTestConfiguration;
+import net.opentsdb.core.TSDB;
+import net.opentsdb.stats.MockTrace;
+import net.opentsdb.stats.Span;
+import net.opentsdb.storage.StorageException;
+
+public class TestLRUUniqueId {
+  private static final String DEFAULT_ID = "default";
+  private static final byte[] UID1 = new byte[] { 0, 0, 1 };
+  private static final byte[] UID2 = new byte[] { 0, 0, 2 };
+  private static final byte[] UID3 = new byte[] { 0, 0, 3 };
+  private static final byte[] UID4 = new byte[] { 0, 0, 4 };
+  
+  private static final String STRING1 = "sys.cpu.user";
+  private static final String STRING2 = "host";
+  private static final String STRING3 = "web01";
+  private static final String STRING4 = "web02";
+  
+  private static TSDB tsdb;
+  private static Configuration config;
+  private MockTrace trace;
+  private UniqueIdStore store;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    tsdb = mock(TSDB.class);
+    config = UnitTestConfiguration.getConfiguration();
+    
+    when(tsdb.getConfig()).thenReturn(config);
+  }
+  
+  @Before
+  public void before() throws Exception {
+    resetConfig();
+    store = mock(UniqueIdStore.class);
+    
+  }
+  
+  @Test
+  public void ctor() throws Exception {
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    assertEquals(UniqueIdType.METRIC, lru.type());
+  }
+  
+  @Test
+  public void getName() throws Exception {
+    when(store.getName(any(UniqueIdType.class), any(byte[].class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(STRING1));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    assertEquals(STRING1, lru.getName(UID1, null).join());
+    assertEquals(STRING1, lru.getName(UID1, null).join());
+    assertEquals(STRING1, lru.getName(UID1, null).join());
+    assertEquals(1, lru.nameCache().size());
+    assertEquals(1, lru.idCache().size());
+    verify(store, times(1)).getName(UniqueIdType.METRIC, UID1, null);
+    
+    trace = new MockTrace();
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    assertEquals(STRING1, lru.getName(UID1, trace.newSpan("UT").start()).join());
+    assertEquals(STRING1, lru.getName(UID1, trace.newSpan("UT").start()).join());
+    assertEquals(STRING1, lru.getName(UID1, trace.newSpan("UT").start()).join());
+    assertEquals(0, trace.spans.size());
+    
+    trace = new MockTrace(true);
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    assertEquals(STRING1, lru.getName(UID1, trace.newSpan("UT").start()).join());
+    assertEquals(STRING1, lru.getName(UID1, trace.newSpan("UT").start()).join());
+    assertEquals(STRING1, lru.getName(UID1, trace.newSpan("UT").start()).join());
+    assertEquals(3, trace.spans.size());
+    assertEquals(LRUUniqueId.class.getName() + ".getName", trace.spans.get(0).id);
+    assertEquals("OK", trace.spans.get(0).tags.get("status"));
+    assertEquals("false", trace.spans.get(0).tags.get("fromCache"));
+    assertEquals("true", trace.spans.get(1).tags.get("fromCache"));
+    assertEquals("true", trace.spans.get(2).tags.get("fromCache"));
+  }
+  
+  @Test
+  public void getNameIllegalArgumentException() throws Exception {
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    try {
+      lru.getName(null, null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    try {
+      lru.getName(new byte[0], null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void getNameModes() throws Exception {
+    // read-write
+    when(store.getName(any(UniqueIdType.class), any(byte[].class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(STRING1));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    assertEquals(STRING1, lru.getName(UID1, null).join());
+    assertEquals(STRING1, lru.getName(UID1, null).join());
+    assertEquals(STRING1, lru.getName(UID1, null).join());
+    verify(store, times(1)).getName(UniqueIdType.METRIC, UID1, null);
+    assertEquals(1, lru.nameCache().size());
+    assertEquals(1, lru.idCache().size());
+    
+    // write only
+    ((UnitTestConfiguration) config).override(
+        "tsd.uid." + DEFAULT_ID + ".metric.mode", "w");
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    assertEquals(STRING1, lru.getName(UID1, null).join());
+    assertEquals(STRING1, lru.getName(UID1, null).join());
+    assertEquals(STRING1, lru.getName(UID1, null).join());
+    verify(store, times(4)).getName(UniqueIdType.METRIC, UID1, null);
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    
+    // read only
+    ((UnitTestConfiguration) config).override(
+        "tsd.uid." + DEFAULT_ID + ".metric.mode", "r");
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    assertEquals(STRING1, lru.getName(UID1, null).join());
+    assertEquals(STRING1, lru.getName(UID1, null).join());
+    assertEquals(STRING1, lru.getName(UID1, null).join());
+    verify(store, times(5)).getName(UniqueIdType.METRIC, UID1, null);
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(1, lru.idCache().size());
+  }
+  
+  @Test
+  public void getNameExceptionReturned() throws Exception {
+    when(store.getName(any(UniqueIdType.class), any(byte[].class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromError(new StorageException("Boo!")));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    Deferred<String> deferred = lru.getName(UID1, null);
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    verify(store, times(1)).getName(UniqueIdType.METRIC, UID1, null);
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    
+    trace = new MockTrace(true);
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    deferred = lru.getName(UID1, trace.newSpan("UT").start());
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    verify(store, times(2)).getName(eq(UniqueIdType.METRIC), eq(UID1), 
+        any(Span.class));
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    assertEquals(1, trace.spans.size());
+    assertEquals("Error", trace.spans.get(0).tags.get("status"));
+  }
+  
+  @Test
+  public void getNameExceptionThrown() throws Exception {
+    when(store.getName(any(UniqueIdType.class), any(byte[].class), 
+        any(Span.class)))
+      .thenThrow(new StorageException("Boo!"));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    Deferred<String> deferred = lru.getName(UID1, null);
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    verify(store, times(1)).getName(UniqueIdType.METRIC, UID1, null);
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    
+    trace = new MockTrace(true);
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    deferred = lru.getName(UID1, trace.newSpan("UT").start());
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    verify(store, times(2)).getName(eq(UniqueIdType.METRIC), eq(UID1), 
+        any(Span.class));
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    assertEquals(1, trace.spans.size());
+    assertEquals("Error", trace.spans.get(0).tags.get("status"));
+  }
+  
+  @Test
+  public void getNames() throws Exception {
+    when(store.getNames(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(Lists.newArrayList(STRING1, STRING2)));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    
+    List<String> names = lru.getNames(Lists.newArrayList(UID1, UID2), null).join();
+    assertEquals(STRING1, names.get(0));
+    assertEquals(STRING2, names.get(1));
+    verify(store, times(1)).getNames(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(2, lru.nameCache().size());
+    assertEquals(2, lru.idCache().size());
+    
+    names = lru.getNames(Lists.newArrayList(UID1, UID2), null).join();
+    assertEquals(STRING1, names.get(0));
+    assertEquals(STRING2, names.get(1));
+    verify(store, times(1)).getNames(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(2, lru.nameCache().size());
+    assertEquals(2, lru.idCache().size());
+    
+    trace = new MockTrace();
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    names = lru.getNames(Lists.newArrayList(UID1, UID2), 
+        trace.newSpan("UT").start()).join();
+    assertEquals(0, trace.spans.size());
+    
+    trace = new MockTrace(true);
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    names = lru.getNames(Lists.newArrayList(UID1, UID2), 
+        trace.newSpan("UT").start()).join();
+    names = lru.getNames(Lists.newArrayList(UID1, UID2), 
+        trace.newSpan("UT").start()).join();
+    assertEquals(2, trace.spans.size());
+    assertEquals(LRUUniqueId.class.getName() + ".getNames", trace.spans.get(0).id);
+    assertEquals("OK", trace.spans.get(0).tags.get("status"));
+    assertEquals("false", trace.spans.get(0).tags.get("fromCache"));
+    assertEquals("true", trace.spans.get(1).tags.get("fromCache"));
+  }
+  
+  @Test
+  public void getNamesIllegalArgumentException() throws Exception {
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    try {
+      lru.getNames(null, null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    try {
+      lru.getNames(Lists.newArrayList(), null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void getNamesPartialCacheHit() throws Exception {
+    when(store.getNames(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(Lists.newArrayList(STRING2)));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    lru.idCache().put(UniqueId.uidToString(UID1), STRING1);
+    
+    List<String> names = lru.getNames(Lists.newArrayList(UID1, UID2), null).join();
+    assertEquals(2, names.size());
+    assertEquals(STRING1, names.get(0));
+    assertEquals(STRING2, names.get(1));
+    verify(store, times(1)).getNames(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(1, lru.nameCache().size());
+    assertEquals(2, lru.idCache().size());
+    
+    // fully satisfied from cache
+    names = lru.getNames(Lists.newArrayList(UID1, UID2), null).join();
+    assertEquals(2, names.size());
+    assertEquals(STRING1, names.get(0));
+    assertEquals(STRING2, names.get(1));
+    verify(store, times(1)).getNames(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(1, lru.nameCache().size());
+    assertEquals(2, lru.idCache().size());
+    
+    // staggered
+    when(store.getNames(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(Lists.newArrayList(STRING1, STRING3)));
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    lru.idCache().put(UniqueId.uidToString(UID2), STRING2);
+    lru.idCache().put(UniqueId.uidToString(UID4), STRING4);
+    
+    names = lru.getNames(Lists.newArrayList(UID1, UID2, UID3, UID4), null).join();
+    assertEquals(4, names.size());
+    assertEquals(STRING1, names.get(0));
+    assertEquals(STRING2, names.get(1));
+    assertEquals(STRING3, names.get(2));
+    assertEquals(STRING4, names.get(3));
+    
+    // diff order
+    when(store.getNames(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(Lists.newArrayList(STRING1, STRING3)));
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    lru.idCache().put(UniqueId.uidToString(UID2), STRING2);
+    lru.idCache().put(UniqueId.uidToString(UID4), STRING4);
+    
+    names = lru.getNames(Lists.newArrayList(UID2, UID4, UID1, UID3), null).join();
+    assertEquals(4, names.size());
+    assertEquals(STRING2, names.get(0));
+    assertEquals(STRING4, names.get(1));
+    assertEquals(STRING1, names.get(2));
+    assertEquals(STRING3, names.get(3));
+  }
+  
+  @Test
+  public void getNamesModes() throws Exception {
+    when(store.getNames(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(Lists.newArrayList(STRING1, STRING2)));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    
+    // read-write
+    List<String> names = lru.getNames(Lists.newArrayList(UID1, UID2), null).join();
+    assertEquals(STRING1, names.get(0));
+    assertEquals(STRING2, names.get(1));
+    verify(store, times(1)).getNames(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(2, lru.nameCache().size());
+    assertEquals(2, lru.idCache().size());
+    
+    // write only
+    ((UnitTestConfiguration) config).override(
+        "tsd.uid." + DEFAULT_ID + ".metric.mode", "w");
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    names = lru.getNames(Lists.newArrayList(UID1, UID2), null).join();
+    assertEquals(STRING1, names.get(0));
+    assertEquals(STRING2, names.get(1));
+    verify(store, times(2)).getNames(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    
+    // read only
+    ((UnitTestConfiguration) config).override(
+        "tsd.uid." + DEFAULT_ID + ".metric.mode", "r");
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    names = lru.getNames(Lists.newArrayList(UID1, UID2), null).join();
+    assertEquals(STRING1, names.get(0));
+    assertEquals(STRING2, names.get(1));
+    verify(store, times(3)).getNames(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(2, lru.idCache().size());
+  }
+  
+  @Test
+  public void getNamesExceptionReturned() throws Exception {
+    when(store.getNames(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromError(new StorageException("Boo!")));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    
+    Deferred<List<String>> deferred = 
+        lru.getNames(Lists.newArrayList(UID1, UID2), null);
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    verify(store, times(1)).getNames(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    
+    trace = new MockTrace(true);
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    deferred = lru.getNames(Lists.newArrayList(UID1, UID2), 
+        trace.newSpan("UT").start());
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    verify(store, times(2)).getNames(eq(UniqueIdType.METRIC), 
+        any(List.class), any(Span.class));
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    assertEquals(1, trace.spans.size());
+    assertEquals("Error", trace.spans.get(0).tags.get("status"));
+  }
+  
+  @Test
+  public void getNamesExceptionThrown() throws Exception {
+    when(store.getNames(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenThrow(new StorageException("Boo!"));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    
+    // read-write
+    Deferred<List<String>> deferred = 
+        lru.getNames(Lists.newArrayList(UID1, UID2), null);
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    verify(store, times(1)).getNames(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    
+    trace = new MockTrace(true);
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    
+    deferred = lru.getNames(Lists.newArrayList(UID1, UID2), 
+        trace.newSpan("UT").start());
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    verify(store, times(2)).getNames(eq(UniqueIdType.METRIC), 
+        any(List.class), any(Span.class));
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    assertEquals(1, trace.spans.size());
+    assertEquals("Error", trace.spans.get(0).tags.get("status"));
+  }
+  
+  @Test
+  public void getId() throws Exception {
+    when(store.getId(any(UniqueIdType.class), anyString(), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(UID1));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    assertArrayEquals(UID1, lru.getId(STRING1, null).join());
+    assertArrayEquals(UID1, lru.getId(STRING1, null).join());
+    assertArrayEquals(UID1, lru.getId(STRING1, null).join());
+    assertEquals(1, lru.nameCache().size());
+    assertEquals(1, lru.idCache().size());
+    verify(store, times(1)).getId(UniqueIdType.METRIC, STRING1, null);
+    
+    trace = new MockTrace();
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    assertArrayEquals(UID1, lru.getId(STRING1, trace.newSpan("UT").start()).join());
+    assertArrayEquals(UID1, lru.getId(STRING1, trace.newSpan("UT").start()).join());
+    assertArrayEquals(UID1, lru.getId(STRING1, trace.newSpan("UT").start()).join());
+    assertEquals(0, trace.spans.size());
+    
+    trace = new MockTrace(true);
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    assertArrayEquals(UID1, lru.getId(STRING1, trace.newSpan("UT").start()).join());
+    assertArrayEquals(UID1, lru.getId(STRING1, trace.newSpan("UT").start()).join());
+    assertArrayEquals(UID1, lru.getId(STRING1, trace.newSpan("UT").start()).join());
+    assertEquals(3, trace.spans.size());
+    assertEquals(LRUUniqueId.class.getName() + ".getId", trace.spans.get(0).id);
+    assertEquals("OK", trace.spans.get(0).tags.get("status"));
+    assertEquals("false", trace.spans.get(0).tags.get("fromCache"));
+    assertEquals("true", trace.spans.get(1).tags.get("fromCache"));
+    assertEquals("true", trace.spans.get(2).tags.get("fromCache"));
+  }
+  
+  @Test
+  public void getIdIllegalArgumentException() throws Exception {
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    try {
+      lru.getId(null, null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    try {
+      lru.getId("", null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void getIdModes() throws Exception {
+    // read-write
+    when(store.getId(any(UniqueIdType.class), anyString(), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(UID1));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    assertArrayEquals(UID1, lru.getId(STRING1, null).join());
+    assertArrayEquals(UID1, lru.getId(STRING1, null).join());
+    assertArrayEquals(UID1, lru.getId(STRING1, null).join());
+    assertEquals(1, lru.nameCache().size());
+    assertEquals(1, lru.idCache().size());
+    verify(store, times(1)).getId(UniqueIdType.METRIC, STRING1, null);
+    
+    // write only
+    ((UnitTestConfiguration) config).override(
+        "tsd.uid." + DEFAULT_ID + ".metric.mode", "w");
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    assertArrayEquals(UID1, lru.getId(STRING1, null).join());
+    assertArrayEquals(UID1, lru.getId(STRING1, null).join());
+    assertArrayEquals(UID1, lru.getId(STRING1, null).join());
+    assertEquals(1, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    verify(store, times(2)).getId(UniqueIdType.METRIC, STRING1, null);
+    
+    // read only
+    ((UnitTestConfiguration) config).override(
+        "tsd.uid." + DEFAULT_ID + ".metric.mode", "r");
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    assertArrayEquals(UID1, lru.getId(STRING1, null).join());
+    assertArrayEquals(UID1, lru.getId(STRING1, null).join());
+    assertArrayEquals(UID1, lru.getId(STRING1, null).join());
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    verify(store, times(5)).getId(UniqueIdType.METRIC, STRING1, null);
+  }
+
+  @Test
+  public void getIdExceptionReturned() throws Exception {
+    when(store.getId(any(UniqueIdType.class), anyString(), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromError(new StorageException("Boo!")));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    
+    Deferred<byte[]> deferred = lru.getId(STRING1, null);
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    verify(store, times(1)).getId(UniqueIdType.METRIC, STRING1, null);
+    
+    trace = new MockTrace(true);
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    deferred = lru.getId(STRING1, trace.newSpan("UT").start());
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    verify(store, times(1)).getId(UniqueIdType.METRIC, STRING1, null);
+    assertEquals(1, trace.spans.size());
+    assertEquals("Error", trace.spans.get(0).tags.get("status"));
+  }
+  
+  @Test
+  public void getIdExceptionThrown() throws Exception {
+    when(store.getId(any(UniqueIdType.class), anyString(), 
+        any(Span.class)))
+      .thenThrow(new StorageException("Boo!"));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    
+    Deferred<byte[]> deferred = lru.getId(STRING1, null);
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    verify(store, times(1)).getId(UniqueIdType.METRIC, STRING1, null);
+    
+    trace = new MockTrace(true);
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    deferred = lru.getId(STRING1, trace.newSpan("UT").start());
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    verify(store, times(1)).getId(UniqueIdType.METRIC, STRING1, null);
+    assertEquals(1, trace.spans.size());
+    assertEquals("Error", trace.spans.get(0).tags.get("status"));
+  }
+  
+  @Test
+  public void getIds() throws Exception {
+    when(store.getIds(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(Lists.newArrayList(UID1, UID2)));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    
+    List<byte[]> ids = lru.getIds(Lists.newArrayList(STRING1, STRING2), null).join();
+    assertArrayEquals(UID1, ids.get(0));
+    assertArrayEquals(UID2, ids.get(1));
+    verify(store, times(1)).getIds(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(2, lru.nameCache().size());
+    assertEquals(2, lru.idCache().size());
+    
+    trace = new MockTrace();
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    ids = lru.getIds(Lists.newArrayList(STRING1, STRING2), 
+        trace.newSpan("UT").start()).join();
+    assertEquals(0, trace.spans.size());
+    
+    trace = new MockTrace(true);
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    ids = lru.getIds(Lists.newArrayList(STRING1, STRING2), 
+        trace.newSpan("UT").start()).join();
+    ids = lru.getIds(Lists.newArrayList(STRING1, STRING2), 
+        trace.newSpan("UT").start()).join();
+    assertEquals(2, trace.spans.size());
+    assertEquals(LRUUniqueId.class.getName() + ".getIds", trace.spans.get(0).id);
+    assertEquals("OK", trace.spans.get(0).tags.get("status"));
+    assertEquals("false", trace.spans.get(0).tags.get("fromCache"));
+    assertEquals("true", trace.spans.get(1).tags.get("fromCache"));
+  }
+  
+  @Test
+  public void getIdsPartialCacheIt() throws Exception {
+    when(store.getIds(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(Lists.newArrayList(UID2)));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    lru.nameCache().put(STRING1, UID1);
+    
+    List<byte[]> ids = lru.getIds(Lists.newArrayList(STRING1, STRING2), null).join();
+    assertArrayEquals(UID1, ids.get(0));
+    assertArrayEquals(UID2, ids.get(1));
+    verify(store, times(1)).getIds(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(2, lru.nameCache().size());
+    assertEquals(1, lru.idCache().size());
+    
+    // fully satisfied from cache
+    ids = lru.getIds(Lists.newArrayList(STRING1, STRING2), null).join();
+    assertArrayEquals(UID1, ids.get(0));
+    assertArrayEquals(UID2, ids.get(1));
+    verify(store, times(1)).getIds(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(2, lru.nameCache().size());
+    assertEquals(1, lru.idCache().size());
+    
+    // staggered
+    when(store.getIds(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(Lists.newArrayList(UID1, UID3)));
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    lru.nameCache().put(STRING2, UID2);
+    lru.nameCache().put(STRING4, UID4);
+    
+    ids = lru.getIds(Lists.newArrayList(STRING1, STRING2, STRING3, STRING4), null).join();
+    assertEquals(4, ids.size());
+    assertArrayEquals(UID1, ids.get(0));
+    assertArrayEquals(UID2, ids.get(1));
+    assertArrayEquals(UID3, ids.get(2));
+    assertArrayEquals(UID4, ids.get(3));
+    verify(store, times(2)).getIds(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(4, lru.nameCache().size());
+    assertEquals(2, lru.idCache().size());
+    
+    // diff order
+    when(store.getIds(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(Lists.newArrayList(UID3, UID1)));
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    lru.nameCache().put(STRING2, UID2);
+    lru.nameCache().put(STRING4, UID4);
+    
+    ids = lru.getIds(Lists.newArrayList(STRING2, STRING4, STRING3, STRING1), null).join();
+    assertEquals(4, ids.size());
+    assertArrayEquals(UID2, ids.get(0));
+    assertArrayEquals(UID4, ids.get(1));
+    assertArrayEquals(UID3, ids.get(2));
+    assertArrayEquals(UID1, ids.get(3));
+    verify(store, times(3)).getIds(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(4, lru.nameCache().size());
+    assertEquals(2, lru.idCache().size());
+  }
+  
+  @Test
+  public void getIdsModes() throws Exception {
+    when(store.getIds(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromResult(Lists.newArrayList(UID1, UID2)));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    
+    List<byte[]> ids = lru.getIds(Lists.newArrayList(STRING1, STRING2), null).join();
+    assertArrayEquals(UID1, ids.get(0));
+    assertArrayEquals(UID2, ids.get(1));
+    verify(store, times(1)).getIds(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(2, lru.nameCache().size());
+    assertEquals(2, lru.idCache().size());
+    
+    // write only
+    ((UnitTestConfiguration) config).override(
+        "tsd.uid." + DEFAULT_ID + ".metric.mode", "w");
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    ids = lru.getIds(Lists.newArrayList(STRING1, STRING2), null).join();
+    assertArrayEquals(UID1, ids.get(0));
+    assertArrayEquals(UID2, ids.get(1));
+    verify(store, times(2)).getIds(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(2, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    
+    // read only
+    ((UnitTestConfiguration) config).override(
+        "tsd.uid." + DEFAULT_ID + ".metric.mode", "r");
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    ids = lru.getIds(Lists.newArrayList(STRING1, STRING2), null).join();
+    assertArrayEquals(UID1, ids.get(0));
+    assertArrayEquals(UID2, ids.get(1));
+    verify(store, times(3)).getIds(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+  }
+
+  @Test
+  public void getIdsExceptionReturned() throws Exception {
+    when(store.getIds(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenReturn(Deferred.fromError(new StorageException("Boo!")));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    
+    Deferred<List<byte[]>> deferred = lru.getIds(
+        Lists.newArrayList(STRING1, STRING2), null);
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    verify(store, times(1)).getIds(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    
+    trace = new MockTrace(true);
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    deferred = lru.getIds(Lists.newArrayList(STRING1, STRING2), 
+        trace.newSpan("UT").start());
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    verify(store, times(2)).getIds(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    assertEquals(1, trace.spans.size());
+    assertEquals("Error", trace.spans.get(0).tags.get("status"));
+  }
+  
+  @Test
+  public void getIdsExceptionThrown() throws Exception {
+    when(store.getIds(any(UniqueIdType.class), any(List.class), 
+        any(Span.class)))
+      .thenThrow(new StorageException("Boo!"));
+    LRUUniqueId lru = new LRUUniqueId(tsdb, DEFAULT_ID, 
+        UniqueIdType.METRIC, store);
+    
+    Deferred<List<byte[]>> deferred = lru.getIds(
+        Lists.newArrayList(STRING1, STRING2), null);
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    verify(store, times(1)).getIds(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    
+    trace = new MockTrace(true);
+    lru = new LRUUniqueId(tsdb, DEFAULT_ID, UniqueIdType.METRIC, store);
+    deferred = lru.getIds(Lists.newArrayList(STRING1, STRING2), 
+        trace.newSpan("UT").start());
+    try {
+      deferred.join();
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    verify(store, times(2)).getIds(eq(UniqueIdType.METRIC), any(List.class), any(Span.class));
+    assertEquals(0, lru.nameCache().size());
+    assertEquals(0, lru.idCache().size());
+    assertEquals(1, trace.spans.size());
+    assertEquals("Error", trace.spans.get(0).tags.get("status"));
+  }
+  
+  private static void resetConfig() {
+    final UnitTestConfiguration c = (UnitTestConfiguration) config;
+    if (c.hasProperty("tsd.uid." + DEFAULT_ID + ".metric.mode")) {
+      c.override("tsd.uid." + DEFAULT_ID + ".metric.mode", "rw");
+    }
+    if (c.hasProperty("tsd.uid." + DEFAULT_ID + ".record_stats")) {
+      c.override("tsd.uid." + DEFAULT_ID + ".record_stats", "true");
+    }
+    if (c.hasProperty("tsd.uid." + DEFAULT_ID + ".lru.name.size")) {
+      c.override("tsd.uid." + DEFAULT_ID + ".lru.name.size", "10");
+    }
+    if (c.hasProperty("tsd.uid." + DEFAULT_ID + ".lru.id.size")) {
+      c.override("tsd.uid." + DEFAULT_ID + ".lru.id.size", "8");
+    }
+  }
+}

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/UniqueId.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/UniqueId.java
@@ -1868,6 +1868,11 @@ public class UniqueId implements UniqueIdStore {
 //    }
 //  }
 
+  @Override
+  public Charset characterSet() {
+    return character_set;
+  }
+  
   class ResolvedFilterImplementation implements ResolvedFilter {
     
     byte[] tag_key;


### PR DESCRIPTION
- Add CacheMode to the UniqueId class to determine which cache we're
  supposed to populate.
- Have the UniqueIdStore return the character set.
- Add the LRU UniqueId cache with Guava implementation of the getId(s)
  and getName(s) implementations.