### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/core/Const.java
+++ b/core/src/main/java/net/opentsdb/core/Const.java
@@ -78,9 +78,6 @@ public final class Const {
   /** Mask to verify a timestamp on 6 bytes in milliseconds */
   public static final long MILLISECOND_MASK = 0xFFFFF00000000000L;
   
-  /** Max time delta (in seconds) we can store in a column qualifier.  */
-  public static final short MAX_TIMESPAN = 3600;
-
   /**
    * Array containing the hexadecimal characters (0 to 9, A to F).
    * This array is read-only, changing its contents leads to an undefined

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
@@ -32,7 +32,6 @@ import net.opentsdb.data.TimeSeriesStringId;
 import net.opentsdb.data.TimeStamp;
 import net.opentsdb.query.filter.TagVFilter;
 import net.opentsdb.query.filter.TagVLiteralOrFilter;
-import net.opentsdb.query.pojo.Downsampler;
 import net.opentsdb.query.pojo.Filter;
 import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.Span;
@@ -68,6 +67,9 @@ public class Schema implements StorageSchema {
    * Otherwise it's an integer value.
    */
   public static final short FLAG_FLOAT = 0x8;
+  
+  /** Max time delta (in seconds) we can store in a column qualifier.  */
+  public static final short MAX_RAW_TIMESPAN = 3600;
   
   /** Number of bytes on which a timestamp is encoded.  */
   public static final short TIMESTAMP_BYTES = 4;
@@ -558,6 +560,25 @@ public class Schema implements StorageSchema {
     throw new UnsupportedOperationException("Implement me!");
   }
   
+  /**
+   * Sets the time in a raw data table row key.
+   * 
+   * @param row The row to modify.
+   * @param base_time The base time to store.
+   * @throws IllegalArgumentException if the row was null, empty or too
+   * short.
+   * @since 2.3
+   */
+  public void setBaseTime(final byte[] row, final int base_time) {
+    if (Bytes.isNullOrEmpty(row)) {
+      throw new IllegalArgumentException("Row cannot be null or empty.");
+    }
+    if (row.length < salt_width + metric_width + TIMESTAMP_BYTES) {
+      throw new IllegalArgumentException("Row is too short.");
+    }
+    Bytes.setInt(row, base_time, salt_width + metric_width);
+  }
+  
   static class ResolvedFilterImplementation implements ResolvedFilter {
     protected byte[] tag_key;
     protected List<byte[]> tag_values;
@@ -664,30 +685,5 @@ public class Schema implements StorageSchema {
   UniqueId tagValues() {
     return tag_values;
   }
-
-  public void setBaseTime(final byte[] key, final long time) {
-    // TODO Auto-generated method stub
-  }
   
-  public long alignDownsamplerBaseTimestamp(Downsampler downsampler,
-      long start_ts) {
-    // TODO Auto-generated method stub
-    return 0;
-  }
-
-  public long alignQueryBaseTimestamp(long start_ts) {
-    // TODO Auto-generated method stub
-    return 0;
-  }
-
-  public long alignDownsamplerNextTimestamp(Downsampler downsampler,
-      long end_ts) {
-    // TODO Auto-generated method stub
-    return 0;
-  }
-
-  public long alignQueryNextTimestamp(long end_ts) {
-    // TODO Auto-generated method stub
-    return 0;
-  }
 }

--- a/core/src/test/java/net/opentsdb/query/pojo/TestTimeSeriesQuery.java
+++ b/core/src/test/java/net/opentsdb/query/pojo/TestTimeSeriesQuery.java
@@ -14,11 +14,14 @@
 // limitations under the License.
 package net.opentsdb.query.pojo;
 
+import net.opentsdb.configuration.Configuration;
+import net.opentsdb.configuration.UnitTestConfiguration;
 import net.opentsdb.query.filter.TagVFilter;
 import net.opentsdb.query.pojo.Join.SetOperator;
 import net.opentsdb.utils.JSON;
 
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -28,13 +31,18 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TestTimeSeriesQuery {
+  
+  private static Configuration configuration;
+  
   private Timespan time;
   private Filter filter;
   private Metric metric;
@@ -87,6 +95,15 @@ public class TestTimeSeriesQuery {
       + "  ]"
       + "}";
 
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    configuration = UnitTestConfiguration.getConfiguration();
+    configuration.register("tsd.query.test1", 42, false, "UT");
+    configuration.register("tsd.query.test2", true, false, "UT");
+    configuration.register("tsd.query.test3", "Tyrell", false, "UT");
+    configuration.register("tsd.query.test4", null, false, "UT");
+  }
+  
   @Before
   public void setup() {
     time = Timespan.newBuilder().setStart("3h-ago").setAggregator("avg")
@@ -312,6 +329,7 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(filter, f1))
         .setMetrics(Arrays.asList(metric, m1))
         .setOutputs(Arrays.asList(output, o1))
+        .addConfig("key1", "value1")
         .build();
     
     TimeSeriesQuery q2 = new TimeSeriesQuery.Builder()
@@ -321,6 +339,7 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(filter, f1))
         .setMetrics(Arrays.asList(metric, m1))
         .setOutputs(Arrays.asList(output, o1))
+        .addConfig("key1", "value1")
         .build();
     assertEquals(q1.hashCode(), q2.hashCode());
     assertArrayEquals(q1.buildTimelessHashCode().asBytes(), 
@@ -344,6 +363,7 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(filter, f1))
         .setMetrics(Arrays.asList(metric, m1))
         .setOutputs(Arrays.asList(output, o1))
+        .addConfig("key1", "value1")
         .build();
     assertNotEquals(q1.hashCode(), q2.hashCode());
     assertArrayEquals(q1.buildTimelessHashCode().asBytes(), 
@@ -367,6 +387,7 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(filter, f1))
         .setMetrics(Arrays.asList(metric, m1))
         .setOutputs(Arrays.asList(output, o1))
+        .addConfig("key1", "value1")
         .build();
     assertEquals(q1.hashCode(), q2.hashCode());
     assertEquals(q1, q2);
@@ -379,6 +400,7 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(f1, filter))  // <-- diff order 
         .setMetrics(Arrays.asList(metric, m1))
         .setOutputs(Arrays.asList(output, o1))
+        .addConfig("key1", "value1")
         .build();
     assertEquals(q1.hashCode(), q2.hashCode());
     assertEquals(q1, q2);
@@ -391,6 +413,7 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(filter, f1))
         .setMetrics(Arrays.asList(m1, metric))  // <-- diff order 
         .setOutputs(Arrays.asList(output, o1))
+        .addConfig("key1", "value1")
         .build();
     assertEquals(q1.hashCode(), q2.hashCode());
     assertEquals(q1, q2);
@@ -403,6 +426,7 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(filter, f1))
         .setMetrics(Arrays.asList(metric, m1))
         .setOutputs(Arrays.asList(o1, output))  // <-- diff order 
+        .addConfig("key1", "value1")
         .build();
     assertEquals(q1.hashCode(), q2.hashCode());
     assertEquals(q1, q2);
@@ -415,6 +439,7 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(filter, f1))
         .setMetrics(Arrays.asList(metric, m1))
         .setOutputs(Arrays.asList(output, o1))
+        .addConfig("key1", "value1")
         .build();
     assertNotEquals(q1.hashCode(), q2.hashCode());
     assertNotEquals(q1, q2);
@@ -427,6 +452,7 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(filter, f1))
         .setMetrics(Arrays.asList(metric, m1))
         .setOutputs(Arrays.asList(output, o1))
+        .addConfig("key1", "value1")
         .build();
     assertNotEquals(q1.hashCode(), q2.hashCode());
     assertNotEquals(q1, q2);
@@ -439,6 +465,7 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(filter))  // <-- diff
         .setMetrics(Arrays.asList(metric, m1))
         .setOutputs(Arrays.asList(output, o1))
+        .addConfig("key1", "value1")
         .build();
     assertNotEquals(q1.hashCode(), q2.hashCode());
     assertNotEquals(q1, q2);
@@ -451,6 +478,7 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(filter, f1))
         .setMetrics(Arrays.asList(metric))  // <-- diff
         .setOutputs(Arrays.asList(output, o1))
+        .addConfig("key1", "value1")
         .build();
     assertNotEquals(q1.hashCode(), q2.hashCode());
     assertNotEquals(q1, q2);
@@ -463,6 +491,7 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(filter, f1))
         .setMetrics(Arrays.asList(metric, m1))
         .setOutputs(Arrays.asList(output))  // <-- diff
+        .addConfig("key1", "value1")
         .build();
     assertNotEquals(q1.hashCode(), q2.hashCode());
     assertNotEquals(q1, q2);
@@ -475,6 +504,7 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(filter, f1))
         .setMetrics(Arrays.asList(metric, m1))
         .setOutputs(Arrays.asList(output, o1))
+        .addConfig("key1", "value1")
         .build();
     assertNotEquals(q1.hashCode(), q2.hashCode());
     assertNotEquals(q1, q2);
@@ -487,6 +517,7 @@ public class TestTimeSeriesQuery {
         //.setFilters(Arrays.asList(filter, f1))  // <-- diff
         .setMetrics(Arrays.asList(metric, m1))
         .setOutputs(Arrays.asList(output, o1))
+        .addConfig("key1", "value1")
         .build();
     assertNotEquals(q1.hashCode(), q2.hashCode());
     assertNotEquals(q1, q2);
@@ -499,12 +530,108 @@ public class TestTimeSeriesQuery {
         .setFilters(Arrays.asList(filter, f1))
         .setMetrics(Arrays.asList(metric, m1))
         //.setOutputs(Arrays.asList(output, o1))  // <-- diff
+        .addConfig("key1", "value1")
+        .build();
+    assertNotEquals(q1.hashCode(), q2.hashCode());
+    assertNotEquals(q1, q2);
+    assertEquals(1, q1.compareTo(q2));
+    
+    q2 = new TimeSeriesQuery.Builder()
+        .setName("q1")
+        .setTime(time)
+        .setExpressions(Arrays.asList(expression, e1))
+        .setFilters(Arrays.asList(filter, f1))
+        .setMetrics(Arrays.asList(metric, m1))
+        .setOutputs(Arrays.asList(output, o1))
+        .addConfig("key1", "value2")  // <-- diff
+        .build();
+    assertNotEquals(q1.hashCode(), q2.hashCode());
+    assertNotEquals(q1, q2);
+    assertEquals(-1, q1.compareTo(q2));
+    
+    q2 = new TimeSeriesQuery.Builder()
+        .setName("q1")
+        .setTime(time)
+        .setExpressions(Arrays.asList(expression, e1))
+        .setFilters(Arrays.asList(filter, f1))
+        .setMetrics(Arrays.asList(metric, m1))
+        .setOutputs(Arrays.asList(output, o1))
+        //.addConfig("key1", "value1")  // <-- diff
         .build();
     assertNotEquals(q1.hashCode(), q2.hashCode());
     assertNotEquals(q1, q2);
     assertEquals(1, q1.compareTo(q2));
   }
 
+  @Test
+  public void getString() throws Exception {
+    TimeSeriesQuery query = TimeSeriesQuery.newBuilder()
+        .setFilters(Arrays.asList(filter))
+        .setMetrics(Arrays.asList(metric))
+        .setName("q1")
+        .setTime(time)
+        .setOutputs(Arrays.asList(output))
+        .addConfig("tsd.query.test6", "foo")
+        .build();
+    
+    assertEquals("foo", query.getString(configuration, "tsd.query.test6"));
+    assertEquals("Tyrell", query.getString(configuration, "tsd.query.test3"));
+    assertNull(query.getString(configuration, "tsd.query.test7"));
+  }
+  
+  @Test
+  public void getInt() throws Exception {
+    TimeSeriesQuery query = TimeSeriesQuery.newBuilder()
+        .setFilters(Arrays.asList(filter))
+        .setMetrics(Arrays.asList(metric))
+        .setName("q1")
+        .setTime(time)
+        .setOutputs(Arrays.asList(output))
+        .addConfig("tsd.query.test6", "24")
+        .build();
+    
+    assertEquals(24, query.getInt(configuration, "tsd.query.test6"));
+    assertEquals(42, query.getInt(configuration, "tsd.query.test1"));
+    try {
+      query.getInt(configuration, "tsd.query.test7");
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void getBoolean() throws Exception {
+    TimeSeriesQuery query = TimeSeriesQuery.newBuilder()
+        .setFilters(Arrays.asList(filter))
+        .setMetrics(Arrays.asList(metric))
+        .setName("q1")
+        .setTime(time)
+        .setOutputs(Arrays.asList(output))
+        .addConfig("tsd.query.test6", "yes")
+        .build();
+    
+    assertTrue(query.getBoolean(configuration, "tsd.query.test6"));
+    assertTrue(query.getBoolean(configuration, "tsd.query.test2"));
+    try {
+      query.getBoolean(configuration, "tsd.query.test7");
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void hasKey() throws Exception {
+    TimeSeriesQuery query = TimeSeriesQuery.newBuilder()
+        .setFilters(Arrays.asList(filter))
+        .setMetrics(Arrays.asList(metric))
+        .setName("q1")
+        .setTime(time)
+        .setOutputs(Arrays.asList(output))
+        .addConfig("tsd.query.test6", "yes")
+        .build();
+    
+    assertTrue(query.hasKey("tsd.query.test6"));
+    assertFalse(query.hasKey("tsd.query.test2"));
+  }
+  
   private TimeSeriesQuery.Builder getDefaultQueryBuilder() {
     return TimeSeriesQuery.newBuilder().setExpressions(Arrays.asList(expression))
           .setFilters(Arrays.asList(filter)).setMetrics(Arrays.asList(metric))


### PR DESCRIPTION
- remove the MAX_TIMESPAN from Const and put it in Schema.
- Move the RollupUsage enum into RollupUtils.
- Pull setBaseTime in from Internal into Schema and remove some function stubs
  we won't actually need.