### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
@@ -557,7 +557,7 @@ public class Schema implements StorageSchema {
   
   public RollupConfig rollupConfig() {
     // TODO - implement
-    throw new UnsupportedOperationException("Implement me!");
+    return null;
   }
   
   /**

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseDataStore.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseDataStore.java
@@ -36,6 +36,7 @@ import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QuerySourceConfig;
+import net.opentsdb.rollup.RollupUtils.RollupUsage;
 import net.opentsdb.stats.Span;
 import net.opentsdb.storage.schemas.tsdb1x.Schema;
 import net.opentsdb.uid.UniqueIdStore;
@@ -53,6 +54,18 @@ public class Tsdb1xHBaseDataStore implements TimeSeriesDataStore {
   public static final String UID_TABLE_KEY = "uid_table";
   public static final String TREE_TABLE_KEY = "tree_table";
   public static final String META_TABLE_KEY = "meta_table";
+  
+  public static final String EXPANSION_LIMIT_KEY = 
+      "tsd.query.filter.expansion_limit";
+  public static final String ROLLUP_USAGE_KEY = 
+      "tsd.query.rollups.default_usage";
+  public static final String SKIP_NSUN_TAGK_KEY = "tsd.query.skip_unresolved_tagks";
+  public static final String SKIP_NSUN_TAGV_KEY = "tsd.query.skip_unresolved_tagvs";
+  public static final String PRE_AGG_KEY = "tsd.query.pre_agg";
+  public static final String FUZZY_FILTER_KEY = "tsd.query.enable_fuzzy_filter";
+  public static final String REVERSE_KEY = "tsd.query.reverse_time";
+  public static final String ROWS_PER_SCAN_KEY = "tsd.query.rows_per_scan";
+  public static final String MAX_MG_CARDINALITY_KEY = "tsd.query.multiget.max_cardinality";
   
   public static final byte[] DATA_FAMILY = 
       "t".getBytes(Const.ASCII_CHARSET);
@@ -114,6 +127,26 @@ public class Tsdb1xHBaseDataStore implements TimeSeriesDataStore {
       }
       meta_table = config.getString(getConfigKey(META_TABLE_KEY))
           .getBytes(Const.ASCII_CHARSET);
+      
+      if (!config.hasProperty(EXPANSION_LIMIT_KEY)) {
+        config.register(EXPANSION_LIMIT_KEY, 4096, true,
+            "The maximum number of UIDs to expand in a literal filter "
+            + "for HBase scanners.");
+      }
+      if (!config.hasProperty(ROLLUP_USAGE_KEY)) {
+        config.register(ROLLUP_USAGE_KEY, "rollup_fallback", true,
+            "The default fallback operation for queries involving rollup tables.");
+      }
+      if (!config.hasProperty(SKIP_NSUN_TAGK_KEY)) {
+        config.register(SKIP_NSUN_TAGK_KEY, "false", true,
+            "Whether or not to simply drop tag keys (names) from query filters "
+            + "that have not been assigned UIDs and try to fetch data anyway.");
+      }
+      if (!config.hasProperty(SKIP_NSUN_TAGV_KEY)) {
+        config.register(SKIP_NSUN_TAGV_KEY, "false", true,
+            "Whether or not to simply drop tag values from query filters "
+            + "that have not been assigned UIDs and try to fetch data anyway.");
+      }
     }
     
     // TODO - shared client!
@@ -228,8 +261,18 @@ public class Tsdb1xHBaseDataStore implements TimeSeriesDataStore {
     return uid_store;
   }
 
-  int maxRowsPerScan() {
+  String dynamicString(final String key) {
+    // TODO - implement
+    return null;
+  }
+  
+  int dynamicInt(final String key) {
     // TODO - implement
     return 0;
+  }
+  
+  boolean dynamicBoolean(final String key) {
+    // TODO - implement
+    return false;
   }
 }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
@@ -97,4 +97,18 @@ public class Tsdb1xQueryNode extends AbstractQueryNode implements SourceNode {
     return ((Tsdb1xHBaseDataStore) factory).schema();
   }
 
+  boolean skipNSUI() {
+    // TODO - implement
+    return false;
+  }
+  
+  boolean fetchDataType(final byte prefix) {
+    // TODO - implement
+    return true;
+  }
+  
+  boolean deleteData() {
+    // TODO  - implement
+    return false;
+  }
 }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryResult.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryResult.java
@@ -75,8 +75,9 @@ public class Tsdb1xQueryResult implements QueryResult {
                       final byte[] value) {
   
   }
-
-  public void exception(final Exception e) {
+  
+  public boolean isFull() {
     // TODO - implement
+    return false;
   }
 }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanners.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanners.java
@@ -63,4 +63,8 @@ public class Tsdb1xScanners {
     
   }
 
+  Tsdb1xQueryNode node() {
+    // TODO - implement
+    return null;
+  }
 }

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/MockBase.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/MockBase.java
@@ -114,7 +114,7 @@ public final class MockBase {
    */
   private ByteMap<ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>>>
   storage = new ByteMap<ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>>>();
-  private HashSet<MockScanner> scanners = new HashSet<MockScanner>(2);
+  private List<MockScanner> scanners = Lists.newArrayList();
 
   /** The default family for shortcuts */
   private byte[] default_family;
@@ -663,8 +663,13 @@ public final class MockBase {
   }
 
   /** @return The set of scanners configured by the caller */
-  public HashSet<MockScanner> getScanners() {
+  public List<MockScanner> getScanners() {
     return scanners;
+  }
+  
+  /** @return The last scanner created. */
+  public MockScanner getLastScanner() {
+    return scanners.isEmpty() ? null : scanners.get(scanners.size() - 1);
   }
 
   /**
@@ -1578,6 +1583,7 @@ public final class MockBase {
           return null;
         }
       }).when(mock_scanner).setReversed(anyBoolean());
+    
     }
 
     @Override
@@ -1876,6 +1882,11 @@ public final class MockBase {
     /** @return The filter for this mock */
     public ScanFilter getFilter() {
       return filter;
+    }
+  
+    /** @return The table name that this scanner was created on. */
+    public byte[] table() {
+      return table;
     }
   }
 

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestQueryUtil.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestQueryUtil.java
@@ -19,8 +19,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+
 import org.hbase.async.Bytes.ByteMap;
 import org.hbase.async.FilterList;
+import org.hbase.async.HBaseClient;
 import org.hbase.async.KeyRegexpFilter;
 import org.hbase.async.ScanFilter;
 import org.hbase.async.Scanner;
@@ -33,8 +36,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import com.google.common.collect.Lists;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ Scanner.class })
-public class TestQueryUtil {
+@PrepareForTest({ HBaseClient.class, Scanner.class })
+public class TestQueryUtil extends UTBase {
   private Scanner scanner;
   
   @Before
@@ -42,107 +45,113 @@ public class TestQueryUtil {
     scanner = mock(Scanner.class);
   }
   
-//  @Test
-//  public void setDataTableScanFilterNoOp() throws Exception {
-//    QueryUtil.setDataTableScanFilter(
-//        scanner,
-//        Lists.<byte[]>newArrayList(), 
-//        new ByteMap<byte[][]>(),
-//        false,
-//        false,
-//        0);
-//    verify(scanner, never()).getCurrentKey();
-//    verify(scanner, never()).setFilter(any(ScanFilter.class));
-//    verify(scanner, never()).setStartKey(any(byte[].class));
-//    verify(scanner, never()).setStopKey(any(byte[].class));
-//  }
-//  
-//  @Test
-//  public void setDataTableScanFilterGroupBy() throws Exception {
-//    QueryUtil.setDataTableScanFilter(
-//        scanner,
-//        Lists.<byte[]>newArrayList(new byte[] { 0, 0, 1 }), 
-//        new ByteMap<byte[][]>(),
-//        false,
-//        false,
-//        0);
-//    verify(scanner, never()).getCurrentKey();
-//    // TODO - validate the regex
-//    verify(scanner, times(1)).setFilter(any(KeyRegexpFilter.class));
-//    verify(scanner, never()).setStartKey(any(byte[].class));
-//    verify(scanner, never()).setStopKey(any(byte[].class));
-//  }
-//  
-//  @Test
-//  public void setDataTableScanFilterTags() throws Exception {
-//    final ByteMap<byte[][]> tags = new ByteMap<byte[][]>();
-//    tags.put(new byte[] { 0, 0, 1 }, new byte[][] { new byte[] {0, 0, 1} });
-//    QueryUtil.setDataTableScanFilter(
-//        scanner,
-//        Lists.<byte[]>newArrayList(), 
-//        tags,
-//        false,
-//        false,
-//        0);
-//    verify(scanner, never()).getCurrentKey();
-//    // TODO - validate the regex
-//    verify(scanner, times(1)).setFilter(any(KeyRegexpFilter.class));
-//    verify(scanner, never()).setStartKey(any(byte[].class));
-//    verify(scanner, never()).setStopKey(any(byte[].class));
-//  }
-//  
-//  @Test
-//  public void setDataTableScanFilterEnableFuzzy() throws Exception {
-//    final ByteMap<byte[][]> tags = new ByteMap<byte[][]>();
-//    tags.put(new byte[] { 0, 0, 1 }, new byte[][] { new byte[] {0, 0, 1} });
-//    QueryUtil.setDataTableScanFilter(
-//        scanner,
-//        Lists.<byte[]>newArrayList(), 
-//        tags,
-//        false,
-//        true,
-//        0);
-//    verify(scanner, never()).getCurrentKey();
-//    // TODO - validate the regex
-//    verify(scanner, times(1)).setFilter(any(KeyRegexpFilter.class));
-//    verify(scanner, never()).setStartKey(any(byte[].class));
-//    verify(scanner, never()).setStopKey(any(byte[].class));
-//  }
-//  
-//  @Test
-//  public void setDataTableScanFilterEnableExplicit() throws Exception {
-//    final ByteMap<byte[][]> tags = new ByteMap<byte[][]>();
-//    tags.put(new byte[] { 0, 0, 1 }, new byte[][] { new byte[] {0, 0, 1} });
-//    QueryUtil.setDataTableScanFilter(
-//        scanner,
-//        Lists.<byte[]>newArrayList(), 
-//        tags,
-//        true,
-//        false,
-//        0);
-//    verify(scanner, never()).getCurrentKey();
-//    // TODO - validate the regex
-//    verify(scanner, times(1)).setFilter(any(KeyRegexpFilter.class));
-//    verify(scanner, never()).setStartKey(any(byte[].class));
-//    verify(scanner, never()).setStopKey(any(byte[].class));
-//  }
-//  
-//  @Test
-//  public void setDataTableScanFilterEnableBoth() throws Exception {
-//    when(scanner.getCurrentKey()).thenReturn(new byte[] { 0, 0, 0, 1 });
-//    final ByteMap<byte[][]> tags = new ByteMap<byte[][]>();
-//    tags.put(new byte[] { 0, 0, 1 }, new byte[][] { new byte[] {0, 0, 1} });
-//    QueryUtil.setDataTableScanFilter(
-//        scanner,
-//        Lists.<byte[]>newArrayList(), 
-//        tags,
-//        true,
-//        true,
-//        0);
-//    verify(scanner, times(2)).getCurrentKey();
-//    // TODO - validate the regex and fuzzy filter
-//    verify(scanner, times(1)).setFilter(any(FilterList.class));
-//    verify(scanner, times(1)).setStartKey(any(byte[].class));
-//    verify(scanner, times(1)).setStopKey(any(byte[].class));
-//  }
+  @Test
+  public void setDataTableScanFilterNoOp() throws Exception {
+    QueryUtil.setDataTableScanFilter(
+        schema,
+        scanner,
+        Lists.<byte[]>newArrayList(), 
+        new ByteMap<List<byte[]>>(),
+        false,
+        false,
+        0);
+    verify(scanner, never()).getCurrentKey();
+    verify(scanner, never()).setFilter(any(ScanFilter.class));
+    verify(scanner, never()).setStartKey(any(byte[].class));
+    verify(scanner, never()).setStopKey(any(byte[].class));
+  }
+  
+  @Test
+  public void setDataTableScanFilterGroupBy() throws Exception {
+    QueryUtil.setDataTableScanFilter(
+        schema,
+        scanner,
+        Lists.<byte[]>newArrayList(new byte[] { 0, 0, 1 }), 
+        new ByteMap<List<byte[]>>(),
+        false,
+        false,
+        0);
+    verify(scanner, never()).getCurrentKey();
+    // TODO - validate the regex
+    verify(scanner, times(1)).setFilter(any(KeyRegexpFilter.class));
+    verify(scanner, never()).setStartKey(any(byte[].class));
+    verify(scanner, never()).setStopKey(any(byte[].class));
+  }
+  
+  @Test
+  public void setDataTableScanFilterTags() throws Exception {
+    final ByteMap<List<byte[]>> tags = new ByteMap<List<byte[]>>();
+    tags.put(new byte[] { 0, 0, 1 }, Lists.newArrayList( new byte[] {0, 0, 1} ));
+    QueryUtil.setDataTableScanFilter(
+        schema,
+        scanner,
+        Lists.<byte[]>newArrayList(), 
+        tags,
+        false,
+        false,
+        0);
+    verify(scanner, never()).getCurrentKey();
+    // TODO - validate the regex
+    verify(scanner, times(1)).setFilter(any(KeyRegexpFilter.class));
+    verify(scanner, never()).setStartKey(any(byte[].class));
+    verify(scanner, never()).setStopKey(any(byte[].class));
+  }
+  
+  @Test
+  public void setDataTableScanFilterEnableFuzzy() throws Exception {
+    final ByteMap<List<byte[]>> tags = new ByteMap<List<byte[]>>();
+    tags.put(new byte[] { 0, 0, 1 }, Lists.newArrayList( new byte[] {0, 0, 1} ));
+    QueryUtil.setDataTableScanFilter(
+        schema,
+        scanner,
+        Lists.<byte[]>newArrayList(), 
+        tags,
+        false,
+        true,
+        0);
+    verify(scanner, never()).getCurrentKey();
+    // TODO - validate the regex
+    verify(scanner, times(1)).setFilter(any(KeyRegexpFilter.class));
+    verify(scanner, never()).setStartKey(any(byte[].class));
+    verify(scanner, never()).setStopKey(any(byte[].class));
+  }
+  
+  @Test
+  public void setDataTableScanFilterEnableExplicit() throws Exception {
+    final ByteMap<List<byte[]>> tags = new ByteMap<List<byte[]>>();
+    tags.put(new byte[] { 0, 0, 1 }, Lists.newArrayList( new byte[] {0, 0, 1} ));
+    QueryUtil.setDataTableScanFilter(
+        schema,
+        scanner,
+        Lists.<byte[]>newArrayList(), 
+        tags,
+        true,
+        false,
+        0);
+    verify(scanner, never()).getCurrentKey();
+    // TODO - validate the regex
+    verify(scanner, times(1)).setFilter(any(KeyRegexpFilter.class));
+    verify(scanner, never()).setStartKey(any(byte[].class));
+    verify(scanner, never()).setStopKey(any(byte[].class));
+  }
+  
+  @Test
+  public void setDataTableScanFilterEnableBoth() throws Exception {
+    when(scanner.getCurrentKey()).thenReturn(new byte[] { 0, 0, 0, 1 });
+    final ByteMap<List<byte[]>> tags = new ByteMap<List<byte[]>>();
+    tags.put(new byte[] { 0, 0, 1 }, Lists.newArrayList( new byte[] {0, 0, 1} ));
+    QueryUtil.setDataTableScanFilter(
+        schema,
+        scanner,
+        Lists.<byte[]>newArrayList(), 
+        tags,
+        true,
+        true,
+        0);
+    verify(scanner, times(2)).getCurrentKey();
+    // TODO - validate the regex and fuzzy filter
+    verify(scanner, times(1)).setFilter(any(FilterList.class));
+    verify(scanner, times(1)).setStartKey(any(byte[].class));
+    verify(scanner, times(1)).setStopKey(any(byte[].class));
+  }
 }

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/UTBase.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/UTBase.java
@@ -137,10 +137,10 @@ public class UTBase {
     config_map = Maps.newHashMap();
     config = UnitTestConfiguration.getConfiguration(config_map);
     uid_factory = mock(UniqueIdFactory.class);
+    data_store = mock(Tsdb1xHBaseDataStore.class);
     
     when(tsdb.getConfig()).thenReturn(config);
     when(tsdb.getRegistry()).thenReturn(registry);
-    data_store = mock(Tsdb1xHBaseDataStore.class);
     when(data_store.tsdb()).thenReturn(tsdb);
     when(data_store.getConfigKey(anyString()))
       .thenAnswer(new Answer<String>() {
@@ -149,6 +149,7 @@ public class UTBase {
         return "tsd.mock." + (String) invocation.getArguments()[0];
       }
     });
+    when(data_store.dataTable()).thenReturn("tsdb".getBytes(Const.ASCII_CHARSET));
     when(data_store.uidTable()).thenReturn(UID_TABLE);
     when(data_store.client()).thenReturn(client);
     when(registry.getSharedObject(any())).thenReturn(data_store);


### PR DESCRIPTION
- Schema now returns a null RollupConfig instead of throwing the exception till
  we finish the implementation.

STORAGE:
- Add a table getter to the MockScanner in MockBase
- Change the scanners set to a list in MockScanner so we can verify easier
- Tweak UTBase to return the default data table
- Change the QueryUtil methods to take a map of lists of byte arrays instead
  of a map of arrays of byte arrays.
- Change Tsdb1xHBaseDataStore to stub out dynamic query properties and
  add getters for various types like string, ints and booleans. Also add some
  static key strings.
- Add some stubs to Tsdb1xQueryNode for scanner behavior.
- Add isFull() to Tsdb1xQueryResult.
- Tweak Tsdb1xScanner to use the overrides in the node and result.