### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/data/MillisecondTimeStamp.java
+++ b/common/src/main/java/net/opentsdb/data/MillisecondTimeStamp.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017  The OpenTSDB Authors.
+// Copyright (C) 2017-2018  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,11 +17,9 @@ package net.opentsdb.data;
 import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.TemporalAmount;
 
 import net.opentsdb.common.Const;
@@ -91,6 +89,20 @@ public class MillisecondTimeStamp implements TimeStamp {
   @Override
   public void update(long epoch, long nano) {
     timestamp = epoch * 1000 + (nano / 1000000);
+  }
+  
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null) {
+      return false;
+    }
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof TimeStamp)) {
+      return false;
+    }
+    return compare(RelationalOperator.EQ, (TimeStamp) o);
   }
   
   @Override

--- a/common/src/main/java/net/opentsdb/data/ZonedNanoTimeStamp.java
+++ b/common/src/main/java/net/opentsdb/data/ZonedNanoTimeStamp.java
@@ -149,6 +149,20 @@ public class ZonedNanoTimeStamp implements TimeStamp {
   }
 
   @Override
+  public boolean equals(final Object o) {
+    if (o == null) {
+      return false;
+    }
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof TimeStamp)) {
+      return false;
+    }
+    return compare(RelationalOperator.EQ, (TimeStamp) o);
+  }
+  
+  @Override
   public boolean compare(final RelationalOperator comparator, 
                          final TimeStamp compareTo) {
     if (compareTo == null) {

--- a/common/src/test/java/net/opentsdb/data/TestMillisecondTimeStamp.java
+++ b/common/src/test/java/net/opentsdb/data/TestMillisecondTimeStamp.java
@@ -586,4 +586,23 @@ public class TestMillisecondTimeStamp {
     } catch (IllegalArgumentException e) { }
   }
   
+  @Test
+  public void equals() throws Exception {
+    TimeStamp ts = new MillisecondTimeStamp(1000);
+    TimeStamp ts2 = null;
+    
+    assertFalse(ts.equals(ts2));
+    assertFalse(ts.equals("not a ts"));
+    assertTrue(ts.equals(ts));
+    
+    ts2 = new MillisecondTimeStamp(1000);
+    assertTrue(ts.equals(ts2));
+    
+    ts2.add(Duration.of(1, ChronoUnit.DAYS));
+    assertFalse(ts.equals(ts2));
+    
+    ts2 = new ZonedNanoTimeStamp(1000L, ZoneId.of("UTC"));
+    assertTrue(ts.equals(ts2));
+  }
+  
 }

--- a/common/src/test/java/net/opentsdb/data/TestZonedNanoTimeStamp.java
+++ b/common/src/test/java/net/opentsdb/data/TestZonedNanoTimeStamp.java
@@ -22,11 +22,9 @@ import static org.junit.Assert.fail;
 import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAmount;
 
 import org.junit.Test;
 
@@ -1344,5 +1342,24 @@ public class TestZonedNanoTimeStamp {
       znt.snapToPreviousInterval(1, ChronoUnit.HALF_DAYS);
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
+  }
+
+  @Test
+  public void equals() throws Exception {
+    TimeStamp ts = new ZonedNanoTimeStamp(1000, UTC);
+    TimeStamp ts2 = null;
+    
+    assertFalse(ts.equals(ts2));
+    assertFalse(ts.equals("not a ts"));
+    assertTrue(ts.equals(ts));
+    
+    ts2 = new ZonedNanoTimeStamp(1000, UTC);
+    assertTrue(ts.equals(ts2));
+    
+    ts2.add(Duration.of(1, ChronoUnit.DAYS));
+    assertFalse(ts.equals(ts2));
+    
+    ts2 = new MillisecondTimeStamp(1000L);
+    assertTrue(ts.equals(ts2));
   }
 }

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
@@ -579,6 +579,11 @@ public class Schema implements StorageSchema {
     Bytes.setInt(row, base_time, salt_width + metric_width);
   }
   
+  public boolean timelessSalting() {
+    // TODO - implement
+    return true;
+  }
+  
   static class ResolvedFilterImplementation implements ResolvedFilter {
     protected byte[] tag_key;
     protected List<byte[]> tag_values;

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
@@ -14,6 +14,8 @@
 // limitations under the License.
 package net.opentsdb.storage;
 
+import java.util.List;
+
 import net.opentsdb.data.TimeStamp;
 import net.opentsdb.query.AbstractQueryNode;
 import net.opentsdb.query.QueryNode;
@@ -22,6 +24,8 @@ import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.QuerySourceConfig;
+import net.opentsdb.rollup.RollupInterval;
+import net.opentsdb.rollup.RollupUtils.RollupUsage;
 import net.opentsdb.storage.schemas.tsdb1x.Schema;
 
 /**
@@ -110,5 +114,15 @@ public class Tsdb1xQueryNode extends AbstractQueryNode implements SourceNode {
   boolean deleteData() {
     // TODO  - implement
     return false;
+  }
+
+  List<RollupInterval> rollupIntervals() {
+    // TODO - implement
+    return null;
+  }
+  
+  RollupUsage rollupUsage() {
+    // TODO - implement
+    return null;
   }
 }


### PR DESCRIPTION
- Add equals() implementations to MillisecondTimeStamp and ZonedNanoTimeStamp.

CORE:
- Add a timelessSalting() flag to Schema for use in multigets.

STORAGE:
- Add rollup information to the Tsdb1xQueryNode class so we can share it and
  move the parsing out of the Tsdb1xScanners class.