### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/QuerySourceConfig.java
+++ b/core/src/main/java/net/opentsdb/query/QuerySourceConfig.java
@@ -1,5 +1,5 @@
 //This file is part of OpenTSDB.
-//Copyright (C) 2017  The OpenTSDB Authors.
+//Copyright (C) 2017-2018  The OpenTSDB Authors.
 //
 //This program is free software: you can redistribute it and/or modify it
 //under the terms of the GNU Lesser General Public License as published by
@@ -11,6 +11,10 @@
 //of the GNU Lesser General Public License along with this program.  If not,
 //see <http://www.gnu.org/licenses/>.
 package net.opentsdb.query;
+
+import com.google.common.base.Strings;
+
+import net.opentsdb.configuration.Configuration;
 
 /**
  * A simple base config class for {@link TimeSeriesDataSource} nodes.
@@ -25,11 +29,29 @@ public class QuerySourceConfig implements QueryNodeConfig {
   /** A unique name for this config. */
   private final String id;
   
-  QuerySourceConfig(final Builder builder) {
+  /** The configuration class in case we need to pull info out. */
+  private final Configuration configuration;
+  
+  /**
+   * Private ctor for the builder.
+   * @param builder The non-null builder.
+   */
+  private QuerySourceConfig(final Builder builder) {
+    if (builder.query == null) {
+      throw new IllegalArgumentException("Query cannot be null.");
+    }
+    if (Strings.isNullOrEmpty(builder.id)) {
+      throw new IllegalArgumentException("ID cannot be null or empty.");
+    }
+    if (builder.configuration == null) {
+      throw new IllegalArgumentException("Configuration cannot be null.");
+    }
     query = builder.query;
     id = builder.id;
+    configuration = builder.configuration;
   }
   
+  /** @return The query the node is executing. */
   public TimeSeriesQuery query() {
     return query;
   }
@@ -39,6 +61,12 @@ public class QuerySourceConfig implements QueryNodeConfig {
     return id;
   }
   
+  /** @return The master configuration class. */
+  public Configuration configuration() {
+    return configuration;
+  }
+  
+  /** @return A new builder. */
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -46,14 +74,23 @@ public class QuerySourceConfig implements QueryNodeConfig {
   public static class Builder {
     private TimeSeriesQuery query;
     private String id;
+    private Configuration configuration;
     
+    /** @param query The non-null query to execute. */
     public Builder setQuery(final TimeSeriesQuery query) {
       this.query = query;
       return this;
     }
     
+    /** @param id The non-null and non-empty ID for this config. */
     public Builder setId(final String id) {
       this.id = id;
+      return this;
+    }
+    
+    /** @param configuration The non-null master config. */
+    public Builder setConfiguration(final Configuration configuration) {
+      this.configuration = configuration;
       return this;
     }
     

--- a/core/src/main/java/net/opentsdb/query/TSDBV2Pipeline.java
+++ b/core/src/main/java/net/opentsdb/query/TSDBV2Pipeline.java
@@ -76,6 +76,7 @@ public class TSDBV2Pipeline extends AbstractQueryPipelineContext {
       final QuerySourceConfig config = QuerySourceConfig.newBuilder()
           .setId(metric.getId())
           .setQuery(sub_query.build())
+          .setConfiguration(tsdb.getConfig())
           .build();
       
       // TODO - get a proper source. For now just the default.

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/RowSeq.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/RowSeq.java
@@ -60,4 +60,10 @@ public interface RowSeq {
    * descending order.
    */
   public void dedupe(final boolean keep_earliest, final boolean reverse);
+  
+  /** @return The size of this object in bytes, including header. */
+  public int size();
+  
+  /** @return A rough estimate of the number of values in this row. */
+  public int dataPoints();
 }

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
@@ -64,6 +64,11 @@ public class Schema implements StorageSchema {
 
   public static final byte APPENDS_PREFIX = 5;
   
+  public static final String QUERY_BYTE_LIMIT_KEY = "tsd.query.limits.bytes";
+  public static final long QUERY_BYTE_LIMIT_DEFAULT = 0;
+  public static final String QUERY_DP_LIMIT_KEY = "tsd.query.limits.data_points";
+  public static final long QUERY_DP_LIMIT_DEFAULT = 0;
+  
   /** Max time delta (in seconds) we can store in a column qualifier.  */
   public static final short MAX_RAW_TIMESPAN = 3600;
   
@@ -168,6 +173,18 @@ public class Schema implements StorageSchema {
     if (tag_values == null) {
       throw new IllegalStateException("Factory " + uid_factory 
           + " returned a null UniqueId instance.");
+    }
+    
+    if (!tsdb.getConfig().hasProperty(QUERY_BYTE_LIMIT_KEY)) {
+      tsdb.getConfig().register(QUERY_BYTE_LIMIT_KEY, 
+          QUERY_BYTE_LIMIT_DEFAULT, true, 
+          "The number of bytes allowed in a single query result or segment");
+    }
+    if (!tsdb.getConfig().hasProperty(QUERY_DP_LIMIT_KEY)) {
+      tsdb.getConfig().register(QUERY_DP_LIMIT_KEY, 
+          QUERY_DP_LIMIT_DEFAULT, true, 
+          "The number of data points or values allowed in a single "
+          + "query result or segment");
     }
     
     codecs = Maps.newHashMapWithExpectedSize(1);

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xQueryResult.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xQueryResult.java
@@ -1,0 +1,184 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.storage.schemas.tsdb1x;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.common.Const;
+import net.opentsdb.configuration.Configuration;
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesId;
+import net.opentsdb.data.TimeSpecification;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QuerySourceConfig;
+import net.opentsdb.query.pojo.TimeSeriesQuery;
+
+/**
+ * The base class for collecting Tsdb1x data fetched from storage.
+ * 
+ * @since 3.0
+ */
+public class Tsdb1xQueryResult implements QueryResult {
+  
+  /** The ID for this sequence. */
+  protected final long sequence_id;
+  
+  /** The parent node for this result. */
+  protected final QueryNode node;
+  
+  /** The schema used for encoding the data in this result. */
+  protected final Schema schema;
+  
+  /** The map of TSUID hashes to time series. */
+  protected final Map<Long, TimeSeries> results;
+  
+  /** The byte limit to determine when we're full. */
+  protected final long byte_limit;
+  
+  /** The data point limit to determine when we're full. */
+  protected final long dp_limit;
+  
+  /** Whether or not the result is full. */
+  protected volatile boolean is_full;
+  
+  /** The number of bytes stored in the result. Rough estimate so far. */
+  protected volatile long bytes;
+  
+  /** The number of values stored in the result. */
+  protected volatile long dps;
+  
+  /**
+   * Default ctor. The node is expected to have a {@link QuerySourceConfig}
+   * configuration that will give us a {@link Configuration} config to
+   * use when determining the byte and dp limits.
+   * @param sequence_id The sequence ID.
+   * @param node The non-null parent node.
+   * @param schema The non-null schema.
+   */
+  public Tsdb1xQueryResult(final long sequence_id, 
+                           final QueryNode node,
+                           final Schema schema) {
+    if (sequence_id < 0) {
+      throw new IllegalArgumentException("Sequence ID cannot be less "
+          + "than zero.");
+    }
+    if (node == null) {
+      throw new IllegalArgumentException("Node cannot be null.");
+    }
+    if (schema == null) {
+      throw new IllegalArgumentException("Schema cannot be null.");
+    }
+    this.sequence_id = sequence_id;
+    this.node = node;
+    this.schema = schema;
+    results = Maps.newConcurrentMap();
+    
+    final Configuration config = 
+        ((QuerySourceConfig) node.config()).configuration();
+    final TimeSeriesQuery query = (TimeSeriesQuery) 
+        ((QuerySourceConfig) node.config()).query();
+    byte_limit = query.getInt(config, Schema.QUERY_BYTE_LIMIT_KEY);
+    dp_limit = query.getInt(config, Schema.QUERY_DP_LIMIT_KEY);
+  }
+  
+  @Override
+  public TimeSpecification timeSpecification() {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public Collection<TimeSeries> timeSeries() {
+    return results.values();
+  }
+
+  @Override
+  public long sequenceId() {
+    return sequence_id;
+  }
+
+  @Override
+  public QueryNode source() {
+    return node;
+  }
+
+  @Override
+  public TypeToken<? extends TimeSeriesId> idType() {
+    return Const.TS_BYTE_ID;
+  }
+
+  @Override
+  public void close() {
+    for (final TimeSeries series : results.values()) {
+      series.close();
+    }
+  }
+  
+  /** @return True if the byte or data point limit has been exceeded. */
+  public boolean isFull() {
+    return is_full;
+  }
+  
+  /**
+   * Adds the sequence to the proper time series set.
+   * NOTE: Since it's fast path, we aren't performing all the data
+   * checks we could. Be careful.
+   * @param tsuid_hash A hash of the TSUID.
+   * @param tsuid The non-null and non-empty TSUID.
+   * @param sequence The non-null row sequence to add.
+   * @param reversed Whether or not to iterate in reverse.
+   * @param keep_earliest Whether or not to keep earlier dupes.
+   */
+  public void addSequence(final long tsuid_hash,
+                          final byte[] tsuid, 
+                          final RowSeq sequence, 
+                          final boolean reversed,
+                          final boolean keep_earliest) {
+    // TODO - figure out the size for the new TimeSeries objects
+    TimeSeries series = results.get(tsuid_hash);
+    if (series == null) {
+      series = new Tsdb1xTimeSeries(tsuid, schema);
+      TimeSeries extant = results.putIfAbsent(tsuid_hash, series);
+      if (extant != null) {
+        // lost the race
+        series = extant;
+      }
+    }
+    ((Tsdb1xTimeSeries) series).addSequence(sequence, 
+                                            reversed, 
+                                            keep_earliest, 
+                                            schema);
+    
+    // NOTE: This can overcount if we have dupes that are dropped when
+    // multiple rows are merged in a sequence.
+    synchronized (this) {
+      bytes += sequence.size();
+      dps += sequence.dataPoints();
+    }
+    
+    // since it's a best effort we don't need the lock
+    if (byte_limit > 0 && bytes > byte_limit) {
+      is_full = true;
+    }
+    if (dp_limit > 0 && dps > dp_limit) {
+      is_full = true;
+    }
+  }
+}

--- a/core/src/test/java/net/opentsdb/query/TestQuerySourceConfig.java
+++ b/core/src/test/java/net/opentsdb/query/TestQuerySourceConfig.java
@@ -1,0 +1,76 @@
+//This file is part of OpenTSDB.
+//Copyright (C) 2018  The OpenTSDB Authors.
+//
+//This program is free software: you can redistribute it and/or modify it
+//under the terms of the GNU Lesser General Public License as published by
+//the Free Software Foundation, either version 2.1 of the License, or (at your
+//option) any later version.  This program is distributed in the hope that it
+//will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+//of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+//General Public License for more details.  You should have received a copy
+//of the GNU Lesser General Public License along with this program.  If not,
+//see <http://www.gnu.org/licenses/>.
+package net.opentsdb.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import net.opentsdb.configuration.Configuration;
+
+public class TestQuerySourceConfig {
+
+  @Test
+  public void builder() throws Exception {
+    final Configuration config = mock(Configuration.class);
+    final TimeSeriesQuery query = mock(TimeSeriesQuery.class);
+    
+    QuerySourceConfig qsc = QuerySourceConfig.newBuilder()
+        .setConfiguration(config)
+        .setQuery(query)
+        .setId("UT")
+        .build();
+    assertSame(config, qsc.configuration());
+    assertSame(query, qsc.query());
+    assertEquals("UT", qsc.getId());
+    
+    try {
+      QuerySourceConfig.newBuilder()
+        //.setConfiguration(config)
+        .setQuery(query)
+        .setId("UT")
+        .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      QuerySourceConfig.newBuilder()
+        .setConfiguration(config)
+        //.setQuery(query)
+        .setId("UT")
+        .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      QuerySourceConfig.newBuilder()
+        .setConfiguration(config)
+        .setQuery(query)
+        //.setId("UT")
+        .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      QuerySourceConfig.newBuilder()
+        .setConfiguration(config)
+        .setQuery(query)
+        .setId("")
+        .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+}

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestNumericRowSeq.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestNumericRowSeq.java
@@ -39,6 +39,8 @@ public class TestNumericRowSeq {
     NumericRowSeq seq = new NumericRowSeq(BASE_TIME);
     assertEquals(BASE_TIME, seq.base_timestamp);
     assertNull(seq.data);
+    assertEquals(NumericRowSeq.HEADER_SIZE, seq.size());
+    assertEquals(0, seq.dataPoints());
     
     seq.addColumn((byte) 0, 
         NumericCodec.buildSecondQualifier(0, (short) 0), new byte[] { 42 });
@@ -79,6 +81,10 @@ public class TestNumericRowSeq {
         NumericCodec.buildMsQualifier(500, (short) 0), new byte[] { 1 },
         NumericCodec.buildNanoQualifier(25000, (short) 0), new byte[] { -1 }),
            seq.data);
+    
+    assertEquals(NumericRowSeq.HEADER_SIZE + 23, seq.size());
+    assertEquals(0, seq.dataPoints());
+    // not incremented as we don't call dedupe.
   }
   
   @Test
@@ -359,6 +365,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 120, 24),
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 60, 42)), 
         seq.data);
+    assertEquals(3, seq.dataPoints());
   }
   
   @Test
@@ -388,6 +395,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 120, 24),
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 180, 1)), 
         seq.data);
+    assertEquals(4, seq.dataPoints());
     
     // reset to reverse in the tree
     seq = new NumericRowSeq(BASE_TIME);    
@@ -407,6 +415,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 60, 42),
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 30, 2)), 
         seq.data);
+    assertEquals(4, seq.dataPoints());
     
     // consecutive dupe
     seq = new NumericRowSeq(BASE_TIME);
@@ -425,6 +434,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 60, 1), 
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 120, 24)), 
         seq.data);
+    assertEquals(3, seq.dataPoints());
     
     // keep first
     seq = new NumericRowSeq(BASE_TIME);
@@ -443,6 +453,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 60, 42), 
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 120, 24)), 
         seq.data);
+    assertEquals(3, seq.dataPoints());
     
     // non-consecutive dupe
     seq = new NumericRowSeq(BASE_TIME);
@@ -461,6 +472,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 60, 42), 
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 120, 1)), 
         seq.data);
+    assertEquals(3, seq.dataPoints());
     
     // keep first
     seq = new NumericRowSeq(BASE_TIME);
@@ -479,6 +491,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 60, 42), 
       NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 120, 24)), 
         seq.data);
+    assertEquals(3, seq.dataPoints());
   }
   
   @Test
@@ -507,6 +520,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.MILLIS, 750, 24),
       NumericCodec.encodeAppendValue(OffsetResolution.MILLIS, 1000, 1)), 
         seq.data);
+    assertEquals(4, seq.dataPoints());
     
     // reset to reverse in the tree
     seq = new NumericRowSeq(BASE_TIME);    
@@ -526,6 +540,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.MILLIS, 500, 42),
       NumericCodec.encodeAppendValue(OffsetResolution.MILLIS, 250, 2)), 
         seq.data);
+    assertEquals(4, seq.dataPoints());
     
     // consecutive dupe
     seq = new NumericRowSeq(BASE_TIME);
@@ -544,6 +559,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.MILLIS, 500, 1), 
       NumericCodec.encodeAppendValue(OffsetResolution.MILLIS, 750, 24)), 
         seq.data);
+    assertEquals(3, seq.dataPoints());
     
     // keep first
     seq = new NumericRowSeq(BASE_TIME);
@@ -562,6 +578,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.MILLIS, 500, 42), 
       NumericCodec.encodeAppendValue(OffsetResolution.MILLIS, 750, 24)), 
         seq.data);
+    assertEquals(3, seq.dataPoints());
     
     // non-consecutive dupe
     seq = new NumericRowSeq(BASE_TIME);
@@ -580,6 +597,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.MILLIS, 500, 42), 
       NumericCodec.encodeAppendValue(OffsetResolution.MILLIS, 750, 1)), 
         seq.data);
+    assertEquals(3, seq.dataPoints());
     
     // keep first
     seq = new NumericRowSeq(BASE_TIME);
@@ -598,6 +616,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.MILLIS, 500, 42), 
       NumericCodec.encodeAppendValue(OffsetResolution.MILLIS, 750, 24)), 
         seq.data);
+    assertEquals(3, seq.dataPoints());
   }
   
   @Test
@@ -626,6 +645,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.NANOS, 750, 24),
       NumericCodec.encodeAppendValue(OffsetResolution.NANOS, 1000, 1)), 
         seq.data);
+    assertEquals(4, seq.dataPoints());
     
     // reset to reverse in the tree
     seq = new NumericRowSeq(BASE_TIME);    
@@ -645,6 +665,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.NANOS, 500, 42),
       NumericCodec.encodeAppendValue(OffsetResolution.NANOS, 250, 2)), 
         seq.data);
+    assertEquals(4, seq.dataPoints());
     
     // consecutive dupe
     seq = new NumericRowSeq(BASE_TIME);
@@ -663,6 +684,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.NANOS, 500, 1), 
       NumericCodec.encodeAppendValue(OffsetResolution.NANOS, 750, 24)), 
         seq.data);
+    assertEquals(3, seq.dataPoints());
     
     // keep first
     seq = new NumericRowSeq(BASE_TIME);
@@ -681,6 +703,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.NANOS, 500, 42), 
       NumericCodec.encodeAppendValue(OffsetResolution.NANOS, 750, 24)), 
         seq.data);
+    assertEquals(3, seq.dataPoints());
     
     // non-consecutive dupe
     seq = new NumericRowSeq(BASE_TIME);
@@ -699,6 +722,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.NANOS, 500, 42), 
       NumericCodec.encodeAppendValue(OffsetResolution.NANOS, 750, 1)), 
         seq.data);
+    assertEquals(3, seq.dataPoints());
     
     // keep first
     seq = new NumericRowSeq(BASE_TIME);
@@ -717,6 +741,7 @@ public class TestNumericRowSeq {
       NumericCodec.encodeAppendValue(OffsetResolution.NANOS, 500, 42), 
       NumericCodec.encodeAppendValue(OffsetResolution.NANOS, 750, 24)), 
         seq.data);
+    assertEquals(3, seq.dataPoints());
   }
   
   @Test

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestTsdb1xQueryResult.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestTsdb1xQueryResult.java
@@ -1,0 +1,267 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.storage.schemas.tsdb1x;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.primitives.Bytes;
+
+import net.openhft.hashing.LongHashFunction;
+import net.opentsdb.common.Const;
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QuerySourceConfig;
+import net.opentsdb.query.pojo.Metric;
+import net.opentsdb.query.pojo.TimeSeriesQuery;
+import net.opentsdb.query.pojo.Timespan;
+import net.opentsdb.storage.schemas.tsdb1x.NumericCodec.OffsetResolution;
+
+public class TestTsdb1xQueryResult extends SchemaBase {
+
+  // GMT: Monday, January 1, 2018 12:15:00 AM
+  public static final int START_TS = 1514765700;
+  
+  // GMT: Monday, January 1, 2018 1:15:00 AM
+  public static final int END_TS = 1514769300;
+  
+  private static final byte[] TSUID_A = 
+      Bytes.concat(METRIC_BYTES, TAGK_BYTES, TAGV_BYTES);
+  private static final byte[] TSUID_B = 
+      Bytes.concat(METRIC_BYTES, TAGK_BYTES, TAGV_B_BYTES);
+  private static final long BASE_TIME = 1514764800;
+  private static final byte[] APPEND_Q = 
+      new byte[] { Schema.APPENDS_PREFIX, 0, 0 };
+  
+  private QueryNode node;
+  private QuerySourceConfig source_config;
+  private TimeSeriesQuery query;
+  private Schema schema;
+  
+  @Before
+  public void before() throws Exception {
+    schema = schema();
+    node = mock(QueryNode.class);
+    source_config = mock(QuerySourceConfig.class);
+    when(node.config()).thenReturn(source_config);
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart(Integer.toString(START_TS))
+            .setEnd(Integer.toString(END_TS))
+            .setAggregator("avg"))
+        .addMetric(Metric.newBuilder()
+            .setMetric(METRIC_STRING))
+        .build();
+    when(source_config.configuration()).thenReturn(config);
+    when(source_config.query()).thenReturn(query);
+  }
+  
+  @Test
+  public void ctorDefaults() throws Exception {
+    Tsdb1xQueryResult result = new Tsdb1xQueryResult(0, node, schema);
+    assertEquals(0, result.sequenceId());
+    assertSame(node, result.source());
+    assertSame(schema, result.schema);
+    assertTrue(result.results.isEmpty());
+    assertEquals(0, result.byte_limit);
+    assertEquals(0, result.dp_limit);
+    assertFalse(result.isFull());
+    assertEquals(0, result.bytes);
+    assertEquals(0, result.dps);
+    assertNull(result.timeSpecification());
+    assertTrue(result.timeSeries().isEmpty());
+    assertEquals(Const.TS_BYTE_ID, result.idType());
+  }
+  
+  @Test
+  public void ctorOverrides() throws Exception {
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart(Integer.toString(START_TS))
+            .setEnd(Integer.toString(END_TS))
+            .setAggregator("avg"))
+        .addMetric(Metric.newBuilder()
+            .setMetric(METRIC_STRING))
+        .addConfig(Schema.QUERY_BYTE_LIMIT_KEY, "42")
+        .addConfig(Schema.QUERY_DP_LIMIT_KEY, "24")
+        .build();
+    when(source_config.query()).thenReturn(query);
+    
+    Tsdb1xQueryResult result = new Tsdb1xQueryResult(9, node, schema);
+    assertEquals(9, result.sequenceId());
+    assertSame(node, result.source());
+    assertSame(schema, result.schema);
+    assertTrue(result.results.isEmpty());
+    assertEquals(42, result.byte_limit);
+    assertEquals(24, result.dp_limit);
+    assertFalse(result.isFull());
+    assertEquals(0, result.bytes);
+    assertEquals(0, result.dps);
+    assertNull(result.timeSpecification());
+    assertTrue(result.timeSeries().isEmpty());
+    assertEquals(Const.TS_BYTE_ID, result.idType());
+  }
+
+  @Test
+  public void ctorExceptions() throws Exception {
+    try {
+      new Tsdb1xQueryResult(-42, node, schema);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      new Tsdb1xQueryResult(9, null, schema);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      new Tsdb1xQueryResult(9, node, null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void addSequence() throws Exception {
+    Tsdb1xQueryResult result = new Tsdb1xQueryResult(9, node, schema);
+    
+    long base_time = BASE_TIME;
+    int value = 0;
+    
+    NumericRowSeq seq = new NumericRowSeq(base_time);
+    for (int i = 0; i < 4; i++) {
+      seq.addColumn(Schema.APPENDS_PREFIX, APPEND_Q, 
+          NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 900 * i, value++));
+    }
+    seq.dedupe(false, false);
+    
+    result.addSequence(LongHashFunction.xx_r39().hashBytes(TSUID_A),
+        TSUID_A, seq, false, false);
+    assertEquals(1, result.results.size());
+    assertEquals(48, result.bytes);
+    assertEquals(4, result.dps);
+    assertFalse(result.isFull());
+    
+    // another TSUID
+    result.addSequence(LongHashFunction.xx_r39().hashBytes(TSUID_B),
+        TSUID_B, seq, false, false);
+    assertEquals(2, result.results.size());
+    assertEquals(96, result.bytes);
+    assertEquals(8, result.dps);
+    assertFalse(result.isFull());
+    
+    List<TimeSeries> series = Lists.newArrayList(result.timeSeries());
+    assertEquals(2, series.size());
+    for (final TimeSeries ts : series) {
+      value = 0;
+      base_time = BASE_TIME;
+      Iterator<TimeSeriesValue<?>> it = ts.iterator(NumericType.TYPE).get();
+      while (it.hasNext()) {
+        TimeSeriesValue<NumericType> v = (TimeSeriesValue<NumericType>) it.next();
+        assertEquals(base_time, v.timestamp().epoch());
+        assertEquals(value++, v.value().longValue());
+        base_time += 900;
+      }
+      assertEquals(4, value);
+    }
+  }
+  
+  @Test
+  public void addSequenceMultipleRows() throws Exception {
+    Tsdb1xQueryResult result = new Tsdb1xQueryResult(9, node, schema);
+    
+    long base_time = BASE_TIME;
+    int value = 0;
+    
+    NumericRowSeq seq = new NumericRowSeq(base_time);
+    for (int i = 0; i < 4; i++) {
+      seq.addColumn(Schema.APPENDS_PREFIX, APPEND_Q, 
+          NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 900 * i, value++));
+    }
+    seq.dedupe(false, false);
+    
+    result.addSequence(LongHashFunction.xx_r39().hashBytes(TSUID_A),
+        TSUID_A, seq, false, false);
+    assertEquals(1, result.results.size());
+    assertEquals(48, result.bytes);
+    assertEquals(4, result.dps);
+    assertFalse(result.isFull());
+    
+    // another TSUID
+    result.addSequence(LongHashFunction.xx_r39().hashBytes(TSUID_B),
+        TSUID_B, seq, false, false);
+    assertEquals(2, result.results.size());
+    assertEquals(96, result.bytes);
+    assertEquals(8, result.dps);
+    assertFalse(result.isFull());
+    
+    List<TimeSeries> series = Lists.newArrayList(result.timeSeries());
+    assertEquals(2, series.size());
+    
+    // next row
+    base_time += 3600;
+    seq = new NumericRowSeq(base_time);
+    for (int i = 0; i < 4; i++) {
+      seq.addColumn(Schema.APPENDS_PREFIX, APPEND_Q, 
+          NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 900 * i, value++));
+    }
+    seq.dedupe(false, false);
+    
+    result.addSequence(LongHashFunction.xx_r39().hashBytes(TSUID_A),
+        TSUID_A, seq, false, false);
+    assertEquals(2, result.results.size());
+    assertEquals(144, result.bytes);
+    assertEquals(12, result.dps);
+    assertFalse(result.isFull());
+    
+    // B
+    result.addSequence(LongHashFunction.xx_r39().hashBytes(TSUID_B),
+        TSUID_B, seq, false, false);
+    assertEquals(2, result.results.size());
+    assertEquals(192, result.bytes);
+    assertEquals(16, result.dps);
+    assertFalse(result.isFull());
+    
+    series = Lists.newArrayList(result.timeSeries());
+    assertEquals(2, series.size());
+    for (final TimeSeries ts : series) {
+      value = 0;
+      base_time = BASE_TIME;
+      Iterator<TimeSeriesValue<?>> it = ts.iterator(NumericType.TYPE).get();
+      while (it.hasNext()) {
+        TimeSeriesValue<NumericType> v = (TimeSeriesValue<NumericType>) it.next();
+        assertEquals(base_time, v.timestamp().epoch());
+        assertEquals(value++, v.value().longValue());
+        base_time += 900;
+      }
+      assertEquals(8, value);
+    }
+  }
+}

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestTsdb1xTimeSeries.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestTsdb1xTimeSeries.java
@@ -1,0 +1,316 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.storage.schemas.tsdb1x;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.google.common.primitives.Bytes;
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.data.TimeSeriesByteId;
+import net.opentsdb.data.TimeSeriesDataType;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.exceptions.IllegalDataException;
+import net.opentsdb.storage.schemas.tsdb1x.NumericCodec.OffsetResolution;
+
+public class TestTsdb1xTimeSeries extends SchemaBase {
+  private static final byte[] TSUID = 
+      Bytes.concat(METRIC_BYTES, TAGK_BYTES, TAGV_BYTES);
+  private static final long BASE_TIME = 1514764800;
+  private static final byte[] APPEND_Q = 
+      new byte[] { Schema.APPENDS_PREFIX, 0, 0 };
+  
+  @Test
+  public void ctor() throws Exception {
+    try {
+      new Tsdb1xTimeSeries(null, schema());
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      new Tsdb1xTimeSeries(new byte[0], schema());
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      new Tsdb1xTimeSeries(TSUID, null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    Tsdb1xTimeSeries series = new Tsdb1xTimeSeries(TSUID, schema());
+    assertArrayEquals(METRIC_BYTES, ((TimeSeriesByteId) series.id()).metric());
+    assertArrayEquals(TAGV_BYTES, ((TimeSeriesByteId) series.id()).tags().get(TAGK_BYTES));
+    assertTrue(series.data.isEmpty());
+    assertTrue(series.types().isEmpty());
+  }
+  
+  @Test
+  public void addSequenceOnce() throws Exception {
+    long base_time = BASE_TIME;
+    int value = 0;
+    
+    NumericRowSeq seq = new NumericRowSeq(base_time);
+    for (int i = 0; i < 4; i++) {
+      seq.addColumn(Schema.APPENDS_PREFIX, APPEND_Q, 
+          NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 900 * i, value++));
+    }
+    seq.dedupe(false, false);
+    
+    Tsdb1xTimeSeries series = new Tsdb1xTimeSeries(TSUID, schema());
+    assertFalse(series.iterator(NumericType.TYPE).isPresent());
+    assertEquals(0, series.data.size());
+    
+    series.addSequence(seq, false, false, schema());
+    assertEquals(1, series.data.size());
+    Iterator<TimeSeriesValue<?>> it = series.iterator(NumericType.TYPE).get();
+    value = 0;
+    base_time = BASE_TIME;
+    while (it.hasNext()) {
+      TimeSeriesValue<NumericType> v = (TimeSeriesValue<NumericType>) it.next();
+      assertEquals(base_time, v.timestamp().epoch());
+      assertEquals(value++, v.value().longValue());
+      base_time += 900;
+    }
+    assertEquals(4, value);
+    
+    Collection<Iterator<TimeSeriesValue<?>>> iterators = series.iterators();
+    assertEquals(1, iterators.size());
+    it = iterators.iterator().next();
+    value = 0;
+    base_time = BASE_TIME;
+    while (it.hasNext()) {
+      TimeSeriesValue<NumericType> v = (TimeSeriesValue<NumericType>) it.next();
+      assertEquals(base_time, v.timestamp().epoch());
+      assertEquals(value++, v.value().longValue());
+      base_time += 900;
+    }
+    assertEquals(4, value);
+    assertEquals(1, series.types().size());
+    assertTrue(series.types().contains(NumericType.TYPE));
+  }
+  
+  @Test
+  public void addSequenceOnceReversed() throws Exception {
+    long base_time = BASE_TIME;
+    int value = 0;
+    
+    NumericRowSeq seq = new NumericRowSeq(base_time);
+    for (int i = 0; i < 4; i++) {
+      seq.addColumn(Schema.APPENDS_PREFIX, APPEND_Q, 
+          NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 900 * i, value++));
+    }
+    seq.dedupe(false, true);
+    
+    Tsdb1xTimeSeries series = new Tsdb1xTimeSeries(TSUID, schema());
+    assertFalse(series.iterator(NumericType.TYPE).isPresent());
+    assertEquals(0, series.data.size());
+    
+    series.addSequence(seq, true, false, schema());
+    assertEquals(1, series.data.size());
+    Iterator<TimeSeriesValue<?>> it = series.iterator(NumericType.TYPE).get();
+    value = 3;
+    base_time = BASE_TIME + 3600 - 900;
+    while (it.hasNext()) {
+      TimeSeriesValue<NumericType> v = (TimeSeriesValue<NumericType>) it.next();
+      assertEquals(base_time, v.timestamp().epoch());
+      assertEquals(value--, v.value().longValue());
+      base_time -= 900;
+    }
+    assertEquals(-1, value);
+    
+    Collection<Iterator<TimeSeriesValue<?>>> iterators = series.iterators();
+    assertEquals(1, iterators.size());
+    it = iterators.iterator().next();
+    value = 3;
+    base_time = BASE_TIME + 3600 - 900;
+    while (it.hasNext()) {
+      TimeSeriesValue<NumericType> v = (TimeSeriesValue<NumericType>) it.next();
+      assertEquals(base_time, v.timestamp().epoch());
+      assertEquals(value--, v.value().longValue());
+      base_time -= 900;
+    }
+    assertEquals(-1, value);
+    assertEquals(1, series.types().size());
+    assertTrue(series.types().contains(NumericType.TYPE));
+  }
+  
+  @Test
+  public void addSequenceTwice() throws Exception {
+    long base_time = BASE_TIME;
+    int value = 0;
+    
+    NumericRowSeq seq = new NumericRowSeq(base_time);
+    for (int i = 0; i < 4; i++) {
+      seq.addColumn(Schema.APPENDS_PREFIX, APPEND_Q, 
+          NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 900 * i, value++));
+    }
+    seq.dedupe(false, false);
+    
+    Tsdb1xTimeSeries series = new Tsdb1xTimeSeries(TSUID, schema());
+    series.addSequence(seq, false, false, schema());
+    
+    base_time += 3600;
+    seq = new NumericRowSeq(base_time);
+    for (int i = 0; i < 4; i++) {
+      seq.addColumn(Schema.APPENDS_PREFIX, APPEND_Q, 
+          NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 900 * i, value++));
+    }
+    seq.dedupe(false, false);
+    series.addSequence(seq, false, false, schema());
+    
+    assertEquals(1, series.data.size());
+    Iterator<TimeSeriesValue<?>> it = series.iterator(NumericType.TYPE).get();
+    value = 0;
+    base_time = BASE_TIME;
+    while (it.hasNext()) {
+      TimeSeriesValue<NumericType> v = (TimeSeriesValue<NumericType>) it.next();
+      assertEquals(base_time, v.timestamp().epoch());
+      assertEquals(value++, v.value().longValue());
+      base_time += 900;
+    }
+    assertEquals(8, value);
+    
+    Collection<Iterator<TimeSeriesValue<?>>> iterators = series.iterators();
+    assertEquals(1, iterators.size());
+    it = iterators.iterator().next();
+    value = 0;
+    base_time = BASE_TIME;
+    while (it.hasNext()) {
+      TimeSeriesValue<NumericType> v = (TimeSeriesValue<NumericType>) it.next();
+      assertEquals(base_time, v.timestamp().epoch());
+      assertEquals(value++, v.value().longValue());
+      base_time += 900;
+    }
+    assertEquals(8, value);
+  }
+  
+  @Test
+  public void addSequenceTwiceReversed() throws Exception {
+    long base_time = BASE_TIME;
+    int value = 0;
+    
+    NumericRowSeq seq = new NumericRowSeq(base_time);
+    for (int i = 0; i < 4; i++) {
+      seq.addColumn(Schema.APPENDS_PREFIX, APPEND_Q, 
+          NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 900 * i, value++));
+    }
+    seq.dedupe(false, true);
+    
+    Tsdb1xTimeSeries series = new Tsdb1xTimeSeries(TSUID, schema());
+    series.addSequence(seq, true, false, schema());
+    
+    base_time += 3600;
+    seq = new NumericRowSeq(base_time);
+    for (int i = 0; i < 4; i++) {
+      seq.addColumn(Schema.APPENDS_PREFIX, APPEND_Q, 
+          NumericCodec.encodeAppendValue(OffsetResolution.SECONDS, 900 * i, value++));
+    }
+    seq.dedupe(false, true);
+    series.addSequence(seq, true, false, schema());
+    
+    assertEquals(1, series.data.size());
+    Iterator<TimeSeriesValue<?>> it = series.iterator(NumericType.TYPE).get();
+    value = 7;
+    base_time = BASE_TIME + (3600 * 2) - 900;
+    while (it.hasNext()) {
+      TimeSeriesValue<NumericType> v = (TimeSeriesValue<NumericType>) it.next();
+      assertEquals(base_time, v.timestamp().epoch());
+      assertEquals(value--, v.value().longValue());
+      base_time -= 900;
+    }
+    assertEquals(-1, value);
+    
+    Collection<Iterator<TimeSeriesValue<?>>> iterators = series.iterators();
+    assertEquals(1, iterators.size());
+    it = iterators.iterator().next();
+    value = 7;
+    base_time = BASE_TIME + (3600 * 2) - 900;
+    while (it.hasNext()) {
+      TimeSeriesValue<NumericType> v = (TimeSeriesValue<NumericType>) it.next();
+      assertEquals(base_time, v.timestamp().epoch());
+      assertEquals(value--, v.value().longValue());
+      base_time -= 900;
+    }
+    assertEquals(-1, value);
+  }
+  
+  @Test
+  public void addSequenceNoCodec() throws Exception {
+    class DummyType implements TimeSeriesDataType { }
+    TypeToken<? extends TimeSeriesDataType> type = 
+        TypeToken.of(DummyType.class);
+    RowSeq seq = mock(RowSeq.class);
+    when(seq.type()).thenAnswer(new Answer<TypeToken<?>>() {
+      @Override
+      public TypeToken<?> answer(InvocationOnMock invocation) throws Throwable {
+        return type;
+      }
+    });
+    
+    Tsdb1xTimeSeries series = new Tsdb1xTimeSeries(TSUID, schema());
+    try {
+      series.addSequence(seq, false, false, schema());
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    Schema mock_schema = mock(Schema.class);
+    try {
+      series.addSequence(seq, false, false, mock_schema);
+      fail("Expected IllegalDataException");
+    } catch (IllegalDataException e) { }
+  }
+  
+  @Test
+  public void addSequenceExceptions() throws Exception {
+    Tsdb1xTimeSeries series = new Tsdb1xTimeSeries(TSUID, schema());
+    try {
+      series.addSequence(null, false, false, schema());
+      fail("Expected NullPointerException");
+    } catch (NullPointerException e) { }
+    
+    NumericRowSeq seq = new NumericRowSeq(BASE_TIME);
+    try {
+      series.addSequence(seq, false, false, null);
+      fail("Expected NullPointerException");
+    } catch (NullPointerException e) { }
+  }
+  
+  @Test
+  public void close() throws Exception {
+    Tsdb1xTimeSeries series = new Tsdb1xTimeSeries(TSUID, schema());
+    assertNotNull(series.data);
+    
+    series.close();
+    assertNull(series.data);
+  }
+  
+  // TODO - test other data types like annotations when ready
+}


### PR DESCRIPTION
- Add the Configuration to QuerySourceConfig so downstream operations
  have access. Also add validation and javadocs. And UTs.
- Add size() and dataPoints() to the RowSeq interface so we can extract that
  info.
- Add a static guestimate for the NumericRowSeq size. We could use JOL but it
  would be too expensive in the fast path.
- Add byte and dp limit keys to the Schema and register them with the config.
- Add the Tsdb1xQueryResult base class for storing row sequences in the proper
  time series.