### PR TITLE
CORE:

### DIFF
--- a/common/src/main/java/net/opentsdb/core/Registry.java
+++ b/common/src/main/java/net/opentsdb/core/Registry.java
@@ -61,7 +61,7 @@ public interface Registry {
    * @return An instantiated plugin if found, null if not.
    * @throws IllegalArgumentException if the clazz was null.
    */
-  public TSDBPlugin getDefaultPlugin(final Class<?> clazz);
+  public <T> T getDefaultPlugin(final Class<T> clazz);
   
   /**
    * Retrieves the plugin with the given class type and ID.
@@ -70,7 +70,7 @@ public interface Registry {
    * @return An instantiated plugin if found, null if not.
    * @throws IllegalArgumentException if the clazz was null.
    */
-  public TSDBPlugin getPlugin(final Class<?> clazz, final String id);
+  public <T> T getPlugin(final Class<T> clazz, final String id);
 
   /**
    * Registers a shared object in the concurrent map if the object was not

--- a/common/src/main/java/net/opentsdb/data/TimeSeriesDataSource.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesDataSource.java
@@ -13,6 +13,7 @@
 package net.opentsdb.data;
 
 import net.opentsdb.query.QueryNode;
+import net.opentsdb.stats.Span;
 
 /**
  * The base interface for a data source such as a local database or remote TSD.
@@ -23,7 +24,8 @@ public interface TimeSeriesDataSource extends QueryNode {
 
   /**
    * Called by the upstream context or nodes to fetch the next set of data.
+   * @param span An optional tracing span.
    */
-  public void fetchNext();
+  public void fetchNext(final Span span);
   
 }

--- a/common/src/main/java/net/opentsdb/query/QueryContext.java
+++ b/common/src/main/java/net/opentsdb/query/QueryContext.java
@@ -17,6 +17,7 @@ package net.opentsdb.query;
 import java.util.Collection;
 
 import net.opentsdb.stats.QueryStats;
+import net.opentsdb.stats.Span;
 
 /**
  * The API used to interact with a query pipeline. This should be given to the
@@ -43,9 +44,10 @@ public interface QueryContext {
   
   /**
    * Travels downstream the pipeline to fetch the next set of results. 
+   * @param span An optional tracing span.
    * @throws IllegalStateException if no sinks was set on this context.
    */
-  public void fetchNext();
+  public void fetchNext(final Span span);
   
   /**
    * Closes the pipeline and releases all resources.
@@ -59,4 +61,5 @@ public interface QueryContext {
   
   /** @return The original query. */
   public TimeSeriesQuery query();
+  
 }

--- a/common/src/main/java/net/opentsdb/query/QueryPipelineContext.java
+++ b/common/src/main/java/net/opentsdb/query/QueryPipelineContext.java
@@ -16,6 +16,8 @@ package net.opentsdb.query;
 
 import java.util.Collection;
 
+import net.opentsdb.stats.Span;
+
 /**
  * The non-user facing pipeline context that provides the entry point and 
  * operations for executing a query. This is instantiated and called by the 
@@ -45,8 +47,9 @@ public interface QueryPipelineContext extends QueryNode {
   
   /**
    * Called by the upstream context or nodes to fetch the next set of data.
+   * @param span An optional tracing span.
    */
-  public void fetchNext();
+  public void fetchNext(final Span span);
   
   /**
    * Returns the upstream nodes for the requested node.

--- a/core/src/main/java/net/opentsdb/core/DefaultRegistry.java
+++ b/core/src/main/java/net/opentsdb/core/DefaultRegistry.java
@@ -244,7 +244,7 @@ public class DefaultRegistry implements Registry {
     if (factory != null) {
       return factory;
     }
-    final TSDBPlugin plugin = plugins.getPlugin(QueryNodeFactory.class, id);
+    final QueryNodeFactory plugin = plugins.getPlugin(QueryNodeFactory.class, id);
     if (plugin == null) {
       return null;
     }
@@ -391,7 +391,7 @@ public class DefaultRegistry implements Registry {
    * @return An instantiated plugin if found, null if not.
    * @throws IllegalArgumentException if the clazz was null.
    */
-  public TSDBPlugin getDefaultPlugin(final Class<?> clazz) {
+  public <T> T getDefaultPlugin(final Class<T> clazz) {
     return getPlugin(clazz, null);
   }
   
@@ -402,7 +402,7 @@ public class DefaultRegistry implements Registry {
    * @return An instantiated plugin if found, null if not.
    * @throws IllegalArgumentException if the clazz was null.
    */
-  public TSDBPlugin getPlugin(final Class<?> clazz, final String id) {
+  public <T> T getPlugin(final Class<T> clazz, final String id) {
     if (plugins == null) {
       throw new IllegalStateException("Plugins have not been loaded. "
           + "Call loadPlugins();");

--- a/core/src/main/java/net/opentsdb/core/PluginsConfig.java
+++ b/core/src/main/java/net/opentsdb/core/PluginsConfig.java
@@ -212,8 +212,8 @@ public class PluginsConfig extends Validatable {
    * @return An instantiated plugin if found, null if not.
    * @throws IllegalArgumentException if the clazz was null.
    */
-  public TSDBPlugin getDefaultPlugin(final Class<?> clazz) {
-    return getPlugin(clazz, null);
+  public <T> T getDefaultPlugin(final Class<T> clazz) {
+    return (T) getPlugin(clazz, null);
   }
   
   /**
@@ -223,7 +223,8 @@ public class PluginsConfig extends Validatable {
    * @return An instantiated plugin if found, null if not.
    * @throws IllegalArgumentException if the clazz was null.
    */
-  public TSDBPlugin getPlugin(final Class<?> clazz, final String id) {
+  @SuppressWarnings("unchecked")
+  public <T> T getPlugin(final Class<T> clazz, final String id) {
     if (clazz == null) {
       throw new IllegalArgumentException("Class cannot be null.");
     }
@@ -231,7 +232,7 @@ public class PluginsConfig extends Validatable {
     if (class_map == null) {
       return null;
     }
-    return class_map.get(id);
+    return (T) class_map.get(id);
   }
   
   /**

--- a/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
+++ b/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
@@ -36,6 +36,7 @@ import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesDataSource;
 import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.TimeSpecification;
+import net.opentsdb.stats.Span;
 
 /**
  * A useful base class for {@link QueryPipelineContext}s that stores references
@@ -213,14 +214,14 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
   }
   
   @Override
-  public void fetchNext() {
+  public void fetchNext(final Span span) {
     if (context.mode() == QueryMode.SINGLE ||
         context.mode() == QueryMode.BOUNDED_SERVER_SYNC_STREAM || 
         context.mode() == QueryMode.CONTINOUS_SERVER_SYNC_STREAM ||
         context.mode() == QueryMode.BOUNDED_SERVER_ASYNC_STREAM ||
         context.mode() == QueryMode.CONTINOUS_SERVER_ASYNC_STREAM) {
       for (final TimeSeriesDataSource source : sources) {
-        source.fetchNext();
+        source.fetchNext(span);
       }
       return;
     }
@@ -230,7 +231,7 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
         source_idx = 0;
       }
       try {
-        sources.get(source_idx++).fetchNext();
+        sources.get(source_idx++).fetchNext(span);
       } catch (Exception e) {
         LOG.error("Failed to fetch next from source: " 
             + sources.get(source_idx - 1), e);

--- a/core/src/main/java/net/opentsdb/query/DefaultQueryContextBuilder.java
+++ b/core/src/main/java/net/opentsdb/query/DefaultQueryContextBuilder.java
@@ -160,8 +160,8 @@ public class DefaultQueryContextBuilder implements QueryContextBuilder {
     }
 
     @Override
-    public void fetchNext() {
-      context.fetchNext();
+    public void fetchNext(final Span span) {
+      context.fetchNext(span);
     }
 
     @Override

--- a/core/src/main/java/net/opentsdb/storage/MockDataStore.java
+++ b/core/src/main/java/net/opentsdb/storage/MockDataStore.java
@@ -330,7 +330,7 @@ public class MockDataStore implements TimeSeriesDataStore {
     }
     
     @Override
-    public void fetchNext() {
+    public void fetchNext(final Span span) {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Fetching next set of data.");
       }
@@ -609,7 +609,7 @@ public class MockDataStore implements TimeSeriesDataStore {
               LOG.debug("Fetching next Seq: " + (sequence_id  + 1) 
                   + " as there is more data: " + pipeline);
             }
-            pipeline.fetchNext();
+            pipeline.fetchNext(null /* TODO */);
           }
           break;
         case CONTINOUS_SERVER_ASYNC_STREAM:
@@ -628,7 +628,7 @@ public class MockDataStore implements TimeSeriesDataStore {
               LOG.debug("Fetching next Seq: " + (sequence_id  + 1) 
                   + " as there is more data: " + pipeline);
             }
-            pipeline.fetchNext();
+            pipeline.fetchNext(null /* TODO */);
           }
         }
       } catch (Exception e) {
@@ -677,7 +677,7 @@ public class MockDataStore implements TimeSeriesDataStore {
           if (LOG.isDebugEnabled()) {
             LOG.debug("Result closed, firing the next!: " + pipeline);
           }
-          pipeline.fetchNext();
+          pipeline.fetchNext(null /* TODO */);
         }
       }
     }

--- a/core/src/main/java/net/opentsdb/storage/SourceNode.java
+++ b/core/src/main/java/net/opentsdb/storage/SourceNode.java
@@ -14,6 +14,7 @@
 // limitations under the License.
 package net.opentsdb.storage;
 
+import net.opentsdb.data.TimeSeriesDataSource;
 import net.opentsdb.data.TimeStamp;
 import net.opentsdb.storage.schemas.tsdb1x.Schema;
 
@@ -22,7 +23,7 @@ import net.opentsdb.storage.schemas.tsdb1x.Schema;
  * 
  * @since 3.0
  */
-public interface SourceNode {
+public interface SourceNode extends TimeSeriesDataSource {
 
   /**
    * A timestamp representing the current end of a slice of time to stop

--- a/core/src/main/java/net/opentsdb/storage/StorageSchema.java
+++ b/core/src/main/java/net/opentsdb/storage/StorageSchema.java
@@ -18,6 +18,7 @@ import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.data.TimeSeriesByteId;
 import net.opentsdb.data.TimeSeriesStringId;
+import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.stats.Span;
 
 /**
@@ -26,7 +27,7 @@ import net.opentsdb.stats.Span;
  * 
  * @since 3.0
  */
-public interface StorageSchema {
+public interface StorageSchema extends QueryNodeFactory {
 
   /** @return A non-null and non-empty unique runtime ID for this storage
    * schema instance. Multiple schemas of the same type can be registered
@@ -44,5 +45,6 @@ public interface StorageSchema {
    */
   public Deferred<TimeSeriesStringId> resolveByteId(final TimeSeriesByteId id, 
                                                     final Span span);
+  
   
 }

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
@@ -15,7 +15,9 @@
 package net.opentsdb.storage.schemas.tsdb1x;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -30,12 +32,18 @@ import com.stumbleupon.async.DeferredGroupException;
 
 import net.opentsdb.configuration.ConfigurationException;
 import net.opentsdb.core.TSDB;
+import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesByteId;
 import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesStringId;
+import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.TimeStamp;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.meta.MetaDataStorageSchema;
+import net.opentsdb.query.QueryIteratorFactory;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryNodeConfig;
+import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.filter.TagVFilter;
 import net.opentsdb.query.filter.TagVLiteralOrFilter;
 import net.opentsdb.query.pojo.Filter;
@@ -202,6 +210,39 @@ public class Schema implements StorageSchema {
     
     codecs = Maps.newHashMapWithExpectedSize(1);
     codecs.put(NumericType.TYPE, new NumericCodec());
+  }
+  
+  @Override
+  public QueryNode newNode(QueryPipelineContext context,
+      QueryNodeConfig config) {
+    return data_store.newNode(context, config);
+  }
+
+  @Override
+  public Collection<TypeToken<?>> types() {
+    return data_store.types();
+  }
+
+  @Override
+  public void registerIteratorFactory(final TypeToken<?> type,
+                                      final QueryIteratorFactory factory) {
+    data_store.registerIteratorFactory(type, factory);
+  }
+
+  @Override
+  public Iterator<TimeSeriesValue<? extends TimeSeriesDataType>> newIterator(
+      final TypeToken<?> type, 
+      final QueryNode node, 
+      final Collection<TimeSeries> sources) {
+    return data_store.newIterator(type, node, sources);
+  }
+
+  @Override
+  public Iterator<TimeSeriesValue<? extends TimeSeriesDataType>> newIterator(
+      final TypeToken<?> type, 
+      final QueryNode node, 
+      final Map<String, TimeSeries> sources) {
+    return data_store.newIterator(type, node, sources);
   }
   
   /**
@@ -752,5 +793,6 @@ public class Schema implements StorageSchema {
   UniqueId tagValues() {
     return tag_values;
   }
+
   
 }

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
@@ -35,6 +35,7 @@ import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesStringId;
 import net.opentsdb.data.TimeStamp;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.meta.MetaDataStorageSchema;
 import net.opentsdb.query.filter.TagVFilter;
 import net.opentsdb.query.filter.TagVLiteralOrFilter;
 import net.opentsdb.query.pojo.Filter;
@@ -637,6 +638,12 @@ public class Schema implements StorageSchema {
 //      throw new IllegalArgumentException("No codec loaded for type: " + type);
 //    }
 //    return codec.newRowSeq(base_time);
+  }
+  
+  /** @return The meta schema if implemented and assigned, null if not. */
+  public MetaDataStorageSchema metaSchema() {
+    // TODO - implement
+    return null;
   }
   
   static class ResolvedFilterImplementation implements ResolvedFilter {

--- a/core/src/test/java/net/opentsdb/query/TestAbstractQueryPipelineContext.java
+++ b/core/src/test/java/net/opentsdb/query/TestAbstractQueryPipelineContext.java
@@ -167,25 +167,25 @@ public class TestAbstractQueryPipelineContext {
         Lists.newArrayList(sink1));
     ctx.initialize();
     
-    verify(ctx.s1, never()).fetchNext();
-    verify(ctx.s2, never()).fetchNext();
+    verify(ctx.s1, never()).fetchNext(null);
+    verify(ctx.s2, never()).fetchNext(null);
     
-    ctx.fetchNext();
-    verify(ctx.s1, never()).fetchNext();
-    verify(ctx.s2, times(1)).fetchNext();
+    ctx.fetchNext(null);
+    verify(ctx.s1, never()).fetchNext(null);
+    verify(ctx.s2, times(1)).fetchNext(null);
     
-    ctx.fetchNext();
-    verify(ctx.s1, times(1)).fetchNext();
-    verify(ctx.s2, times(1)).fetchNext();
+    ctx.fetchNext(null);
+    verify(ctx.s1, times(1)).fetchNext(null);
+    verify(ctx.s2, times(1)).fetchNext(null);
     
-    ctx.fetchNext();
-    verify(ctx.s1, times(1)).fetchNext();
-    verify(ctx.s2, times(2)).fetchNext();
+    ctx.fetchNext(null);
+    verify(ctx.s1, times(1)).fetchNext(null);
+    verify(ctx.s2, times(2)).fetchNext(null);
     
-    doThrow(new IllegalStateException("Boo!")).when(ctx.s1).fetchNext();
-    ctx.fetchNext();
-    verify(ctx.s1, times(2)).fetchNext();
-    verify(ctx.s2, times(2)).fetchNext();
+    doThrow(new IllegalStateException("Boo!")).when(ctx.s1).fetchNext(null);
+    ctx.fetchNext(null);
+    verify(ctx.s1, times(2)).fetchNext(null);
+    verify(ctx.s2, times(2)).fetchNext(null);
     verify(sink1, times(1)).onError(any(Throwable.class));
     
     // Test the single mutli-source case.
@@ -193,12 +193,12 @@ public class TestAbstractQueryPipelineContext {
     ctx = new TestContext(tsdb, query, context, Lists.newArrayList(sink1));
     ctx.initialize();
     
-    verify(ctx.s1, never()).fetchNext();
-    verify(ctx.s2, never()).fetchNext();
+    verify(ctx.s1, never()).fetchNext(null);
+    verify(ctx.s2, never()).fetchNext(null);
     
-    ctx.fetchNext();
-    verify(ctx.s1, times(1)).fetchNext();
-    verify(ctx.s2, times(1)).fetchNext();
+    ctx.fetchNext(null);
+    verify(ctx.s1, times(1)).fetchNext(null);
+    verify(ctx.s2, times(1)).fetchNext(null);
   }
   
   @Test

--- a/core/src/test/java/net/opentsdb/query/TestTSDBV2Pipeline.java
+++ b/core/src/test/java/net/opentsdb/query/TestTSDBV2Pipeline.java
@@ -135,7 +135,7 @@ public class TestTSDBV2Pipeline {
         .setMode(QueryMode.SINGLE)
         .addQuerySink(listener)
         .build();
-    ctx.fetchNext();
+    ctx.fetchNext(null);
     
     listener.completed.join(1000);
     listener.call_limit.join(1000);
@@ -203,7 +203,7 @@ public class TestTSDBV2Pipeline {
         .setMode(QueryMode.SINGLE)
         .addQuerySink(listener)
         .build();
-    ctx.fetchNext();
+    ctx.fetchNext(null);
     
     listener.completed.join(1000);
     listener.call_limit.join(1000);
@@ -293,7 +293,7 @@ public class TestTSDBV2Pipeline {
         .setMode(QueryMode.SINGLE)
         .addQuerySink(listener)
         .build();
-    ctx.fetchNext();
+    ctx.fetchNext(null);
     
     listener.completed.join(1000);
     listener.call_limit.join(1000);
@@ -365,7 +365,7 @@ public class TestTSDBV2Pipeline {
         .setMode(QueryMode.SINGLE)
         .addQuerySink(listener)
         .build();
-    ctx.fetchNext();
+    ctx.fetchNext(null);
     
     listener.completed.join(1000);
     listener.call_limit.join(1000);
@@ -441,7 +441,7 @@ public class TestTSDBV2Pipeline {
         if (on_next == 4) {
           call_limit.callback(null);
         }
-        ctx.fetchNext();
+        ctx.fetchNext(null);
       }
   
       @Override
@@ -458,7 +458,7 @@ public class TestTSDBV2Pipeline {
         .addQuerySink(listener)
         .build();
     listener.ctx = ctx;
-    ctx.fetchNext();
+    ctx.fetchNext(null);
     
     listener.completed.join(1000);
     listener.call_limit.join(1000);
@@ -516,7 +516,7 @@ public class TestTSDBV2Pipeline {
         if (on_next == 4) {
           call_limit.callback(null);
         }
-        ctx.fetchNext();
+        ctx.fetchNext(null);
       }
   
       @Override
@@ -533,7 +533,7 @@ public class TestTSDBV2Pipeline {
         .addQuerySink(listener)
         .build();
     listener.ctx = ctx;
-    ctx.fetchNext();
+    ctx.fetchNext(null);
     
     listener.completed.join(1000);
     listener.call_limit.join(1000);
@@ -609,7 +609,7 @@ public class TestTSDBV2Pipeline {
         if (on_next == 4) {
           call_limit.callback(null);
         }
-        ctx.fetchNext();
+        ctx.fetchNext(null);
       }
   
       @Override
@@ -626,7 +626,7 @@ public class TestTSDBV2Pipeline {
         .addQuerySink(listener)
         .build();
     listener.ctx = ctx;
-    ctx.fetchNext();
+    ctx.fetchNext(null);
     
     listener.call_limit.join(1000);
     try {
@@ -721,7 +721,7 @@ public class TestTSDBV2Pipeline {
         .addQuerySink(listener)
         .build();
     listener.ctx = ctx;
-    ctx.fetchNext();
+    ctx.fetchNext(null);
     
     listener.completed.join(1000);
     listener.call_limit.join(1000);
@@ -813,7 +813,7 @@ public class TestTSDBV2Pipeline {
         .addQuerySink(listener)
         .build();
     listener.ctx = ctx;
-    ctx.fetchNext();
+    ctx.fetchNext(null);
     
     listener.call_limit.join(1000);
     try {
@@ -908,7 +908,7 @@ public class TestTSDBV2Pipeline {
         .addQuerySink(listener)
         .build();
     listener.ctx = ctx;
-    ctx.fetchNext();
+    ctx.fetchNext(null);
     
     listener.completed.join(1000);
     listener.call_limit.join(1000);
@@ -1000,7 +1000,7 @@ public class TestTSDBV2Pipeline {
         .addQuerySink(listener)
         .build();
     listener.ctx = ctx;
-    ctx.fetchNext();
+    ctx.fetchNext(null);
     
     listener.call_limit.join(1000);
     try {

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
@@ -364,7 +364,7 @@ final public class QueryRpc {
     }
     
     try {
-      ctx.fetchNext();
+      ctx.fetchNext(query_span);
     } catch (Exception e) {
       LOG.error("Unexpected exception adding callbacks to deferred.", e);
       request.setAttribute(OpenTSDBApplication.QUERY_EXCEPTION_ATTRIBUTE, e);

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/HBaseExecutor.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/HBaseExecutor.java
@@ -12,33 +12,26 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package net.opentsdb.meta;
+package net.opentsdb.storage;
 
-import java.util.List;
-
-import com.google.common.reflect.TypeToken;
-
-import net.opentsdb.data.TimeSeriesId;
+import net.opentsdb.stats.Span;
 
 /**
- * The result from a meta data store query.
- * 
- * @since 3.0
+ * An executor to fetch data from HBase. E.g. via scan or multi-gets.
  */
-public interface MetaDataStorageResult {
-  public static enum MetaResult {
-    DATA,
-    NO_DATA_FALLBACK,
-    NO_DATA,
-    EXCEPTION_FALLBACK,
-    EXCEPTION
-  }
+public interface HBaseExecutor {
+
+  /**
+   * Attempts to fetch the next set of data from HBase.
+   * @param result A non-null query result to store data into.
+   * @param span An optional tracer span.
+   * @throws IllegalArgumentException if the result was null.
+   * @throws IllegalStateException if current result was set.
+   */
+  public void fetchNext(final Tsdb1xQueryResult result, final Span span); 
   
-  public MetaResult result();
-  
-  public Throwable exception();
-  
-  public List<TimeSeriesId> timeSeries();
-  
-  public TypeToken<? extends TimeSeriesId> idType();
+  /**
+   * Releases resources held by the executor.
+   */
+  public void close();
 }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseDataStore.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseDataStore.java
@@ -36,7 +36,6 @@ import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QuerySourceConfig;
-import net.opentsdb.rollup.RollupUtils.RollupUsage;
 import net.opentsdb.stats.Span;
 import net.opentsdb.storage.schemas.tsdb1x.Schema;
 import net.opentsdb.uid.UniqueIdStore;
@@ -63,11 +62,13 @@ public class Tsdb1xHBaseDataStore implements TimeSeriesDataStore {
       "tsd.query.rollups.default_usage";
   public static final String SKIP_NSUN_TAGK_KEY = "tsd.query.skip_unresolved_tagks";
   public static final String SKIP_NSUN_TAGV_KEY = "tsd.query.skip_unresolved_tagvs";
+  public static final String SKIP_NSUI_KEY = "tsd.query.skip_unresolved_ids";
+  public static final String ALLOW_DELETE_KEY = "tsd.query.allow_delete";
+  public static final String DELETE_KEY = "tsd.query.delete";
   public static final String PRE_AGG_KEY = "tsd.query.pre_agg";
   public static final String FUZZY_FILTER_KEY = "tsd.query.enable_fuzzy_filter";
   public static final String ROWS_PER_SCAN_KEY = "tsd.query.rows_per_scan";
   public static final String MAX_MG_CARDINALITY_KEY = "tsd.query.multiget.max_cardinality";
-  
   
   public static final byte[] DATA_FAMILY = 
       "t".getBytes(Const.ASCII_CHARSET);

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseDataStore.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseDataStore.java
@@ -265,17 +265,14 @@ public class Tsdb1xHBaseDataStore implements TimeSeriesDataStore {
   }
 
   String dynamicString(final String key) {
-    // TODO - implement
-    return null;
+    return tsdb.getConfig().getString(key);
   }
   
   int dynamicInt(final String key) {
-    // TODO - implement
-    return 0;
+    return tsdb.getConfig().getInt(key);
   }
   
   boolean dynamicBoolean(final String key) {
-    // TODO - implement
-    return false;
+    return tsdb.getConfig().getBoolean(key);
   }
 }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xMultiGet.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xMultiGet.java
@@ -85,7 +85,7 @@ import net.opentsdb.utils.DateTime;
  * 
  * @since 2.4
  */
-public class Tsdb1xMultiGet {
+public class Tsdb1xMultiGet implements HBaseExecutor {
   private static final Logger LOG = LoggerFactory.getLogger(Tsdb1xMultiGet.class);
   
   /** The upstream query node that owns this scanner set. */
@@ -323,13 +323,7 @@ public class Tsdb1xMultiGet {
     
   }
   
-  /**
-   * Attempts to fetch the next set of data from HBase.
-   * @param result A non-null query result to store data into.
-   * @param span An optional tracer span.
-   * @throws IllegalArgumentException if the result was null.
-   * @throws IllegalStateException if current result was set.
-   */
+  @Override
   public synchronized void fetchNext(final Tsdb1xQueryResult result, 
                                      final Span span) {
     if (result == null) {
@@ -354,6 +348,11 @@ public class Tsdb1xMultiGet {
       current_result = null;
       node.onNext(result);
     }
+  }
+  
+  @Override
+  public void close() {
+    // no-op
   }
   
   /**

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
@@ -14,9 +14,33 @@
 // limitations under the License.
 package net.opentsdb.storage;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+import com.stumbleupon.async.DeferredGroupException;
+
+import net.opentsdb.common.Const;
+import net.opentsdb.data.TimeSeriesByteId;
+import net.opentsdb.data.TimeSeriesId;
+import net.opentsdb.data.TimeSeriesStringId;
 import net.opentsdb.data.TimeStamp;
+import net.opentsdb.exceptions.IllegalDataException;
+import net.opentsdb.exceptions.QueryDownstreamException;
+import net.opentsdb.meta.MetaDataStorageResult;
 import net.opentsdb.query.AbstractQueryNode;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeConfig;
@@ -24,19 +48,65 @@ import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.QuerySourceConfig;
+import net.opentsdb.query.pojo.Downsampler;
+import net.opentsdb.query.pojo.TimeSeriesQuery;
 import net.opentsdb.rollup.RollupInterval;
 import net.opentsdb.rollup.RollupUtils.RollupUsage;
+import net.opentsdb.stats.Span;
 import net.opentsdb.storage.schemas.tsdb1x.Schema;
+import net.opentsdb.uid.NoSuchUniqueName;
+import net.opentsdb.uid.UniqueIdType;
+import net.opentsdb.utils.Bytes;
+import net.opentsdb.utils.Bytes.ByteMap;
+import net.opentsdb.utils.DateTime;
+import net.opentsdb.utils.Exceptions;
 
 /**
- * A query node implementation for the V1 schema from OpenTSDB.
+ * A query node implementation for the V1 schema from OpenTSDB. If the 
+ * schema was loaded with a meta-data store, the node will query meta
+ * first. If the meta results were empty and fallback is enabled, or if
+ * meta is not enabled, we'll perform scans.
  * 
  * @since 3.0
  */
 public class Tsdb1xQueryNode extends AbstractQueryNode implements SourceNode {
-
+  private static final Logger LOG = LoggerFactory.getLogger(
+      Tsdb1xQueryNode.class);
+  
   /** The query source config. */
-  private final QuerySourceConfig config;
+  protected final QuerySourceConfig config;
+  
+  /** The sequence ID counter. */
+  protected final AtomicLong sequence_id;
+  
+  /** Whether the node has been initialized. Initialization starts with
+   * the call to {@link #fetchNext(Span)}. */
+  protected final AtomicBoolean initialized;
+  
+  /** Whether or not the node is initializing. This is a block on calling
+   * {@link #fetchNext(Span)} multiple times. */
+  protected final AtomicBoolean initializing;
+  
+  /** The executor for this node. */
+  protected HBaseExecutor executor;
+  
+  /** Whether or not to skip NoSuchUniqueName errors for tag keys on resolution. */
+  protected final boolean skip_nsun_tagks;
+  
+  /** Whether or not to skip NoSuchUniqueName errors for tag values on resolution. */
+  protected final boolean skip_nsun_tagvs;
+  
+  /** Whether or not to skip name-less IDs when received from HBase. */
+  protected final boolean skip_nsui;
+  
+  /** Whether or not to delete the data found by this query. */
+  protected final boolean delete;
+  
+  /** Rollup intervals matching the query downsampler if applicable. */
+  protected final List<RollupInterval> rollup_intervals;
+  
+  /** Rollup fallback mode. */
+  protected final RollupUsage rollup_usage;
   
   /**
    * Default ctor.
@@ -52,7 +122,77 @@ public class Tsdb1xQueryNode extends AbstractQueryNode implements SourceNode {
       throw new IllegalArgumentException("Configuration cannot be null.");
     }
     this.config = config;
-    // TODO Auto-generated constructor stub
+    if (config.query() == null) {
+      throw new IllegalArgumentException("Can't execute a query without "
+          + "a query!");
+    }
+    if (config.configuration() == null) {
+      throw new IllegalArgumentException("Can't execute a query without "
+          + "a configuration in the source config!");
+    }
+    if (((TimeSeriesQuery) config.query()).getMetrics() == null || 
+        ((TimeSeriesQuery) config.query()).getMetrics().isEmpty() ||
+        ((TimeSeriesQuery) config.query()).getMetrics().size() > 1) {
+      throw new IllegalArgumentException("The node can only handle one metric at a time.");
+    }
+    sequence_id = new AtomicLong();
+    initialized = new AtomicBoolean();
+    initializing = new AtomicBoolean();
+    
+    final TimeSeriesQuery query = (TimeSeriesQuery) config.query();
+    if (query.hasKey(Tsdb1xHBaseDataStore.SKIP_NSUN_TAGK_KEY)) {
+      skip_nsun_tagks = query.getBoolean(config.configuration(), 
+          Tsdb1xHBaseDataStore.SKIP_NSUN_TAGK_KEY);
+    } else {
+      skip_nsun_tagks = ((Tsdb1xHBaseDataStore) factory)
+          .dynamicBoolean(Tsdb1xHBaseDataStore.SKIP_NSUN_TAGK_KEY);
+    }
+    if (query.hasKey(Tsdb1xHBaseDataStore.SKIP_NSUN_TAGV_KEY)) {
+      skip_nsun_tagvs = query.getBoolean(config.configuration(), 
+          Tsdb1xHBaseDataStore.SKIP_NSUN_TAGV_KEY);
+    } else {
+      skip_nsun_tagvs = ((Tsdb1xHBaseDataStore) factory)
+          .dynamicBoolean(Tsdb1xHBaseDataStore.SKIP_NSUN_TAGV_KEY);
+    }
+    if (query.hasKey(Tsdb1xHBaseDataStore.SKIP_NSUI_KEY)) {
+      skip_nsui = query.getBoolean(config.configuration(), 
+          Tsdb1xHBaseDataStore.SKIP_NSUI_KEY);
+    } else {
+      skip_nsui = ((Tsdb1xHBaseDataStore) factory)
+          .dynamicBoolean(Tsdb1xHBaseDataStore.SKIP_NSUI_KEY);
+    }
+    if (query.hasKey(Tsdb1xHBaseDataStore.DELETE_KEY)) {
+      delete = query.getBoolean(config.configuration(), 
+          Tsdb1xHBaseDataStore.DELETE_KEY);
+    } else {
+      delete = ((Tsdb1xHBaseDataStore) factory)
+          .dynamicBoolean(Tsdb1xHBaseDataStore.DELETE_KEY);
+    }
+    if (query.hasKey(Tsdb1xHBaseDataStore.ROLLUP_USAGE_KEY)) {
+      rollup_usage = RollupUsage.parse(query.getString(config.configuration(),
+          Tsdb1xHBaseDataStore.ROLLUP_USAGE_KEY));
+    } else {
+      rollup_usage = RollupUsage.parse(((Tsdb1xHBaseDataStore) factory)
+          .dynamicString(Tsdb1xHBaseDataStore.ROLLUP_USAGE_KEY));
+    }
+    
+    if (((Tsdb1xHBaseDataStore) factory).schema() != null && 
+        rollup_usage != RollupUsage.ROLLUP_RAW) {
+      Downsampler ds = query.getMetrics().get(0).getDownsampler();
+      if (ds != null) {
+        rollup_intervals = ((Tsdb1xHBaseDataStore) factory).schema().rollupConfig().getRollupInterval(
+            DateTime.parseDuration(ds.getInterval()) / 1000, ds.getInterval());
+      } else if (query.getTime().getDownsampler() != null) {
+        ds = query.getTime().getDownsampler();
+        rollup_intervals = ((Tsdb1xHBaseDataStore) factory).schema().rollupConfig().getRollupInterval(
+            DateTime.parseDuration(ds.getInterval()) / 1000, ds.getInterval());
+      } else {
+        rollup_intervals = null;
+      }
+    } else {
+      rollup_intervals = null;
+    }
+    initialize();
   }
 
   @Override
@@ -62,37 +202,58 @@ public class Tsdb1xQueryNode extends AbstractQueryNode implements SourceNode {
 
   @Override
   public String id() {
-    return "Tsdb1xAsyncHBaseQueryNode";
+    return config.getId();
   }
 
   @Override
   public void close() {
-    // TODO Auto-generated method stub
-    
+    if (executor != null) {
+      executor.close();
+    }
   }
 
   @Override
-  public void onComplete(QueryNode downstream, long final_sequence,
-      long total_sequences) {
-    // TODO Auto-generated method stub
-    
+  public void fetchNext(final Span span) {
+    // TODO - how do I determine if we have an outstanding request and 
+    // should queue or block another fetch? hmmm.
+    if (!initialized.get()) {
+      if (initializing.compareAndSet(false, true)) {
+        setup(span);
+        return;
+      } else {
+        throw new IllegalStateException("Don't call me until I'm "
+            + "finished setting up!");
+      }
+    }
+
+    executor.fetchNext(new Tsdb1xQueryResult(
+          sequence_id.getAndIncrement(), 
+          Tsdb1xQueryNode.this, 
+          ((Tsdb1xHBaseDataStore) factory).schema()), 
+    span);
+
+  }
+  
+  @Override
+  public void onComplete(final QueryNode downstream, 
+                         final long final_sequence,
+                         final long total_sequences) {
+    completeUpstream(final_sequence, total_sequences);
   }
 
   @Override
-  public void onNext(QueryResult next) {
-    // TODO Auto-generated method stub
-    
+  public void onNext(final QueryResult next) {
+    sendUpstream(next);
   }
 
   @Override
-  public void onError(Throwable t) {
-    // TODO Auto-generated method stub
-    
+  public void onError(final Throwable t) {
+    sendUpstream(t);
   }
 
   @Override
   public TimeStamp sequenceEnd() {
-    // TODO Auto-generated method stub
+    // TODO implement when the query has this information.
     return null;
   }
 
@@ -101,28 +262,452 @@ public class Tsdb1xQueryNode extends AbstractQueryNode implements SourceNode {
     return ((Tsdb1xHBaseDataStore) factory).schema();
   }
 
+  /** @return Whether or not to skip name-less UIDs found in storage. */
   boolean skipNSUI() {
-    // TODO - implement
-    return false;
+    return skip_nsui;
   }
   
+  /**
+   * @param prefix A 1 to 254 prefix for a data type.
+   * @return True if the type should be included, false if we're filtering
+   * out that data type.
+   */
   boolean fetchDataType(final byte prefix) {
     // TODO - implement
     return true;
   }
   
+  /** @return Whether or not to delete the found data. */
   boolean deleteData() {
-    // TODO  - implement
-    return false;
+    return delete;
   }
 
+  /** @return A list of applicable rollup intervals. May be null. */
   List<RollupInterval> rollupIntervals() {
-    // TODO - implement
-    return null;
+    return rollup_intervals;
   }
   
+  /** @return The rollup usage mode. */
   RollupUsage rollupUsage() {
-    // TODO - implement
-    return null;
+    return rollup_usage;
+  }
+
+  /**
+   * Initializes the query, either calling meta or setting up the scanner.
+   * @param span An optional tracing span.
+   */
+  @VisibleForTesting
+  void setup(final Span span) {
+    if (((Tsdb1xHBaseDataStore) factory).schema().metaSchema() != null) {
+      final Span child;
+      if (span != null) {
+        child = span.newChild(getClass().getName() + ".setup").start();
+      } else {
+        child = span;
+      }
+      ((Tsdb1xHBaseDataStore) factory).schema().metaSchema().runQuery(config.query())
+          .addCallback(new MetaCB(child))
+          .addErrback(new MetaErrorCB(child));
+    } else {
+      synchronized (this) {
+        executor = new Tsdb1xScanners(Tsdb1xQueryNode.this, 
+            (TimeSeriesQuery) config.query());
+        if (initialized.compareAndSet(false, true)) {
+          executor.fetchNext(new Tsdb1xQueryResult(
+              sequence_id.incrementAndGet(), 
+              Tsdb1xQueryNode.this, 
+              ((Tsdb1xHBaseDataStore) factory).schema()), 
+          span);
+        } else {
+          LOG.error("WTF? We lost an initialization race??");
+        }
+      }
+    }
+  }
+  
+  /**
+   * A class to catch exceptions fetching data from meta.
+   */
+  class MetaErrorCB implements Callback<Object, Exception> {
+    final Span span;
+    
+    MetaErrorCB(final Span span) {
+      this.span = span;
+    }
+    
+    @Override
+    public Object call(final Exception ex) throws Exception {
+      if (span != null) {
+        span.setErrorTags(ex)
+            .finish();
+      }
+      sendUpstream(ex);
+      return null;
+    }
+    
+  }
+  
+  /**
+   * Handles the logic of what to do based on the results of a meta call
+   * e.g. continue with meta if we have data, stop without data or fallback
+   * to scans.
+   */
+  class MetaCB implements Callback<Object, MetaDataStorageResult> {
+    final Span span;
+    
+    MetaCB(final Span span) {
+      this.span = span;
+    }
+    
+    @Override
+    public Object call(final MetaDataStorageResult result) throws Exception {
+      if (span != null) {
+        span.setSuccessTags()
+            .setTag("metaResponse", result.result().toString())
+            .finish();
+      }
+      
+      switch (result.result()) {
+      case DATA:
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Received results from meta store, setting up "
+              + "multi-gets.");
+        }
+        resolveMeta(result, span);
+        return null;
+      case NO_DATA:
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("No data returned from meta store.");
+        }
+        initialized.compareAndSet(false, true);
+        completeUpstream(0, 0);
+        return null;
+      case EXCEPTION:
+        LOG.warn("Unrecoverable exception from meta store: ", 
+            result.exception());
+        initialized.compareAndSet(false, true);
+        sendUpstream(result.exception());
+        return null;
+      case NO_DATA_FALLBACK:
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("No data returned from meta store." 
+              + " Falling back to scans.");
+        }
+        break; // fall through to scans
+      case EXCEPTION_FALLBACK:
+        LOG.warn("Exception from meta store, falling back", 
+            result.exception());
+        break;
+      default: // fall through to scans
+        final QueryDownstreamException ex = new QueryDownstreamException(
+            "Unhandled meta result type: " + result.result());
+        LOG.error("WTF? Shouldn't happen.", ex);
+        initialized.compareAndSet(false, true);
+        sendUpstream(ex);
+        return null;
+      }
+      
+      synchronized (Tsdb1xQueryNode.this) {
+        executor = new Tsdb1xScanners(Tsdb1xQueryNode.this, 
+            (TimeSeriesQuery) config.query());
+        if (initialized.compareAndSet(false, true)) {
+          executor.fetchNext(new Tsdb1xQueryResult(
+              sequence_id.incrementAndGet(), 
+              Tsdb1xQueryNode.this, 
+              ((Tsdb1xHBaseDataStore) factory).schema()), 
+          span);
+        } else {
+          LOG.error("WTF? We lost an initialization race??");
+        }
+      }
+      return null;
+    }
+    
+  }
+  
+  /**
+   * Processes the list of TSUIDs from the meta data store, resolving 
+   * strings to UIDs.
+   * @param result A non-null result with the 
+   * {@link MetaDataStorageResult#timeSeries()} populated. 
+   * @param span An optional tracing span.
+   */
+  @VisibleForTesting
+  void resolveMeta(final MetaDataStorageResult result, final Span span) {
+    final Span child;
+    if (span != null) {
+      child = span.newChild(getClass().getName() + ".resolveMeta").start();
+    } else {
+      child = span;
+    }
+    
+    final int metric_width = ((Tsdb1xHBaseDataStore) factory).schema().metricWidth();
+    final int tagk_width = ((Tsdb1xHBaseDataStore) factory).schema().tagkWidth();
+    final int tagv_width = ((Tsdb1xHBaseDataStore) factory).schema().tagvWidth();
+    
+    if (result.idType() == Const.TS_BYTE_ID) {
+      // easy! Just flatten the bytes.
+      final List<byte[]> tsuids = Lists.newArrayListWithExpectedSize(
+          result.timeSeries().size());
+      final byte[] metric = ((TimeSeriesByteId) result.timeSeries()
+          .get(0)).metric();
+      for (final TimeSeriesId raw_id : result.timeSeries()) {
+        final TimeSeriesByteId id = (TimeSeriesByteId) raw_id;
+        if (Bytes.memcmp(metric, id.metric()) != 0) {
+          throw new IllegalDataException("Meta returned two or more "
+              + "metrics. The initial metric was " + Bytes.pretty(metric) 
+              + " and another was " + Bytes.pretty(id.metric()));
+        }
+        final byte[] tsuid = new byte[metric_width + 
+                                      (id.tags().size() * tagk_width) + 
+                                      (id.tags().size() * tagv_width)
+                                      ];
+        System.arraycopy(id.metric(), 0, tsuid, 0, metric_width);
+        int idx = metric_width;
+        // no need to sort since the id specifies a ByteMap, already sorted!
+        for (final Entry<byte[], byte[]> entry : id.tags().entrySet()) {
+          System.arraycopy(entry.getKey(), 0, tsuid, idx, tagk_width);
+          idx += tagk_width;
+          System.arraycopy(entry.getValue(), 0, tsuid, idx, tagv_width);
+          idx += tagv_width;
+        }
+        
+        tsuids.add(tsuid);
+      }
+      
+      synchronized (this) {
+        executor = new Tsdb1xMultiGet(Tsdb1xQueryNode.this, 
+            (TimeSeriesQuery) config.query(), 
+            tsuids);
+        if (initialized.compareAndSet(false, true)) {
+          if (child != null) {
+            child.setSuccessTags()
+                 .finish();
+          }
+          executor.fetchNext(new Tsdb1xQueryResult(
+              sequence_id.incrementAndGet(), 
+              Tsdb1xQueryNode.this, 
+              ((Tsdb1xHBaseDataStore) factory).schema()), 
+          span);
+        } else {
+          LOG.error("WTF? We lost an initialization race??");
+        }
+      }
+    } else {
+      final String metric = ((TimeSeriesStringId) 
+          result.timeSeries().get(0)).metric();
+      Set<String> dedupe_tagks = Sets.newHashSet();
+      Set<String> dedupe_tagvs = Sets.newHashSet();
+      // since it's quite possible that a result would share a number of 
+      // common tag keys and values, we dedupe into maps then resolve those 
+      // and compile the TSUIDs from them. 
+      for (final TimeSeriesId raw_id : result.timeSeries()) {
+        final TimeSeriesStringId id = (TimeSeriesStringId) raw_id;
+        if (metric != null && !metric.equals(id.metric())) {
+          throw new IllegalDataException("Meta returned two or more "
+              + "metrics. The initial metric was " + metric 
+              + " and another was " + id.metric());
+        }
+        
+        for (final Entry<String, String> entry : id.tags().entrySet()) {
+          dedupe_tagks.add(entry.getKey());
+          dedupe_tagvs.add(entry.getValue());
+        }
+      }
+      
+      // now resolve
+      final List<String> tagks = Lists.newArrayList(dedupe_tagks);
+      final List<String> tagvs = Lists.newArrayList(dedupe_tagvs);
+      final byte[] metric_uid = new byte[((Tsdb1xHBaseDataStore) factory)
+                                         .schema().metricWidth()];
+      final Map<String, byte[]> tagk_map = 
+          Maps.newHashMapWithExpectedSize(tagks.size());
+      final Map<String, byte[]> tagv_map = 
+          Maps.newHashMapWithExpectedSize(tagvs.size());
+      final List<byte[]> tsuids = Lists.newArrayListWithExpectedSize(
+          result.timeSeries().size());
+      
+      /** Catches and passes errors upstream. */
+      class ErrorCB implements Callback<Object, Exception> {
+        @Override
+        public Object call(final Exception ex) throws Exception {
+          if (ex instanceof DeferredGroupException) {
+            if (child != null) {
+              child.setErrorTags(Exceptions.getCause((DeferredGroupException) ex))
+                   .finish();
+            }
+            sendUpstream(Exceptions.getCause((DeferredGroupException) ex));
+          } else {
+            if (child != null) {
+              child.setErrorTags(ex)
+                     .finish();
+            }
+            sendUpstream(ex);
+          }
+          return null;
+        }
+      }
+      
+      /** Handles copying the resolved metric. */
+      class MetricCB implements Callback<Object, byte[]> {
+        @Override
+        public Object call(final byte[] uid) throws Exception {
+          if (uid == null) {
+            final NoSuchUniqueName ex = 
+                new NoSuchUniqueName(Schema.METRIC_TYPE, metric);
+            if (child != null) {
+              child.setErrorTags(ex)
+                   .finish();
+            }
+            throw ex;
+          }
+          
+          for (int i = 0; i < uid.length; i++) {
+            metric_uid[i] = uid[i];
+          }
+          return null;
+        }
+      }
+      
+      /** Populates the tag to UID maps. */
+      class TagCB implements Callback<Object, List<byte[]>> {
+        final boolean is_tagvs;
+        
+        TagCB(final boolean is_tagvs) {
+          this.is_tagvs = is_tagvs;
+        }
+
+        @Override
+        public Object call(final List<byte[]> uids) throws Exception {
+          if (is_tagvs) {
+            for (int i = 0; i < uids.size(); i++) {
+              if (uids.get(i) == null) {
+                if (skip_nsun_tagvs) {
+                  if (LOG.isDebugEnabled()) {
+                    LOG.debug("Dropping tag value without an ID: " 
+                        + tagvs.get(i));
+                  }
+                  continue;
+                }
+                
+                final NoSuchUniqueName ex = 
+                    new NoSuchUniqueName(Schema.TAGV_TYPE, tagvs.get(i));
+                if (child != null) {
+                  child.setErrorTags(ex)
+                       .finish();
+                }
+                throw ex;
+              }
+              
+              tagv_map.put(tagvs.get(i), uids.get(i));
+            }
+          } else {
+            for (int i = 0; i < uids.size(); i++) {
+              if (uids.get(i) == null) {
+                if (skip_nsun_tagks) {
+                  if (LOG.isDebugEnabled()) {
+                    LOG.debug("Dropping tag key without an ID: " 
+                        + tagks.get(i));
+                  }
+                  continue;
+                }
+                
+                final NoSuchUniqueName ex = 
+                    new NoSuchUniqueName(Schema.TAGK_TYPE, tagks.get(i));
+                if (child != null) {
+                  child.setErrorTags(ex)
+                       .finish();
+                }
+                throw ex;
+              }
+              
+              tagk_map.put(tagks.get(i), uids.get(i));
+            }
+          }
+          
+          return null;
+        }
+      }
+
+      /** The final callback that creates the TSUIDs. */
+      class GroupCB implements Callback<Object, ArrayList<Object>> {
+        @Override
+        public Object call(final ArrayList<Object> ignored) throws Exception {
+          // TODO - maybe a better way but the TSUIDs have to be sorted
+          // on the key values.
+          final ByteMap<byte[]> sorter = new ByteMap<byte[]>();
+          for (final TimeSeriesId raw_id : result.timeSeries()) {
+            final TimeSeriesStringId id = (TimeSeriesStringId) raw_id;
+            sorter.clear();
+            
+            boolean keep_goin = true;
+            for (final Entry<String, String> entry : id.tags().entrySet()) {
+              final byte[] tagk = tagk_map.get(entry.getKey());
+              final byte[] tagv = tagv_map.get(entry.getValue());
+              if (tagk == null || tagv == null) {
+                keep_goin = false;
+                break;
+              }
+              sorter.put(tagk, tagv);
+            }
+            
+            if (!keep_goin) {
+              // dropping due to a NSUN tagk or tagv
+              continue;
+            }
+            
+            final byte[] tsuid = new byte[metric_width + 
+                                          (id.tags().size() * tagk_width) + 
+                                          (id.tags().size() * tagv_width)
+                                          ];
+            System.arraycopy(metric_uid, 0, tsuid, 0, metric_width);
+            int idx = metric_width;
+            for (final Entry<byte[], byte[]> entry : sorter.entrySet()) {
+              System.arraycopy(entry.getKey(), 0, tsuid, idx, tagk_width);
+              idx += tagk_width;
+              System.arraycopy(entry.getValue(), 0, tsuid, idx, tagv_width);
+              idx += tagv_width;
+            }
+            
+            tsuids.add(tsuid);
+          }
+          
+          // TODO - what happens if we didn't resolve anything???
+          synchronized (this) {
+            executor = new Tsdb1xMultiGet(
+                Tsdb1xQueryNode.this, 
+                (TimeSeriesQuery) config.query(), 
+                tsuids);
+            if (initialized.compareAndSet(false, true)) {
+              if (child != null) {
+                child.setSuccessTags()
+                     .finish();
+              }
+              executor.fetchNext(new Tsdb1xQueryResult(
+                  sequence_id.incrementAndGet(), 
+                  Tsdb1xQueryNode.this, 
+                  ((Tsdb1xHBaseDataStore) factory).schema()), 
+              span);
+            } else {
+              LOG.error("WTF? We lost an initialization race??");
+            }
+          }
+          
+          return null;
+        }
+      }
+      
+      final List<Deferred<Object>> deferreds = Lists.newArrayListWithCapacity(3);
+      deferreds.add(((Tsdb1xHBaseDataStore) factory).schema()
+          .getId(UniqueIdType.METRIC, metric, span)
+            .addCallbacks(new MetricCB(), new ErrorCB()));
+      deferreds.add(((Tsdb1xHBaseDataStore) factory).schema()
+          .getIds(UniqueIdType.TAGK, tagks, span)
+            .addCallbacks(new TagCB(false), new ErrorCB()));
+      deferreds.add(((Tsdb1xHBaseDataStore) factory).schema()
+          .getIds(UniqueIdType.TAGV, tagvs, span)
+            .addCallbacks(new TagCB(true), new ErrorCB()));
+      Deferred.group(deferreds).addCallbacks(new GroupCB(), new ErrorCB());
+    }
   }
 }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanners.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanners.java
@@ -80,7 +80,7 @@ import net.opentsdb.utils.DateTime;
  * 
  * @since 3.0
  */
-public class Tsdb1xScanners {
+public class Tsdb1xScanners implements HBaseExecutor {
   private static final Logger LOG = LoggerFactory.getLogger(Tsdb1xScanners.class);
   
   /** The state of the scanners. */

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xScanners.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xScanners.java
@@ -85,12 +85,6 @@ import net.opentsdb.utils.UnitTestException;
   Tsdb1xScanner.class })
 public class TestTsdb1xScanners extends UTBase {
 
-  // GMT: Monday, January 1, 2018 12:15:00 AM
-  public static final int START_TS = 1514765700;
-  
-  // GMT: Monday, January 1, 2018 1:15:00 AM
-  public static final int END_TS = 1514769300;
-  
   public Tsdb1xQueryNode node;
   public TimeSeriesQuery query;
   public RollupConfig rollup_config;

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/UTBase.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/UTBase.java
@@ -100,6 +100,12 @@ public class UTBase {
   public static final byte[] DATA_TABLE = "tsdb".getBytes(Const.ASCII_CHARSET);
   public static final byte[] UID_TABLE = "tsdb-uid".getBytes(Const.ASCII_CHARSET);
   
+  // GMT: Monday, January 1, 2018 12:15:00 AM
+  public static final int START_TS = 1514765700;
+  
+  // GMT: Monday, January 1, 2018 1:15:00 AM
+  public static final int END_TS = 1514769300;
+  
   /** The types of series to use as a helper. */
   public static enum Series {
     /** Two metrics but one series each. */
@@ -176,6 +182,7 @@ public class UTBase {
         });
     
     schema = spy(new Schema(tsdb, null));
+    when(data_store.schema()).thenReturn(schema);
     
     storage = new MockBase(client, true, true, true, true);
     loadUIDTable();


### PR DESCRIPTION
- Add a tracing span to the fetchNext() methods.
- Add an idType() to the MetaDataStorageResult class.
- SourceNode now extends TimeSeriesDataSource.
- Add a stub in Schema to return a meta data schema.

STORAGE:
- Add more query flags to Tsdb1xHBaseDataStore. Need to move them eventually.
- Add the HBaseExecutor interface and have the multiget and scanners implement
  it.
- Implement the Tsdb1xQueryNode to setup the executors and fetch data.