### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/data/types/numeric/BaseNumericAggregator.java
+++ b/core/src/main/java/net/opentsdb/data/types/numeric/BaseNumericAggregator.java
@@ -53,7 +53,7 @@ public abstract class BaseNumericAggregator implements NumericAggregator {
    * An implementation of a numeric value. Takes either a long or a double and
    * implements the {@link NumericType} over it.
    */
-  protected class NumericValue implements NumericType {
+  protected static class NumericValue implements NumericType {
     private final boolean is_integer;
     private final long value;
     

--- a/core/src/main/java/net/opentsdb/data/types/numeric/BaseNumericFillPolicy.java
+++ b/core/src/main/java/net/opentsdb/data/types/numeric/BaseNumericFillPolicy.java
@@ -21,7 +21,20 @@ import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
  * A base class that implements some of the numeric fill policies. For those
  * that are added later that this class does not support, it will throw
  * {@link UnsupportedOperationException}s.
- * 
+ * <p>
+ * TODO - find a way to determine if we should return a long or double.
+ * For now min and max will return a double.
+ * <p>
+ * Implementation:
+ * <ul>
+ * <li>NONE: isInteger=false, value=null</li>
+ * <li>NULL: isInteger=false, value=null</li>
+ * <li>ZERO: isInteger=true, value=0</li>
+ * <li>NOT_A_NUMBER: isInteger=false, value=NaN</li>
+ * <li>MIN: isInteger=false, value=Double.MIN_VALUE</li>
+ * <li>MAX: isInteger=false, value=Double.MAX_VALUE</li>
+ * <li>SCALAR: isInteger=false, value=UnsupportedOperationException</li>
+ * </ul>
  * @since 3.0
  */
 public class BaseNumericFillPolicy implements QueryFillPolicy<NumericType>, 
@@ -50,6 +63,8 @@ public class BaseNumericFillPolicy implements QueryFillPolicy<NumericType>,
       return null;
     case ZERO:
     case NOT_A_NUMBER:
+    case MIN:
+    case MAX:
       return this;
     default:
       throw new UnsupportedOperationException("This class must be overidden to "
@@ -62,11 +77,8 @@ public class BaseNumericFillPolicy implements QueryFillPolicy<NumericType>,
     switch(config.fillPolicy()) {
     case ZERO:
       return true;
-    case NOT_A_NUMBER:
-      return false;
     default:
-      throw new UnsupportedOperationException("This class must be overidden to "
-          + "support the policy.");
+      return false;
     }
   }
 
@@ -79,7 +91,17 @@ public class BaseNumericFillPolicy implements QueryFillPolicy<NumericType>,
   @Override
   public double doubleValue() {
     // If here then we're a NaN fill
-    return Double.NaN;
+    switch(config.fillPolicy()) {
+    case NOT_A_NUMBER:
+      return Double.NaN;
+    case MIN:
+      return Double.MIN_VALUE;
+    case MAX:
+      return Double.MAX_VALUE;
+    default:
+      throw new UnsupportedOperationException("This class must be "
+          + "overidden to support the policy.");
+    }
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericInterpolatorConfig.java
+++ b/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericInterpolatorConfig.java
@@ -66,6 +66,16 @@ public class NumericInterpolatorConfig implements QueryIteratorInterpolatorConfi
     return new BaseNumericFillPolicy(this);
   }
   
+  @Override
+  public String toString() {
+    return new StringBuilder()
+        .append("fill=")
+        .append(fill_policy)
+        .append(", realFill=")
+        .append(real_fill)
+        .toString();
+  }
+  
   /** @return A new builder for the config. */
   public static Builder newBuilder() {
     return new Builder();

--- a/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericInterpolatorFactory.java
+++ b/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericInterpolatorFactory.java
@@ -67,6 +67,7 @@ public class NumericInterpolatorFactory {
     }
   }
   
+  /** The linear interpolation factory. */
   public static class LERP extends BaseTSDBPlugin 
                            implements QueryIteratorInterpolatorFactory {
   @Override
@@ -120,6 +121,9 @@ public class NumericInterpolatorFactory {
     } else if (parts.length == 2) {
       aggregator = parts[1];
       fill = null;
+    } else if (parts.length == 1) {
+      aggregator = parts[0];
+      fill = null;
     } else {
       return NumericInterpolatorConfig.newBuilder()
           .setFillPolicy(FillPolicy.NONE)
@@ -130,6 +134,10 @@ public class NumericInterpolatorFactory {
     final FillPolicy fill_policy;
     if (Strings.isNullOrEmpty(fill) && aggregator.equals("zimsum")) {
       fill_policy = FillPolicy.ZERO;
+    } else if (Strings.isNullOrEmpty(fill) && aggregator.contains("max")) {
+      fill_policy = FillPolicy.MIN;
+    } else if (Strings.isNullOrEmpty(fill) && aggregator.contains("min")) {
+      fill_policy = FillPolicy.MAX;
     } else if (Strings.isNullOrEmpty(fill)) {
       fill_policy = FillPolicy.NONE;
     } else {

--- a/core/src/main/java/net/opentsdb/query/pojo/FillPolicy.java
+++ b/core/src/main/java/net/opentsdb/query/pojo/FillPolicy.java
@@ -26,7 +26,9 @@ public enum FillPolicy {
   ZERO("zero"),
   NOT_A_NUMBER("nan"),
   NULL("null"),
-  SCALAR("scalar");
+  SCALAR("scalar"),
+  MIN("min"),
+  MAX("max");
 
   // The user-friendly name of this policy.
   private final String name;

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
@@ -433,16 +433,17 @@ public class Schema implements TimeSeriesDataStore {
     class ErrorCB implements Callback<List<ResolvedFilter>, Exception> {
       @Override
       public List<ResolvedFilter> call(final Exception ex) throws Exception {
+        Throwable t = ex;
+        if (t instanceof DeferredGroupException) {
+          t = Exceptions.getCause((DeferredGroupException) ex);
+        }
         if (child != null) {
           child.setErrorTags()
-            .log("Exception", 
-                (ex instanceof DeferredGroupException) ? 
-                    Exceptions.getCause((DeferredGroupException) ex) : ex)
+            .log("Exception", t)
             .finish();
         }
-        throw new StorageException("Failed to fetch IDs.", 
-            (ex instanceof DeferredGroupException) ? 
-                Exceptions.getCause((DeferredGroupException) ex) : ex);
+        throw new StorageException("Failed to resolve IDs: " 
+            + t.getMessage(), t);
       }
     }
     

--- a/core/src/test/java/net/opentsdb/data/types/numeric/TestBaseNumericFillPolicy.java
+++ b/core/src/test/java/net/opentsdb/data/types/numeric/TestBaseNumericFillPolicy.java
@@ -60,7 +60,10 @@ public class TestBaseNumericFillPolicy {
         .setRealFillPolicy(FillWithRealPolicy.NONE)
         .build());
     assertTrue(fill.isInteger());
-    assertTrue(Double.isNaN(fill.fill().doubleValue()));
+    try {
+      fill.fill().doubleValue();
+      fail("Expected UnsupportedOperationException");
+    } catch (UnsupportedOperationException e) { }
     assertEquals(0, fill.fill().toDouble(), 0.001);
     assertEquals(0, fill.fill().longValue());
     
@@ -68,33 +71,38 @@ public class TestBaseNumericFillPolicy {
         .setFillPolicy(FillPolicy.NONE)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
         .build());
-    try {
-      fill.isInteger();
-      fail("Expected UnsupportedOperationException");
-    } catch (UnsupportedOperationException e) { }
+    assertFalse(fill.isInteger());
     assertNull(fill.fill());
     
     fill = new BaseNumericFillPolicy(NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NULL)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
         .build());
-    try {
-      fill.isInteger();
-      fail("Expected UnsupportedOperationException");
-    } catch (UnsupportedOperationException e) { }
+    assertFalse(fill.isInteger());
     assertNull(fill.fill());
     
     fill = new BaseNumericFillPolicy(NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.SCALAR)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
         .build());
-    try {
-      fill.isInteger();
-      fail("Expected UnsupportedOperationException");
-    } catch (UnsupportedOperationException e) { }
+    assertFalse(fill.isInteger());
     try {
       fill.fill();
       fail("Expected UnsupportedOperationException");
     } catch (UnsupportedOperationException e) { }
+    
+    fill = new BaseNumericFillPolicy(NumericInterpolatorConfig.newBuilder()
+        .setFillPolicy(FillPolicy.MAX)
+        .setRealFillPolicy(FillWithRealPolicy.NONE)
+        .build());
+    assertFalse(fill.isInteger());
+    assertEquals(Double.MAX_VALUE, fill.fill().doubleValue(), 0.00001);
+    
+    fill = new BaseNumericFillPolicy(NumericInterpolatorConfig.newBuilder()
+        .setFillPolicy(FillPolicy.MIN)
+        .setRealFillPolicy(FillWithRealPolicy.NONE)
+        .build());
+    assertFalse(fill.isInteger());
+    assertEquals(Double.MIN_VALUE, fill.fill().doubleValue(), 0.00001);
   }
 }

--- a/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestNumericInterpolatorFactory.java
+++ b/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestNumericInterpolatorFactory.java
@@ -102,6 +102,10 @@ public class TestNumericInterpolatorFactory {
     assertEquals(FillPolicy.NONE, config.fillPolicy());
     assertEquals(FillWithRealPolicy.NONE, config.realFillPolicy());
     
+    config = NumericInterpolatorFactory.parse("sum");
+    assertEquals(FillPolicy.NONE, config.fillPolicy());
+    assertEquals(FillWithRealPolicy.NONE, config.realFillPolicy());
+    
     config = NumericInterpolatorFactory.parse("1m-sum-nan");
     assertEquals(FillPolicy.NOT_A_NUMBER, config.fillPolicy());
     assertEquals(FillWithRealPolicy.NONE, config.realFillPolicy());
@@ -128,6 +132,22 @@ public class TestNumericInterpolatorFactory {
     
     config = NumericInterpolatorFactory.parse("1m");
     assertEquals(FillPolicy.NONE, config.fillPolicy());
+    assertEquals(FillWithRealPolicy.NONE, config.realFillPolicy());
+    
+    config = NumericInterpolatorFactory.parse("1m-mimmax");
+    assertEquals(FillPolicy.MIN, config.fillPolicy());
+    assertEquals(FillWithRealPolicy.NONE, config.realFillPolicy());
+    
+    config = NumericInterpolatorFactory.parse("1m-max");
+    assertEquals(FillPolicy.MIN, config.fillPolicy());
+    assertEquals(FillWithRealPolicy.NONE, config.realFillPolicy());
+    
+    config = NumericInterpolatorFactory.parse("1m-mimmin");
+    assertEquals(FillPolicy.MAX, config.fillPolicy());
+    assertEquals(FillWithRealPolicy.NONE, config.realFillPolicy());
+    
+    config = NumericInterpolatorFactory.parse("1m-min");
+    assertEquals(FillPolicy.MAX, config.fillPolicy());
     assertEquals(FillWithRealPolicy.NONE, config.realFillPolicy());
     
     try {

--- a/core/src/test/java/net/opentsdb/query/pojo/TestDownsamplingSpecification.java
+++ b/core/src/test/java/net/opentsdb/query/pojo/TestDownsamplingSpecification.java
@@ -69,7 +69,7 @@ public class TestDownsamplingSpecification {
 
   @Test(expected = RuntimeException.class)
   public void testBadFillPolicy() {
-    new DownsamplingSpecification("10m-avg-max");
+    new DownsamplingSpecification("10m-nosuchagg-nosuchagg");
   }
 
   @Test (expected = IllegalArgumentException.class)
@@ -140,7 +140,7 @@ public class TestDownsamplingSpecification {
 
   @Test(expected = IllegalArgumentException.class)
   public void testStringCtorBadFillPolicy() {
-    new DownsamplingSpecification("10m-avg-max");
+    new DownsamplingSpecification("10m-nosuchagg-nosuchagg");
   }
   
   @Test

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
@@ -434,19 +434,19 @@ final public class QueryRpc {
         final JsonV2QuerySerdes serdes = new JsonV2QuerySerdes(json);
         serdes.serialize(context, options, output, result);
         
-        if (options.showSummary()) {
-          json.writeObjectFieldStart("summary");
-          json.writeStringField("queryHash", Bytes.byteArrayToString(
-              query.buildTimelessHashCode().asBytes()));
-          json.writeStringField("queryId", Bytes.byteArrayToString(
-              query.buildHashCode().asBytes()));
-          json.writeStringField("traceId", context.stats().trace() == null ? "null" : 
-            context.stats().trace().traceId());
-          if (context.stats().trace() != null) {
-            //trace.serializeJSON("trace", json);
-          }
-          json.writeEndObject();
-        }
+//        if (options.showSummary()) {
+//          json.writeObjectFieldStart("summary");
+//          json.writeStringField("queryHash", Bytes.byteArrayToString(
+//              query.buildTimelessHashCode().asBytes()));
+//          json.writeStringField("queryId", Bytes.byteArrayToString(
+//              query.buildHashCode().asBytes()));
+//          json.writeStringField("traceId", context.stats().trace() == null ? "null" : 
+//            context.stats().trace().traceId());
+//          if (context.stats().trace() != null) {
+//            //trace.serializeJSON("trace", json);
+//          }
+//          json.writeEndObject();
+//        }
         
         // final
         json.writeEndArray();

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanner.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanner.java
@@ -726,7 +726,7 @@ public class Tsdb1xScanner {
     
     @Override
     public Object call(final Boolean matched) throws Exception {
-      if (matched) {
+      if (matched != null && matched) {
         result.decode(row, rollup_interval);
       }
       return null;

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xUniqueIdStore.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xUniqueIdStore.java
@@ -398,7 +398,8 @@ public class Tsdb1xUniqueIdStore implements UniqueIdStore {
             }
             throw new StorageException("UID resolution failed for ID " 
                 + ids.get(i), results.get(i).getException());
-          } else if (results.get(i).getCells() == null) {
+          } else if (results.get(i).getCells() == null ||
+                     results.get(i).getCells().isEmpty()) {
             names.add(null);
           } else {
             names.add(new String(results.get(i).getCells().get(0).value(), 
@@ -611,7 +612,8 @@ public class Tsdb1xUniqueIdStore implements UniqueIdStore {
             }
             throw new StorageException("UID resolution failed for name " 
                 + names.get(i), results.get(i).getException());
-          } else if (results.get(i).getCells() != null) {
+          } else if (results.get(i).getCells() != null &&
+                     !results.get(i).getCells().isEmpty()) {
             uids.add(results.get(i).getCells().get(0).value());
           } else {
             uids.add(null);

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xScanners.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xScanners.java
@@ -54,6 +54,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
 import com.google.common.collect.Lists;
+import com.google.common.primitives.Bytes;
 import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.core.Const;
@@ -265,11 +266,16 @@ public class TestTsdb1xScanners extends UTBase {
         .build();
     
     Tsdb1xScanners scanners = new Tsdb1xScanners(node, query);
-    byte[] start = scanners.setStartKey(METRIC_BYTES, null);
+    byte[] start = scanners.setStartKey(METRIC_BYTES, null, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, START_TS - 900, null), start);
     
+    // with fuzzy
+    byte[] fuzzy = Bytes.concat(new byte[3], new byte[4], TAGK_BYTES, new byte[3]);
+    start = scanners.setStartKey(METRIC_BYTES, null, fuzzy);
+    assertArrayEquals(makeRowKey(METRIC_BYTES, START_TS - 900, TAGK_BYTES, new byte[3]), start);
+    
     // rollup
-    start = scanners.setStartKey(METRIC_BYTES, interval);
+    start = scanners.setStartKey(METRIC_BYTES, interval, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, START_TS - 900, null), start);
     
     // rollup further in
@@ -282,7 +288,7 @@ public class TestTsdb1xScanners extends UTBase {
             .setMetric(METRIC_STRING))
         .build();
     scanners = new Tsdb1xScanners(node, query);
-    start = scanners.setStartKey(METRIC_BYTES, interval);
+    start = scanners.setStartKey(METRIC_BYTES, interval, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, START_TS - 900, null), start);
     
     // rollup with rate on edge
@@ -296,7 +302,7 @@ public class TestTsdb1xScanners extends UTBase {
             .setMetric(METRIC_STRING))
         .build();
     scanners = new Tsdb1xScanners(node, query);
-    start = scanners.setStartKey(METRIC_BYTES, interval);
+    start = scanners.setStartKey(METRIC_BYTES, interval, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, START_TS - 900 - 86400, null), start);
     
     // downsample
@@ -312,7 +318,7 @@ public class TestTsdb1xScanners extends UTBase {
             .setMetric(METRIC_STRING))
         .build();
     scanners = new Tsdb1xScanners(node, query);
-    start = scanners.setStartKey(METRIC_BYTES, null);
+    start = scanners.setStartKey(METRIC_BYTES, null, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, END_TS - 900, null), start);
     
     // downsample 2 hours
@@ -328,7 +334,7 @@ public class TestTsdb1xScanners extends UTBase {
             .setMetric(METRIC_STRING))
         .build();
     scanners = new Tsdb1xScanners(node, query);
-    start = scanners.setStartKey(METRIC_BYTES, null);
+    start = scanners.setStartKey(METRIC_BYTES, null, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, START_TS - 900, null), start);
     
     // downsample prefer the metric
@@ -347,7 +353,7 @@ public class TestTsdb1xScanners extends UTBase {
                 .setInterval("1h")))
         .build();
     scanners = new Tsdb1xScanners(node, query);
-    start = scanners.setStartKey(METRIC_BYTES, null);
+    start = scanners.setStartKey(METRIC_BYTES, null, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, END_TS - 900, null), start);
   }
   
@@ -635,7 +641,7 @@ public class TestTsdb1xScanners extends UTBase {
     verify(caught.get(0), times(1)).setMaxNumRows(1024);
     verify(caught.get(0), times(1)).setReversed(false);
     verify(caught.get(0), times(1)).setStartKey(
-        makeRowKey(METRIC_BYTES, START_TS - 900, null));
+        makeRowKey(METRIC_BYTES, START_TS - 900, TAGK_BYTES, new byte[3]));
     verify(caught.get(0), times(1)).setStopKey(
         makeRowKey(METRIC_BYTES, END_TS - 900 + 3600, null));
     FilterList filter = (FilterList) storage.getLastScanner().getFilter();
@@ -1386,7 +1392,7 @@ public class TestTsdb1xScanners extends UTBase {
     verify(caught.get(0), times(1)).setMaxNumRows(1024);
     verify(caught.get(0), times(1)).setReversed(false);
     verify(caught.get(0), times(1)).setStartKey(
-        makeRowKey(METRIC_BYTES, START_TS - 900, null));
+        makeRowKey(METRIC_BYTES, START_TS - 900, TAGK_BYTES, new byte[3]));
     verify(caught.get(0), times(1)).setStopKey(
         makeRowKey(METRIC_BYTES, 1514851200, null));
     verify(caught.get(0), times(1)).setFilter(any(FilterList.class));
@@ -1404,7 +1410,7 @@ public class TestTsdb1xScanners extends UTBase {
     verify(caught.get(1), times(1)).setMaxNumRows(1024);
     verify(caught.get(1), times(1)).setReversed(false);
     verify(caught.get(1), times(1)).setStartKey(
-        makeRowKey(METRIC_BYTES, START_TS - 900, null));
+        makeRowKey(METRIC_BYTES, START_TS - 900, TAGK_BYTES, new byte[3]));
     verify(caught.get(1), times(1)).setStopKey(
         makeRowKey(METRIC_BYTES, END_TS - 900 + 3600, null));
     verify(caught.get(1), times(1)).setFilter(any(FuzzyRowFilter.class));


### PR DESCRIPTION
- Make the NumericValue in BaseNumericAggregator static, save refs.
- Add MIN and MAX to BaseNumericFillPolicy as doubles for now. Would prefer to
  have some way to determine if it should be an int or float.
- Add a toString() to BaseNumericFillPolicy
- Add MAX and MIN fills to the NumericInterpolatorFactory parser and the
  FillPolicy enum.
- Unwrap DGEs in the Schema filter resolver callback.
- Disable summary printing in QueryRPC for now.

STORAGE:
- Fix an NPE in the Scanner matched callback. Can return a null.
- Fix fuzzy keys so they're salted in the Scanners setup, set the metric in
  the fuzzy key and use the fuzzy key as the start key for the scanner, when
  applicable. Also create the setScannerFilter() helper. It's ugly.
- Add isEmpty() checks to the UniqueIdStore.