### PR TITLE
Allow TagVNotLiteralOrFilter to filter single character tag values

### DIFF
--- a/src/query/filter/TagVNotLiteralOrFilter.java
+++ b/src/query/filter/TagVNotLiteralOrFilter.java
@@ -60,8 +60,11 @@ public class TagVNotLiteralOrFilter extends TagVFilter {
     this.case_insensitive = case_insensitive;
     
     // we have to have at least one character.
-    if (filter == null || filter.length() < 2) {
+    if (filter == null || filter.isEmpty()) {
       throw new IllegalArgumentException("Filter cannot be null or empty");
+    }
+    if (filter.length() == 1 && filter.charAt(0) == '|') {
+      throw new IllegalArgumentException("Filter must contain more than just a pipe");
     }
     final String[] split = filter.split("\\|");
     if (case_insensitive) {

--- a/test/query/filter/TestTagVNotLiteralOrFilter.java
+++ b/test/query/filter/TestTagVNotLiteralOrFilter.java
@@ -122,6 +122,13 @@ public class TestTagVNotLiteralOrFilter {
     assertFalse(filter.match(tags).join());
     assertTrue(((TagVNotLiteralOrFilter)filter).isCaseInsensitive());
   }
+
+  @Test
+  public void matchSingleCharacterTagValue() throws Exception {
+    TagVFilter filter = new TagVNotLiteralOrFilter(TAGK, "c");
+    tags.put(TAGK, "c");
+    assertFalse(filter.match(tags).join());
+  }
   
   @Test (expected = IllegalArgumentException.class)
   public void ctorNullTagk() throws Exception {


### PR DESCRIPTION
Bit of an edge case.  The not_literal_or filter does not work for single character tag values.  So `zimsum:sys.cpu.nice{}{host=not_literal_or(5)}` fails, but `zimsum:sys.cpu.nice{}{host=not_literal_or(50)}` and `zimsum:sys.cpu.nice{}{host=not_literal_or(|5)}` succeed.

Fixed by borrowing the validation logic from src/query/filter/TagVLiteralOrFilter.java.