### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/core/TSDB.java
+++ b/common/src/main/java/net/opentsdb/core/TSDB.java
@@ -14,7 +14,9 @@
 // limitations under the License.
 package net.opentsdb.core;
 
+import io.netty.util.Timer;
 import net.opentsdb.configuration.Configuration;
+import net.opentsdb.stats.StatsCollector;
 
 /**
  * The core interface for an OpenTSDB client.
@@ -28,4 +30,12 @@ public interface TSDB {
   
   /** @return The non-null registry for components. */
   public Registry getRegistry();
+  
+  /** @return The non-null metric and stats collector/reporter. */
+  public StatsCollector getStatsCollector();
+
+  /** @return A timer used for scheduling non-critical maintenance tasks
+   * like metrics collection, expirations, etc. */
+  public Timer getMaintenanceTimer();
+  
 }

--- a/common/src/main/java/net/opentsdb/stats/BlackholeStatsCollector.java
+++ b/common/src/main/java/net/opentsdb/stats/BlackholeStatsCollector.java
@@ -1,0 +1,88 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.stats;
+
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.core.TSDB;
+
+/**
+ * A default implementation of the stats collector that simply ignores
+ * the measurements. This can be used as the default as we guarantee not
+ * to return a null collector object to measurements.
+ * 
+ * @since 3.0
+ */
+public class BlackholeStatsCollector implements StatsCollector {
+
+  @Override
+  public String id() {
+    return "BlackholeStatsCollector";
+  }
+
+  @Override
+  public Deferred<Object> initialize(final TSDB tsdb) {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
+  }
+
+  @Override
+  public void incrementCounter(final String metric, final String... tags) {
+    // Muahaha!
+  }
+
+  @Override
+  public void incrementCounter(final String metric, 
+                               final long amount, 
+                               final String... tags) {
+    // Muahaha!
+  }
+
+  @Override
+  public void setGauge(final String metric, 
+                       final long value, 
+                       final String... tags) {
+    // Muahaha!
+  }
+
+  @Override
+  public void setGauge(final String metric, 
+                       final double value, 
+                       final String... tags) {
+    // Muahaha!
+  }
+
+  @Override
+  public StatsTimer startTimer(final String metric, final boolean histo) {
+    return TMR;
+  }
+
+  static class BlackholeTimer implements StatsTimer {
+    @Override
+    public void stop(final String... tags) {
+      // Muahaha!
+    }
+  }
+  private static final BlackholeTimer TMR = new BlackholeTimer();
+}

--- a/common/src/main/java/net/opentsdb/stats/StatsCollector.java
+++ b/common/src/main/java/net/opentsdb/stats/StatsCollector.java
@@ -1,0 +1,86 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.stats;
+
+import net.opentsdb.core.TSDBPlugin;
+
+/**
+ * A metric collection class.
+ * 
+ * WIP
+ * 
+ * @since 3.0
+ */
+public interface StatsCollector extends TSDBPlugin {
+
+  /**
+   * Increments a monotonically increasing counter by one.
+   * @param metric The non-null and non-empty metric name.
+   * @param tags An optional set of tag key, value, key, value pairs.
+   */
+  public void incrementCounter(final String metric, 
+                               final String... tags);
+  
+  /**
+   * Adds the given positive amount to a monotonically increasing counter.
+   * @param metric The non-null and non-empty metric name.
+   * @param amount The amount to add.
+   * @param tags An optional set of tag key, value, key, value pairs.
+   */
+  public void incrementCounter(final String metric, 
+                               final long amount, 
+                               final String... tags);
+  
+  /**
+   * Sets the gauge value.
+   * @param metric The non-null and non-empty metric name.
+   * @param value Gauge value.
+   * @param tags An optional set of tag key, value, key, value pairs.
+   */
+  public void setGauge(final String metric, 
+                       final long value, 
+                       final String... tags);
+  
+  /**
+   * Sets the gauge value.
+   * @param metric The non-null and non-empty metric name.
+   * @param value Gauge value.
+   * @param tags An optional set of tag key, value, key, value pairs.
+   */
+  public void setGauge(final String metric, 
+                       final double value, 
+                       final String... tags);
+  
+  /**
+   * Configures and returns a timer to measure a latency. Starts the clock
+   * on the timer on return.
+   * @param metric The non-null and non-empty metric name.
+   * @param histo Whether or not to track the latency in a histogram.
+   * @return A non-null timer.
+   */
+  public StatsTimer startTimer(final String metric, final boolean histo);
+  
+  /**
+   * A latency tracking class.
+   */
+  public interface StatsTimer {
+    
+    /**
+     * Stops and records the latency in the timer.
+     * @param tags An optional set of tag key, value, key, value pairs.
+     */
+    public void stop(final String... tags);
+  }
+}

--- a/core/src/main/java/net/opentsdb/core/BaseTSDBPlugin.java
+++ b/core/src/main/java/net/opentsdb/core/BaseTSDBPlugin.java
@@ -16,8 +16,6 @@ package net.opentsdb.core;
 
 import com.stumbleupon.async.Deferred;
 
-import net.opentsdb.stats.StatsCollector;
-
 /**
  * The base class used for TSDB plugins of all types.
  * 
@@ -50,15 +48,4 @@ public abstract class BaseTSDBPlugin implements TSDBPlugin {
   @Override
   public abstract String version();
 
-  /**
-   * Called by the TSD when a request for statistics collection has come in. The
-   * implementation may provide one or more statistics. If no statistics are
-   * available for the implementation just ignore this.
-   * @param collector The collector used for emitting statistics.
-   */
-  public void collectStats(final StatsCollector collector) {
-    if (collector == null) {
-      return;
-    }
-  }
 }

--- a/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
+++ b/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 
 import net.opentsdb.core.DefaultTSDB;
+import net.opentsdb.core.TSDB;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesDataSource;
 import net.opentsdb.data.TimeSeriesId;
@@ -56,7 +57,7 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
       AbstractQueryPipelineContext.class);
   
   /** The TSDB to which we belong. */
-  protected final DefaultTSDB tsdb;
+  protected final TSDB tsdb;
   
   /** The query we're working on. */
   protected TimeSeriesQuery query;
@@ -103,7 +104,7 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
    * @param sinks A collection of one or more sinks to publish to.
    * @throws IllegalArgumentException if any argument was null.
    */
-  public AbstractQueryPipelineContext(final DefaultTSDB tsdb, 
+  public AbstractQueryPipelineContext(final TSDB tsdb, 
                                       final TimeSeriesQuery query, 
                                       final QueryContext context,
                                       final Collection<QuerySink> sinks) {

--- a/core/src/main/java/net/opentsdb/query/DefaultQueryContextBuilder.java
+++ b/core/src/main/java/net/opentsdb/query/DefaultQueryContextBuilder.java
@@ -20,6 +20,7 @@ import java.util.List;
 import com.google.common.collect.Lists;
 
 import net.opentsdb.core.DefaultTSDB;
+import net.opentsdb.core.TSDB;
 import net.opentsdb.stats.QueryStats;
 import net.opentsdb.stats.Span;
 
@@ -32,7 +33,7 @@ import net.opentsdb.stats.Span;
  */
 public class DefaultQueryContextBuilder implements QueryContextBuilder {
   /** The TSDB to pull configs and settings from. */
-  private DefaultTSDB tsdb;
+  private TSDB tsdb;
   
   /** The list of sinks to callback with results. */
   private List<QuerySink> sinks;
@@ -55,7 +56,7 @@ public class DefaultQueryContextBuilder implements QueryContextBuilder {
    * @return The builder.
    * @throws IllegalArgumentException if the TSDB object was null.
    */
-  public static QueryContextBuilder newBuilder(final DefaultTSDB tsdb) {
+  public static QueryContextBuilder newBuilder(final TSDB tsdb) {
     if (tsdb == null) {
       throw new IllegalArgumentException("TSDB cannot be null.");
     }

--- a/core/src/main/java/net/opentsdb/query/TSDBV2Pipeline.java
+++ b/core/src/main/java/net/opentsdb/query/TSDBV2Pipeline.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Sets;
 import net.opentsdb.common.Const;
 import net.opentsdb.configuration.ConfigurationException;
 import net.opentsdb.core.DefaultTSDB;
+import net.opentsdb.core.TSDB;
 import net.opentsdb.data.types.numeric.Aggregators;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
@@ -68,7 +69,7 @@ public class TSDBV2Pipeline extends AbstractQueryPipelineContext {
   * @param sinks A collection of one or more sinks to publish to.
   * @throws IllegalArgumentException if any argument was null.
   */
-  public TSDBV2Pipeline(final DefaultTSDB tsdb, 
+  public TSDBV2Pipeline(final TSDB tsdb, 
                         final TimeSeriesQuery query, 
                         final QueryContext context,
                         final Collection<QuerySink> sinks) {

--- a/core/src/main/java/net/opentsdb/stats/StatsCollectorBasic.java
+++ b/core/src/main/java/net/opentsdb/stats/StatsCollectorBasic.java
@@ -36,10 +36,10 @@ import java.util.Map.Entry;
  * 
  * @since 1.0
  */
-public abstract class StatsCollector {
+public abstract class StatsCollectorBasic {
 
   private static final Logger LOG =
-    LoggerFactory.getLogger(StatsCollector.class);
+    LoggerFactory.getLogger(StatsCollectorBasic.class);
 
   /** Tags to add to every stat emitted by the collector */
   private static Map<String, String> global_tags;
@@ -58,7 +58,7 @@ public abstract class StatsCollector {
    * @param prefix A prefix to add to every metric name, for example
    * `tsd'.
    */
-  public StatsCollector(final String prefix) {
+  public StatsCollectorBasic(final String prefix) {
     this.prefix = prefix;
     if (global_tags != null && !global_tags.isEmpty()) {
       for (final Entry<String, String> entry : global_tags.entrySet()) {

--- a/implementation/redis/src/test/java/net/opentsdb/query/execution/cache/TestRedisClusterQueryCache.java
+++ b/implementation/redis/src/test/java/net/opentsdb/query/execution/cache/TestRedisClusterQueryCache.java
@@ -52,6 +52,7 @@ import net.opentsdb.core.DefaultRegistry;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.query.context.QueryContext;
 import net.opentsdb.query.execution.QueryExecution;
+import net.opentsdb.stats.BlackholeStatsCollector;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 
@@ -80,6 +81,7 @@ public class TestRedisClusterQueryCache {
     
     when(tsdb.getConfig()).thenReturn(config);
     when(tsdb.getRegistry()).thenReturn(registry);
+    when(tsdb.getStatsCollector()).thenReturn(new BlackholeStatsCollector());
     
     PowerMockito.whenNew(JedisCluster.class).withAnyArguments()
       .thenAnswer(new Answer<JedisCluster>() {

--- a/implementation/redis/src/test/java/net/opentsdb/query/execution/cache/TestRedisQueryCache.java
+++ b/implementation/redis/src/test/java/net/opentsdb/query/execution/cache/TestRedisQueryCache.java
@@ -49,6 +49,7 @@ import net.opentsdb.core.DefaultRegistry;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.query.context.QueryContext;
 import net.opentsdb.query.execution.QueryExecution;
+import net.opentsdb.stats.BlackholeStatsCollector;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
@@ -79,6 +80,7 @@ public class TestRedisQueryCache {
     
     when(tsdb.getConfig()).thenReturn(config);
     when(tsdb.getRegistry()).thenReturn(registry);
+    when(tsdb.getStatsCollector()).thenReturn(new BlackholeStatsCollector());
     
     PowerMockito.whenNew(JedisPool.class).withAnyArguments()
       .thenReturn(connection_pool);


### PR DESCRIPTION
- Add StatsCollector interface to the common lib that provides interfaces for
  collecting metrics.
- Add a blackhole implementation of the stats collector.
- Add the stats collector to the TSDB interface along with a timer getter.

CORE:
- Remove the old collectStats method from the BaseTSDBPlugin.
- Load stats plugin in DefaultTSDB and return the timer.
- Fix the ctors in a few places that had DefaulTSDB instead of TSDB.
- Use the new stats collector in the Guava LRU classes.

REDIS:
- Use the new stats collector. TODO - tags.

SERVLET:
- Just playing with stats right now.