### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xQueryResult.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xQueryResult.java
@@ -211,4 +211,23 @@ public class Tsdb1xQueryResult implements QueryResult {
       is_full = true;
     }
   }
+
+  /** @return An error message based on the byte or dp limit. Note that 
+   * this method doesn't check to see if we "are" full. If it's not full
+   * then the DP error is returned. */
+  public String resultIsFullErrorMessage() {
+    if (byte_limit > 0 && bytes > byte_limit) {
+      // TODO - properly format in MB or GB or KB...
+      final long mbs = (byte_limit / 1024 / 1024);
+      return "Sorry, you have attempted to fetch more than our maximum "
+          + "amount of " + (mbs > 0 ? mbs : 
+            ((double) byte_limit / 1024. / 1024.)) + "MB from storage. " 
+          + "Please try filtering using more tags or decrease your time range.";
+    }
+    
+    return "Sorry, you have attempted to fetch more than our limit of " 
+      + dp_limit + " data points. Please try filtering "
+      + "using more tags or decrease your time range.";
+  }
+  
 }

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestTsdb1xQueryResult.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestTsdb1xQueryResult.java
@@ -348,4 +348,34 @@ public class TestTsdb1xQueryResult extends SchemaBase {
       assertEquals(-1, value);
     }
   }
+
+  @Test
+  public void resultIsFullErrorMessage() throws Exception {
+    Tsdb1xQueryResult result = new Tsdb1xQueryResult(9, node, schema);
+    
+    // not full
+    assertTrue(result.resultIsFullErrorMessage().contains("data points"));
+    
+    query = TimeSeriesQuery.newBuilder()
+        .setTime(Timespan.newBuilder()
+            .setStart(Integer.toString(START_TS))
+            .setEnd(Integer.toString(END_TS))
+            .setAggregator("avg"))
+        .addMetric(Metric.newBuilder()
+            .setMetric(METRIC_STRING))
+        .addConfig(Schema.QUERY_BYTE_LIMIT_KEY, "42")
+        .addConfig(Schema.QUERY_DP_LIMIT_KEY, "24")
+        .build();
+    when(source_config.query()).thenReturn(query);
+    
+    // byte limit
+    result = new Tsdb1xQueryResult(9, node, schema);
+    result.bytes = 1024;
+    assertTrue(result.resultIsFullErrorMessage().contains("MB from storage"));
+    
+    // dp limit
+    result.bytes = 1;
+    result.dps = 42;
+    assertTrue(result.resultIsFullErrorMessage().contains("data points"));
+  }
 }


### PR DESCRIPTION
- Add an error message generator to the Tsdb1xQueryResult when it's full.

STORAGE:
- Add handling to the scanner to throw an exception when the result is full and
  the mode is SINGLE to mimic 2.4 and keep from OOMing.