### PR TITLE
ELASTICSEARCH:

### DIFF
--- a/implementation/elasticsearch/src/main/java/net/opentsdb/meta/ESClient.java
+++ b/implementation/elasticsearch/src/main/java/net/opentsdb/meta/ESClient.java
@@ -35,12 +35,14 @@ public interface ESClient {
    * returns the results in a list, one per cluster.
    * @param query The query to execute.
    * @param index The index to search.
+   * @param The number of records to return in the results.
    * @param span An optional tracing span.
    * @return A deferred resolving to a list of search response objects 
    * or an exception if the query couldn't execute.
    */
   public Deferred<List<SearchResponse>> runQuery(final QueryBuilder query, 
                                                  final String index,
+                                                 final int size,
                                                  final Span span);
   
 }

--- a/implementation/elasticsearch/src/main/java/net/opentsdb/meta/ESClusterClient.java
+++ b/implementation/elasticsearch/src/main/java/net/opentsdb/meta/ESClusterClient.java
@@ -162,6 +162,7 @@ public class ESClusterClient implements ESClient, TSDBPlugin {
   @Override
   public Deferred<List<SearchResponse>> runQuery(final QueryBuilder query,
                                                  final String index,
+                                                 final int size,
                                                  final Span span) {
     if (query == null) {
       return Deferred.fromError(new IllegalArgumentException(
@@ -208,8 +209,10 @@ public class ESClusterClient implements ESClient, TSDBPlugin {
       final SearchSourceBuilder search_builder = new SearchSourceBuilder()
           .timeout(TimeValue.timeValueMillis(
             tsdb.getConfig().getLong(QUERY_TIMEOUT_KEY)))
+          .size(size)
           .query(query);  
       search_request.source(search_builder);
+      search_request.indices(index);
       
       client.searchAsync(search_request, new FutureCB(), EMPTY_HEADERS);
     } catch (Exception e) {

--- a/implementation/elasticsearch/src/test/java/net/opentsdb/meta/TestESClusterClient.java
+++ b/implementation/elasticsearch/src/test/java/net/opentsdb/meta/TestESClusterClient.java
@@ -197,17 +197,17 @@ public class TestESClusterClient {
     
     // bad queries
     try {
-      es.runQuery(null, "idx", null).join();
+      es.runQuery(null, "idx", 1, null).join();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
     
     try {
-      es.runQuery(query, null, null).join();
+      es.runQuery(query, null, 1, null).join();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
     
     try {
-      es.runQuery(query, "", null).join();
+      es.runQuery(query, "", 1, null).join();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
   }


### PR DESCRIPTION
- Add the result size param to the runQuery() method.