### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/common/Const.java
+++ b/common/src/main/java/net/opentsdb/common/Const.java
@@ -60,12 +60,16 @@ public final class Const {
     MAX_NUM_TAGS = tags;
   }
   
-  /** The default ASCII character set for encoding tables and qualifiers that
-   * don't depend on user input that may be encoded with UTF.
-   * Charset to use with our server-side row-filter.
-   * We use this one because it preserves every possible byte unchanged.
+  /** The default extended ASCII character set for encoding tables and 
+   * qualifiers that don't depend on user input that may be encoded with 
+   * UTF. Charset to use with our server-side row-filter. This was used
+   * in 1.x and 2.x. We use this one because it preserves every 
+   * possible byte unchanged.
    */
-  public static final Charset ASCII_CHARSET = Charset.forName("ISO-8859-1");
+  public static final Charset ISO_8859_CHARSET = Charset.forName("ISO-8859-1");
+  
+  /** Just the basic ASCII character set. */
+  public static final Charset ASCII_US_CHARSET = Charset.forName("US-ASCII");
   
   /** Used for metrics, tags names and tag values */
   public static final Charset UTF8_CHARSET = Charset.forName("UTF8");

--- a/core/src/main/java/net/opentsdb/core/PluginsConfig.java
+++ b/core/src/main/java/net/opentsdb/core/PluginsConfig.java
@@ -422,7 +422,7 @@ public class PluginsConfig extends Validatable {
         
         if (index >= configs.size() || index < 0) {
           if (LOG.isDebugEnabled() && index > 0) {
-            LOG.debug("Completed loading.");
+            LOG.debug("Completed loading of plugins.");
           }
           deferred.callback(null);
         } else {
@@ -731,10 +731,33 @@ public class PluginsConfig extends Validatable {
    */
   void registerPlugin(final PluginConfig config) {
     if (Strings.isNullOrEmpty(config.getId()) && !config.getIsDefault()) {
+      // see if the plugin has already been registered.
+      final Map<String, TSDBPlugin> extant = plugins.get(config.clazz);
+      if (extant != null && extant.containsKey(
+          config.instantiated_plugin.getClass().getCanonicalName())) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Plugin already exists: " + config);
+        }
+        config.instantiated_plugin.shutdown();
+        return;
+      }
+      
       registerPlugin(config.clazz, 
           config.instantiated_plugin.getClass().getCanonicalName(), 
           config.instantiated_plugin);
     } else {
+      if (!config.getIsDefault()) {
+        // see if the plugin has already been registered.
+        final Map<String, TSDBPlugin> extant = plugins.get(config.clazz);
+        if (extant != null && extant.containsKey(config.getId())) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Plugin already exists: " + config);
+          }
+          config.instantiated_plugin.shutdown();
+          return;
+        }
+      }
+      
       registerPlugin(config.clazz, 
           config.getIsDefault() ? null : config.getId(), 
           config.instantiated_plugin);

--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV2QuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV2QuerySerdes.java
@@ -74,6 +74,13 @@ public class JsonV2QuerySerdes implements TimeSeriesSerdes, TSDBPlugin {
   private final JsonGenerator json;
   
   /**
+   * Unused ctor for the plugin for now. TEMP!
+   */
+  public JsonV2QuerySerdes() {
+    json = null;
+  }
+  
+  /**
    * Default ctor.
    * @param generator A non-null JSON generator.
    */

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
@@ -18,9 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -39,7 +37,6 @@ import net.opentsdb.common.Const;
 import net.opentsdb.configuration.ConfigurationException;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.data.BaseTimeSeriesStringId;
-import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesByteId;
 import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesStringId;
@@ -48,7 +45,6 @@ import net.opentsdb.data.TimeStamp;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.meta.MetaDataStorageSchema;
-import net.opentsdb.query.QueryIteratorFactory;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
@@ -88,6 +84,7 @@ public class Schema implements TimeSeriesDataStore {
   public static final String QUERY_REVERSE_KEY = "tsd.query.time.descending";
   public static final String QUERY_KEEP_FIRST_KEY = "tsd.query.duplicates.keep_earliest";
   public static final String TIMELESS_SALTING_KEY = "tsd.storage.salt.timeless";
+  public static final String OLD_SALTING_KEY = "tsd.storage.salt.old";
   
   /** Max time delta (in seconds) we can store in a column qualifier.  */
   public static final short MAX_RAW_TIMESPAN = 3600;
@@ -113,9 +110,13 @@ public class Schema implements TimeSeriesDataStore {
   protected int salt_buckets;
   protected int salt_width;
   
+  protected final boolean timeless_salting;
+  protected final boolean old_salting;
   protected final RollupConfig rollup_config;
   
   protected Map<TypeToken<?>, Codec> codecs;
+  
+  protected MetaDataStorageSchema meta_schema;
   
   public Schema(final TSDB tsdb, final String id) {
     this.tsdb = tsdb;
@@ -243,12 +244,22 @@ public class Schema implements TimeSeriesDataStore {
       tsdb.getConfig().register(TIMELESS_SALTING_KEY, true, false,
           "Whether or not timestamps are incorporated into the salting "
           + "calculations. When true, time is not incorporated, when false "
-          + "it is included.");
+          + "it is included. NOTE: For almost all uses, leave this as true.");
+    }
+    if (!tsdb.getConfig().hasProperty(OLD_SALTING_KEY)) {
+      tsdb.getConfig().register(OLD_SALTING_KEY, false, false,
+          "Whether or not to enable the old, stringified salting "
+          + "calculation. DO NOT SET THIS TO TRUE!");
     }
     
+    timeless_salting = tsdb.getConfig().getBoolean(TIMELESS_SALTING_KEY);
+    old_salting = tsdb.getConfig().getBoolean(OLD_SALTING_KEY);
     codecs = Maps.newHashMapWithExpectedSize(2);
     codecs.put(NumericType.TYPE, new NumericCodec());
     codecs.put(NumericSummaryType.TYPE, new NumericSummaryCodec());
+    
+    meta_schema = tsdb.getRegistry()
+        .getDefaultPlugin(MetaDataStorageSchema.class);
   }
   
   @Override
@@ -635,22 +646,72 @@ public class Schema implements TimeSeriesDataStore {
    * @param row_key A non-null and non-empty row key.
    */
   public void prefixKeyWithSalt(final byte[] row_key) {
-    // TODO - implement
+    if (salt_width < 1) {
+      return;
+    }
+    if ((row_key.length < salt_width + metric_width) ||    
+        (Bytes.memcmp(row_key, new byte[salt_width + metric_width], 
+            salt_width, metric_width) == 0)) {    
+        //Metric id is 0, which means it is a global row. Don't prefix it with salt   
+        return;
+      }
+    
+    if (timeless_salting) {
+      // we want the metric and tags, not the timestamp
+      int hash = 1;
+      for (int i = salt_width; i < row_key.length; i++) {
+        hash = 31 * hash + row_key[i];
+        if (i + 1 == salt_width + metric_width) {
+          i = salt_width + metric_width + Const.TIMESTAMP_BYTES - 1;
+        }
+      }
+      int modulo = hash % salt_buckets;
+      if (modulo < 0) {
+        // make sure we return a positive salt.
+        modulo = modulo * -1;
+      }
+      prefixKeyWithSalt(row_key, modulo);
+    } else if (old_salting) {
+      // DON'T DO THIS! Don't USE IT!
+      int modulo = (new String(Arrays.copyOfRange(row_key, salt_width,    
+          row_key.length), Const.ASCII_US_CHARSET)).hashCode() % salt_buckets;   
+      if (modulo < 0) {
+        // make sure we return a positive salt.
+        modulo = modulo * -1;   
+      }
+      prefixKeyWithSalt(row_key, modulo);
+    } else {
+      int hash = 1;
+      for (int i = salt_width; i < row_key.length; i++) {
+        hash = 31 * hash + row_key[i];
+      }
+      int modulo = hash % salt_buckets;
+      if (modulo < 0) {
+        // make sure we return a positive salt.
+        modulo = modulo * -1;
+      }
+      prefixKeyWithSalt(row_key, modulo);
+    }
   }
   
+  /**
+   * Sets the bucket on the row key. The row key must be pre-allocated
+   * the proper number of salt bytes at the start of the array.
+   * @param row_key A non-null and non-empty row key.
+   * @param bucket A 0 based positive bucket ID.
+   */
   public void prefixKeyWithSalt(final byte[] row_key, final int bucket) {
     if (salt_width == 1) {
       row_key[0] = (byte) bucket;
       return;
     }
     
-    final byte[] salt = new byte[salt_width];
     int shift = 0;
     for (int i = 0; i <= salt_width; i++) {
-      salt[salt_width - i] = (byte) (bucket >>> shift);
+      row_key[salt_width - i] = 0;
+      row_key[salt_width - i] = (byte) (bucket >>> shift);
       shift += 8;
     }
-    System.arraycopy(salt, 0, row_key, 0, salt_width);
   }
   
   public RollupConfig rollupConfig() {
@@ -676,9 +737,9 @@ public class Schema implements TimeSeriesDataStore {
     Bytes.setInt(row, base_time, salt_width + metric_width);
   }
   
+  /** @return Whether or not timeless salting is enabled. */
   public boolean timelessSalting() {
-    // TODO - implement
-    return true;
+    return timeless_salting;
   }
   
   public net.opentsdb.storage.schemas.tsdb1x.Span<? extends TimeSeriesDataType> newSpan(
@@ -704,8 +765,7 @@ public class Schema implements TimeSeriesDataStore {
   
   /** @return The meta schema if implemented and assigned, null if not. */
   public MetaDataStorageSchema metaSchema() {
-    // TODO - implement
-    return null;
+    return meta_schema;
   }
   
   static class ResolvedFilterImplementation implements ResolvedFilter {
@@ -991,5 +1051,5 @@ public class Schema implements TimeSeriesDataStore {
     // TODO Auto-generated method stub
     return null;
   }
-
+  
 }

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
@@ -707,9 +707,9 @@ public class Schema implements TimeSeriesDataStore {
     }
     
     int shift = 0;
-    for (int i = 0; i <= salt_width; i++) {
-      row_key[salt_width - i] = 0;
-      row_key[salt_width - i] = (byte) (bucket >>> shift);
+    for (int i = 0; i < salt_width; i++) {
+      row_key[salt_width - i - 1] = 0;
+      row_key[salt_width - i - 1] = (byte) (bucket >>> shift);
       shift += 8;
     }
   }

--- a/core/src/test/java/net/opentsdb/core/TestPluginsConfig.java
+++ b/core/src/test/java/net/opentsdb/core/TestPluginsConfig.java
@@ -1233,6 +1233,22 @@ public class TestPluginsConfig {
   }
   
   @Test
+  public void initializeDupeWithDefaults() throws Exception {
+    final List<PluginConfig> configs = Lists.newArrayList();
+    PluginConfig c = PluginConfig.newBuilder()
+        .setType("net.opentsdb.stats.StatsCollector")
+        .setId("BlackholeStatsCollector")
+        .setPlugin("net.opentsdb.stats.BlackholeStatsCollector")
+        .build();
+    configs.add(c);
+    
+    config.setLoadDefaultInstances(false);
+    config.setConfigs(configs);
+    
+    assertNull(config.initialize(tsdb).join(1));
+  }
+  
+  @Test
   public void shutdownEmpty() throws Exception {
     assertNull(config.shutdown().join());
   }

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/SchemaBase.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/SchemaBase.java
@@ -115,7 +115,7 @@ public class SchemaBase {
     tsdb = new MockTSDB();
     store_factory = mock(Tsdb1xDataStoreFactory.class);
     store = mock(Tsdb1xDataStore.class);
-    uid_store = spy(new MockUIDStore(Const.ASCII_CHARSET));
+    uid_store = spy(new MockUIDStore(Const.ISO_8859_CHARSET));
     uid_factory = mock(UniqueIdFactory.class);
     
     // return the default

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchema.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchema.java
@@ -826,5 +826,119 @@ public class TestSchema extends SchemaBase {
     assertEquals(4, key[0]);
   }
   
-  // TODO - test multi-byte salting.
+  @Test
+  public void prefixKeyWithSaltMultiByte() throws Exception {
+    MockTSDB tsdb = new MockTSDB();
+    when(tsdb.registry.getDefaultPlugin(Tsdb1xDataStoreFactory.class))
+      .thenReturn(store_factory);
+    when(store_factory.newInstance(any(TSDB.class), anyString(), any(Schema.class)))
+      .thenReturn(store);    
+    when(tsdb.registry.getSharedObject("default_uidstore"))
+      .thenReturn(uid_store);
+    when(tsdb.registry.getPlugin(UniqueIdFactory.class, "LRU"))
+      .thenReturn(uid_factory);
+    tsdb.config.register("tsd.storage.uid.width.metric", 4, false, "UT");
+    tsdb.config.register("tsd.storage.uid.width.tagk", 4, false, "UT");
+    tsdb.config.register("tsd.storage.uid.width.tagv", 4, false, "UT");
+    tsdb.config.register("tsd.storage.salt.buckets", 20, false, "UT");
+    tsdb.config.register("tsd.storage.salt.width", 3, false, "UT");
+    
+    Schema schema = new Schema(tsdb, null);
+    
+    byte[] key = new byte[] { 0, 0, 0, 0, -41, -87, -12, 91, 8, 107, 64, 0, 0, 
+        0, 1, 0, 0, 0, 1, 0, 0, 0, 2, 69, 124, 52, -106, 0, 0, 0, 22, 
+        34, -87, 25, 92, 0, 0, 0, 80, 6, 67, 94, -84, 0, 0, 0, 89, 0, 
+        0, -17, -1, 0, 0, 16, 116, 72, 112, 67, 25 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(6, key[2]);
+    assertEquals(0, key[1]);
+    assertEquals(0, key[0]);
+    
+    key = new byte[] { 0, 0, 0, -27, 89, 20, -100, 91, 8, 65, 16, 0, 0, 0, 1, 
+        0, 0, 0, 1, 0, 0, 0, 2, 16, -1, 42, -124, 0, 0, 0, 56, 0, 5, 
+        79, -91 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(7, key[2]);
+    assertEquals(0, key[1]);
+    assertEquals(0, key[0]);
+    
+    key = new byte[] { 0, 0, 12, -27, 89, 20, -100, 91, 8, 51, 0, 0, 0, 0, 1, 
+        0, 0, 0, 1, 0, 0, 0, 2, 16, -1, 44, 81, 0, 0, 0, 56, 0, 5, 79, 
+        -91 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(0, key[2]);
+    assertEquals(0, key[1]);
+    assertEquals(0, key[0]);
+    
+    // Switch every hour/interval
+    tsdb.config.override(Schema.TIMELESS_SALTING_KEY, false);
+    tsdb.config.override("tsd.storage.uid.width.metric", 4);
+    tsdb.config.override("tsd.storage.uid.width.tagk", 4);
+    tsdb.config.override("tsd.storage.uid.width.tagv", 4);
+    tsdb.config.override("tsd.storage.salt.buckets", 20);
+    tsdb.config.override("tsd.storage.salt.width", 3);
+    
+    schema = new Schema(tsdb, null);
+    
+    key = new byte[] { 0, 0, 0, 0, -41, -87, -12, 91, 8, 107, 64, 0, 0, 
+        0, 1, 0, 0, 0, 1, 0, 0, 0, 2, 69, 124, 52, -106, 0, 0, 0, 22, 
+        34, -87, 25, 92, 0, 0, 0, 80, 6, 67, 94, -84, 0, 0, 0, 89, 0, 
+        0, -17, -1, 0, 0, 16, 116, 72, 112, 67, 25 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(4, key[2]);
+    assertEquals(0, key[1]);
+    assertEquals(0, key[0]);
+    
+    key = new byte[] { 0, 0, 0, -27, 89, 20, -100, 91, 8, 65, 16, 0, 0, 0, 1, 
+        0, 0, 0, 1, 0, 0, 0, 2, 16, -1, 42, -124, 0, 0, 0, 56, 0, 5, 
+        79, -91 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(3, key[2]);
+    assertEquals(0, key[1]);
+    assertEquals(0, key[0]);
+    
+    key = new byte[] { 0, 0, 12, -27, 89, 20, -100, 91, 8, 51, 0, 0, 0, 0, 1, 
+        0, 0, 0, 1, 0, 0, 0, 2, 16, -1, 44, 81, 0, 0, 0, 56, 0, 5, 79, 
+        -91 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(6, key[2]);
+    assertEquals(0, key[1]);
+    assertEquals(0, key[0]);
+    
+    // OLD school. Don't do it!!
+    tsdb.config.override(Schema.OLD_SALTING_KEY, true);
+    tsdb.config.override(Schema.TIMELESS_SALTING_KEY, false);
+    tsdb.config.override("tsd.storage.uid.width.metric", 4);
+    tsdb.config.override("tsd.storage.uid.width.tagk", 4);
+    tsdb.config.override("tsd.storage.uid.width.tagv", 4);
+    tsdb.config.override("tsd.storage.salt.buckets", 20);
+    tsdb.config.override("tsd.storage.salt.width", 3);
+    
+    schema = new Schema(tsdb, null);
+    
+    key = new byte[] { 0, 0, 0, 0, -41, -87, -12, 91, 8, 107, 64, 0, 0, 
+        0, 1, 0, 0, 0, 1, 0, 0, 0, 2, 69, 124, 52, -106, 0, 0, 0, 22, 
+        34, -87, 25, 92, 0, 0, 0, 80, 6, 67, 94, -84, 0, 0, 0, 89, 0, 
+        0, -17, -1, 0, 0, 16, 116, 72, 112, 67, 25 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(10, key[2]);
+    assertEquals(0, key[1]);
+    assertEquals(0, key[0]);
+    
+    key = new byte[] { 0, 0, 0, -27, 89, 20, -100, 91, 8, 65, 16, 0, 0, 0, 1, 
+        0, 0, 0, 1, 0, 0, 0, 2, 16, -1, 42, -124, 0, 0, 0, 56, 0, 5, 
+        79, -91 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(8, key[2]);
+    assertEquals(0, key[1]);
+    assertEquals(0, key[0]);
+    
+    key = new byte[] { 0, 0, 12, -27, 89, 20, -100, 91, 8, 51, 0, 0, 0, 0, 1, 
+        0, 0, 0, 1, 0, 0, 0, 2, 16, -1, 44, 81, 0, 0, 0, 56, 0, 5, 79, 
+        -91 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(4, key[2]);
+    assertEquals(0, key[1]);
+    assertEquals(0, key[0]);
+  }
 }

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchema.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchema.java
@@ -728,4 +728,103 @@ public class TestSchema extends SchemaBase {
             schema.saltWidth() + schema.metricWidth() + Schema.TIMESTAMP_BYTES));
   }
   
+  @Test
+  public void prefixKeyWithSalt() throws Exception {
+    MockTSDB tsdb = new MockTSDB();
+    when(tsdb.registry.getDefaultPlugin(Tsdb1xDataStoreFactory.class))
+      .thenReturn(store_factory);
+    when(store_factory.newInstance(any(TSDB.class), anyString(), any(Schema.class)))
+      .thenReturn(store);    
+    when(tsdb.registry.getSharedObject("default_uidstore"))
+      .thenReturn(uid_store);
+    when(tsdb.registry.getPlugin(UniqueIdFactory.class, "LRU"))
+      .thenReturn(uid_factory);
+    tsdb.config.register("tsd.storage.uid.width.metric", 4, false, "UT");
+    tsdb.config.register("tsd.storage.uid.width.tagk", 4, false, "UT");
+    tsdb.config.register("tsd.storage.uid.width.tagv", 4, false, "UT");
+    tsdb.config.register("tsd.storage.salt.buckets", 20, false, "UT");
+    tsdb.config.register("tsd.storage.salt.width", 1, false, "UT");
+    
+    Schema schema = new Schema(tsdb, null);
+    
+    byte[] key = new byte[] { 0, 0, -41, -87, -12, 91, 8, 107, 64, 0, 0, 
+        0, 1, 0, 0, 0, 1, 0, 0, 0, 2, 69, 124, 52, -106, 0, 0, 0, 22, 
+        34, -87, 25, 92, 0, 0, 0, 80, 6, 67, 94, -84, 0, 0, 0, 89, 0, 
+        0, -17, -1, 0, 0, 16, 116, 72, 112, 67, 25 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(6, key[0]);
+    
+    key = new byte[] { 0, -27, 89, 20, -100, 91, 8, 65, 16, 0, 0, 0, 1, 
+        0, 0, 0, 1, 0, 0, 0, 2, 16, -1, 42, -124, 0, 0, 0, 56, 0, 5, 
+        79, -91 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(7, key[0]);
+    
+    key = new byte[] { 12, -27, 89, 20, -100, 91, 8, 51, 0, 0, 0, 0, 1, 
+        0, 0, 0, 1, 0, 0, 0, 2, 16, -1, 44, 81, 0, 0, 0, 56, 0, 5, 79, 
+        -91 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(0, key[0]);
+    
+    // Switch every hour/interval
+    tsdb.config.override(Schema.TIMELESS_SALTING_KEY, false);
+    tsdb.config.override("tsd.storage.uid.width.metric", 4);
+    tsdb.config.override("tsd.storage.uid.width.tagk", 4);
+    tsdb.config.override("tsd.storage.uid.width.tagv", 4);
+    tsdb.config.override("tsd.storage.salt.buckets", 20);
+    tsdb.config.override("tsd.storage.salt.width", 1);
+    
+    schema = new Schema(tsdb, null);
+    
+    key = new byte[] { 0, 0, -41, -87, -12, 91, 8, 107, 64, 0, 0, 
+        0, 1, 0, 0, 0, 1, 0, 0, 0, 2, 69, 124, 52, -106, 0, 0, 0, 22, 
+        34, -87, 25, 92, 0, 0, 0, 80, 6, 67, 94, -84, 0, 0, 0, 89, 0, 
+        0, -17, -1, 0, 0, 16, 116, 72, 112, 67, 25 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(4, key[0]);
+    
+    key = new byte[] { 0, -27, 89, 20, -100, 91, 8, 65, 16, 0, 0, 0, 1, 
+        0, 0, 0, 1, 0, 0, 0, 2, 16, -1, 42, -124, 0, 0, 0, 56, 0, 5, 
+        79, -91 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(3, key[0]);
+    
+    key = new byte[] { 12, -27, 89, 20, -100, 91, 8, 51, 0, 0, 0, 0, 1, 
+        0, 0, 0, 1, 0, 0, 0, 2, 16, -1, 44, 81, 0, 0, 0, 56, 0, 5, 79, 
+        -91 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(6, key[0]);
+    
+    // OLD school. Don't do it!!
+    tsdb.config.override(Schema.OLD_SALTING_KEY, true);
+    tsdb.config.override(Schema.TIMELESS_SALTING_KEY, false);
+    tsdb.config.override("tsd.storage.uid.width.metric", 4);
+    tsdb.config.override("tsd.storage.uid.width.tagk", 4);
+    tsdb.config.override("tsd.storage.uid.width.tagv", 4);
+    tsdb.config.override("tsd.storage.salt.buckets", 20);
+    tsdb.config.override("tsd.storage.salt.width", 1);
+    
+    schema = new Schema(tsdb, null);
+    
+    key = new byte[] { 0, 0, -41, -87, -12, 91, 8, 107, 64, 0, 0, 
+        0, 1, 0, 0, 0, 1, 0, 0, 0, 2, 69, 124, 52, -106, 0, 0, 0, 22, 
+        34, -87, 25, 92, 0, 0, 0, 80, 6, 67, 94, -84, 0, 0, 0, 89, 0, 
+        0, -17, -1, 0, 0, 16, 116, 72, 112, 67, 25 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(10, key[0]);
+    
+    key = new byte[] { 0, -27, 89, 20, -100, 91, 8, 65, 16, 0, 0, 0, 1, 
+        0, 0, 0, 1, 0, 0, 0, 2, 16, -1, 42, -124, 0, 0, 0, 56, 0, 5, 
+        79, -91 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(8, key[0]);
+    
+    key = new byte[] { 12, -27, 89, 20, -100, 91, 8, 51, 0, 0, 0, 0, 1, 
+        0, 0, 0, 1, 0, 0, 0, 2, 16, -1, 44, 81, 0, 0, 0, 56, 0, 5, 79, 
+        -91 };
+    schema.prefixKeyWithSalt(key);
+    assertEquals(4, key[0]);
+  }
+  
+  // TODO - test multi-byte salting.
 }

--- a/implementation/elasticsearch/pom.xml
+++ b/implementation/elasticsearch/pom.xml
@@ -136,6 +136,13 @@
                <filters>
                   <filter>
                      <artifact>*:*</artifact>
+                     <excludes> 
+                          <exclude>META-INF/*.SF</exclude> 
+                          <exclude>META-INF/*.DSA</exclude>  
+                          <exclude>META-INF/*.RSA</exclude>
+                          <exclude>org.slf4j:*</exclude>  
+                          <exclude>net.opentsdb:*</exclude>   
+                        </excludes>
                   </filter>
                </filters>
             </configuration>

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseDataStore.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseDataStore.java
@@ -73,7 +73,7 @@ public class Tsdb1xHBaseDataStore implements Tsdb1xDataStore {
   public static final String MAX_MG_CARDINALITY_KEY = "tsd.query.multiget.max_cardinality";
   
   public static final byte[] DATA_FAMILY = 
-      "t".getBytes(Const.ASCII_CHARSET);
+      "t".getBytes(Const.ISO_8859_CHARSET);
   
   private final TSDB tsdb;
   private final String id;
@@ -117,25 +117,25 @@ public class Tsdb1xHBaseDataStore implements Tsdb1xDataStore {
             "The name of the raw data table for OpenTSDB.");
       }
       data_table = config.getString(getConfigKey(DATA_TABLE_KEY))
-          .getBytes(Const.ASCII_CHARSET);
+          .getBytes(Const.ISO_8859_CHARSET);
       if (!config.hasProperty(getConfigKey(UID_TABLE_KEY))) {
         config.register(getConfigKey(UID_TABLE_KEY), "tsdb-uid", false, 
             "The name of the UID mapping table for OpenTSDB.");
       }
       uid_table = config.getString(getConfigKey(UID_TABLE_KEY))
-          .getBytes(Const.ASCII_CHARSET);
+          .getBytes(Const.ISO_8859_CHARSET);
       if (!config.hasProperty(getConfigKey(TREE_TABLE_KEY))) {
         config.register(getConfigKey(TREE_TABLE_KEY), "tsdb-tree", false, 
             "The name of the Tree table for OpenTSDB.");
       }
       tree_table = config.getString(getConfigKey(TREE_TABLE_KEY))
-          .getBytes(Const.ASCII_CHARSET);
+          .getBytes(Const.ISO_8859_CHARSET);
       if (!config.hasProperty(getConfigKey(META_TABLE_KEY))) {
         config.register(getConfigKey(META_TABLE_KEY), "tsdb-meta", false, 
             "The name of the Meta data table for OpenTSDB.");
       }
       meta_table = config.getString(getConfigKey(META_TABLE_KEY))
-          .getBytes(Const.ASCII_CHARSET);
+          .getBytes(Const.ISO_8859_CHARSET);
       
       // asynchbase flags
       if (!config.hasProperty(getConfigKey(ZK_QUORUM_KEY))) {
@@ -212,6 +212,15 @@ public class Tsdb1xHBaseDataStore implements Tsdb1xDataStore {
       }
       if (!config.hasProperty(ROWS_PER_SCAN_KEY)) {
         config.register(ROWS_PER_SCAN_KEY, "128", true,
+            "TODO");
+      }
+      
+      if (!config.hasProperty(MULTI_GET_CONCURRENT_KEY)) {
+        config.register(MULTI_GET_CONCURRENT_KEY, "20", true,
+            "TODO");
+      }
+      if (!config.hasProperty(MULTI_GET_BATCH_KEY)) {
+        config.register(MULTI_GET_BATCH_KEY, "1024", true,
             "TODO");
       }
       if (!config.hasProperty(MAX_MG_CARDINALITY_KEY)) {

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xHBaseDataStore.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xHBaseDataStore.java
@@ -58,8 +58,8 @@ public class TestTsdb1xHBaseDataStore {
   public void ctorDefault() throws Exception {
     final Tsdb1xHBaseDataStore store = 
         new Tsdb1xHBaseDataStore(factory, "UT", mock(Schema.class));
-    assertArrayEquals("tsdb".getBytes(Const.ASCII_CHARSET), store.dataTable());
-    assertArrayEquals("tsdb-uid".getBytes(Const.ASCII_CHARSET), store.uidTable());
+    assertArrayEquals("tsdb".getBytes(Const.ISO_8859_CHARSET), store.dataTable());
+    assertArrayEquals("tsdb-uid".getBytes(Const.ISO_8859_CHARSET), store.uidTable());
     assertSame(tsdb, store.tsdb());
     assertNotNull(store.uidStore());
     verify(registry, times(1)).registerSharedObject(eq("UT_uidstore"), 

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/UTBase.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/UTBase.java
@@ -94,8 +94,8 @@ public class UTBase {
   public static final int TS_NSUI_SERIES_COUNT = 16;
   public static final int TS_NSUI_SERIES_INTERVAL = 3600;
   
-  public static final byte[] DATA_TABLE = "tsdb".getBytes(Const.ASCII_CHARSET);
-  public static final byte[] UID_TABLE = "tsdb-uid".getBytes(Const.ASCII_CHARSET);
+  public static final byte[] DATA_TABLE = "tsdb".getBytes(Const.ISO_8859_CHARSET);
+  public static final byte[] UID_TABLE = "tsdb-uid".getBytes(Const.ISO_8859_CHARSET);
   
   // GMT: Monday, January 1, 2018 12:15:00 AM
   public static final int START_TS = 1514765700;
@@ -150,7 +150,7 @@ public class UTBase {
         return "tsd.mock." + (String) invocation.getArguments()[0];
       }
     });
-    when(data_store.dataTable()).thenReturn("tsdb".getBytes(Const.ASCII_CHARSET));
+    when(data_store.dataTable()).thenReturn("tsdb".getBytes(Const.ISO_8859_CHARSET));
     when(data_store.uidTable()).thenReturn(UID_TABLE);
     when(data_store.client()).thenReturn(client);
     when(tsdb.registry.getSharedObject(any())).thenReturn(data_store);
@@ -184,19 +184,19 @@ public class UTBase {
   public static void loadUIDTable() {
     bothUIDs(UniqueIdType.METRIC, METRIC_STRING, METRIC_BYTES);
     bothUIDs(UniqueIdType.METRIC, METRIC_B_STRING, METRIC_B_BYTES);
-    storage.throwException(METRIC_STRING_EX.getBytes(Const.ASCII_CHARSET), 
+    storage.throwException(METRIC_STRING_EX.getBytes(Const.ISO_8859_CHARSET), 
         new UnitTestException(), true);
     storage.throwException(METRIC_BYTES_EX, new UnitTestException(), true);
     
     bothUIDs(UniqueIdType.TAGK, TAGK_STRING, TAGK_BYTES);
     bothUIDs(UniqueIdType.TAGK, TAGK_B_STRING, TAGK_B_BYTES);
-    storage.throwException(TAGK_STRING_EX.getBytes(Const.ASCII_CHARSET), 
+    storage.throwException(TAGK_STRING_EX.getBytes(Const.ISO_8859_CHARSET), 
         new UnitTestException(), true);
     storage.throwException(TAGK_BYTES_EX, new UnitTestException(), true);
     
     bothUIDs(UniqueIdType.TAGV, TAGV_STRING, TAGV_BYTES);
     bothUIDs(UniqueIdType.TAGV, TAGV_B_STRING, TAGV_B_BYTES);
-    storage.throwException(TAGV_STRING_EX.getBytes(Const.ASCII_CHARSET), 
+    storage.throwException(TAGV_STRING_EX.getBytes(Const.ISO_8859_CHARSET), 
         new UnitTestException(), true);
     storage.throwException(TAGV_BYTES_EX, new UnitTestException(), true);
     
@@ -232,7 +232,7 @@ public class UTBase {
           + " isn't supported here.");
     }
     storage.addColumn(UID_TABLE, 
-        name.getBytes(Const.ASCII_CHARSET), 
+        name.getBytes(Const.ISO_8859_CHARSET), 
         Tsdb1xUniqueIdStore.ID_FAMILY,
         qualifier, 
         id);
@@ -240,7 +240,7 @@ public class UTBase {
         id, 
         Tsdb1xUniqueIdStore.NAME_FAMILY,
         qualifier, 
-        name.getBytes(Const.ASCII_CHARSET));
+        name.getBytes(Const.ISO_8859_CHARSET));
   }
   
   /**
@@ -276,7 +276,7 @@ public class UTBase {
    * @throws Exception
    */
   public static void loadRawData() throws Exception {
-    final byte[] table = "tsdb".getBytes(Const.ASCII_CHARSET);
+    final byte[] table = "tsdb".getBytes(Const.ISO_8859_CHARSET);
     for (int i = 0; i < TS_SINGLE_SERIES_COUNT; i++) {
       storage.addColumn(table, makeRowKey(
           METRIC_BYTES, 


### PR DESCRIPTION
- Change the ASCII_CHARSET to ISO_8859_CHARSET which is what it really is
  and add a US ASCII set.

CORE:
- Don't throw an exception on duplicate plugins being loaded, just shutdown the
  dupe.
- Add a temp empty ctor to the JsonV2QuerySerdes to suppress plugin messages.
- Add the old and timeless salting configs to the Schema as well as load the
  default meta plugin.
- Add the row key salting calculation to the schema class. And modify the bucket
  salting method to avoid the byte instantiation.

ELASTICSEARCH:
- Exclude signatures from the shaded jar.

UNDERTOW:
- Log the auth filter loading.

STORAGE:
- Stub registering the multi-get properties in the HBase data store.
- Fix a bug in Tsdb1xMultiGet where it was incrementing the timestamp on the
  initial fetch so we'd miss the first hour of data. Also make sure we return
  the current result from a fetchNext() call.