### PR TITLE
CORE:

### DIFF
--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
@@ -629,7 +629,7 @@ final public class QueryRpc {
       trace.firstSpan()
         .setTag("status", "Error")
         .setTag("finalThread", Thread.currentThread().getName())
-        .setTag("error", e.getMessage())
+        .setTag("error", e.getMessage() == null ? "null" : e.getMessage())
         .log("exception", e)
         .finish();
     }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
@@ -389,6 +389,8 @@ public class Tsdb1xQueryNode extends AbstractQueryNode implements SourceNode {
           LOG.debug("No data returned from meta store.");
         }
         initialized.compareAndSet(false, true);
+        sendUpstream(new Tsdb1xQueryResult(0, Tsdb1xQueryNode.this, 
+            ((Tsdb1xHBaseDataStore) factory).schema()));
         completeUpstream(0, 0);
         return null;
       case EXCEPTION:

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xQueryNode.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xQueryNode.java
@@ -580,6 +580,8 @@ public class TestTsdb1xQueryNode extends UTBase {
     
     assertNull(node.executor);
     assertTrue(node.initialized.get());
+    verify(upstream_a, times(1)).onNext(any(QueryResult.class));
+    verify(upstream_b, times(1)).onNext(any(QueryResult.class));
     verify(upstream_a, times(1)).onComplete(node, 0, 0);
     verify(upstream_b, times(1)).onComplete(node, 0, 0);
   }


### PR DESCRIPTION
- Handle a null trace tag in QueryRpc.

STORAGE:
- Return an empty result from the meta query node if the response was empty
  without fallback.