### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/meta/MetaDataStorageSchema.java
+++ b/core/src/main/java/net/opentsdb/meta/MetaDataStorageSchema.java
@@ -17,6 +17,7 @@ package net.opentsdb.meta;
 import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.query.TimeSeriesQuery;
+import net.opentsdb.stats.Span;
 
 /**
  * Handles querying a meta data store for time series identifiers given
@@ -26,6 +27,16 @@ import net.opentsdb.query.TimeSeriesQuery;
  */
 public interface MetaDataStorageSchema {
 
-  public Deferred<MetaDataStorageResult> runQuery(final TimeSeriesQuery query);
+  /**
+   * Executes the given query, resolving it against a meta-data set.
+   * @param query A non-null query to resolve.
+   * @param span An optional tracing span.
+   * @return A deferred resolving to a meta data storage result or
+   * an exception if something went very wrong. It's better to return
+   * a result with the exception set.
+   */
+  public Deferred<MetaDataStorageResult> runQuery(
+      final TimeSeriesQuery query,
+      final Span span);
 
 }

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/exceptions/GenericExceptionMapper.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/exceptions/GenericExceptionMapper.java
@@ -21,6 +21,9 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import net.opentsdb.utils.JSON;
@@ -32,9 +35,13 @@ import net.opentsdb.utils.JSON;
  * @since 3.0
  */
 public class GenericExceptionMapper implements ExceptionMapper<Throwable> {
+  private static final Logger LOG = LoggerFactory.getLogger(
+      GenericExceptionMapper.class);
   
   @Override
   public Response toResponse(final Throwable t) {
+    LOG.error("Unexpected exception", t);
+    
     final ThrowableProxy tp = new ThrowableProxy(t);
     tp.calculatePackagingData();
     final String formattedTrace = ThrowableProxyUtil.asString(tp);

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/exceptions/QueryExecutionExceptionMapper.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/exceptions/QueryExecutionExceptionMapper.java
@@ -22,6 +22,9 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.Maps;
 
 import ch.qos.logback.classic.spi.ThrowableProxy;
@@ -38,7 +41,9 @@ import net.opentsdb.utils.JSON;
  */
 public class QueryExecutionExceptionMapper implements 
   ExceptionMapper<QueryExecutionException> {
-
+  private static final Logger LOG = LoggerFactory.getLogger(
+      QueryExecutionExceptionMapper.class);
+  
   /** Whether or not to show the stack traces. */
   private final boolean show_trace;
   
@@ -58,8 +63,8 @@ public class QueryExecutionExceptionMapper implements
   
   @Override
   public Response toResponse(final QueryExecutionException e) {
+    LOG.error("Query exception", e);
     final Map<String, Object> outer_map = Maps.newHashMapWithExpectedSize(1);
-
     outer_map.put("error", recursiveExceptions(0, e));
     final Status status = Status.fromStatusCode(e.getStatusCode());
     return Response.status(status != null ? status : Status.INTERNAL_SERVER_ERROR)

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xMultiGet.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xMultiGet.java
@@ -536,6 +536,9 @@ public class Tsdb1xMultiGet implements HBaseExecutor {
       synchronized (Tsdb1xMultiGet.this) {
         outstanding--;
       }
+      if (has_failed) {
+        return null;
+      }
       
       for (final GetResultOrException result : results) {
         if (result.getException() != null) {
@@ -547,10 +550,12 @@ public class Tsdb1xMultiGet implements HBaseExecutor {
           continue;
         }
         
-        current_result.decode(result.getCells(), 
-            (rollup_index < 0 || 
-             rollup_index >= node.rollupIntervals().size() 
-               ? null : node.rollupIntervals().get(rollup_index)));
+        if (current_result != null) {
+          current_result.decode(result.getCells(), 
+              (rollup_index < 0 || 
+               rollup_index >= node.rollupIntervals().size() 
+                 ? null : node.rollupIntervals().get(rollup_index)));
+        }
       }
       
       onComplete();

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
@@ -308,15 +308,10 @@ public class Tsdb1xQueryNode extends AbstractQueryNode implements SourceNode {
   @VisibleForTesting
   void setup(final Span span) {
     if (((Tsdb1xHBaseDataStore) factory).schema().metaSchema() != null) {
-      final Span child;
-      if (span != null) {
-        child = span.newChild(getClass().getName() + ".setup").start();
-      } else {
-        child = span;
-      }
-      ((Tsdb1xHBaseDataStore) factory).schema().metaSchema().runQuery(config.query())
-          .addCallback(new MetaCB(child))
-          .addErrback(new MetaErrorCB(child));
+      ((Tsdb1xHBaseDataStore) factory).schema().metaSchema()
+        .runQuery(config.query(), span)
+          .addCallback(new MetaCB(span))
+          .addErrback(new MetaErrorCB(span));
     } else {
       synchronized (this) {
         executor = new Tsdb1xScanners(Tsdb1xQueryNode.this, 

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xQueryNode.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xQueryNode.java
@@ -113,7 +113,7 @@ public class TestTsdb1xQueryNode extends UTBase {
     
     when(source_config.configuration()).thenReturn(tsdb.config);
     when(source_config.query()).thenReturn(query);
-    when(meta_schema.runQuery(any(TimeSeriesQuery.class)))
+    when(meta_schema.runQuery(any(TimeSeriesQuery.class), any(Span.class)))
       .thenReturn(meta_deferred);
     
     PowerMockito.whenNew(Tsdb1xQueryResult.class).withAnyArguments()
@@ -406,7 +406,7 @@ public class TestTsdb1xQueryNode extends UTBase {
     assertTrue(node.initializing.get());
     PowerMockito.verifyNew(Tsdb1xQueryResult.class, never())
       .withArguments(anyLong(), any(Tsdb1xQueryNode.class), any(Schema.class));
-    verify(meta_schema, times(1)).runQuery(eq(query));
+    verify(meta_schema, times(1)).runQuery(eq(query), any(Span.class));
     
     try {
       node.fetchNext(null);
@@ -447,7 +447,7 @@ public class TestTsdb1xQueryNode extends UTBase {
     assertFalse(node.initialized.get());
     PowerMockito.verifyNew(Tsdb1xQueryResult.class, never())
       .withArguments(anyLong(), any(Tsdb1xQueryNode.class), any(Schema.class));
-    verify(meta_schema, times(1)).runQuery(eq(query));
+    verify(meta_schema, times(1)).runQuery(eq(query), any(Span.class));
   }
 
   @Test


### PR DESCRIPTION
- Add a span to the MetaDataStorageSchema interface when running a query.
  Tracing is good.

SERVLET:
- Log exceptions passed through the ExceptionMappers.

STORAGE:
- Handle an edge condition in the mutli-get class if the results have already
  been passed up and the results are null.