### PR TITLE
COMMON:

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -45,6 +45,10 @@
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+      </dependency>
       
       <!-- TESTING Deps -->    
       <dependency>

--- a/common/src/main/java/net/opentsdb/data/TimeSeriesByteId.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesByteId.java
@@ -115,6 +115,11 @@ public interface TimeSeriesByteId extends TimeSeriesId,
    */
   public ByteSet uniqueIds();
   
+  /** @return A flag to tell the {@link #decode(boolean, Span)} method 
+   * whether or not the metric is encoded. This is due to metrics possibly
+   * being overwritten during joins in expressions. */
+  public boolean skipMetric();
+  
   /**
    * Returns the string version of the time series ID based on the schema
    * used to encode the byte IDs.

--- a/common/src/main/java/net/opentsdb/query/execution/graph/ExecutionGraphNode.java
+++ b/common/src/main/java/net/opentsdb/query/execution/graph/ExecutionGraphNode.java
@@ -30,7 +30,7 @@ import com.google.common.collect.Ordering;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 
-import net.opentsdb.core.Const;
+import net.opentsdb.common.Const;
 import net.opentsdb.query.QueryNodeConfig;
 
 /**

--- a/core/src/main/java/net/opentsdb/data/BaseTimeSeriesByteId.java
+++ b/core/src/main/java/net/opentsdb/data/BaseTimeSeriesByteId.java
@@ -71,6 +71,9 @@ public class BaseTimeSeriesByteId implements TimeSeriesByteId {
   /** A cached hash code ID. May have some */
   protected volatile long cached_hash; 
   
+  /** Whether or not to skip the metric during decoding. */
+  protected boolean skip_metric;
+  
   /**
    * Private CTor used by the builder. Converts the Strings to byte arrays
    * using UTF8.
@@ -125,6 +128,7 @@ public class BaseTimeSeriesByteId implements TimeSeriesByteId {
     } else {
       unique_ids = new ByteSet();
     }
+    skip_metric = builder.skip_metric;
   }
 
   @Override
@@ -172,6 +176,11 @@ public class BaseTimeSeriesByteId implements TimeSeriesByteId {
     return unique_ids;
   }
 
+  @Override
+  public boolean skipMetric() {
+    return skip_metric;
+  }
+  
   @Override
   public int compareTo(final TimeSeriesByteId o) {
     return ComparisonChain.start()
@@ -317,6 +326,7 @@ public class BaseTimeSeriesByteId implements TimeSeriesByteId {
     protected List<byte[]> aggregated_tags;
     protected List<byte[]> disjoint_tags;
     protected ByteSet unique_ids; 
+    protected boolean skip_metric;
     
     /**
      * Default private ctor.
@@ -408,6 +418,11 @@ public class BaseTimeSeriesByteId implements TimeSeriesByteId {
         unique_ids = new ByteSet();
       }
       unique_ids.add(id);
+      return this;
+    }
+    
+    public Builder setSkipMetric(final boolean skip_metric) {
+      this.skip_metric = skip_metric;
       return this;
     }
     

--- a/core/src/main/java/net/opentsdb/query/SemanticQuery.java
+++ b/core/src/main/java/net/opentsdb/query/SemanticQuery.java
@@ -213,7 +213,8 @@ public class SemanticQuery implements TimeSeriesQuery {
     if (node == null) {
       throw new IllegalArgumentException("Need a graph!");
     }
-    builder.setExecutionGraph(ExecutionGraph.parse(tsdb, node).build());
+    builder.setExecutionGraph(ExecutionGraph.parse(
+        JSON.getMapper(), tsdb, node).build());
     
     node = root.get("filters");
     if (node != null) {

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/TSUID.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/TSUID.java
@@ -313,6 +313,11 @@ public class TSUID implements TimeSeriesByteId {
   }
 
   @Override
+  public boolean skipMetric() {
+    return false;
+  }
+  
+  @Override
   public TypeToken<? extends TimeSeriesId> type() {
     return Const.TS_BYTE_ID;
   }


### PR DESCRIPTION
- Add a flag to TimeSeriesByteId to indicate whether or not we should
  decode the metric or if it's been overwritten by an expression.

CORE:
- Implement the skip flag in the Base byte ID and handle it in the
  Schema class.
- Add a UT for Schema ID resolution.