### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/MultiQueryNodeFactory.java
+++ b/common/src/main/java/net/opentsdb/query/MultiQueryNodeFactory.java
@@ -1,0 +1,48 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query;
+
+import java.util.Collection;
+import java.util.List;
+
+import net.opentsdb.query.execution.graph.ExecutionGraphNode;
+
+/**
+ * An interface for a node factory that will generate more than one node
+ * from the configuration. An example might be an expression node that 
+ * would spawn it's own DAG of binary input nodes with a single output.
+ * Also multi-source queries.
+ * 
+ * @since 3.0
+ */
+public interface MultiQueryNodeFactory extends QueryNodeFactory {
+
+  /**
+   * Instantiates a new node using the given context and config.
+   * @param context A non-null query pipeline context.
+   * @param id An ID for this node.
+   * @param config A query node config. May be null if the node does not
+   * require a configuration.
+   * @param nodes A non-null list of the execution graph nodes that will
+   * be populated with new configs from this factory.
+   * @return A non-null and non-empty collection of instantiated nodes 
+   * if successful.
+   */
+  public Collection<QueryNode> newNodes(final QueryPipelineContext context, 
+                                        final String id,
+                                        final QueryNodeConfig config,
+                                        final List<ExecutionGraphNode> nodes);
+  
+}

--- a/common/src/main/java/net/opentsdb/query/QueryNodeFactory.java
+++ b/common/src/main/java/net/opentsdb/query/QueryNodeFactory.java
@@ -16,32 +16,11 @@ package net.opentsdb.query;
 
 /**
  * The factory used to generate a {@link QueryNode} for a new query execution.
+ * Implementations can be single or multi-node.
  * 
  * @since 3.0
  */
 public interface QueryNodeFactory {
-
-  /**
-   * Instantiates a new node using the given context and the default
-   * configuration for this node.
-   * @param context A non-null query pipeline context.
-   * @param id An ID for this node.
-   * @return An instantiated node if successful.
-   */
-  public QueryNode newNode(final QueryPipelineContext context, 
-                           final String id);
-  
-  /**
-   * Instantiates a new node using the given context and config.
-   * @param context A non-null query pipeline context.
-   * @param id An ID for this node.
-   * @param config A query node config. May be null if the node does not
-   * require a configuration.
-   * @return An instantiated node if successful.
-   */
-  public QueryNode newNode(final QueryPipelineContext context, 
-                           final String id,
-                           final QueryNodeConfig config);
   
   /**
    * The descriptive ID of the factory used when parsing queries.

--- a/common/src/main/java/net/opentsdb/query/QuerySourceFactory.java
+++ b/common/src/main/java/net/opentsdb/query/QuerySourceFactory.java
@@ -19,7 +19,7 @@ import net.opentsdb.data.TimeSeriesDataSource;
 /**
  * 
  */
-public interface QuerySourceFactory extends QueryNodeFactory {
+public interface QuerySourceFactory extends SingleQueryNodeFactory {
 
   /**
    * Returns a new node given the context and config.

--- a/common/src/main/java/net/opentsdb/query/SingleQueryNodeFactory.java
+++ b/common/src/main/java/net/opentsdb/query/SingleQueryNodeFactory.java
@@ -1,0 +1,46 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query;
+
+/**
+ * Represents a factory that returns a single query node.
+ * 
+ * @since 3.0
+ */
+public interface SingleQueryNodeFactory extends QueryNodeFactory {
+
+  /**
+   * Instantiates a new node using the given context and the default
+   * configuration for this node.
+   * @param context A non-null query pipeline context.
+   * @param id An ID for this node.
+   * @return An instantiated node if successful.
+   */
+  public QueryNode newNode(final QueryPipelineContext context, 
+                           final String id);
+  
+  /**
+   * Instantiates a new node using the given context and config.
+   * @param context A non-null query pipeline context.
+   * @param id An ID for this node.
+   * @param config A query node config. May be null if the node does not
+   * require a configuration.
+   * @return An instantiated node if successful.
+   */
+  public QueryNode newNode(final QueryPipelineContext context, 
+                           final String id,
+                           final QueryNodeConfig config);
+  
+}

--- a/common/src/main/java/net/opentsdb/query/processor/ProcessorFactory.java
+++ b/common/src/main/java/net/opentsdb/query/processor/ProcessorFactory.java
@@ -27,6 +27,7 @@ import net.opentsdb.query.QueryIteratorFactory;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.SingleQueryNodeFactory;
 
 /**
  * A factory for generating {@link QueryNode}s that perform some kind of
@@ -35,7 +36,7 @@ import net.opentsdb.query.QueryResult;
  * 
  * @since 3.0
  */
-public interface ProcessorFactory extends QueryNodeFactory {
+public interface ProcessorFactory extends SingleQueryNodeFactory {
   
   /**
    * @return The types of data this factory can instantiate iterators for.

--- a/common/src/test/java/net/opentsdb/query/execution/graph/TestExecutionGraph.java
+++ b/common/src/test/java/net/opentsdb/query/execution/graph/TestExecutionGraph.java
@@ -46,8 +46,8 @@ import net.opentsdb.core.MockTSDB;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeConfig;
-import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.SingleQueryNodeFactory;
 
 public class TestExecutionGraph {
 
@@ -538,7 +538,7 @@ public class TestExecutionGraph {
     }
   }
   
-  static class MockFactoryA implements QueryNodeFactory {
+  static class MockFactoryA implements SingleQueryNodeFactory {
 
     @Override
     public QueryNode newNode(QueryPipelineContext context, String id) {
@@ -646,7 +646,7 @@ public class TestExecutionGraph {
 
   }
   
-  static class MockFactoryB implements QueryNodeFactory {
+  static class MockFactoryB implements SingleQueryNodeFactory {
 
     @Override
     public QueryNode newNode(QueryPipelineContext context, String id) {

--- a/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
+++ b/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
@@ -44,6 +44,7 @@ import net.opentsdb.query.execution.graph.ExecutionGraph;
 import net.opentsdb.query.execution.graph.ExecutionGraphNode;
 import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.Span;
+import net.opentsdb.utils.Pair;
 
 /**
  * A useful base class for {@link QueryPipelineContext}s that stores references
@@ -79,7 +80,11 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
   /** The upstream query context this pipeline context belongs to. */
   protected final QueryContext context;
   
+  /** The original user defined execution graph. */
   protected final ExecutionGraph execution_graph;
+  
+  /** A mutable copy of the nodes. */
+  protected final List<ExecutionGraphNode> nodes;
   
   /** The set of query sinks. */
   protected final Collection<QuerySink> sinks;
@@ -149,6 +154,7 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
     graph.addVertex(this);
     roots = Sets.newHashSet();
     sources = Lists.newArrayList();
+    nodes = Lists.newArrayList(execution_graph.getNodes());
   }
   
   @Override
@@ -465,9 +471,10 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
         Maps.newHashMapWithExpectedSize(execution_graph.getNodes().size());
     final Set<String> unique_ids = 
         Sets.newHashSetWithExpectedSize(execution_graph.getNodes().size());
+    List<Pair<MultiQueryNodeFactory, ExecutionGraphNode>> multis = null;
     
     // first pass to instantiate the nodes.
-    for (final ExecutionGraphNode node : execution_graph.getNodes()) {
+    for (final ExecutionGraphNode node : nodes) {
       if (unique_ids.contains(node.getId())) {
         throw new IllegalArgumentException("The node id \"" 
             + node.getId() + "\" appeared more than once in the "
@@ -486,6 +493,17 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
             + "configuration " + node);
       }
       
+      // we can only handle singles here, multis we run through in a second
+      // pass.
+      if (!(factory instanceof SingleQueryNodeFactory)) {
+        if (multis == null) {
+          multis = Lists.newArrayList();
+        }
+        multis.add(new Pair<MultiQueryNodeFactory, ExecutionGraphNode>(
+            (MultiQueryNodeFactory) factory, node));
+        continue;
+      }
+      
       final QueryNode query_node;
       QueryNodeConfig node_config = node.getConfig() != null ? 
           node.getConfig() : node_configs.get(node.getId());
@@ -493,9 +511,11 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
         node_config = node_configs.get(node.getType());
       }
       if (node_config != null) {
-        query_node = factory.newNode(this, node.getId(), node_config);
+        query_node = ((SingleQueryNodeFactory) factory)
+            .newNode(this, node.getId(), node_config);
       } else {
-        query_node = factory.newNode(this, node.getId());
+        query_node = ((SingleQueryNodeFactory) factory)
+            .newNode(this, node.getId());
       }
       if (query_node == null) {
         throw new IllegalStateException("Factory returned a null "
@@ -507,8 +527,43 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
       graph.addVertex(query_node);
     }
     
-    // second pass to build the graph.
-    for (final ExecutionGraphNode node : execution_graph.getNodes()) {
+    // if there are multis that change the DAG, let's set em up now
+    if (multis != null) {
+      for (final Pair<MultiQueryNodeFactory, ExecutionGraphNode> pair : multis) {
+        QueryNodeConfig node_config = pair.getValue().getConfig() != null ? 
+            pair.getValue().getConfig() : node_configs.get(pair.getValue().getId());
+        if (node_config == null) {
+          node_config = node_configs.get(pair.getValue().getType());
+        }
+        if (node_config == null) {
+          throw new IllegalArgumentException("No config supplied for "
+              + "node: " + pair.getValue().getId());
+        }
+        
+        final Collection<QueryNode> query_nodes = pair.getKey().newNodes(
+            this, pair.getValue().getId(), node_config, nodes);
+        if (query_nodes == null || query_nodes.isEmpty()) {
+          throw new IllegalStateException("Factory returned a null or "
+              + "empty list of nodes for " + pair.getValue().getId());
+        }
+        for (final QueryNode node : query_nodes) {
+          if (node == null) {
+            throw new IllegalStateException("Factory returned a null "
+                + "node for " + pair.getValue().getId());
+          }
+          
+          map.put(node.id(), node);
+          graph.addVertex(node);
+        }
+        
+        // Important! We have to remove the original node config for
+        // debugging so we know it was replaced.
+        nodes.remove(pair.getValue());
+      }
+    }
+    
+    // second (or third) pass to build the graph.
+    for (final ExecutionGraphNode node : nodes) {
       if (node != null && 
           node.getSources() != null && 
           !node.getSources().isEmpty()) {
@@ -516,6 +571,9 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
         for (final String source : node.getSources()) {
           try {
             graph.addDagEdge(query_node, map.get(source));
+          } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Failed to add node: " 
+                + node, e);
           } catch (CycleFoundException e) {
             throw new IllegalArgumentException("A cycle was detected "
                 + "adding node: " + node, e);

--- a/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
+++ b/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
@@ -31,7 +31,7 @@ import net.opentsdb.storage.TimeSeriesDataStoreFactory;
  * 
  * @since 3.0
  */
-public class QueryDataSourceFactory implements QueryNodeFactory, TSDBPlugin {
+public class QueryDataSourceFactory implements SingleQueryNodeFactory, TSDBPlugin {
   
   /** The TSDB to pull the registry from. */
   private TSDB tsdb;

--- a/core/src/test/java/net/opentsdb/query/TestTSDBV2QueryContextBuilder.java
+++ b/core/src/test/java/net/opentsdb/query/TestTSDBV2QueryContextBuilder.java
@@ -71,7 +71,7 @@ public class TestTSDBV2QueryContextBuilder {
     STORE_FACTORY = new MockDataStoreFactory();
     TSDB.config.register("MockDataStore.timestamp", 1483228800000L, false, "UT");
     
-    QueryNodeFactory factory = mock(QueryNodeFactory.class);
+    SingleQueryNodeFactory factory = mock(SingleQueryNodeFactory.class);
     when(factory.newNode(any(QueryPipelineContext.class), anyString()))
       .thenAnswer(new Answer<QueryNode>() {
         @Override


### PR DESCRIPTION
- Split the QueryNodeFactory into Single and Multi as we'll need the multi
  for expressions and other types of nodes.

CORE:
- Tweak AbstractQueryPipelineContext to handle the split node factories to
  allow nodes to be inserted in a graph.