### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/execution/graph/ExecutionGraphNode.java
+++ b/common/src/main/java/net/opentsdb/query/execution/graph/ExecutionGraphNode.java
@@ -171,6 +171,28 @@ public class ExecutionGraphNode implements Comparable<ExecutionGraphNode> {
         .toString();
   }
   
+  /**
+   * Overrides an extant source removing the old and optionally adding a
+   * new one. Note that if the old node did not exist, we just add the
+   * new node.
+   * @param old The non-null old source to remove.
+   * @param new_source A new source. If null or empty, nothing is added.
+   * @throws IllegalArgumentException if the old source was null or empty
+   * or the sources list is null or empty. 
+   */
+  public void overrideSource(final String old, final String new_source) {
+    if (Strings.isNullOrEmpty(old)) {
+      throw new IllegalArgumentException("Old source cannot be null.");
+    }
+    if (sources == null || sources.isEmpty()) {
+      throw new IllegalArgumentException("Source list was null or empty.");
+    }
+    sources.remove(old);
+    if (!Strings.isNullOrEmpty(new_source)) {
+      sources.add(new_source);
+    }
+  }
+  
   /** @return A new node builder. */
   public static Builder newBuilder() {
     return new Builder();

--- a/common/src/test/java/net/opentsdb/query/execution/graph/TestExecutionGraphNode.java
+++ b/common/src/test/java/net/opentsdb/query/execution/graph/TestExecutionGraphNode.java
@@ -153,6 +153,56 @@ public class TestExecutionGraphNode {
   }
 
   @Test
+  public void overrideSource() throws Exception {
+    ExecutionGraphNode node = ExecutionGraphNode.newBuilder()
+        .setId("TestNode")
+        .setType("Rate")
+        .setSources(Lists.newArrayList("node1", "node2"))
+        .setConfig(MockConfigA.newBuilder()
+            .setFoo("foo")
+            .setId("TestNode")
+            .build())
+        .build();
+    
+    assertEquals(2, node.getSources().size());
+    assertTrue(node.getSources().contains("node1"));
+    assertTrue(node.getSources().contains("node2"));
+    
+    node.overrideSource("node1", "node3");
+    assertEquals(2, node.getSources().size());
+    assertTrue(node.getSources().contains("node3"));
+    assertTrue(node.getSources().contains("node2"));
+    
+    node.overrideSource("node2", null);
+    assertEquals(1, node.getSources().size());
+    assertTrue(node.getSources().contains("node3"));
+    
+    node.overrideSource("node4", "node5");
+    assertEquals(2, node.getSources().size());
+    assertTrue(node.getSources().contains("node3"));
+    assertTrue(node.getSources().contains("node5"));
+    
+    try {
+      node.overrideSource(null, "node5");
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      node.overrideSource("", "node5");
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    node.overrideSource("node3", null);
+    node.overrideSource("node5", null);
+    
+    // now it's empty
+    try {
+      node.overrideSource("node5", "node6");
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
   public void hashCodeEqualsCompareTo() throws Exception {
     final ExecutionGraphNode n1 = ExecutionGraphNode.newBuilder()
         .setId("TestNode")

--- a/core/src/main/java/net/opentsdb/query/processor/BaseMultiQueryNodeFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/BaseMultiQueryNodeFactory.java
@@ -1,0 +1,181 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.processor;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.core.TSDBPlugin;
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesDataType;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.query.MultiQueryNodeFactory;
+import net.opentsdb.query.QueryIteratorFactory;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryResult;
+
+/**
+ * A factory for generating {@link QueryNode}s that perform some kind of
+ * data manipulation, hence the need to instantiate new iterators to work
+ * over various types of data.
+ * 
+ * @since 3.0
+ */
+public abstract class BaseMultiQueryNodeFactory 
+    implements MultiQueryNodeFactory, TSDBPlugin {
+  private final Logger LOG = LoggerFactory.getLogger(getClass());
+  
+  /** The ID of this node factory. */
+  protected final String id;
+  
+  /** The map of iterator factories keyed on type. */
+  protected final Map<TypeToken<?>, QueryIteratorFactory> iterator_factories;
+  
+  /**
+   * Default ctor.
+   * @param id A non-null and non-empty ID.
+   */
+  public BaseMultiQueryNodeFactory(final String id) {
+    if (Strings.isNullOrEmpty(id)) {
+      throw new IllegalArgumentException("ID cannot be null or empty.");
+    }
+    this.id = id;
+    iterator_factories = Maps.newHashMapWithExpectedSize(3);
+  }
+  
+  @Override
+  public String id() {
+    return id;
+  }
+  
+  /**
+   * @return The types of data this factory can instantiate iterators for.
+   */
+  public Collection<TypeToken<?>> types() {
+    return iterator_factories.keySet();
+  }
+  
+  /**
+   * Registers a specific iterator factory for a given type.
+   * @param type A non-null type.
+   * @param factory A non-null factory for the type.
+   */
+  public void registerIteratorFactory(final TypeToken<?> type,
+                                      final QueryIteratorFactory factory) {
+    if (type == null) {
+      throw new IllegalArgumentException("Type cannot be null.");
+    }
+    if (factory == null) {
+      throw new IllegalArgumentException("Factory cannot be null.");
+    }
+    if (iterator_factories.containsKey(type)) {
+      LOG.warn("Replacing existing iterator factory: " + 
+          iterator_factories.get(type) + " with factory: " + factory);
+    }
+    iterator_factories.put(type, factory);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Registering iteratator factory: " + factory 
+          + " with type: " + type);
+    }
+  }
+
+  /**
+   * Returns an instantiated iterator of the given type if supported
+   * @param type A non-null type.
+   * @param node The parent node.
+   * @param result The result this source is a part of.
+   * @param sources A collection of sources to incorporate in the iterator.
+   * @return A non-null iterator if successful or null if an iterator is
+   * not present for the type.
+   */
+  public Iterator<TimeSeriesValue<? extends TimeSeriesDataType>> newIterator(
+      final TypeToken<?> type,
+      final QueryNode node,
+      final QueryResult result,
+      final Collection<TimeSeries> sources) {
+    if (type == null) {
+      throw new IllegalArgumentException("Type cannot be null.");
+    }
+    if (node == null) {
+      throw new IllegalArgumentException("Node cannot be null.");
+    }
+    if (sources == null || sources.isEmpty()) {
+      throw new IllegalArgumentException("Sources cannot be null or empty.");
+    }
+    
+    final QueryIteratorFactory factory = iterator_factories.get(type);
+    if (factory == null) {
+      return null;
+    }
+    return factory.newIterator(node, result, sources);
+  }
+
+  /**
+   * Returns an instantiated iterator of the given type if supported
+   * @param type A non-null type.
+   * @param node The parent node.
+   * @param result The result this source is a part of.
+   * @param sources A map of sources to incorporate in the iterator.
+   * @return A non-null iterator if successful or null if an iterator is
+   * not present for the type.
+   */
+  public Iterator<TimeSeriesValue<? extends TimeSeriesDataType>> newIterator(
+      final TypeToken<?> type,
+      final QueryNode node,
+      final QueryResult result,
+      final Map<String, TimeSeries> sources) {
+    if (type == null) {
+      throw new IllegalArgumentException("Type cannot be null.");
+    }
+    if (node == null) {
+      throw new IllegalArgumentException("Node cannot be null.");
+    }
+    if (sources == null || sources.isEmpty()) {
+      throw new IllegalArgumentException("Sources cannot be null or empty.");
+    }
+    
+    final QueryIteratorFactory factory = iterator_factories.get(type);
+    if (factory == null) {
+      return null;
+    }
+    return factory.newIterator(node, result, sources);
+  }
+
+  @Override
+  public Deferred<Object> initialize(final TSDB tsdb) {
+    return Deferred.fromResult(null);
+  }
+  
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+  
+  @Override
+  public String version() {
+    return "3.0.0";
+  }
+
+}

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionFactory.java
@@ -1,0 +1,152 @@
+//This file is part of OpenTSDB.
+//Copyright (C) 2018  The OpenTSDB Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+package net.opentsdb.query.processor.expressions;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.types.numeric.NumericSummaryType;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.QueryIteratorFactory;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryNodeConfig;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.execution.graph.ExecutionGraphNode;
+import net.opentsdb.query.processor.BaseMultiQueryNodeFactory;
+import net.opentsdb.query.processor.expressions.ExpressionParseNode.OperandType;
+
+/**
+ * A factory used to instantiate expression nodes in the graph. This 
+ * config will modify the list of nodes so make sure to pass in a copy 
+ * of those given by the user.
+ * 
+ * TODO - we can walk the nodes and look for duplicates. It's a pain to
+ * do though.
+ * 
+ * @since 3.0
+ */
+public class ExpressionFactory extends BaseMultiQueryNodeFactory {
+  
+  /**
+   * Required empty ctor.
+   */
+  public ExpressionFactory() {
+    super("expression");
+    registerIteratorFactory(NumericType.TYPE, new NumericIteratorFactory());
+    registerIteratorFactory(NumericSummaryType.TYPE, 
+        new NumericSummaryIteratorFactory());
+  }
+
+  @Override
+  public Collection<QueryNode> newNodes(final QueryPipelineContext context, 
+                                        final String id,
+                                        final QueryNodeConfig config, 
+                                        final List<ExecutionGraphNode> nodes) {
+    
+    final ExpressionConfig c = (ExpressionConfig) config;
+    final ExpressionParser parser = 
+        new ExpressionParser(c.getExpression(), id);
+    final List<ExpressionParseNode> configs = parser.parse();
+    final List<QueryNode> query_nodes = 
+        Lists.newArrayListWithExpectedSize(configs.size());
+    
+    for (final ExpressionParseNode parse_node : configs) {
+      final BinaryExpressionNode node =
+          new BinaryExpressionNode(this, context, parse_node.getId(), 
+          (ExpressionConfig) config, parse_node);
+      query_nodes.add(node);
+      
+      final ExecutionGraphNode.Builder builder = ExecutionGraphNode
+          .newBuilder()
+            .setConfig(parse_node)
+            .setId(parse_node.getId());
+      if (parse_node.leftType() == OperandType.SUB_EXP || 
+          parse_node.leftType() == OperandType.VARIABLE) {
+        builder.addSource((String) parse_node.left());
+      }
+      if (parse_node.rightType() == OperandType.SUB_EXP || 
+          parse_node.rightType() == OperandType.VARIABLE) {
+        builder.addSource((String) parse_node.right());
+      }
+      
+      nodes.add(builder.build());
+    }
+    return query_nodes;
+  }
+
+  @Override
+  public Class<? extends QueryNodeConfig> nodeConfigClass() {
+    return ExpressionConfig.class;
+  }
+  
+  /**
+   * The default numeric iterator factory.
+   */
+  protected class NumericIteratorFactory implements QueryIteratorFactory {
+
+    @Override
+    public Iterator<TimeSeriesValue<?>> newIterator(final QueryNode node,
+                                                    final QueryResult result,
+                                                    final Collection<TimeSeries> sources) {
+      throw new UnsupportedOperationException("Expression iterators must have a map.");
+    }
+
+    @Override
+    public Iterator<TimeSeriesValue<?>> newIterator(final QueryNode node,
+                                                    final QueryResult result,
+                                                    final Map<String, TimeSeries> sources) {
+      return new ExpressionNumericIterator(node, result, sources);
+    }
+
+    @Override
+    public Collection<TypeToken<?>> types() {
+      return Lists.newArrayList(NumericType.TYPE);
+    }
+        
+  }
+
+  /**
+   * Handles summaries.
+   */
+  protected class NumericSummaryIteratorFactory implements QueryIteratorFactory {
+
+    @Override
+    public Iterator<TimeSeriesValue<?>> newIterator(final QueryNode node,
+                                                    final QueryResult result,
+                                                    final Collection<TimeSeries> sources) {
+      throw new UnsupportedOperationException("Expression iterators must have a map.");
+    }
+
+    @Override
+    public Iterator<TimeSeriesValue<?>> newIterator(final QueryNode node,
+                                                    final QueryResult result,
+                                                    final Map<String, TimeSeries> sources) {
+      return new ExpressionNumericSummaryIterator(node, result, sources);
+    }
+    
+    @Override
+    public Collection<TypeToken<?>> types() {
+      return Lists.newArrayList(NumericSummaryType.TYPE);
+    }
+  }
+}

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParser.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParser.java
@@ -15,6 +15,7 @@
 package net.opentsdb.query.processor.expressions;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -163,6 +164,21 @@ public class ExpressionParser extends DefaultErrorStrategy
     
     public double doubleValue() {
       return Double.longBitsToDouble(number);
+    }
+  
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null) {
+        return false;
+      }
+      if (o == this) {
+        return true;
+      }
+      if (!(o instanceof NumericLiteral)) {
+        return false;
+      }
+      return Objects.equals(is_integer, ((NumericLiteral) o).is_integer) &&
+             Objects.equals(number, ((NumericLiteral) o).number);
     }
   }
   

--- a/core/src/test/java/net/opentsdb/query/processor/TestBaseMultiQueryNodeFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/TestBaseMultiQueryNodeFactory.java
@@ -1,0 +1,207 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2017  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.processor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyCollection;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesDataType;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.types.annotation.AnnotationType;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.QueryIteratorFactory;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryNodeConfig;
+import net.opentsdb.query.QueryNodeFactory;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.execution.graph.ExecutionGraphNode;
+
+public class TestBaseMultiQueryNodeFactory {
+
+  @Test
+  public void ctor() throws Exception {
+    QueryNodeFactory factory = new MockNodeFactory("Mock!");
+    assertEquals("Mock!", factory.id());
+    
+    try {
+      new MockNodeFactory(null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      new MockNodeFactory("");
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void registerIteratorFactory() throws Exception {
+    QueryIteratorFactory mock1 = mock(QueryIteratorFactory.class);
+    QueryIteratorFactory mock2 = mock(QueryIteratorFactory.class);
+    
+    MockNodeFactory factory = new MockNodeFactory("Mock!");
+    factory.registerIteratorFactory(NumericType.TYPE, mock1);
+    
+    assertEquals(1, factory.types().size());
+    assertSame(mock1, factory.iterator_factories.get(NumericType.TYPE));
+    
+    factory.registerIteratorFactory(AnnotationType.TYPE, mock2);
+    assertEquals(2, factory.types().size());
+    assertSame(mock1, factory.iterator_factories.get(NumericType.TYPE));
+    assertSame(mock2, factory.iterator_factories.get(AnnotationType.TYPE));
+    
+    // replace
+    factory.registerIteratorFactory(NumericType.TYPE, mock2);
+    assertEquals(2, factory.types().size());
+    assertSame(mock2, factory.iterator_factories.get(NumericType.TYPE));
+    assertSame(mock2, factory.iterator_factories.get(AnnotationType.TYPE));
+    
+    try {
+      factory.registerIteratorFactory(null, mock2);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      factory.registerIteratorFactory(NumericType.TYPE, null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  @Test
+  public void newIteratorList() throws Exception {
+    Iterator<TimeSeriesValue<? extends TimeSeriesDataType>> iterator = 
+        mock(Iterator.class);
+    QueryIteratorFactory mock1 = mock(QueryIteratorFactory.class);
+    when(mock1.newIterator(any(QueryNode.class), any(QueryResult.class), anyCollection()))
+      .thenReturn((Iterator<TimeSeriesValue<? extends TimeSeriesDataType>>) iterator);
+    QueryNode node = mock(QueryNode.class);
+    MockNodeFactory factory = new MockNodeFactory("Mock!");
+    
+    assertNull(factory.newIterator(NumericType.TYPE, node, null,
+        Lists.newArrayList(mock(TimeSeries.class))));
+    
+    factory.registerIteratorFactory(NumericType.TYPE, mock1);
+    Iterator<TimeSeriesValue<? extends TimeSeriesDataType>> from_factory = 
+        factory.newIterator(NumericType.TYPE, node, null,
+            Lists.<TimeSeries>newArrayList(mock(TimeSeries.class)));
+    assertSame(iterator, from_factory);
+    
+    try {
+      factory.newIterator(null, node, null,
+          Lists.newArrayList(mock(TimeSeries.class)));
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      factory.newIterator(NumericType.TYPE, null, null,
+          Lists.newArrayList(mock(TimeSeries.class)));
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      factory.newIterator(NumericType.TYPE, node, null,(Collection) null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      factory.newIterator(NumericType.TYPE, node, null,Lists.newArrayList());
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  @Test
+  public void newIteratorMap() throws Exception {
+    Iterator<TimeSeriesValue<? extends TimeSeriesDataType>> iterator = 
+        mock(Iterator.class);
+    Map<String, TimeSeries> sources = Maps.newHashMap();
+    sources.put("a", mock(TimeSeries.class));
+    QueryIteratorFactory mock1 = mock(QueryIteratorFactory.class);
+    when(mock1.newIterator(any(QueryNode.class), any(QueryResult.class), anyMap()))
+      .thenReturn((Iterator<TimeSeriesValue<? extends TimeSeriesDataType>>) iterator);
+    QueryNode node = mock(QueryNode.class);
+    MockNodeFactory factory = new MockNodeFactory("Mock!");
+    
+    assertNull(factory.newIterator(NumericType.TYPE, node, null,sources));
+    
+    factory.registerIteratorFactory(NumericType.TYPE, mock1);
+    Iterator<TimeSeriesValue<? extends TimeSeriesDataType>> from_factory = 
+        factory.newIterator(NumericType.TYPE, node, null,sources);
+    assertSame(iterator, from_factory);
+    
+    try {
+      factory.newIterator(null, node, null,sources);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      factory.newIterator(NumericType.TYPE, null, null,sources);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      factory.newIterator(NumericType.TYPE, node, null,(Map) null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      factory.newIterator(NumericType.TYPE, node, null,Maps.newHashMap());
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  /** Mock class to test the abstract. */
+  class MockNodeFactory extends BaseMultiQueryNodeFactory {
+
+    public MockNodeFactory(final String id) {
+      super(id);
+    }
+
+    @Override
+    public Collection<QueryNode> newNodes(final QueryPipelineContext context, 
+                                          final String id,
+                                          final QueryNodeConfig config, 
+                                          final List<ExecutionGraphNode> nodes) {
+      return Lists.newArrayList(mock(QueryNode.class));
+    }
+    
+    @Override
+    public Class<? extends QueryNodeConfig> nodeConfigClass() {
+      // TODO Auto-generated method stub
+      return null;
+    }
+    
+  }
+}

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionFactory.java
@@ -1,0 +1,201 @@
+//This file is part of OpenTSDB.
+//Copyright (C) 2018  The OpenTSDB Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+package net.opentsdb.query.processor.expressions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+import net.opentsdb.data.types.numeric.NumericSummaryType;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
+import net.opentsdb.query.execution.graph.ExecutionGraphNode;
+import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
+import net.opentsdb.query.joins.JoinConfig;
+import net.opentsdb.query.joins.JoinConfig.JoinType;
+import net.opentsdb.query.pojo.FillPolicy;
+import net.opentsdb.query.processor.expressions.ExpressionParseNode.ExpressionOp;
+import net.opentsdb.query.processor.expressions.ExpressionParseNode.OperandType;
+import net.opentsdb.query.processor.expressions.ExpressionParser.NumericLiteral;
+
+public class TestExpressionFactory {
+
+  private static QueryPipelineContext CONTEXT;
+  protected static NumericInterpolatorConfig NUMERIC_CONFIG;
+  
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    CONTEXT =  mock(QueryPipelineContext.class);
+    NUMERIC_CONFIG = 
+        (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
+      .setFillPolicy(FillPolicy.NOT_A_NUMBER)
+      .setRealFillPolicy(FillWithRealPolicy.NONE)
+      .setType(NumericType.TYPE.toString())
+      .build();
+  }
+  
+  @Test
+  public void ctor() throws Exception {
+    ExpressionFactory factory = new ExpressionFactory();
+    assertEquals(2, factory.types().size());
+    assertTrue(factory.types().contains(NumericType.TYPE));
+    assertTrue(factory.types().contains(NumericSummaryType.TYPE));
+  }
+  
+  @Test
+  public void newNodesSimpleBinary() throws Exception {
+    ExpressionFactory factory = new ExpressionFactory();
+    
+    ExpressionConfig config = 
+        (ExpressionConfig) ExpressionConfig.newBuilder()
+        .setExpression("a + b")
+        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+            .setType(JoinType.NATURAL)
+            .build())
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setId("e1")
+        .build();
+    
+    List<ExecutionGraphNode> nodes = Lists.newArrayList();
+    nodes.add(ExecutionGraphNode.newBuilder()
+        .setId("a")
+        .build());
+    nodes.add(ExecutionGraphNode.newBuilder()
+        .setId("b")
+        .build());
+    
+    Collection<QueryNode> new_nodes = factory.newNodes(
+        CONTEXT, "e1", config, nodes);
+    assertEquals(1, new_nodes.size());
+    
+    Iterator<QueryNode> iterator = new_nodes.iterator();
+    BinaryExpressionNode exp_node = (BinaryExpressionNode) iterator.next();
+    assertEquals("e1", exp_node.id());
+    assertSame(config, exp_node.config());
+    
+    assertEquals(3, nodes.size());
+    assertTrue(nodes.get(2).getSources().contains("a"));
+    assertTrue(nodes.get(2).getSources().contains("b"));
+    ExpressionParseNode parse_node = (ExpressionParseNode) nodes.get(2).getConfig();
+    assertEquals("a", parse_node.left());
+    assertEquals(OperandType.VARIABLE, parse_node.leftType());
+    assertEquals("b", parse_node.right());
+    assertEquals(OperandType.VARIABLE, parse_node.rightType());
+    assertEquals(ExpressionOp.ADD, parse_node.operator());
+    
+    // literal
+    nodes.remove(2);
+    config = 
+        (ExpressionConfig) ExpressionConfig.newBuilder()
+        .setExpression("a + 42")
+        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+            .setType(JoinType.NATURAL)
+            .build())
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setId("e1")
+        .build();
+    
+    new_nodes = factory.newNodes(
+        CONTEXT, "e1", config, nodes);
+    assertEquals(1, new_nodes.size());
+    
+    iterator = new_nodes.iterator();
+    exp_node = (BinaryExpressionNode) iterator.next();
+    assertEquals("e1", exp_node.id());
+    assertSame(config, exp_node.config());
+    
+    assertEquals(3, nodes.size());
+    assertTrue(nodes.get(2).getSources().contains("a"));
+    parse_node = (ExpressionParseNode) nodes.get(2).getConfig();
+    assertEquals("a", parse_node.left());
+    assertEquals(OperandType.VARIABLE, parse_node.leftType());
+    assertTrue(parse_node.right() instanceof NumericLiteral);
+    assertEquals(OperandType.LITERAL_NUMERIC, parse_node.rightType());
+    assertEquals(ExpressionOp.ADD, parse_node.operator());
+  }
+  
+  @Test
+  public void newNodesTwoNewNodes() throws Exception {
+    ExpressionFactory factory = new ExpressionFactory();
+    
+    ExpressionConfig config = 
+        (ExpressionConfig) ExpressionConfig.newBuilder()
+        .setExpression("a + b + c")
+        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+            .setType(JoinType.NATURAL)
+            .build())
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setId("e1")
+        .build();
+    
+    List<ExecutionGraphNode> nodes = Lists.newArrayList();
+    nodes.add(ExecutionGraphNode.newBuilder()
+        .setId("a")
+        .build());
+    nodes.add(ExecutionGraphNode.newBuilder()
+        .setId("b")
+        .build());
+    nodes.add(ExecutionGraphNode.newBuilder()
+        .setId("c")
+        .build());
+    
+    Collection<QueryNode> new_nodes = factory.newNodes(
+        CONTEXT, "e1", config, nodes);
+    assertEquals(2, new_nodes.size());
+    
+    Iterator<QueryNode> iterator = new_nodes.iterator();
+    BinaryExpressionNode exp_node = (BinaryExpressionNode) iterator.next();
+    assertEquals("e1_SubExp#0", exp_node.id());
+    assertSame(config, exp_node.config());
+    
+    exp_node = (BinaryExpressionNode) iterator.next();
+    assertEquals("e1", exp_node.id());
+    assertSame(config, exp_node.config());
+    
+    assertEquals(5, nodes.size());
+    assertEquals(2, nodes.get(3).getSources().size());
+    assertTrue(nodes.get(3).getSources().contains("a"));
+    assertTrue(nodes.get(3).getSources().contains("b"));
+    
+    ExpressionParseNode parse_node = (ExpressionParseNode) nodes.get(3).getConfig();
+    assertEquals("a", parse_node.left());
+    assertEquals(OperandType.VARIABLE, parse_node.leftType());
+    assertEquals("b", parse_node.right());
+    assertEquals(OperandType.VARIABLE, parse_node.rightType());
+    assertEquals(ExpressionOp.ADD, parse_node.operator());
+    
+    assertEquals(2, nodes.get(4).getSources().size());
+    assertTrue(nodes.get(4).getSources().contains("e1_SubExp#0"));
+    assertTrue(nodes.get(4).getSources().contains("c"));
+    parse_node = (ExpressionParseNode) nodes.get(4).getConfig();
+    assertEquals("e1_SubExp#0", parse_node.left());
+    assertEquals(OperandType.SUB_EXP, parse_node.leftType());
+    assertEquals("c", parse_node.right());
+    assertEquals(OperandType.VARIABLE, parse_node.rightType());
+    assertEquals(ExpressionOp.ADD, parse_node.operator());
+  }
+}


### PR DESCRIPTION
- Add an overrideSource() method to the ExecutionGraphNode so that we can later
  on, dedupe configs for complex expressions in a single query. Not using it yet.

CORE:
- Add an equals method to the NumericLiteral in ExpressionParser.
- Add a BaseMultiQueryNodeFactory for processors that generate multiple nodes.
- Add the ExpressionFactory to populate a graph with expression nodes.