### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/QuerySourceConfig.java
+++ b/core/src/main/java/net/opentsdb/query/QuerySourceConfig.java
@@ -70,9 +70,6 @@ public class QuerySourceConfig extends BaseQueryNodeConfig {
    */
   protected QuerySourceConfig(final Builder builder) {
     super(builder);
-    if (builder.query == null) {
-      throw new IllegalArgumentException("Query cannot be null.");
-    }
     if (Strings.isNullOrEmpty(builder.start)) {
       throw new IllegalArgumentException("Start time cannot be null "
           + "or empty.");

--- a/core/src/main/java/net/opentsdb/query/joins/Joiner.java
+++ b/core/src/main/java/net/opentsdb/query/joins/Joiner.java
@@ -123,7 +123,8 @@ public class Joiner {
     }
     
     if (results.get(0).idType() == Const.TS_BYTE_ID && 
-        encoded_joins == null) {
+        encoded_joins == null &&
+        config.getType() != JoinType.NATURAL) {
       throw new IllegalStateException("Received a result with encoded "
           + "IDs but the local encoded tags map was null.");
     }
@@ -240,7 +241,8 @@ public class Joiner {
     }
     
     if (results.get(0).idType() == Const.TS_BYTE_ID && 
-        encoded_joins == null) {
+        encoded_joins == null &&
+        config.getType() != JoinType.NATURAL) {
       throw new IllegalStateException("Received a result with encoded "
           + "IDs but the local encoded tags map was null.");
     }
@@ -285,18 +287,20 @@ public class Joiner {
           
           if (Bytes.memcmp(filter, key) == 0) {
             boolean satisfied_joins = true;
-            for (final Entry<byte[], byte[]> tags : encoded_joins) {
-              if (left) {
-                if (!id.tags().containsKey(tags.getKey())) {
-                  satisfied_joins = false;
-                  break;
-                  // TODO - log ejection
-                }
-              } else {
-                if (!id.tags().containsKey(tags.getValue())) {
-                  satisfied_joins = false;
-                  break;
-                  // TODO - log ejection
+            if (encoded_joins != null) {
+              for (final Entry<byte[], byte[]> tags : encoded_joins) {
+                if (left) {
+                  if (!id.tags().containsKey(tags.getKey())) {
+                    satisfied_joins = false;
+                    break;
+                    // TODO - log ejection
+                  }
+                } else {
+                  if (!id.tags().containsKey(tags.getValue())) {
+                    satisfied_joins = false;
+                    break;
+                    // TODO - log ejection
+                  }
                 }
               }
             }

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNode.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNode.java
@@ -134,29 +134,26 @@ public class BinaryExpressionNode extends AbstractQueryNode {
       final List<String> metrics = Lists.newArrayListWithExpectedSize(2);
       if (expression_config.leftType() == OperandType.VARIABLE) {
         metrics.add((String) expression_config.left());
-      } else {
-        metrics.add(null);
+      } else if (expression_config.leftType() == OperandType.SUB_EXP){
+        left_metric = ((String) expression_config.left()).getBytes(Const.UTF8_CHARSET);
       }
+      
       if (expression_config.rightType() == OperandType.VARIABLE) {
         metrics.add((String) expression_config.right());
-      } else {
-        metrics.add(null);
+      } else if (expression_config.rightType() == OperandType.SUB_EXP) {
+        right_metric = ((String) expression_config.right()).getBytes(Const.UTF8_CHARSET);
       }
       
       class ResolveCB implements Callback<Object, List<byte[]>> {
         @Override
         public Object call(final List<byte[]> uids) throws Exception {
-          if (uids.get(0) == null) {
-            // COULD be an alias.
-            left_metric = ((String) expression_config.left()).getBytes(Const.UTF8_CHARSET);
-          } else {
-            left_metric = uids.get(0);
+          int idx = 0;
+          if (expression_config.leftType() == OperandType.VARIABLE) {
+            left_metric = uids.get(idx++);
           }
-          if (uids.get(1) == null) {
-            // COULD be an alias.
-            right_metric = ((String) expression_config.right()).getBytes(Const.UTF8_CHARSET);
-          } else {
-            right_metric = uids.get(1);
+          
+          if (expression_config.rightType() == OperandType.VARIABLE) {
+            right_metric = uids.get(idx);
           }
           // fall through to the next step
           onNext(next);
@@ -225,7 +222,6 @@ public class BinaryExpressionNode extends AbstractQueryNode {
       result.join();
       try {
         sendUpstream(result);
-        completeUpstream(0, 0); // TODO - fix me
       } catch (Exception e) {
         sendUpstream(e);
       }
@@ -235,7 +231,6 @@ public class BinaryExpressionNode extends AbstractQueryNode {
         result.join();
         try {
           sendUpstream(result);
-          completeUpstream(0, 0); // TODO - fix me
         } catch (Exception e) {
           sendUpstream(e);
         }

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionConfig.java
@@ -49,7 +49,7 @@ import net.opentsdb.query.joins.JoinConfig;
  * @since 3.0
  */
 @JsonInclude(Include.NON_NULL)
-@JsonDeserialize(builder = ExpressionConfig.class)
+@JsonDeserialize(builder = ExpressionConfig.Builder.class)
 public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators {
   
   /** The original expression string. */

--- a/core/src/test/java/net/opentsdb/query/TestQuerySourceConfig.java
+++ b/core/src/test/java/net/opentsdb/query/TestQuerySourceConfig.java
@@ -40,16 +40,6 @@ public class TestQuerySourceConfig {
     
     try {
       QuerySourceConfig.newBuilder()
-        //.setQuery(query)
-        .setStart("1h-ago")
-        .setMetric("system.cpu.user")
-        .setId("UT")
-        .build();
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
-    
-    try {
-      QuerySourceConfig.newBuilder()
         .setQuery(query)
         //.setStart("1h-ago")
         .setMetric("system.cpu.user")

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
@@ -379,7 +379,7 @@ public class TestBinaryExpressionNode {
     verify(store, times(1)).encodeJoinMetrics(any(List.class), any(Span.class));
     verify(store, never()).encodeJoinKeys(any(List.class), any(Span.class));
     assertNull(node.left_metric);
-    assertNull(node.right_metric);
+    assertArrayEquals("sub".getBytes(Const.UTF8_CHARSET), node.right_metric);
     assertNull(node.joiner.encodedJoins());
     
     // callback.
@@ -543,15 +543,15 @@ public class TestBinaryExpressionNode {
     verify(upstream, never()).onComplete(any(QueryNode.class), anyLong(), anyLong());
     verify(store, times(1)).encodeJoinMetrics(any(List.class), any(Span.class));
     verify(store, times(1)).encodeJoinKeys(any(List.class), any(Span.class));
-    assertArrayEquals(new byte[] { 0, 0, 1 }, node.left_metric);
-    assertArrayEquals("b".getBytes(Const.UTF8_CHARSET), node.right_metric);
+    assertNull(node.left_metric);
+    assertArrayEquals(new byte[] { 0, 0, 1 }, node.right_metric);
     assertNull(node.joiner.encodedJoins());
     
     // callback tags now
     tags.callback(Lists.newArrayList(new byte[] { 0, 0, 3 }, new byte[] { 0, 0, 3 }));
     verify(upstream, times(1)).onNext(any(QueryResult.class));
     verify(upstream, never()).onError(any(Throwable.class));
-    verify(upstream, times(1)).onComplete(any(QueryNode.class), anyLong(), anyLong());
+    verify(upstream, never()).onComplete(any(QueryNode.class), anyLong(), anyLong());
     verify(store, times(1)).encodeJoinMetrics(any(List.class), any(Span.class));
     verify(store, times(1)).encodeJoinKeys(any(List.class), any(Span.class));
     assertEquals(1, node.joiner.encodedJoins().size());
@@ -614,21 +614,21 @@ public class TestBinaryExpressionNode {
     assertNull(node.joiner.encodedJoins());
     
     // callback.
-    metrics.callback(Lists.newArrayList(null, new byte[] { 0, 0, 2 }));
+    metrics.callback(Lists.newArrayList(new byte[] { 0, 0, 2 }));
     verify(upstream, never()).onNext(any(QueryResult.class));
     verify(upstream, never()).onError(any(Throwable.class));
     verify(upstream, never()).onComplete(any(QueryNode.class), anyLong(), anyLong());
     verify(store, times(1)).encodeJoinMetrics(any(List.class), any(Span.class));
     verify(store, times(1)).encodeJoinKeys(any(List.class), any(Span.class));
-    assertArrayEquals("a".getBytes(Const.UTF8_CHARSET), node.left_metric);
-    assertArrayEquals(new byte[] { 0, 0, 2 }, node.right_metric);
+    assertArrayEquals(new byte[] { 0, 0, 2 }, node.left_metric);
+    assertNull(node.right_metric);
     assertNull(node.joiner.encodedJoins());
     
     // callback tags now
     tags.callback(Lists.newArrayList(new byte[] { 0, 0, 3 }, new byte[] { 0, 0, 3 }));
     verify(upstream, times(1)).onNext(any(QueryResult.class));
     verify(upstream, never()).onError(any(Throwable.class));
-    verify(upstream, times(1)).onComplete(any(QueryNode.class), anyLong(), anyLong());
+    verify(upstream, never()).onComplete(any(QueryNode.class), anyLong(), anyLong());
     verify(store, times(1)).encodeJoinMetrics(any(List.class), any(Span.class));
     verify(store, times(1)).encodeJoinKeys(any(List.class), any(Span.class));
     assertEquals(1, node.joiner.encodedJoins().size());


### PR DESCRIPTION
- Remove the requirement that the query is st in the builder for
  QuerySourceConfig as deserialization of semantic queries won't have it.
- Fix Joiner bug with NATURAL and null encoded tags.
- Fix the BinaryExpression node to NOT complete upstream on responses and
  to only send the raw metric names for resolution in byte IDs.
- Fix the ExpressionTimeSeries to cast the factory properly and handle null
  time series. (and add UTs)