### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/execution/graph/ExecutionGraphNode.java
+++ b/common/src/main/java/net/opentsdb/query/execution/graph/ExecutionGraphNode.java
@@ -162,12 +162,13 @@ public class ExecutionGraphNode implements Comparable<ExecutionGraphNode> {
   @Override
   public String toString() {
     return new StringBuilder()
-        .append("id=")
+        .append("{id=")
         .append(id)
         .append(", sources=")
         .append(sources)
         .append(", type=")
         .append(type)
+        .append("}")
         .toString();
   }
   

--- a/core/src/main/java/net/opentsdb/query/joins/ByteIdOverride.java
+++ b/core/src/main/java/net/opentsdb/query/joins/ByteIdOverride.java
@@ -30,7 +30,7 @@ import net.opentsdb.utils.Bytes.ByteMap;
 
 /**
  * A simple wrapper for single-sided joins that wraps the source 
- * ID with the proper alias.
+ * ID with the proper alias for use as the alias and metric.
  * 
  * @since 3.0
  */
@@ -85,7 +85,7 @@ public class ByteIdOverride implements TimeSeriesByteId {
 
   @Override
   public byte[] metric() {
-    return id.metric();
+    return alias.getBytes(Const.UTF8_CHARSET);
   }
 
   @Override
@@ -115,7 +115,7 @@ public class ByteIdOverride implements TimeSeriesByteId {
 
   @Override
   public boolean skipMetric() {
-    return id.skipMetric();
+    return true;
   }
   
 }

--- a/core/src/main/java/net/opentsdb/query/joins/StringIdOverride.java
+++ b/core/src/main/java/net/opentsdb/query/joins/StringIdOverride.java
@@ -25,7 +25,7 @@ import net.opentsdb.data.TimeSeriesStringId;
 
 /**
  * A simple wrapper for single-sided joins that wraps the source 
- * ID with the proper alias.
+ * ID with the proper alias for use as the alias and metric.
  * 
  * @since 3.0
  */
@@ -75,7 +75,7 @@ public class StringIdOverride implements TimeSeriesStringId {
 
   @Override
   public String metric() {
-    return id.metric();
+    return alias;
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNode.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNode.java
@@ -70,7 +70,16 @@ public class BinaryExpressionNode extends AbstractQueryNode {
   /** Used to filtering when we're working on encoded IDs. */
   protected byte[] left_metric;
   protected byte[] right_metric;
+  protected boolean resolved_metrics;
   
+  /**
+   * Default ctor.
+   * @param factory The factory we came from.
+   * @param context The non-null context.
+   * @param id The ID of this node.
+   * @param config The non-null overall expression config.
+   * @param expression_config The non-null sub-expression config.
+   */
   public BinaryExpressionNode(final QueryNodeFactory factory,
                               final QueryPipelineContext context, 
                               final String id, 
@@ -127,10 +136,12 @@ public class BinaryExpressionNode extends AbstractQueryNode {
       }
     }
     
+    // Try to resolve the variable names as metrics. This should return
+    // and empty
     if (next.idType() == Const.TS_BYTE_ID &&
         (expression_config.leftType() == OperandType.VARIABLE || 
          expression_config.rightType() == OperandType.VARIABLE) && 
-        (left_metric == null && right_metric == null)) {
+        !resolved_metrics) {
       final List<String> metrics = Lists.newArrayListWithExpectedSize(2);
       if (expression_config.leftType() == OperandType.VARIABLE) {
         metrics.add((String) expression_config.left());
@@ -155,6 +166,7 @@ public class BinaryExpressionNode extends AbstractQueryNode {
           if (expression_config.rightType() == OperandType.VARIABLE) {
             right_metric = uids.get(idx);
           }
+          resolved_metrics = true;
           // fall through to the next step
           onNext(next);
           return null;

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionConfig.java
@@ -64,6 +64,9 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators {
   /** Whether or not NaN is infectious. */
   private final boolean infectious_nan;
   
+  /** The resulting metric name. */
+  private final String as;
+  
   /**
    * Protected ctor.
    * @param builder The non-null builder.
@@ -83,6 +86,11 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators {
     join_config = builder.joinConfig;
     variable_interpolators = builder.variable_interpolators;
     infectious_nan = builder.infectiousNan;
+    if (Strings.isNullOrEmpty(builder.as)) {
+      as = getId();
+    } else {
+      as = builder.as;
+    }
   }
   
   /** @return The raw expression string to be parsed. */
@@ -103,6 +111,11 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators {
   /** @return Whether or not nans are infectious. */
   public boolean getInfectiousNan() {
     return infectious_nan;
+  }
+  
+  /** @return The new name for the metric. */
+  public String getAs() {
+    return as;
   }
   
   /**
@@ -141,7 +154,9 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators {
     hashes.add(Const.HASH_FUNCTION().newHasher()
         .putBoolean(infectious_nan)
         .putString(id, Const.UTF8_CHARSET)
-        .putString(expression, Const.UTF8_CHARSET).hash());
+        .putString(expression, Const.UTF8_CHARSET)
+        .putString(as, Const.UTF8_CHARSET)
+        .hash());
     if (variable_interpolators != null && !variable_interpolators.isEmpty()) {
       final Map<String, List<QueryInterpolatorConfig>> sorted = 
           new TreeMap<String, List<QueryInterpolatorConfig>>(variable_interpolators);
@@ -186,6 +201,7 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators {
         .compare(variable_interpolators, ((ExpressionConfig) o).variable_interpolators, VARIABLE_INTERP_CMP)
         .compare(interpolator_configs, ((ExpressionConfig) o).interpolator_configs, INTERPOLATOR_CMP)
         .compare(infectious_nan, ((ExpressionConfig) o).infectious_nan)
+        .compare(as, ((ExpressionConfig) o).as)
         .result();
   }
 
@@ -207,7 +223,8 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators {
            Objects.equals(join_config, other.join_config) &&
            Objects.equals(variable_interpolators, other.variable_interpolators) &&
            Objects.equals(interpolator_configs, other.interpolator_configs) &&
-           Objects.equals(infectious_nan, other.infectious_nan);
+           Objects.equals(infectious_nan, other.infectious_nan) &&
+           Objects.equals(as, other.as);
   }
 
   @Override
@@ -229,6 +246,8 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators {
     private Map<String, List<QueryInterpolatorConfig>> variable_interpolators;
     @JsonProperty
     private boolean infectiousNan;
+    @JsonProperty
+    private String as;
     
     public Builder setExpression(final String expression) {
       this.expression = expression;
@@ -262,6 +281,11 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators {
     
     public Builder setInfectiousNan(final boolean infectious_nan) {
       this.infectiousNan = infectious_nan;
+      return this;
+    }
+    
+    public Builder setAs(final String as) {
+      this.as = as;
       return this;
     }
     

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParseNode.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParseNode.java
@@ -96,14 +96,17 @@ public class ExpressionParseNode extends BaseQueryNodeConfig {
   /** ID shadow needed to allow for overrides. */
   private String id;
   
+  /** The output metric name. Defaults to the ID. */
+  private String as;
+  
   /** The left operand. */
-  private final Object left;
+  private Object left;
   
   /** The type of the left operand. */
   private final OperandType left_type;
   
   /** The right operand. */
-  private final Object right;
+  private Object right;
   
   /** The type of the right operand. */
   private final OperandType right_type;
@@ -131,6 +134,12 @@ public class ExpressionParseNode extends BaseQueryNodeConfig {
     op = builder.op;
     negate = builder.negate;
     not = builder.not;
+    as = id;
+  }
+  
+  /** @return The name to use for the metric. Defaults to the ID. */
+  public String as() {
+    return as;
   }
   
   /** @return The left operand. */
@@ -176,6 +185,16 @@ public class ExpressionParseNode extends BaseQueryNodeConfig {
   /** @return Whether or not to "not" the output. */
   public boolean not() {
     return not;
+  }
+  
+  /** @param id The new id to set. */
+  public void setLeft(final String id) {
+    left = id;
+  }
+  
+  /** @param id The new id to set. */
+  public void setRight(final String id) {
+    right = id;
   }
   
   @Override
@@ -235,6 +254,14 @@ public class ExpressionParseNode extends BaseQueryNodeConfig {
    */
   void overrideId(final String id) {
     this.id = id;
+  }
+  
+  /**
+   * Package private method to override the as string.
+   * @param as The non-null as string to set for the new metric.
+   */
+  void overrideAs(final String as) {
+    this.as = as;
   }
   
   static Builder newBuilder() {

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionTimeSeries.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionTimeSeries.java
@@ -32,7 +32,6 @@ import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.processor.BaseMultiQueryNodeFactory;
-import net.opentsdb.query.processor.ProcessorFactory;
 
 /**
  * A container class for computing a binary operation on one or two 
@@ -92,7 +91,8 @@ public class ExpressionTimeSeries implements TimeSeries {
     if (right != null) {
       types.addAll(right.types());
     }
-    id = node.joiner().joinIds(left, right, node.id());
+    id = node.joiner().joinIds(left, right, 
+        ((ExpressionConfig) node.config()).getAs());
   }
   
   @Override

--- a/core/src/test/java/net/opentsdb/query/joins/TestJoiner.java
+++ b/core/src/test/java/net/opentsdb/query/joins/TestJoiner.java
@@ -1304,7 +1304,7 @@ public class TestJoiner extends BaseJoinTest {
     id = (TimeSeriesStringId) joiner.joinIds(L_1, null, ALIAS2);
     assertEquals(ALIAS2, id.alias());
     assertEquals(NAMESPACE, id.namespace());
-    assertEquals(METRIC_L, id.metric());
+    assertEquals(ALIAS2, id.metric());
     assertEquals(1, id.tags().size());
     assertEquals("web01", id.tags().get("host"));
     assertTrue(id.aggregatedTags().isEmpty());
@@ -1314,7 +1314,7 @@ public class TestJoiner extends BaseJoinTest {
     id = (TimeSeriesStringId) joiner.joinIds(null, R_1, ALIAS2);
     assertEquals(ALIAS2, id.alias());
     assertEquals(NAMESPACE, id.namespace());
-    assertEquals(METRIC_R, id.metric());
+    assertEquals(ALIAS2, id.metric());
     assertEquals(1, id.tags().size());
     assertEquals("web01", id.tags().get("host"));
     assertTrue(id.aggregatedTags().isEmpty());
@@ -1348,7 +1348,7 @@ public class TestJoiner extends BaseJoinTest {
     id = (TimeSeriesStringId) joiner.joinIds(L_1, ts, ALIAS2);
     assertEquals(ALIAS2, id.alias());
     assertEquals(NAMESPACE, id.namespace());
-    assertEquals(METRIC_L, id.metric());
+    assertEquals(ALIAS2, id.metric());
     assertEquals(0, id.tags().size());
     assertEquals(1, id.aggregatedTags().size());
     assertTrue(id.aggregatedTags().contains("host"));
@@ -1397,7 +1397,7 @@ public class TestJoiner extends BaseJoinTest {
     id = (TimeSeriesStringId) joiner.joinIds(L_1, R_1, ALIAS2);
     assertEquals(ALIAS2, id.alias());
     assertEquals(NAMESPACE, id.namespace());
-    assertEquals(METRIC_L, id.metric());
+    assertEquals(ALIAS2, id.metric());
     assertEquals(1, id.tags().size());
     assertEquals("web01", id.tags().get("host"));
     assertTrue(id.aggregatedTags().isEmpty());
@@ -1414,7 +1414,7 @@ public class TestJoiner extends BaseJoinTest {
     id = (TimeSeriesStringId) joiner.joinIds(L_1, R_1, ALIAS2);
     assertEquals(ALIAS2, id.alias());
     assertEquals(NAMESPACE, id.namespace());
-    assertEquals(METRIC_R, id.metric());
+    assertEquals(ALIAS2, id.metric());
     assertEquals(1, id.tags().size());
     assertEquals("web01", id.tags().get("host"));
     assertTrue(id.aggregatedTags().isEmpty());
@@ -1446,7 +1446,7 @@ public class TestJoiner extends BaseJoinTest {
     id = (TimeSeriesByteId) joiner.joinIds(L_1, null, ALIAS2);
     assertArrayEquals(ALIAS2_BYTES, id.alias());
     assertArrayEquals(NAMESPACE_BYTES, id.namespace());
-    assertArrayEquals(METRIC_L_BYTES, id.metric());
+    assertArrayEquals(ALIAS2_BYTES, id.metric());
     assertEquals(1, id.tags().size());
     assertArrayEquals(WEB01, id.tags().get(HOST));
     assertTrue(id.aggregatedTags().isEmpty());
@@ -1456,7 +1456,7 @@ public class TestJoiner extends BaseJoinTest {
     id = (TimeSeriesByteId) joiner.joinIds(null, R_1, ALIAS2);
     assertArrayEquals(ALIAS2_BYTES, id.alias());
     assertArrayEquals(NAMESPACE_BYTES, id.namespace());
-    assertArrayEquals(METRIC_R_BYTES, id.metric());
+    assertArrayEquals(ALIAS2_BYTES, id.metric());
     assertEquals(1, id.tags().size());
     assertArrayEquals(WEB01, id.tags().get(HOST));
     assertTrue(id.aggregatedTags().isEmpty());
@@ -1490,7 +1490,7 @@ public class TestJoiner extends BaseJoinTest {
     id = (TimeSeriesByteId) joiner.joinIds(L_1, ts, ALIAS2);
     assertArrayEquals(ALIAS2_BYTES, id.alias());
     assertArrayEquals(NAMESPACE_BYTES, id.namespace());
-    assertArrayEquals(METRIC_L_BYTES, id.metric());
+    assertArrayEquals(ALIAS2_BYTES, id.metric());
     assertEquals(0, id.tags().size());
     assertEquals(1, id.aggregatedTags().size());
     assertTrue(id.aggregatedTags().contains(HOST));
@@ -1539,7 +1539,7 @@ public class TestJoiner extends BaseJoinTest {
     id = (TimeSeriesByteId) joiner.joinIds(L_1, R_1, ALIAS2);
     assertArrayEquals(ALIAS2_BYTES, id.alias());
     assertArrayEquals(NAMESPACE_BYTES, id.namespace());
-    assertArrayEquals(METRIC_L_BYTES, id.metric());
+    assertArrayEquals(ALIAS2_BYTES, id.metric());
     assertEquals(1, id.tags().size());
     assertArrayEquals(WEB01, id.tags().get(HOST));
     assertTrue(id.aggregatedTags().isEmpty());
@@ -1556,7 +1556,7 @@ public class TestJoiner extends BaseJoinTest {
     id = (TimeSeriesByteId) joiner.joinIds(L_1, R_1, ALIAS2);
     assertArrayEquals(ALIAS2_BYTES, id.alias());
     assertArrayEquals(NAMESPACE_BYTES, id.namespace());
-    assertArrayEquals(METRIC_R_BYTES, id.metric());
+    assertArrayEquals(ALIAS2_BYTES, id.metric());
     assertEquals(1, id.tags().size());
     assertArrayEquals(WEB01, id.tags().get(HOST));
     assertTrue(id.aggregatedTags().isEmpty());

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionConfig.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionConfig.java
@@ -50,10 +50,33 @@ public class TestExpressionConfig {
               .setId("jc")
               .build())
           .addVariableInterpolator("a", numeric_config)
+          .setAs("some.metric.name")
           .addInterpolatorConfig(numeric_config)
           .setId("e1")
           .build();
     assertEquals("e1", config.getId());
+    assertEquals("some.metric.name", config.getAs());
+    assertEquals("a + b", config.getExpression());
+    assertEquals(JoinType.INNER, config.getJoinConfig().getType());
+    assertEquals("host", config.getJoinConfig().getJoins().get("host"));
+    assertSame(numeric_config, config.interpolatorConfig(NumericType.TYPE));
+    assertSame(numeric_config, config.getVariableInterpolators().get("a").get(0));
+    
+    config = (ExpressionConfig) 
+        ExpressionConfig.newBuilder()
+          .setExpression("a + b")
+          .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+              .addJoins("host", "host")
+              .setType(JoinType.INNER)
+              .setId("jc")
+              .build())
+          //.setAs("some.metric.name") // defaults
+          .addVariableInterpolator("a", numeric_config)
+          .addInterpolatorConfig(numeric_config)
+          .setId("e1")
+          .build();
+    assertEquals("e1", config.getId());
+    assertEquals("e1", config.getAs());
     assertEquals("a + b", config.getExpression());
     assertEquals(JoinType.INNER, config.getJoinConfig().getType());
     assertEquals("host", config.getJoinConfig().getJoins().get("host"));
@@ -68,6 +91,7 @@ public class TestExpressionConfig {
               .setType(JoinType.INNER)
               .setId("jc")
               .build())
+          .setAs("e1")
           .addInterpolatorConfig(numeric_config)
           .setId("e1")
           .build();
@@ -82,6 +106,7 @@ public class TestExpressionConfig {
               .setType(JoinType.INNER)
               .setId("jc")
               .build())
+          .setAs("e1")
           .addInterpolatorConfig(numeric_config)
           .setId("e1")
           .build();
@@ -96,6 +121,7 @@ public class TestExpressionConfig {
           //    .setType(JoinType.INNER)
           //    .setId("jc")
           //    .build())
+          .setAs("e1")
           .addInterpolatorConfig(numeric_config)
           .setId("e1")
           .build();
@@ -110,6 +136,7 @@ public class TestExpressionConfig {
               .setType(JoinType.INNER)
               .setId("jc")
               .build())
+          .setAs("e1")
           //.addInterpolatorConfig(numeric_config)
           .setId("e1")
           .build();
@@ -142,6 +169,7 @@ public class TestExpressionConfig {
               .setId("jc")
               .build())
           .addVariableInterpolator("a", numeric_config)
+          .setAs("e1")
           .addInterpolatorConfig(numeric_config)
           .setId("e1")
           .build();
@@ -155,6 +183,7 @@ public class TestExpressionConfig {
               .setId("jc")
               .build())
           .addVariableInterpolator("a", numeric_config)
+          .setAs("e1")
           .addInterpolatorConfig(numeric_config)
           .setId("e1")
           .build();
@@ -171,6 +200,7 @@ public class TestExpressionConfig {
               .setId("jc")
               .build())
           .addVariableInterpolator("a", numeric_config)
+          .setAs("e1")
           .addInterpolatorConfig(numeric_config)
           .setId("e1")
           .build();
@@ -187,6 +217,7 @@ public class TestExpressionConfig {
               .setId("jc")
               .build())
           .addVariableInterpolator("a", numeric_config)
+          .setAs("e1")
           .addInterpolatorConfig(numeric_config)
           .setId("e1")
           .build();
@@ -203,6 +234,7 @@ public class TestExpressionConfig {
               .setId("jc")
               .build())
           .addVariableInterpolator("a", numeric_config2) // <-- DIFF
+          .setAs("e1")
           .addInterpolatorConfig(numeric_config)
           .setId("e1")
           .build();
@@ -219,6 +251,7 @@ public class TestExpressionConfig {
               .setId("jc")
               .build())
           //.addVariableInterpolator("a", numeric_config)
+          .setAs("e1")
           .addInterpolatorConfig(numeric_config)
           .setId("e1")
           .build();
@@ -235,6 +268,24 @@ public class TestExpressionConfig {
               .setId("jc")
               .build())
           .addVariableInterpolator("a", numeric_config)
+          .setAs("e2") // <-- DIFF
+          .addInterpolatorConfig(numeric_config)
+          .setId("e1")
+          .build();
+    assertNotEquals(c1.hashCode(), c2.hashCode());
+    assertNotEquals(c1, c2);
+    assertEquals(-1, c1.compareTo(c2));
+    
+    c2 = (ExpressionConfig) 
+        ExpressionConfig.newBuilder()
+          .setExpression("a + b")
+          .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+              .addJoins("host", "host")
+              .setType(JoinType.INNER)
+              .setId("jc")
+              .build())
+          .addVariableInterpolator("a", numeric_config)
+          .setAs("e1")
           .addInterpolatorConfig(numeric_config2) // <-- DIFF
           .setId("e1")
           .build();
@@ -251,6 +302,7 @@ public class TestExpressionConfig {
               .setId("jc")
               .build())
           .addVariableInterpolator("a", numeric_config)
+          .setAs("e1")
           .addInterpolatorConfig(numeric_config)
           .setId("e2") // <-- DIFF
           .build();
@@ -267,6 +319,7 @@ public class TestExpressionConfig {
               .setId("jc")
               .build())
           .addVariableInterpolator("a", numeric_config)
+          .setAs("e1")
           .setInfectiousNan(true) // <-- DIFF
           .addInterpolatorConfig(numeric_config)
           .setId("e1")
@@ -301,6 +354,7 @@ public class TestExpressionConfig {
               .setId("jc")
               .build())
           .addVariableInterpolator("a", numeric_config2)
+          .setAs("e1")
           .addInterpolatorConfig(numeric_config)
           .setId("e1")
           .build();

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionFactory.java
@@ -32,30 +32,39 @@ import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.QuerySourceConfig;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.execution.graph.ExecutionGraphNode;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.joins.JoinConfig;
 import net.opentsdb.query.joins.JoinConfig.JoinType;
 import net.opentsdb.query.pojo.FillPolicy;
+import net.opentsdb.query.processor.downsample.DownsampleConfig;
 import net.opentsdb.query.processor.expressions.ExpressionParseNode.ExpressionOp;
 import net.opentsdb.query.processor.expressions.ExpressionParseNode.OperandType;
 import net.opentsdb.query.processor.expressions.ExpressionParser.NumericLiteral;
+import net.opentsdb.query.processor.groupby.GroupByConfig;
 
 public class TestExpressionFactory {
 
   private static QueryPipelineContext CONTEXT;
   protected static NumericInterpolatorConfig NUMERIC_CONFIG;
+  protected static JoinConfig JOIN_CONFIG;
   
   @BeforeClass
   public static void beforeClass() throws Exception {
     CONTEXT =  mock(QueryPipelineContext.class);
+    
     NUMERIC_CONFIG = 
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.NONE)
       .setType(NumericType.TYPE.toString())
       .build();
+    
+    JOIN_CONFIG = (JoinConfig) JoinConfig.newBuilder()
+        .setType(JoinType.NATURAL)
+        .build();
   }
   
   @Test
@@ -73,19 +82,33 @@ public class TestExpressionFactory {
     ExpressionConfig config = 
         (ExpressionConfig) ExpressionConfig.newBuilder()
         .setExpression("a + b")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setType(JoinType.NATURAL)
-            .build())
+        .setJoinConfig(JOIN_CONFIG)
         .addInterpolatorConfig(NUMERIC_CONFIG)
         .setId("e1")
         .build();
     
     List<ExecutionGraphNode> nodes = Lists.newArrayList();
     nodes.add(ExecutionGraphNode.newBuilder()
-        .setId("a")
+        .setId("e1")
+        .setType("expression")
+        .setConfig(config)
+        .setSources(Lists.newArrayList("a", "b"))
         .build());
     nodes.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
+        .setId("a")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.a")
+            .build())
+        .build());
+    nodes.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
         .setId("b")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.b")
+            .build())
         .build());
     
     Collection<QueryNode> new_nodes = factory.newNodes(
@@ -97,24 +120,21 @@ public class TestExpressionFactory {
     assertEquals("e1", exp_node.id());
     assertSame(config, exp_node.config());
     
-    assertEquals(3, nodes.size());
-    assertTrue(nodes.get(2).getSources().contains("a"));
-    assertTrue(nodes.get(2).getSources().contains("b"));
-    ExpressionParseNode parse_node = (ExpressionParseNode) nodes.get(2).getConfig();
-    assertEquals("a", parse_node.left());
+    assertEquals(4, nodes.size());
+    assertTrue(nodes.get(3).getSources().contains("a"));
+    assertTrue(nodes.get(3).getSources().contains("b"));
+    ExpressionParseNode parse_node = (ExpressionParseNode) nodes.get(3).getConfig();
+    assertEquals("metric.a", parse_node.left());
     assertEquals(OperandType.VARIABLE, parse_node.leftType());
-    assertEquals("b", parse_node.right());
+    assertEquals("metric.b", parse_node.right());
     assertEquals(OperandType.VARIABLE, parse_node.rightType());
     assertEquals(ExpressionOp.ADD, parse_node.operator());
     
     // literal
-    nodes.remove(2);
-    config = 
-        (ExpressionConfig) ExpressionConfig.newBuilder()
+    nodes.remove(3);
+    config = (ExpressionConfig) ExpressionConfig.newBuilder()
         .setExpression("a + 42")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setType(JoinType.NATURAL)
-            .build())
+        .setJoinConfig(JOIN_CONFIG)
         .addInterpolatorConfig(NUMERIC_CONFIG)
         .setId("e1")
         .build();
@@ -128,10 +148,10 @@ public class TestExpressionFactory {
     assertEquals("e1", exp_node.id());
     assertSame(config, exp_node.config());
     
-    assertEquals(3, nodes.size());
-    assertTrue(nodes.get(2).getSources().contains("a"));
-    parse_node = (ExpressionParseNode) nodes.get(2).getConfig();
-    assertEquals("a", parse_node.left());
+    assertEquals(4, nodes.size());
+    assertTrue(nodes.get(3).getSources().contains("a"));
+    parse_node = (ExpressionParseNode) nodes.get(3).getConfig();
+    assertEquals("metric.a", parse_node.left());
     assertEquals(OperandType.VARIABLE, parse_node.leftType());
     assertTrue(parse_node.right() instanceof NumericLiteral);
     assertEquals(OperandType.LITERAL_NUMERIC, parse_node.rightType());
@@ -145,22 +165,43 @@ public class TestExpressionFactory {
     ExpressionConfig config = 
         (ExpressionConfig) ExpressionConfig.newBuilder()
         .setExpression("a + b + c")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setType(JoinType.NATURAL)
-            .build())
+        .setJoinConfig(JOIN_CONFIG)
         .addInterpolatorConfig(NUMERIC_CONFIG)
         .setId("e1")
         .build();
     
     List<ExecutionGraphNode> nodes = Lists.newArrayList();
     nodes.add(ExecutionGraphNode.newBuilder()
+        .setId("e1")
+        .setType("expression")
+        .setConfig(config)
+        .setSources(Lists.newArrayList("a", "b", "c"))
+        .build());
+    nodes.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
         .setId("a")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.a")
+            .build())
         .build());
     nodes.add(ExecutionGraphNode.newBuilder()
         .setId("b")
+        .setType("DataSource")
+        .setId("b")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.b")
+            .build())
         .build());
     nodes.add(ExecutionGraphNode.newBuilder()
         .setId("c")
+        .setType("DataSource")
+        .setId("c")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.c")
+            .build())
         .build());
     
     Collection<QueryNode> new_nodes = factory.newNodes(
@@ -176,26 +217,388 @@ public class TestExpressionFactory {
     assertEquals("e1", exp_node.id());
     assertSame(config, exp_node.config());
     
-    assertEquals(5, nodes.size());
-    assertEquals(2, nodes.get(3).getSources().size());
-    assertTrue(nodes.get(3).getSources().contains("a"));
-    assertTrue(nodes.get(3).getSources().contains("b"));
+    assertEquals(6, nodes.size());
+    assertEquals(2, nodes.get(4).getSources().size());
+    assertTrue(nodes.get(4).getSources().contains("a"));
+    assertTrue(nodes.get(4).getSources().contains("b"));
     
-    ExpressionParseNode parse_node = (ExpressionParseNode) nodes.get(3).getConfig();
-    assertEquals("a", parse_node.left());
+    ExpressionParseNode parse_node = (ExpressionParseNode) nodes.get(4).getConfig();
+    assertEquals("metric.a", parse_node.left());
     assertEquals(OperandType.VARIABLE, parse_node.leftType());
-    assertEquals("b", parse_node.right());
+    assertEquals("metric.b", parse_node.right());
     assertEquals(OperandType.VARIABLE, parse_node.rightType());
     assertEquals(ExpressionOp.ADD, parse_node.operator());
     
-    assertEquals(2, nodes.get(4).getSources().size());
-    assertTrue(nodes.get(4).getSources().contains("e1_SubExp#0"));
-    assertTrue(nodes.get(4).getSources().contains("c"));
-    parse_node = (ExpressionParseNode) nodes.get(4).getConfig();
+    assertEquals(2, nodes.get(5).getSources().size());
+    assertTrue(nodes.get(5).getSources().contains("e1_SubExp#0"));
+    assertTrue(nodes.get(5).getSources().contains("c"));
+    parse_node = (ExpressionParseNode) nodes.get(5).getConfig();
     assertEquals("e1_SubExp#0", parse_node.left());
     assertEquals(OperandType.SUB_EXP, parse_node.leftType());
-    assertEquals("c", parse_node.right());
+    assertEquals("metric.c", parse_node.right());
     assertEquals(OperandType.VARIABLE, parse_node.rightType());
     assertEquals(ExpressionOp.ADD, parse_node.operator());
+  }
+
+  @Test
+  public void validateLiteralMetrics() throws Exception {
+    ExpressionConfig c = (ExpressionConfig) ExpressionConfig.newBuilder()
+        .setExpression("metric.a + metric.b")
+        .setJoinConfig(JOIN_CONFIG)
+        .setAs("e1")
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setId("e1")
+        .build();
+    
+    List<ExecutionGraphNode> graph = Lists.newArrayList();
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("Expression")
+        .setId("e1")
+        .setConfig(c)
+        .addSource("a")
+        .addSource("b")
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
+        .setId("a")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.a")
+            .build())
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
+        .setId("b")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.b")
+            .build())
+        .build());
+    
+    ExpressionFactory factory = new ExpressionFactory();
+    Collection<QueryNode> new_nodes = factory.newNodes(
+        CONTEXT, "e1", c, graph);
+    assertEquals(1, new_nodes.size());
+    
+    BinaryExpressionNode node = (BinaryExpressionNode) new_nodes.iterator().next();
+    assertEquals("metric.a", node.expressionConfig().left());
+    assertEquals("metric.b", node.expressionConfig().right());
+  }
+  
+  @Test
+  public void validateLiteralMetricThroughNodes() throws Exception {
+    ExpressionConfig c = (ExpressionConfig) ExpressionConfig.newBuilder()
+        .setExpression("metric.a + metric.b")
+        .setJoinConfig(JOIN_CONFIG)
+        .setAs("e1")
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setId("e1")
+        .build();
+    
+    List<ExecutionGraphNode> graph = Lists.newArrayList();
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("Expression")
+        .setId("e1")
+        .setConfig(c)
+        .addSource("gb")
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("GroupBy")
+        .setId("gb")
+        .setConfig(GroupByConfig.newBuilder()
+            .setAggregator("sum")
+            .addTagKey("host")
+            .addInterpolatorConfig(NUMERIC_CONFIG)
+            .build())
+        .addSource("a")
+        .addSource("b")
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
+        .setId("a")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.a")
+            .build())
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
+        .setId("b")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.b")
+            .build())
+        .build());
+    
+    ExpressionFactory factory = new ExpressionFactory();
+    Collection<QueryNode> new_nodes = factory.newNodes(
+        CONTEXT, "e1", c, graph);
+    assertEquals(1, new_nodes.size());
+    
+    BinaryExpressionNode node = (BinaryExpressionNode) new_nodes.iterator().next();
+    assertEquals("metric.a", node.expressionConfig().left());
+    assertEquals("metric.b", node.expressionConfig().right());
+  }
+  
+  @Test
+  public void validateIdThroughNodes() throws Exception {
+    ExpressionConfig c = (ExpressionConfig) ExpressionConfig.newBuilder()
+        .setExpression("a + b")
+        .setJoinConfig(JOIN_CONFIG)
+        .setAs("e1")
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setId("e1")
+        .build();
+    
+    List<ExecutionGraphNode> graph = Lists.newArrayList();
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("Expression")
+        .setId("e1")
+        .setConfig(c)
+        .addSource("gb")
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("GroupBy")
+        .setId("gb")
+        .setConfig(GroupByConfig.newBuilder()
+            .setAggregator("sum")
+            .addTagKey("host")
+            .addInterpolatorConfig(NUMERIC_CONFIG)
+            .build())
+        .addSource("ds")
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("Downsample")
+        .setId("ds")
+        .setConfig(DownsampleConfig.newBuilder()
+            .setAggregator("sum")
+            .setInterval("1m")
+            .addInterpolatorConfig(NUMERIC_CONFIG)
+            .build())
+        .addSource("a")
+        .addSource("b")
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
+        .setId("a")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.a")
+            .build())
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
+        .setId("b")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.b")
+            .build())
+        .build());
+    
+    ExpressionFactory factory = new ExpressionFactory();
+    Collection<QueryNode> new_nodes = factory.newNodes(
+        CONTEXT, "e1", c, graph);
+    assertEquals(1, new_nodes.size());
+    
+    BinaryExpressionNode node = (BinaryExpressionNode) new_nodes.iterator().next();
+    assertEquals("metric.a", node.expressionConfig().left());
+    assertEquals("metric.b", node.expressionConfig().right());
+  }
+
+  @Test
+  public void validateTernaryIdsThroughNodes() throws Exception {
+    ExpressionConfig c = (ExpressionConfig) ExpressionConfig.newBuilder()
+        .setExpression("a + b + c")
+        .setJoinConfig(JOIN_CONFIG)
+        .setAs("e1")
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setId("e1")
+        .build();
+    
+    List<ExecutionGraphNode> graph = Lists.newArrayList();
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("Expression")
+        .setId("e1")
+        .setConfig(c)
+        .addSource("gb")
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("GroupBy")
+        .setId("gb")
+        .setConfig(GroupByConfig.newBuilder()
+            .setAggregator("sum")
+            .addTagKey("host")
+            .addInterpolatorConfig(NUMERIC_CONFIG)
+            .build())
+        .addSource("ds")
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("Downsample")
+        .setId("ds")
+        .setConfig(DownsampleConfig.newBuilder()
+            .setAggregator("sum")
+            .setInterval("1m")
+            .addInterpolatorConfig(NUMERIC_CONFIG)
+            .build())
+        .addSource("a")
+        .addSource("b")
+        .addSource("c")
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
+        .setId("a")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.a")
+            .build())
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
+        .setId("b")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.b")
+            .build())
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
+        .setId("c")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.c")
+            .build())
+        .build());
+    
+    ExpressionFactory factory = new ExpressionFactory();
+    Collection<QueryNode> new_nodes = factory.newNodes(
+        CONTEXT, "e1", c, graph);
+    assertEquals(2, new_nodes.size());
+    
+    Iterator<QueryNode> iterator = new_nodes.iterator();
+    BinaryExpressionNode node = (BinaryExpressionNode) iterator.next();
+    assertEquals("metric.a", node.expressionConfig().left());
+    assertEquals("metric.b", node.expressionConfig().right());
+    
+    node = (BinaryExpressionNode) iterator.next();
+    assertEquals("e1_SubExp#0", node.expressionConfig().left());
+    assertEquals("metric.c", node.expressionConfig().right());
+  }
+  
+  @Test
+  public void validateIdOfExpression() throws Exception {
+    ExpressionConfig c = (ExpressionConfig) ExpressionConfig.newBuilder()
+        .setExpression("a + b")
+        .setJoinConfig(JOIN_CONFIG)
+        .setAs("my.new.metric")
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setId("e1")
+        .build();
+    
+    ExpressionConfig c2 = (ExpressionConfig) ExpressionConfig.newBuilder()
+        .setExpression("e1 * c")
+        .setJoinConfig(JOIN_CONFIG)
+        .setAs("e")
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setId("e2")
+        .build();
+    
+    List<ExecutionGraphNode> graph = Lists.newArrayList();
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("Expression")
+        .setId("e1")
+        .setConfig(c)
+        .addSource("gb")
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("Expression")
+        .setId("e2")
+        .setConfig(c2)
+        .addSource("gb")
+        .addSource("e1")
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("GroupBy")
+        .setId("gb")
+        .setConfig(GroupByConfig.newBuilder()
+            .setAggregator("sum")
+            .addTagKey("host")
+            .addInterpolatorConfig(NUMERIC_CONFIG)
+            .build())
+        .addSource("ds")
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("Downsample")
+        .setId("ds")
+        .setConfig(DownsampleConfig.newBuilder()
+            .setAggregator("sum")
+            .setInterval("1m")
+            .addInterpolatorConfig(NUMERIC_CONFIG)
+            .build())
+        .addSource("a")
+        .addSource("b")
+        .addSource("c")
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
+        .setId("a")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.a")
+            .build())
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
+        .setId("b")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.b")
+            .build())
+        .build());
+    
+    graph.add(ExecutionGraphNode.newBuilder()
+        .setType("DataSource")
+        .setId("c")
+        .setConfig(QuerySourceConfig.newBuilder()
+            .setStart("1h-ago")
+            .setMetric("metric.c")
+            .build())
+        .build());
+    
+    ExpressionFactory factory = new ExpressionFactory();
+    Collection<QueryNode> new_nodes = factory.newNodes(
+        CONTEXT, "e1", c, graph);
+    assertEquals(1, new_nodes.size());
+    
+    BinaryExpressionNode node = (BinaryExpressionNode) new_nodes.iterator().next();
+    assertEquals("metric.a", node.expressionConfig().left());
+    assertEquals("metric.b", node.expressionConfig().right());
+    
+    // simulate removal
+    graph.remove(0);
+    
+    new_nodes = factory.newNodes(CONTEXT, "e2", c2, graph);
+    assertEquals(1, new_nodes.size());
+    node = (BinaryExpressionNode) new_nodes.iterator().next();
+    assertEquals("my.new.metric", node.expressionConfig().left());
+    assertEquals("metric.c", node.expressionConfig().right());
   }
 }

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionParser.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionParser.java
@@ -21,17 +21,43 @@ import static org.junit.Assert.fail;
 import java.util.List;
 
 import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
+import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
+import net.opentsdb.query.joins.JoinConfig;
+import net.opentsdb.query.joins.JoinConfig.JoinType;
+import net.opentsdb.query.pojo.FillPolicy;
 import net.opentsdb.query.processor.expressions.ExpressionParseNode.ExpressionOp;
 import net.opentsdb.query.processor.expressions.ExpressionParseNode.OperandType;
 import net.opentsdb.query.processor.expressions.ExpressionParser.NumericLiteral;
 
 public class TestExpressionParser {
 
+  protected static NumericInterpolatorConfig NUMERIC_CONFIG;
+  protected static JoinConfig JOIN_CONFIG;
+  
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    NUMERIC_CONFIG = 
+        (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
+      .setFillPolicy(FillPolicy.NOT_A_NUMBER)
+      .setRealFillPolicy(FillWithRealPolicy.NONE)
+      .setType(NumericType.TYPE.toString())
+      .build();
+    
+    JOIN_CONFIG = (JoinConfig) JoinConfig.newBuilder()
+        .setType(JoinType.INNER)
+        .addJoins("host", "host")
+        .setId("join")
+        .build();
+  }
+  
   @Test
   public void parseBinaryOperators() throws Exception {
-    ExpressionParser parser = new ExpressionParser("a.metric + b.metric", "e1");
+    ExpressionParser parser = new ExpressionParser(config("a.metric + b.metric"));
     List<ExpressionParseNode> nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals("e1", nodes.get(0).getId());
@@ -41,100 +67,110 @@ public class TestExpressionParser {
     assertEquals("b.metric", nodes.get(0).right());
     assertEquals(ExpressionOp.ADD, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric - b.metric", "e1");
+    parser = new ExpressionParser(config("a.metric - b.metric"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals("e1", nodes.get(0).getId());
+    assertEquals("my.new.metric", nodes.get(0).as());
     assertEquals(OperandType.VARIABLE, nodes.get(0).leftType());
     assertEquals("a.metric", nodes.get(0).left());
     assertEquals(OperandType.VARIABLE, nodes.get(0).rightType());
     assertEquals("b.metric", nodes.get(0).right());
     assertEquals(ExpressionOp.SUBTRACT, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric * b.metric", "e1");
+    parser = new ExpressionParser(config("a.metric * b.metric"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals("e1", nodes.get(0).getId());
+    assertEquals("my.new.metric", nodes.get(0).as());
     assertEquals(OperandType.VARIABLE, nodes.get(0).leftType());
     assertEquals("a.metric", nodes.get(0).left());
     assertEquals(OperandType.VARIABLE, nodes.get(0).rightType());
     assertEquals("b.metric", nodes.get(0).right());
     assertEquals(ExpressionOp.MULTIPLY, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric / b.metric", "e1");
+    parser = new ExpressionParser(config("a.metric / b.metric"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals("e1", nodes.get(0).getId());
+    assertEquals("my.new.metric", nodes.get(0).as());
     assertEquals(OperandType.VARIABLE, nodes.get(0).leftType());
     assertEquals("a.metric", nodes.get(0).left());
     assertEquals(OperandType.VARIABLE, nodes.get(0).rightType());
     assertEquals("b.metric", nodes.get(0).right());
     assertEquals(ExpressionOp.DIVIDE, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric % b.metric", "e1");
+    parser = new ExpressionParser(config("a.metric % b.metric"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals("e1", nodes.get(0).getId());
+    assertEquals("my.new.metric", nodes.get(0).as());
     assertEquals(OperandType.VARIABLE, nodes.get(0).leftType());
     assertEquals("a.metric", nodes.get(0).left());
     assertEquals(OperandType.VARIABLE, nodes.get(0).rightType());
     assertEquals("b.metric", nodes.get(0).right());
     assertEquals(ExpressionOp.MOD, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric == b.metric", "e1");
+    parser = new ExpressionParser(config("a.metric == b.metric"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals("e1", nodes.get(0).getId());
+    assertEquals("my.new.metric", nodes.get(0).as());
     assertEquals(OperandType.VARIABLE, nodes.get(0).leftType());
     assertEquals("a.metric", nodes.get(0).left());
     assertEquals(OperandType.VARIABLE, nodes.get(0).rightType());
     assertEquals("b.metric", nodes.get(0).right());
     assertEquals(ExpressionOp.EQ, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric != b.metric", "e1");
+    parser = new ExpressionParser(config("a.metric != b.metric"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals("e1", nodes.get(0).getId());
+    assertEquals("my.new.metric", nodes.get(0).as());
     assertEquals(OperandType.VARIABLE, nodes.get(0).leftType());
     assertEquals("a.metric", nodes.get(0).left());
     assertEquals(OperandType.VARIABLE, nodes.get(0).rightType());
     assertEquals("b.metric", nodes.get(0).right());
     assertEquals(ExpressionOp.NE, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric > b.metric", "e1");
+    parser = new ExpressionParser(config("a.metric > b.metric"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals("e1", nodes.get(0).getId());
+    assertEquals("my.new.metric", nodes.get(0).as());
     assertEquals(OperandType.VARIABLE, nodes.get(0).leftType());
     assertEquals("a.metric", nodes.get(0).left());
     assertEquals(OperandType.VARIABLE, nodes.get(0).rightType());
     assertEquals("b.metric", nodes.get(0).right());
     assertEquals(ExpressionOp.GT, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric < b.metric", "e1");
+    parser = new ExpressionParser(config("a.metric < b.metric"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals("e1", nodes.get(0).getId());
+    assertEquals("my.new.metric", nodes.get(0).as());
     assertEquals(OperandType.VARIABLE, nodes.get(0).leftType());
     assertEquals("a.metric", nodes.get(0).left());
     assertEquals(OperandType.VARIABLE, nodes.get(0).rightType());
     assertEquals("b.metric", nodes.get(0).right());
     assertEquals(ExpressionOp.LT, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric >= b.metric", "e1");
+    parser = new ExpressionParser(config("a.metric >= b.metric"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals("e1", nodes.get(0).getId());
+    assertEquals("my.new.metric", nodes.get(0).as());
     assertEquals(OperandType.VARIABLE, nodes.get(0).leftType());
     assertEquals("a.metric", nodes.get(0).left());
     assertEquals(OperandType.VARIABLE, nodes.get(0).rightType());
     assertEquals("b.metric", nodes.get(0).right());
     assertEquals(ExpressionOp.GE, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric <= b.metric", "e1");
+    parser = new ExpressionParser(config("a.metric <= b.metric"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals("e1", nodes.get(0).getId());
+    assertEquals("my.new.metric", nodes.get(0).as());
     assertEquals(OperandType.VARIABLE, nodes.get(0).leftType());
     assertEquals("a.metric", nodes.get(0).left());
     assertEquals(OperandType.VARIABLE, nodes.get(0).rightType());
@@ -144,12 +180,13 @@ public class TestExpressionParser {
 
   @Test
   public void parseBinaryTwoBranches() throws Exception {
-    ExpressionParser parser = new ExpressionParser(
-        "a.metric + b.metric + c.metric", "e1");
+    ExpressionParser parser = 
+        new ExpressionParser(config("a.metric + b.metric + c.metric"));
     List<ExpressionParseNode> nodes = parser.parse();
     assertEquals(2, nodes.size());
     
     assertEquals("e1_SubExp#0", nodes.get(0).getId());
+    assertEquals("e1_SubExp#0", nodes.get(0).as());
     assertEquals(OperandType.VARIABLE, nodes.get(0).leftType());
     assertEquals("a.metric", nodes.get(0).left());
     assertEquals(OperandType.VARIABLE, nodes.get(0).rightType());
@@ -157,6 +194,7 @@ public class TestExpressionParser {
     assertEquals(ExpressionOp.ADD, nodes.get(0).operator());
     
     assertEquals("e1", nodes.get(1).getId());
+    assertEquals("my.new.metric", nodes.get(1).as());
     assertEquals(OperandType.SUB_EXP, nodes.get(1).leftType());
     assertEquals("e1_SubExp#0", nodes.get(1).left());
     assertEquals(OperandType.VARIABLE, nodes.get(1).rightType());
@@ -164,11 +202,12 @@ public class TestExpressionParser {
     assertEquals(ExpressionOp.ADD, nodes.get(1).operator());
     
     // change order of precedence
-    parser = new ExpressionParser("a.metric + (b.metric + c.metric)", "e1");
+    parser = new ExpressionParser(config("a.metric + (b.metric + c.metric)"));
     nodes = parser.parse();
     assertEquals(2, nodes.size());
     
     assertEquals("e1_SubExp#0", nodes.get(0).getId());
+    assertEquals("e1_SubExp#0", nodes.get(0).as());
     assertEquals(OperandType.VARIABLE, nodes.get(0).leftType());
     assertEquals("b.metric", nodes.get(0).left());
     assertEquals(OperandType.VARIABLE, nodes.get(0).rightType());
@@ -176,6 +215,7 @@ public class TestExpressionParser {
     assertEquals(ExpressionOp.ADD, nodes.get(0).operator());
     
     assertEquals("e1", nodes.get(1).getId());
+    assertEquals("my.new.metric", nodes.get(1).as());
     assertEquals(OperandType.VARIABLE, nodes.get(1).leftType());
     assertEquals("a.metric", nodes.get(1).left());
     assertEquals(OperandType.SUB_EXP, nodes.get(1).rightType());
@@ -183,59 +223,59 @@ public class TestExpressionParser {
     assertEquals(ExpressionOp.ADD, nodes.get(1).operator());
     
     // numeric squashing, test all operators
-    parser = new ExpressionParser("a.metric + (42 + 2)", "e1");
+    parser = new ExpressionParser(config("a.metric + (42 + 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(44L, ((NumericLiteral) nodes.get(0).right()).longValue());
     
-    parser = new ExpressionParser("a.metric + (42 - 2)", "e1");
+    parser = new ExpressionParser(config("a.metric + (42 - 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(40L, ((NumericLiteral) nodes.get(0).right()).longValue());
     
-    parser = new ExpressionParser("a.metric + (42 * 2)", "e1");
+    parser = new ExpressionParser(config("a.metric + (42 * 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(84, ((NumericLiteral) nodes.get(0).right()).longValue());
     
-    parser = new ExpressionParser("a.metric + (42 / 2)", "e1");
+    parser = new ExpressionParser(config("a.metric + (42 / 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(21, ((NumericLiteral) nodes.get(0).right()).longValue());
     
     // to double
-    parser = new ExpressionParser("a.metric + (42 / 5)", "e1");
+    parser = new ExpressionParser(config("a.metric + (42 / 5)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(8.4, ((NumericLiteral) nodes.get(0).right()).doubleValue(), 0.001);
     
-    parser = new ExpressionParser("a.metric + (42 % 2)", "e1");
+    parser = new ExpressionParser(config("a.metric + (42 % 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(0, ((NumericLiteral) nodes.get(0).right()).longValue());
     
     // doubles
-    parser = new ExpressionParser("a.metric + (42.5 + 2)", "e1");
+    parser = new ExpressionParser(config("a.metric + (42.5 + 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(44.5, ((NumericLiteral) nodes.get(0).right()).doubleValue(), 0.001);
     
-    parser = new ExpressionParser("a.metric + (42.5 - 2)", "e1");
+    parser = new ExpressionParser(config("a.metric + (42.5 - 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(40.5, ((NumericLiteral) nodes.get(0).right()).doubleValue(), 0.001);
     
-    parser = new ExpressionParser("a.metric + (42.5 * 2)", "e1");
+    parser = new ExpressionParser(config("a.metric + (42.5 * 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(85, ((NumericLiteral) nodes.get(0).right()).doubleValue(), 0.001);
     
-    parser = new ExpressionParser("a.metric + (42.5 / 2)", "e1");
+    parser = new ExpressionParser(config("a.metric + (42.5 / 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(21.25, ((NumericLiteral) nodes.get(0).right()).doubleValue(), 0.001);
     
-    parser = new ExpressionParser("a.metric + (42.5 % 2)", "e1");
+    parser = new ExpressionParser(config("a.metric + (42.5 % 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(0.0, ((NumericLiteral) nodes.get(0).right()).doubleValue(), 0.001);
@@ -244,7 +284,7 @@ public class TestExpressionParser {
   @Test
   public void parseBinaryRelational() throws Exception {
     ExpressionParser parser = new ExpressionParser(
-        "a.metric == 42", "e1");
+        config("a.metric == 42"));
     List<ExpressionParseNode> nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals("e1", nodes.get(0).getId());
@@ -254,44 +294,44 @@ public class TestExpressionParser {
     assertEquals(42, ((NumericLiteral) nodes.get(0).right()).longValue());
     assertEquals(ExpressionOp.EQ, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric != 42", "e1");
+    parser = new ExpressionParser(config("a.metric != 42"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(42, ((NumericLiteral) nodes.get(0).right()).longValue());
     assertEquals(ExpressionOp.NE, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric > 42", "e1");
+    parser = new ExpressionParser(config("a.metric > 42"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(42, ((NumericLiteral) nodes.get(0).right()).longValue());
     assertEquals(ExpressionOp.GT, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric < 42", "e1");
+    parser = new ExpressionParser(config("a.metric < 42"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(42, ((NumericLiteral) nodes.get(0).right()).longValue());
     assertEquals(ExpressionOp.LT, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric >= 42", "e1");
+    parser = new ExpressionParser(config("a.metric >= 42"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(42, ((NumericLiteral) nodes.get(0).right()).longValue());
     assertEquals(ExpressionOp.GE, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric <= 42", "e1");
+    parser = new ExpressionParser(config("a.metric <= 42"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(42, ((NumericLiteral) nodes.get(0).right()).longValue());
     assertEquals(ExpressionOp.LE, nodes.get(0).operator());
     
     // check negative numbers
-    parser = new ExpressionParser("a.metric <= -42", "e1");
+    parser = new ExpressionParser(config("a.metric <= -42"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(-42, ((NumericLiteral) nodes.get(0).right()).longValue());
     assertEquals(ExpressionOp.LE, nodes.get(0).operator());
     
-    parser = new ExpressionParser("a.metric <= -42.75", "e1");
+    parser = new ExpressionParser(config("a.metric <= -42.75"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(-42.75, ((NumericLiteral) nodes.get(0).right()).doubleValue(), 0.001);
@@ -301,7 +341,7 @@ public class TestExpressionParser {
   @Test
   public void parseLogicalRelational() throws Exception {
     ExpressionParser parser = new ExpressionParser(
-        "a.metric > 0 && b.metric > 0", "e1");
+        config("a.metric > 0 && b.metric > 0"));
     List<ExpressionParseNode> nodes = parser.parse();
     assertEquals(3, nodes.size());
     assertEquals("e1_SubExp#0", nodes.get(0).getId());
@@ -336,7 +376,7 @@ public class TestExpressionParser {
 //    assertEquals("e1_SubExp#1", nodes.get(2).right());
 //    assertEquals(ExpressionOp.OR, nodes.get(2).operator());
     
-    parser = new ExpressionParser("a.metric > 0 || b.metric > 0", "e1");
+    parser = new ExpressionParser(config("a.metric > 0 || b.metric > 0"));
     nodes = parser.parse();
     assertEquals(3, nodes.size());
     assertEquals("e1_SubExp#0", nodes.get(0).getId());
@@ -376,7 +416,7 @@ public class TestExpressionParser {
   public void parseNot() throws Exception {
     // explicit
     ExpressionParser parser = new ExpressionParser(
-        "a.metric > 0 && !(b.metric > 0)", "e1");
+        config("a.metric > 0 && !(b.metric > 0)"));
     List<ExpressionParseNode> nodes = parser.parse();
     assertEquals(3, nodes.size());
     assertEquals("e1_SubExp#0", nodes.get(0).getId());
@@ -402,8 +442,7 @@ public class TestExpressionParser {
     assertEquals(ExpressionOp.AND, nodes.get(2).operator());
     
     // implicit
-    parser = new ExpressionParser(
-        "a.metric > 0 && !b.metric > 0", "e1");
+    parser = new ExpressionParser(config("a.metric > 0 && !b.metric > 0"));
     nodes = parser.parse();
     assertEquals(3, nodes.size());
     assertEquals("e1_SubExp#0", nodes.get(0).getId());
@@ -433,31 +472,41 @@ public class TestExpressionParser {
   public void parseFailures() throws Exception {
     // numeric OP numeric not allowed
     try {
-      new ExpressionParser("42 * 1", "e1").parse();
+      new ExpressionParser(config("42 * 1")).parse();
       fail("Expected ParseCancellationException");
     } catch (ParseCancellationException e) { }
     
     // nor single variables
     try {
-      new ExpressionParser("a", "e1").parse();
+      new ExpressionParser(config("a")).parse();
       fail("Expected ParseCancellationException");
     } catch (ParseCancellationException e) { }
     
     // logical on raw metrics, nope.
     try {
-      new ExpressionParser("a && b", "e1").parse();
+      new ExpressionParser(config("a && b")).parse();
       fail("Expected ParseCancellationException");
     } catch (ParseCancellationException e) { }
     
     // reltional on two numerics?
     try {
-      new ExpressionParser("a.metric + (42 > 2)", "e1").parse();
+      new ExpressionParser(config("a.metric + (42 > 2)")).parse();
       fail("Expected ParseCancellationException");
     } catch (ParseCancellationException e) { }
     
     try {
-      new ExpressionParser("-a.metric * 1", "e1").parse();
+      new ExpressionParser(config("-a.metric * 1")).parse();
       fail("Expected ParseCancellationException");
     } catch (ParseCancellationException e) { }
+  }
+
+  ExpressionConfig config(final String exp) {
+    return (ExpressionConfig) ExpressionConfig.newBuilder()
+      .setExpression(exp)
+      .setJoinConfig(JOIN_CONFIG)
+      .setAs("my.new.metric")
+      .addInterpolatorConfig(NUMERIC_CONFIG)
+      .setId("e1")
+      .build();
   }
 }

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionTimeSeries.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionTimeSeries.java
@@ -42,11 +42,17 @@ import net.opentsdb.data.types.annotation.AnnotationType;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
+import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
+import net.opentsdb.query.joins.JoinConfig;
 import net.opentsdb.query.joins.Joiner;
+import net.opentsdb.query.joins.JoinConfig.JoinType;
+import net.opentsdb.query.pojo.FillPolicy;
 
 public class TestExpressionTimeSeries {
 
   private BinaryExpressionNode node;
+  private ExpressionConfig config;
   private QueryResult result;
   private Joiner joiner;
   private TimeSeries left;
@@ -97,6 +103,28 @@ public class TestExpressionTimeSeries {
           return mock(Iterator.class);
         }
       });
+    
+    JoinConfig jc = (JoinConfig) JoinConfig.newBuilder()
+        .setType(JoinType.INNER)
+        .addJoins("host", "host")
+        .setId("join")
+        .build();
+    
+    NumericInterpolatorConfig numeric_config = 
+        (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
+      .setFillPolicy(FillPolicy.NOT_A_NUMBER)
+      .setRealFillPolicy(FillWithRealPolicy.NONE)
+      .setType(NumericType.TYPE.toString())
+      .build();
+    
+    config = (ExpressionConfig) ExpressionConfig.newBuilder()
+        .setExpression("metric.a + metric.b")
+        .setJoinConfig(jc)
+        .setAs("e1")
+        .addInterpolatorConfig(numeric_config)
+        .setId("e1")
+        .build();
+    when(node.config()).thenReturn(config);
   }
   
   @Test


### PR DESCRIPTION
- Add bracket in the ExecutionGraphNode toString()

CORE:
- Tweak the Join code to use the "as" name for the metrics regardless of
  join type. Much cleaner for matching on metrics in expressions.
- Add "as" as the new name for a metric in the ExpressionConfig. Defaults to
  the expression ID.
- Fix the ExpressionFactory to walk the node graph and find and validate the
  expression variable names. It will replace the names when appropriate to
  make sure we match the proper metrics.