### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/core/Registry.java
+++ b/common/src/main/java/net/opentsdb/core/Registry.java
@@ -21,7 +21,7 @@ import com.stumbleupon.async.Deferred;
 import net.opentsdb.query.QueryIteratorFactory;
 import net.opentsdb.query.interpolation.QueryInterpolatorFactory;
 import net.opentsdb.query.QueryNodeFactory;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 
 /**
  * A shared location for registering context, mergers, plugins, etc.
@@ -121,9 +121,9 @@ public interface Registry {
    */
   public QueryIteratorFactory getQueryIteratorFactory(final String id);
   
-  public TimeSeriesDataStore getDefaultStore();
+  public ReadableTimeSeriesDataStore getDefaultStore();
   
-  public TimeSeriesDataStore getStore(final String id);
+  public ReadableTimeSeriesDataStore getStore(final String id);
   
   /** @return Package private shutdown returning the deferred to wait on. */
   public Deferred<Object> shutdown();

--- a/common/src/main/java/net/opentsdb/data/TimeSeriesByteId.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesByteId.java
@@ -17,7 +17,7 @@ import java.util.List;
 import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.stats.Span;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.utils.ByteSet;
 import net.opentsdb.utils.Bytes.ByteMap;
 
@@ -37,7 +37,7 @@ public interface TimeSeriesByteId extends TimeSeriesId,
    * 
    * @return A non-null data store.
    */
-  public TimeSeriesDataStore dataStore();
+  public ReadableTimeSeriesDataStore dataStore();
   
   /**
    * A simple id for identifying the time series. The alias may be null or

--- a/common/src/main/java/net/opentsdb/data/TimeSeriesDatum.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesDatum.java
@@ -1,0 +1,38 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data;
+
+/**
+ * A single value consisting of an ID and a typed value.
+ * 
+ * @since 3.0
+ */
+public interface TimeSeriesDatum {
+
+  /**
+   * The non-null ID for the value.
+   * @return A non-null ID.
+   */
+  public TimeSeriesDatumId id();
+  
+  /**
+   * A non-null value incorporating the timestamp and a value. Note that
+   * the value of this value may be null and a store has to decide how
+   * to handle that.
+   * @return The non-null value.
+   */
+  public TimeSeriesValue<? extends TimeSeriesDataType> value();
+  
+}

--- a/common/src/main/java/net/opentsdb/data/TimeSeriesDatumByteId.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesDatumByteId.java
@@ -1,0 +1,58 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data;
+
+import net.opentsdb.utils.Bytes.ByteMap;
+
+/**
+ * An ID representing a single dataum or value. This is opposed to the
+ * {@link TimeSeriesId} which is used at query time and may include 
+ * multiple time series wrapped up into a new ID. Hence this ID does not
+ * have any aggregated or disjoint tag keys.
+ * 
+ * @since 3.0
+ */
+public interface TimeSeriesDatumByteId extends TimeSeriesDatumId {
+
+  /**
+   * An optional tenant or group name for the time series.
+   * May be null or empty if namespaces are not in use for the platform.
+   *  
+   * @return A non-empty byte array if set, null if not used.
+   */
+  public byte[] namespace();
+  
+  /**
+   * The metric component of the time series ID. This is a required value and
+   * may not be null or empty.
+   *  
+   * @return A non-null and non-empty byte array.
+   */
+  public byte[] metric();
+  
+  /**
+   * A map of tag name and value pairs included in the sources for this time 
+   * series. If the underlying storage system does not support tags or none of
+   * the source time series had tags pairs in common, this list may be empty.
+   * The map key represents a tag name (tagk) and the map value represents a 
+   * tag value (tagv).
+   * <p>
+   * Invariant: Each tag pair must appear in every source time series.
+   * 
+   * @return A non-null map of zero or more tag pairs.
+   */
+  public ByteMap<byte[]> tags();
+  
+}

--- a/common/src/main/java/net/opentsdb/data/TimeSeriesDatumId.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesDatumId.java
@@ -1,0 +1,48 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data;
+
+import com.google.common.reflect.TypeToken;
+
+/**
+ * An ID representing a single dataum or value. This is opposed to the
+ * {@link TimeSeriesId} which is used at query time and may include 
+ * multiple time series wrapped up into a new ID. Hence this ID does not
+ * have any aggregated or disjoint tag keys.
+ * 
+ * @since 3.0
+ */
+public interface TimeSeriesDatumId extends Comparable<TimeSeriesDatumId> {
+
+  /**
+   * The type of series dealt with. Either a {@link TimeSeriesByteId} or
+   * {@link TimeSeriesStringId}
+   * @return A non-null type token.
+   */
+  public TypeToken<? extends TimeSeriesId> type();
+  
+  @Override
+  public boolean equals(final Object other);
+  
+  @Override
+  public int hashCode();
+  
+  /**
+   * The hash code as a Long value for reducing hash collisions.
+   * @return A hash code as a 64 bit signed integer.
+   */
+  public long buildHashCode();
+
+}

--- a/common/src/main/java/net/opentsdb/data/TimeSeriesDatumIterable.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesDatumIterable.java
@@ -1,0 +1,25 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data;
+
+/**
+ * An interface used when writing values that wraps multiple data in a
+ * single batch. 
+ * 
+ * @since 3.0
+ */
+public interface TimeSeriesDatumIterable extends Iterable<TimeSeriesDatum> {
+
+}

--- a/common/src/main/java/net/opentsdb/data/TimeSeriesDatumStringId.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesDatumStringId.java
@@ -1,0 +1,58 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data;
+
+import java.util.Map;
+
+/**
+ * An ID representing a single dataum or value. This is opposed to the
+ * {@link TimeSeriesId} which is used at query time and may include 
+ * multiple time series wrapped up into a new ID. Hence this ID does not
+ * have any aggregated or disjoint tag keys.
+ * 
+ * @since 3.0
+ */
+public interface TimeSeriesDatumStringId extends TimeSeriesDatumId {
+
+  /**
+   * An optional tenant or group name for the time series.
+   * May be null or empty if namespaces are not in use for the platform.
+   *  
+   * @return A string if set, null if not used.
+   */
+  public String namespace();
+  
+  /**
+   * The metric component of the time series ID. This is a required value and
+   * may not be null or empty.
+   *  
+   * @return A non-null and non-empty string.
+   */
+  public String metric();
+  
+  /**
+   * A map of tag name and value pairs included in the sources for this time 
+   * series. If the underlying storage system does not support tags or none of
+   * the source time series had tags pairs in common, this list may be empty.
+   * The map key represents a tag name (tagk) and the map value represents a 
+   * tag value (tagv).
+   * <p>
+   * Invariant: Each tag pair must appear in every source time series.
+   * 
+   * @return A non-null map of zero or more tag pairs.
+   */
+  public Map<String, String> tags();
+  
+}

--- a/common/src/main/java/net/opentsdb/data/TimeSeriesDatumStringWrapperId.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesDatumStringWrapperId.java
@@ -1,0 +1,148 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Strings;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.common.Const;
+import net.opentsdb.utils.Comparators.MapComparator;
+
+/**
+ * A wrapper to convert a {@link TimeSeriesDatumStringId} to a 
+ * {@link TimeSeriesStringId}.
+ * 
+ * @since 3.0
+ */
+public class TimeSeriesDatumStringWrapperId implements TimeSeriesStringId {
+
+  /** A static comparator instantiation. */
+  public static final MapComparator<String, String> STR_MAP_CMP = 
+      new MapComparator<String, String>();
+
+  /** The ID. */
+  protected final TimeSeriesDatumStringId id;
+ 
+  /**
+   * Protected ctor. Call {@link #wrap(TimeSeriesDatumStringId)}.
+   * @param id The non-null ID.
+   */
+  protected TimeSeriesDatumStringWrapperId(final TimeSeriesDatumStringId id) {
+    this.id = id;
+  }
+  
+  /**
+   * Wraps the given ID.
+   * @param id The non-null ID to wrap.
+   * @return The wrapped ID.
+   * @throws IllegalArgumentException if the ID was null.
+   */
+  public static TimeSeriesDatumStringWrapperId wrap(
+      final TimeSeriesDatumStringId id) {
+    if (id == null) {
+      throw new IllegalArgumentException("The ID to wrap cannot be null.");
+    }
+    return new TimeSeriesDatumStringWrapperId(id);
+  }
+
+  @Override
+  public boolean encoded() {
+    return false;
+  }
+
+  @Override
+  public TypeToken<? extends TimeSeriesId> type() {
+    return Const.TS_STRING_ID;
+  }
+
+  @Override
+  public int compareTo(final TimeSeriesStringId o) {
+    return ComparisonChain.start()
+        .compare(Strings.nullToEmpty(id.namespace()), 
+            Strings.nullToEmpty(o.namespace()))
+        .compare(id.metric(), o.metric())
+        .compare(id.tags(), o.tags(), STR_MAP_CMP)
+        .result();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || !(o instanceof TimeSeriesStringId)) {
+      return false;
+    }
+    
+    final TimeSeriesStringId id = (TimeSeriesStringId) o;
+    return Objects.equal(namespace(), id.namespace()) &&
+           Objects.equal(metric(), id.metric()) &&
+           Objects.equal(tags(), id.tags());
+  }
+  
+  @Override
+  public int hashCode() {
+    return id.hashCode();
+  }
+  
+  /** @return A HashCode object for deterministic, non-secure hashing */
+  public long buildHashCode() {
+    return id.buildHashCode();
+  }
+  
+  @Override
+  public String alias() {
+    return null;
+  }
+
+  @Override
+  public String namespace() {
+    return id.namespace();
+  }
+
+  @Override
+  public String metric() {
+    return id.metric();
+  }
+
+  @Override
+  public Map<String, String> tags() {
+    return id.tags();
+  }
+
+  @Override
+  public List<String> aggregatedTags() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<String> disjointTags() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Set<String> uniqueIds() {
+    // TODO Auto-generated method stub
+    return Collections.emptySet();
+  }
+  
+}

--- a/common/src/main/java/net/opentsdb/data/TimeSeriesId.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesId.java
@@ -36,4 +36,5 @@ public interface TimeSeriesId {
    * @return A non-null type token.
    */
   public TypeToken<? extends TimeSeriesId> type();
+
 }

--- a/common/src/main/java/net/opentsdb/storage/ReadableTimeSeriesDataStore.java
+++ b/common/src/main/java/net/opentsdb/storage/ReadableTimeSeriesDataStore.java
@@ -20,10 +20,8 @@ import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.data.TimeSeriesByteId;
 import net.opentsdb.data.TimeSeriesStringId;
-import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeConfig;
-import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.stats.Span;
 
@@ -42,9 +40,8 @@ import net.opentsdb.stats.Span;
  * 
  * @since 3.0
  */
-public interface TimeSeriesDataStore {
+public interface ReadableTimeSeriesDataStore {
   
-
   /**
    * Instantiates a new node using the given context and the default
    * configuration for this node.
@@ -76,19 +73,6 @@ public interface TimeSeriesDataStore {
   /** @return A class to use for serdes for configuring nodes of this
    * type. */
   public Class<? extends QueryNodeConfig> nodeConfigClass();
-  
-  /**
-   * Writes the given value to the data store.
-   * @param id A non-null ID for the value.
-   * @param value A non-null value to write.
-   * @param trace An optional tracer.
-   * @param span An optional span for tracing.
-   * @return A deferred resolving to null on success or an exception if the 
-   * value was unable to be written.
-   */
-  public Deferred<Object> write(final TimeSeriesStringId id,
-                                         final TimeSeriesValue<?> value, 
-                                         final Span span);
   
   /**
    * For stores that are able to encode time series IDs, this method should

--- a/common/src/main/java/net/opentsdb/storage/TimeSeriesDataStoreFactory.java
+++ b/common/src/main/java/net/opentsdb/storage/TimeSeriesDataStoreFactory.java
@@ -35,7 +35,7 @@ public interface TimeSeriesDataStoreFactory extends TSDBPlugin {
    * @param id An optional ID.
    * @return An instantiated time series data store.
    */
-  public TimeSeriesDataStore newInstance(final TSDB tsdb, final String id);
+  public ReadableTimeSeriesDataStore newInstance(final TSDB tsdb, final String id);
   
   /**
    * The type of {@link TimeSeriesId}s returned from this store by default.

--- a/common/src/main/java/net/opentsdb/storage/WritableTimeSeriesDataStore.java
+++ b/common/src/main/java/net/opentsdb/storage/WritableTimeSeriesDataStore.java
@@ -1,0 +1,80 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.storage;
+
+import java.util.List;
+
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.auth.AuthState;
+import net.opentsdb.data.TimeSeriesDatumIterable;
+import net.opentsdb.data.TimeSeriesDatum;
+import net.opentsdb.stats.Span;
+
+/**
+ * The interface used for implementing a data store that can accept 
+ * writes via the OpenTSDB APIs.
+ * 
+ * @since 3.0
+ */
+public interface WritableTimeSeriesDataStore {
+
+  /**
+   * An enum used by callers to determine whether or not the write was
+   * successful.
+   */
+  public static enum WriteState {
+    /** The write was successful and the original message can be dropped. */
+    OK,
+    
+    /** The write was not successful due to issues such as waiting for a
+     * UID assignment, throttling or temporary unavailability. The value
+     * should be retried at a later time. */
+    RETRY,
+    
+    /** The value was rejected due to permissions, invalid tags, the type
+     * of data or another issue. The value should be dropped. */
+    REJECTED,
+    
+    /** An error happened during storage. The value can be retried. */
+    ERROR
+  }
+  
+  /**
+   * Writes the given value to the data store.
+   * @param state A required state to use for authorization, filtering 
+   * and routing.
+   * @param datum A single value.
+   * @param span An optional span for tracing.
+   * @return A deferred resolving to a WriteState.
+   */
+  public Deferred<WriteState> write(final AuthState state, 
+                                    final TimeSeriesDatum datum, 
+                                    final Span span);
+  
+  /**
+   * Writes the given value to the data store.
+   * @param state A required state to use for authorization, filtering 
+   * and routing.
+   * @param data A set of values to store.
+   * @param span An optional span for tracing.
+   * @return A deferred resolving to a list of WriteStates in the same
+   * same order and number as the entries in the data iterator.
+   */
+  public Deferred<List<WriteState>> write(final AuthState state, 
+                                          final TimeSeriesDatumIterable data, 
+                                          final Span span);
+  
+}

--- a/common/src/test/java/net/opentsdb/data/TestTimeSeriesDatumStringWrapperId.java
+++ b/common/src/test/java/net/opentsdb/data/TestTimeSeriesDatumStringWrapperId.java
@@ -1,0 +1,96 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.common.Const;
+
+public class TestTimeSeriesDatumStringWrapperId {
+
+  @Test
+  public void wrap() throws Exception {
+    final TimeSeriesDatumStringId id = new TimeSeriesDatumStringId() {
+
+      @Override
+      public TypeToken<? extends TimeSeriesId> type() {
+        return Const.TS_STRING_ID;
+      }
+
+      @Override
+      public int hashCode() {
+        return Long.hashCode(buildHashCode());
+      }
+      
+      @Override
+      public long buildHashCode() {
+        return 42;
+      }
+
+      @Override
+      public int compareTo(final TimeSeriesDatumId o) {
+        return 0;
+      }
+
+      @Override
+      public String namespace() {
+        return "mynamespace";
+      }
+
+      @Override
+      public String metric() {
+        return "sys.cpu.busy";
+      }
+
+      @Override
+      public Map<String, String> tags() {
+        return ImmutableMap.<String, String>builder()
+            .put("host", "web01")
+            .put("owner", "tyrion")
+            .build();
+      }
+      
+    };
+    
+    TimeSeriesStringId wrapped = TimeSeriesDatumStringWrapperId.wrap(id);
+    assertNotSame(id, wrapped);
+    assertEquals("mynamespace", wrapped.namespace());
+    assertEquals("sys.cpu.busy", wrapped.metric());
+    assertEquals(2, wrapped.tags().size());
+    assertEquals("web01", wrapped.tags().get("host"));
+    assertEquals("tyrion", wrapped.tags().get("owner"));
+    assertTrue(wrapped.aggregatedTags().isEmpty());
+    assertTrue(wrapped.disjointTags().isEmpty());
+    
+    assertTrue(wrapped.equals(wrapped));
+    assertEquals(0, wrapped.compareTo(wrapped));
+    assertEquals(42, wrapped.hashCode());
+    
+    try {
+      TimeSeriesDatumStringWrapperId.wrap(null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+}

--- a/core/src/main/java/net/opentsdb/core/DefaultRegistry.java
+++ b/core/src/main/java/net/opentsdb/core/DefaultRegistry.java
@@ -62,7 +62,7 @@ import net.opentsdb.query.plan.QueryPlannnerFactory;
 import net.opentsdb.query.plan.QueryPlanner;
 import net.opentsdb.query.pojo.TimeSeriesQuery;
 import net.opentsdb.query.serdes.TimeSeriesSerdes;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.utils.Deferreds;
 import net.opentsdb.utils.JSON;
 
@@ -102,7 +102,7 @@ public class DefaultRegistry implements Registry {
   
   private final Map<String, QueryNodeFactory> node_factories;
   
-  private final Map<String, TimeSeriesDataStore> data_stores;
+  private final Map<String, ReadableTimeSeriesDataStore> data_stores;
   
   /** A concurrent map of shared objects used by various plugins such as 
    * connection pools, etc. */
@@ -258,11 +258,11 @@ public class DefaultRegistry implements Registry {
     return factory;
   }
   
-  public TimeSeriesDataStore getDefaultStore() {
+  public ReadableTimeSeriesDataStore getDefaultStore() {
     return data_stores.get(null);
   }
   
-  public TimeSeriesDataStore getStore(final String id) {
+  public ReadableTimeSeriesDataStore getStore(final String id) {
     return data_stores.get(id);
   }
   

--- a/core/src/main/java/net/opentsdb/data/BaseTimeSeriesByteId.java
+++ b/core/src/main/java/net/opentsdb/data/BaseTimeSeriesByteId.java
@@ -27,7 +27,7 @@ import com.stumbleupon.async.Deferred;
 import net.openhft.hashing.LongHashFunction;
 import net.opentsdb.common.Const;
 import net.opentsdb.stats.Span;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.utils.ByteSet;
 import net.opentsdb.utils.Bytes;
 import net.opentsdb.utils.Bytes.ByteMap;
@@ -42,7 +42,7 @@ import net.opentsdb.utils.Bytes.ByteMap;
 public class BaseTimeSeriesByteId implements TimeSeriesByteId {
   
   /** The data store used to resolve the encoded ID to strings. */
-  protected final TimeSeriesDataStore data_store; 
+  protected final ReadableTimeSeriesDataStore data_store; 
   
   /** Whether or not the byte arrays are specially encoded values. */
   protected boolean encoded;
@@ -132,7 +132,7 @@ public class BaseTimeSeriesByteId implements TimeSeriesByteId {
   }
 
   @Override
-  public TimeSeriesDataStore dataStore() {
+  public ReadableTimeSeriesDataStore dataStore() {
     return data_store;
   }
   
@@ -312,12 +312,12 @@ public class BaseTimeSeriesByteId implements TimeSeriesByteId {
    * @return A new builder.
    * @throws IllegalArgumentException if the data store was null.
    */
-  public static Builder newBuilder(final TimeSeriesDataStore data_store) {
+  public static Builder newBuilder(final ReadableTimeSeriesDataStore data_store) {
     return new Builder(data_store);
   }
   
   public static final class Builder {
-    protected final TimeSeriesDataStore data_store;
+    protected final ReadableTimeSeriesDataStore data_store;
     protected boolean encoded;
     protected byte[] alias;
     protected byte[] namespace;
@@ -332,7 +332,7 @@ public class BaseTimeSeriesByteId implements TimeSeriesByteId {
      * Default private ctor.
      * @param data_store A non-null store.
      */
-    private Builder(final TimeSeriesDataStore data_store) {
+    private Builder(final ReadableTimeSeriesDataStore data_store) {
       if (data_store == null) {
         throw new IllegalArgumentException("Storage schema cannot be null.");
       }

--- a/core/src/main/java/net/opentsdb/data/BaseTimeSeriesDatumStringId.java
+++ b/core/src/main/java/net/opentsdb/data/BaseTimeSeriesDatumStringId.java
@@ -1,0 +1,230 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.google.common.base.Objects;
+import com.google.common.base.Strings;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
+
+import net.openhft.hashing.LongHashFunction;
+import net.opentsdb.common.Const;
+import net.opentsdb.utils.Comparators.MapComparator;
+
+/**
+ * A basic {@link TimeSeriesDatumStringId} implementation that accepts 
+ * strings for all parameters. Includes a useful builder and after 
+ * building, all lists are immutable.
+ * 
+ * @since 3.0
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(builder = BaseTimeSeriesDatumStringId.Builder.class)
+public class BaseTimeSeriesDatumStringId implements TimeSeriesDatumStringId {
+  
+  public static final MapComparator<String, String> STR_MAP_CMP = 
+      new MapComparator<String, String>();
+  
+  /** An optional namespace. */
+  protected String namespace;
+  
+  /** The required non-null and non-empty metric name. */
+  protected String metric;
+  
+  /** A map of tag key/value pairs for the ID. */
+  protected Map<String, String> tags;
+  
+  /** A cached hash code ID. */
+  protected volatile long cached_hash; 
+  
+  /**
+   * Private CTor used by the builder. Converts the Strings to byte arrays
+   * using UTF8.
+   * @param builder A non-null builder.
+   */
+  private BaseTimeSeriesDatumStringId(final Builder builder) {
+    namespace = builder.namespace;
+    metric = builder.metric;
+    if (Strings.isNullOrEmpty(metric)) {
+      throw new IllegalArgumentException("Metric cannot be null or empty.");
+    }
+    if (builder.tags != null && !builder.tags.isEmpty()) {
+      for (final Entry<String, String> pair : builder.tags.entrySet()) {
+        if (pair.getKey() == null) {
+          throw new IllegalArgumentException("Tag key cannot be null.");
+        }
+        if (pair.getValue() == null) {
+          throw new IllegalArgumentException("Tag value cannot be null.");
+        }
+        tags = Collections.unmodifiableMap(builder.tags);
+      }
+    } else {
+      tags = Collections.emptyMap();
+    }
+  }
+
+  @Override
+  public String namespace() {
+    return namespace;
+  }
+
+  @Override
+  public String metric() {
+    return metric;
+  }
+
+  @Override
+  public Map<String, String> tags() {
+    return tags;
+  }
+
+  @Override
+  public int compareTo(final TimeSeriesDatumId o) {
+    if (!(o instanceof TimeSeriesDatumStringId)) {
+      return -1;
+    }
+    return ComparisonChain.start()
+        .compare(Strings.nullToEmpty(namespace), 
+            Strings.nullToEmpty(((TimeSeriesDatumStringId) o).namespace()))
+        .compare(metric, ((TimeSeriesDatumStringId) o).metric())
+        .compare(tags, ((TimeSeriesDatumStringId) o).tags(), STR_MAP_CMP)
+        .result();
+  }
+  
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o)
+      return true;
+    if (o == null || !(o instanceof TimeSeriesDatumStringId))
+      return false;
+    
+    final TimeSeriesDatumStringId id = (TimeSeriesDatumStringId) o;
+    if (!Objects.equal(namespace(), id.namespace())) {
+      return false;
+    }
+    if (!Objects.equal(metric(), id.metric())) {
+      return false;
+    }
+    if (!Objects.equal(tags(), id.tags())) {
+      return false;
+    }
+    return true;
+  }
+  
+  @Override
+  public int hashCode() {
+    if (cached_hash == 0) {
+      cached_hash = buildHashCode();
+    }
+    return Long.hashCode(cached_hash);
+  }
+  
+  /** @return A HashCode object for deterministic, non-secure hashing */
+  public long buildHashCode() {
+    final StringBuilder buf = new StringBuilder();
+    buf.append(namespace);
+    buf.append(metric);
+    final TreeMap<String, String> sorted = 
+        new TreeMap<String, String>(tags);
+    if (tags != null) {
+      for (final Entry<String, String> pair : sorted.entrySet()) {
+        buf.append(pair.getKey());
+        buf.append(pair.getValue());
+      }
+    }
+    return LongHashFunction.xx_r39().hashChars(buf.toString());
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder buf = new StringBuilder()
+        .append("namespace=")
+        .append(namespace)
+        .append(", metric=")
+        .append(metric)
+        .append(", tags=")
+        .append(tags);
+    return buf.toString();
+  }
+  
+  @Override
+  public TypeToken<? extends TimeSeriesId> type() {
+    return Const.TS_STRING_ID;
+  }
+  
+  /** @return A new builder or the SimpleStringTimeSeriesID. */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+  
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
+  public static final class Builder {
+    @JsonProperty
+    private String namespace;
+    @JsonProperty
+    private String metric;
+    @JsonProperty
+    private Map<String, String> tags;
+    
+    public Builder setNamespace(final String namespace) {
+      this.namespace = namespace;
+      return this;
+    }
+    
+    public Builder setMetric(final String metric) {
+      this.metric = metric;
+      return this;
+    }
+    
+    /**
+     * Sets the tags map. <b>NOTE:</b> This will maintain a reference to the
+     * map and will NOT make a copy. Be sure to avoid mutating the map after 
+     * passing it to the builder.
+     * @param metrics A non-null list of metrics.
+     * @return The builder object.
+     */
+    public Builder setTags(final Map<String, String> tags) {
+      this.tags = tags;
+      return this;
+    }
+    
+    public Builder addTags(final String key, final String value) {
+      if (tags == null) {
+        tags = Maps.newHashMap();
+      }
+      tags.put(key, value);
+      return this;
+    }
+    
+    public BaseTimeSeriesDatumStringId build() {
+      return new BaseTimeSeriesDatumStringId(this);
+    }
+  }
+
+}

--- a/core/src/main/java/net/opentsdb/data/MergedTimeSeriesId.java
+++ b/core/src/main/java/net/opentsdb/data/MergedTimeSeriesId.java
@@ -27,7 +27,7 @@ import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 
 import net.opentsdb.common.Const;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.utils.ByteSet;
 import net.opentsdb.utils.Bytes;
 import net.opentsdb.utils.Bytes.ByteMap;
@@ -70,7 +70,7 @@ public class MergedTimeSeriesId {
     protected byte[] namespace;
     protected byte[] metric;
     protected TypeToken<? extends TimeSeriesId> type;
-    protected TimeSeriesDataStore data_store;
+    protected ReadableTimeSeriesDataStore data_store;
     
     /**
      * Sets the alias override to the given string or null.

--- a/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
+++ b/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
@@ -19,7 +19,7 @@ import com.stumbleupon.async.Deferred;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.core.TSDBPlugin;
 import net.opentsdb.exceptions.QueryExecutionException;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.storage.TimeSeriesDataStoreFactory;
 
 /**
@@ -52,7 +52,7 @@ public class QueryDataSourceFactory implements SingleQueryNodeFactory, TSDBPlugi
         throw new RuntimeException("No factory!");
       }
       
-      final TimeSeriesDataStore store = factory.newInstance(tsdb, null);
+      final ReadableTimeSeriesDataStore store = factory.newInstance(tsdb, null);
       if (store == null) {
         throw new QueryExecutionException("Unable to get a data store "
             + "instance from factory: " + factory.id(), 0);

--- a/core/src/main/java/net/opentsdb/query/joins/ByteIdOverride.java
+++ b/core/src/main/java/net/opentsdb/query/joins/ByteIdOverride.java
@@ -24,7 +24,7 @@ import net.opentsdb.data.TimeSeriesByteId;
 import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.TimeSeriesStringId;
 import net.opentsdb.stats.Span;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.utils.ByteSet;
 import net.opentsdb.utils.Bytes.ByteMap;
 
@@ -69,7 +69,7 @@ public class ByteIdOverride implements TimeSeriesByteId {
   }
 
   @Override
-  public TimeSeriesDataStore dataStore() {
+  public ReadableTimeSeriesDataStore dataStore() {
     return id.dataStore();
   }
 

--- a/core/src/main/java/net/opentsdb/query/processor/groupby/GroupBy.java
+++ b/core/src/main/java/net/opentsdb/query/processor/groupby/GroupBy.java
@@ -33,7 +33,7 @@ import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.processor.groupby.GroupByConfig;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 
 /**
  * Performs the time series grouping aggregation by sorting time series according
@@ -122,7 +122,7 @@ public class GroupBy extends AbstractQueryNode {
       
       final Iterator<TimeSeries> iterator = next.timeSeries().iterator();
       if (iterator.hasNext()) {
-        final TimeSeriesDataStore store = ((TimeSeriesByteId) 
+        final ReadableTimeSeriesDataStore store = ((TimeSeriesByteId) 
             iterator.next().id()).dataStore();
         if (store == null) {
           throw new RuntimeException("The data store was null for a byte series!");

--- a/core/src/main/java/net/opentsdb/storage/MockDataStoreFactory.java
+++ b/core/src/main/java/net/opentsdb/storage/MockDataStoreFactory.java
@@ -33,7 +33,7 @@ public class MockDataStoreFactory extends BaseTSDBPlugin
   private volatile MockDataStore mds;
   
   @Override
-  public TimeSeriesDataStore newInstance(final TSDB tsdb, final String id) {
+  public ReadableTimeSeriesDataStore newInstance(final TSDB tsdb, final String id) {
     // DCLP for the singleton.
     if (mds == null) {
       synchronized (this) {

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
@@ -54,7 +54,7 @@ import net.opentsdb.query.pojo.Filter;
 import net.opentsdb.rollup.DefaultRollupConfig;
 import net.opentsdb.stats.Span;
 import net.opentsdb.storage.StorageException;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.uid.NoSuchUniqueId;
 import net.opentsdb.uid.UniqueId;
 import net.opentsdb.uid.UniqueIdFactory;
@@ -73,7 +73,7 @@ import net.opentsdb.utils.JSON;
  * 
  * @since 3.0
  */
-public class Schema implements TimeSeriesDataStore {
+public class Schema implements ReadableTimeSeriesDataStore {
 
   public static final byte APPENDS_PREFIX = 5;
   
@@ -909,13 +909,6 @@ public class Schema implements TimeSeriesDataStore {
     return tag_values;
   }
   
-  @Override
-  public Deferred<Object> write(TimeSeriesStringId id, TimeSeriesValue<?> value,
-      Span span) {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
   @Override
   public Deferred<TimeSeriesStringId> resolveByteId(final TimeSeriesByteId id, 
                                                     final Span span) {

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/SchemaFactory.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/SchemaFactory.java
@@ -24,7 +24,7 @@ import net.opentsdb.common.Const;
 import net.opentsdb.core.BaseTSDBPlugin;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.data.TimeSeriesId;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.storage.TimeSeriesDataStoreFactory;
 
 /**
@@ -43,7 +43,7 @@ public class SchemaFactory extends BaseTSDBPlugin
   protected Map<String, Schema> schemas = Maps.newConcurrentMap();
   
   @Override
-  public TimeSeriesDataStore newInstance(final TSDB tsdb, final String id) {
+  public ReadableTimeSeriesDataStore newInstance(final TSDB tsdb, final String id) {
     // DCLP on the default.
     if (Strings.isNullOrEmpty(id)) {
       if (default_schema == null) {      

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/TSUID.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/TSUID.java
@@ -32,7 +32,7 @@ import net.opentsdb.data.TimeSeriesByteId;
 import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.TimeSeriesStringId;
 import net.opentsdb.stats.Span;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.uid.NoSuchUniqueId;
 import net.opentsdb.uid.UniqueIdType;
 import net.opentsdb.utils.ByteSet;
@@ -323,7 +323,7 @@ public class TSUID implements TimeSeriesByteId {
   }
 
   @Override
-  public TimeSeriesDataStore dataStore() {
+  public ReadableTimeSeriesDataStore dataStore() {
     return schema;
   }
 

--- a/core/src/test/java/net/opentsdb/data/TestBaseTimeDatumSeriesId.java
+++ b/core/src/test/java/net/opentsdb/data/TestBaseTimeDatumSeriesId.java
@@ -1,0 +1,302 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2017  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNull;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.common.collect.Maps;
+
+import net.opentsdb.common.Const;
+
+public class TestBaseTimeDatumSeriesId {
+  
+  @Test
+  public void namespace() throws Exception {
+    TimeSeriesDatumStringId id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setNamespace("Tyrell")
+        .setMetric("sys.cpu.user")
+        .build();
+    assertEquals("Tyrell", id.namespace());
+    
+    id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setNamespace("")
+        .setMetric("sys.cpu.user")
+        .build();
+    assertEquals("", id.namespace());
+    
+    id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setNamespace(null)
+        .setMetric("sys.cpu.user")
+        .build();
+    assertNull(id.namespace());
+    
+    id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setMetric("sys.cpu.user")
+        .build();
+    assertNull(id.namespace());
+  }
+  
+  @Test
+  public void metric() throws Exception {
+    TimeSeriesDatumStringId id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setMetric("sys.cpu.user")
+        .build();
+    assertEquals("sys.cpu.user", id.metric());
+    
+    try {
+      id = BaseTimeSeriesDatumStringId.newBuilder()
+          .setMetric("")
+          .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      id = BaseTimeSeriesDatumStringId.newBuilder()
+          .setMetric(null)
+          .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      id = BaseTimeSeriesDatumStringId.newBuilder()
+          .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void tags() throws Exception {
+    Map<String, String> tags = Maps.newHashMap();
+    tags.put("host", "web01");
+    tags.put("colo", "lax");
+    TimeSeriesDatumStringId id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setTags(tags)
+        .setMetric("sys.cpu.user")
+        .build();
+    assertEquals(2, id.tags().size());
+    assertEquals("web01", 
+        id.tags().get("host"));
+    assertEquals("lax", 
+        id.tags().get("colo"));
+    
+    tags = Maps.newHashMap();
+    tags.put("colo", "");
+    id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setTags(tags)
+        .setMetric("sys.cpu.user")
+        .build();
+    assertEquals(1, id.tags().size());
+    assertEquals("", 
+        id.tags().get("colo"));
+    
+    tags = Maps.newHashMap();
+    tags.put("colo", null);
+    try {
+      id = BaseTimeSeriesDatumStringId.newBuilder()
+          .setTags(tags)
+          .setMetric("sys.cpu.user")
+          .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    tags = Maps.newHashMap();
+    tags.put("", "lax");
+    id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setTags(tags)
+        .setMetric("sys.cpu.user")
+        .build();
+    assertEquals(1, id.tags().size());
+    assertEquals("lax", 
+        id.tags().get(""));
+    
+    tags = Maps.newHashMap();
+    tags.put(null, "lax");
+    try {
+      id = BaseTimeSeriesDatumStringId.newBuilder()
+          .setTags(tags)
+          .setMetric("sys.cpu.user")
+          .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    tags = Maps.newHashMap();
+    id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setTags(tags)
+        .setMetric("sys.cpu.user")
+        .build();
+    assertEquals(0, id.tags().size());
+    
+    id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setTags(null)
+        .setMetric("sys.cpu.user")
+        .build();
+    assertEquals(0, id.tags().size());
+    
+    id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setMetric("sys.cpu.user")
+        .build();
+    assertEquals(0, id.tags().size());
+    
+    id = BaseTimeSeriesDatumStringId.newBuilder()
+        .addTags("host", "web01")
+        .addTags("colo", "lax")
+        .setMetric("sys.cpu.user")
+        .build();
+    assertEquals(2, id.tags().size());
+    assertEquals("web01", 
+        id.tags().get("host"));
+    assertEquals("lax", 
+        id.tags().get("colo"));
+    
+    id = BaseTimeSeriesDatumStringId.newBuilder()
+        .addTags("colo", "")
+        .setMetric("sys.cpu.user")
+        .build();
+    assertEquals(1, id.tags().size());
+    assertEquals("", 
+        id.tags().get("colo"));
+    
+    try {
+      id = BaseTimeSeriesDatumStringId.newBuilder()
+          .addTags("colo", null)
+          .setMetric("sys.cpu.user")
+          .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    id = BaseTimeSeriesDatumStringId.newBuilder()
+        .addTags("", "lax")
+        .setMetric("sys.cpu.user")
+        .build();
+    assertEquals(1, id.tags().size());
+    assertEquals("lax", 
+        id.tags().get(""));
+    
+    try {
+      id = BaseTimeSeriesDatumStringId.newBuilder()
+          .addTags(null, "lax")
+          .setMetric("sys.cpu.user")
+          .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      id = BaseTimeSeriesDatumStringId.newBuilder()
+          .addTags(null, null)
+          .setMetric("sys.cpu.user")
+          .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void hashCodeEqualsCompareTo() throws Exception {
+    Map<String, String> tags = Maps.newHashMap();
+    tags.put("host", "web01");
+    tags.put("colo", "lax");
+    
+    final BaseTimeSeriesDatumStringId id1 = BaseTimeSeriesDatumStringId.newBuilder()
+        .setNamespace("OpenTSDB")
+        .setMetric("sys.cpu.user")
+        .setTags(tags)
+        .build();
+    
+    BaseTimeSeriesDatumStringId id2 = BaseTimeSeriesDatumStringId.newBuilder()
+        .setNamespace("OpenTSDB")
+        .setMetric("sys.cpu.user")
+        .setTags(tags)
+        .build();
+    assertEquals(id1.hashCode(), id2.hashCode());
+    assertEquals(id1, id2);
+    assertEquals(0, id1.compareTo(id2));
+    
+    id2 = BaseTimeSeriesDatumStringId.newBuilder()
+        .setNamespace("Yahoo") // <-- Diff
+        .setMetric("sys.cpu.user")
+        .setTags(tags)
+        .build();
+    assertNotEquals(id1.hashCode(), id2.hashCode());
+    assertNotEquals(id1, id2);
+    assertEquals(-1, id1.compareTo(id2));
+    
+    id2 = BaseTimeSeriesDatumStringId.newBuilder()
+        //.setNamespace("OpenTSDB") // <-- Diff
+        .setMetric("sys.cpu.user")
+        .setTags(tags)
+        .build();
+    assertNotEquals(id1.hashCode(), id2.hashCode());
+    assertNotEquals(id1, id2);
+    assertEquals(1, id1.compareTo(id2));
+    
+    id2 = BaseTimeSeriesDatumStringId.newBuilder()
+        .setNamespace("OpenTSDB")
+        .setMetric("sys.cpu.idle") // <-- Diff
+        .setTags(tags)
+        .build();
+    assertNotEquals(id1.hashCode(), id2.hashCode());
+    assertNotEquals(id1, id2);
+    assertEquals(1, id1.compareTo(id2));
+    
+    Map<String, String> tags2 = Maps.newHashMap();
+    tags.put("host", "web02"); // <-- Diff
+    tags.put("colo", "lax");
+    
+    id2 = BaseTimeSeriesDatumStringId.newBuilder()
+        .setNamespace("OpenTSDB")
+        .setMetric("sys.cpu.user")
+        .setTags(tags2) // <-- Diff
+        .build();
+    assertNotEquals(id1.hashCode(), id2.hashCode());
+    assertNotEquals(id1, id2);
+    assertEquals(-1, id1.compareTo(id2));
+    
+    tags2 = Maps.newHashMap();
+    tags.put("host", "web01");
+    //tags.put("colo", "lax"); // <-- Diff
+    
+    id2 = BaseTimeSeriesDatumStringId.newBuilder()
+        .setNamespace("OpenTSDB")
+        .setMetric("sys.cpu.user")
+        .setTags(tags2) // <-- Diff
+        .build();
+    assertNotEquals(id1.hashCode(), id2.hashCode());
+    assertNotEquals(id1, id2);
+    assertEquals(-1, id1.compareTo(id2));
+    
+    id2 = BaseTimeSeriesDatumStringId.newBuilder()
+        .setNamespace("OpenTSDB")
+        .setMetric("sys.cpu.user")
+        //.setTags(tags) // <-- Diff
+        .build();
+    assertNotEquals(id1.hashCode(), id2.hashCode());
+    assertNotEquals(id1, id2);
+    assertEquals(-1, id1.compareTo(id2));
+  }
+
+  @Test
+  public void type() throws Exception {
+    TimeSeriesDatumStringId id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setMetric("sys.cpu.user")
+        .build();
+    assertEquals(Const.TS_STRING_ID, id.type());
+  }
+}

--- a/core/src/test/java/net/opentsdb/data/TestBaseTimeSeriesByteId.java
+++ b/core/src/test/java/net/opentsdb/data/TestBaseTimeSeriesByteId.java
@@ -36,7 +36,7 @@ import com.google.common.collect.Lists;
 import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.stats.Span;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.utils.ByteSet;
 import net.opentsdb.utils.Bytes.ByteMap;
 
@@ -57,11 +57,11 @@ public class TestBaseTimeSeriesByteId {
     SET.add(new byte[] { 's', '1' });
     SET.add(new byte[] { 's', '2' });
   }
-  private TimeSeriesDataStore data_store;
+  private ReadableTimeSeriesDataStore data_store;
   
   @Before
   public void before() throws Exception {
-    data_store = mock(TimeSeriesDataStore.class);
+    data_store = mock(ReadableTimeSeriesDataStore.class);
   }
   
   @Test

--- a/core/src/test/java/net/opentsdb/data/TestMergedTimeSeriesId.java
+++ b/core/src/test/java/net/opentsdb/data/TestMergedTimeSeriesId.java
@@ -25,7 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import net.opentsdb.common.Const;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 
 public class TestMergedTimeSeriesId {
   private static final byte[] BYTES_1 = "Tyrell".getBytes();
@@ -44,11 +44,11 @@ public class TestMergedTimeSeriesId {
   private static final byte[] METRIC = "ice.dragon".getBytes();
   private static final byte[] METRIC_ALT = "ice.dragon".getBytes();
   
-  private TimeSeriesDataStore data_store;
+  private ReadableTimeSeriesDataStore data_store;
   
   @Before
   public void before() throws Exception {
-    data_store = mock(TimeSeriesDataStore.class);
+    data_store = mock(ReadableTimeSeriesDataStore.class);
   }
   
   @Test
@@ -141,7 +141,7 @@ public class TestMergedTimeSeriesId {
       assertEquals(2, builder.ids.size());
       assertEquals(Const.TS_BYTE_ID, builder.type);
       
-      d = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+      d = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
           .setNamespace(BYTES_2_ALT)
           .setMetric(METRIC)
           .build();

--- a/core/src/test/java/net/opentsdb/query/execution/serdes/TestJsonV2QuerySerdes.java
+++ b/core/src/test/java/net/opentsdb/query/execution/serdes/TestJsonV2QuerySerdes.java
@@ -48,7 +48,7 @@ import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.pojo.TimeSeriesQuery;
 import net.opentsdb.query.pojo.Timespan;
 import net.opentsdb.query.serdes.SerdesOptions;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.utils.UnitTestException;
 
 public class TestJsonV2QuerySerdes {
@@ -58,14 +58,14 @@ public class TestJsonV2QuerySerdes {
   private TimeSeriesQuery query;
   private NumericMillisecondShard ts1;
   private NumericMillisecondShard ts2;
-  private TimeSeriesDataStore store;
+  private ReadableTimeSeriesDataStore store;
   private JsonV2QuerySerdesOptions options;
   
   @Before
   public void before() throws Exception {
     context = mock(QueryContext.class);
     result = mock(QueryResult.class);
-    store = mock(TimeSeriesDataStore.class);
+    store = mock(ReadableTimeSeriesDataStore.class);
     query = TimeSeriesQuery.newBuilder()
         .setTime(Timespan.newBuilder()
             .setStart("1486045800000")

--- a/core/src/test/java/net/opentsdb/query/joins/BaseJoinTest.java
+++ b/core/src/test/java/net/opentsdb/query/joins/BaseJoinTest.java
@@ -34,7 +34,7 @@ import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.joins.JoinConfig.JoinType;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 
 public class BaseJoinTest {
   protected static final String ID = "UT";
@@ -157,7 +157,7 @@ public class BaseJoinTest {
         .addAggregatedTag("host")
         .build();
     
-    TAGLESS_BYTE = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TAGLESS_BYTE = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_L_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_L_BYTES)
@@ -174,7 +174,7 @@ public class BaseJoinTest {
         .addTags("role", "db")
         .build();
     
-    MANY_TAGS_BYTE = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    MANY_TAGS_BYTE = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_L_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_L_BYTES)
@@ -203,7 +203,7 @@ public class BaseJoinTest {
         .addDisjointTag("role")
         .build();
     
-    TAG_PROMOTION_L_BYTE = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TAG_PROMOTION_L_BYTE = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_L_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_L_BYTES)
@@ -212,7 +212,7 @@ public class BaseJoinTest {
         .addDisjointTag(DC)
         .build();
     
-    TAG_PROMOTION_R_BYTE = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TAG_PROMOTION_R_BYTE = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_L_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_R_BYTES)
@@ -508,14 +508,14 @@ public class BaseJoinTest {
   }
   
   protected void setByteIds() throws Exception {
-    l1_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    l1_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_L_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_L_BYTES)
         .addTags(HOST, WEB01)
         .build();
     when(L_1.id()).thenReturn(l1_id);
-    r1_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    r1_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_R_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_R_BYTES)
@@ -523,7 +523,7 @@ public class BaseJoinTest {
         .build();
     when(R_1.id()).thenReturn(r1_id);
     
-    l2_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    l2_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_L_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_L_BYTES)
@@ -531,7 +531,7 @@ public class BaseJoinTest {
         .build();
     when(L_2.id()).thenReturn(l2_id);
     
-    r3_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    r3_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_R_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_R_BYTES)
@@ -539,14 +539,14 @@ public class BaseJoinTest {
         .build();
     when(R_3.id()).thenReturn(r3_id);
     
-    l4_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    l4_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_L_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_L_BYTES)
         .addTags(HOST, WEB04)
         .build();
     when(L_4.id()).thenReturn(l4_id);
-    r4a_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    r4a_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_R_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_R_BYTES)
@@ -554,7 +554,7 @@ public class BaseJoinTest {
         .addTags(OWNER, TYRION)
         .build();
     when(R_4A.id()).thenReturn(r4a_id);
-    r4b_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    r4b_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_R_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_R_BYTES)
@@ -563,7 +563,7 @@ public class BaseJoinTest {
         .build();
     when(R_4B.id()).thenReturn(r4b_id);
     
-    l5a_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    l5a_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_L_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_L_BYTES)
@@ -571,7 +571,7 @@ public class BaseJoinTest {
         .addTags(OWNER, TYRION)
         .build();
     when(L_5A.id()).thenReturn(l5a_id);
-    l5b_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    l5b_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_L_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_L_BYTES)
@@ -579,7 +579,7 @@ public class BaseJoinTest {
         .addTags(OWNER, CERSEI)
         .build();
     when(L_5B.id()).thenReturn(l5b_id);
-    r5_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    r5_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_R_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_R_BYTES)
@@ -587,7 +587,7 @@ public class BaseJoinTest {
         .build();
     when(R_5.id()).thenReturn(r5_id);
     
-    l6a_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    l6a_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_L_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_L_BYTES)
@@ -595,7 +595,7 @@ public class BaseJoinTest {
         .addTags(OWNER, TYRION)
         .build();
     when(L_6A.id()).thenReturn(l6a_id);
-    l6b_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    l6b_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_L_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_L_BYTES)
@@ -603,7 +603,7 @@ public class BaseJoinTest {
         .addTags(OWNER, CERSEI)
         .build();
     when(L_6B.id()).thenReturn(l6b_id);
-    r6a_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    r6a_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_R_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_R_BYTES)
@@ -611,7 +611,7 @@ public class BaseJoinTest {
         .addTags(OWNER, TYRION)
         .build();
     when(R_6A.id()).thenReturn(r6a_id);
-    r6b_id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    r6b_id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setAlias(ALIAS_R_BYTES)
         .setNamespace(NAMESPACE_BYTES)
         .setMetric(METRIC_R_BYTES)

--- a/core/src/test/java/net/opentsdb/query/joins/TestJoiner.java
+++ b/core/src/test/java/net/opentsdb/query/joins/TestJoiner.java
@@ -45,7 +45,7 @@ import net.opentsdb.data.BaseTimeSeriesByteId;
 import net.opentsdb.data.BaseTimeSeriesStringId;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.joins.JoinConfig.JoinType;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.utils.Pair;
 import net.opentsdb.utils.Bytes.ByteMap;
 
@@ -679,7 +679,7 @@ public class TestJoiner extends BaseJoinTest {
     
     // extra tags will hash to the same value
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_L_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)
@@ -728,7 +728,7 @@ public class TestJoiner extends BaseJoinTest {
     
     // extra tags will hash to the same value
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_R_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)
@@ -766,7 +766,7 @@ public class TestJoiner extends BaseJoinTest {
     
     // extra tags will hash to the same value
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_R_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)
@@ -805,7 +805,7 @@ public class TestJoiner extends BaseJoinTest {
     
     // extra tags will be kicked out.
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_L_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)
@@ -854,7 +854,7 @@ public class TestJoiner extends BaseJoinTest {
     
     // extra tags will be kicked out.
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_R_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)
@@ -900,7 +900,7 @@ public class TestJoiner extends BaseJoinTest {
     
     // extra tags will be kicked out.
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_R_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)
@@ -951,7 +951,7 @@ public class TestJoiner extends BaseJoinTest {
     assertSame(ts, set.left_map.get(hash).get(0));
     
     // missing some tags will fail.
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_L_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)
@@ -995,7 +995,7 @@ public class TestJoiner extends BaseJoinTest {
     assertNull(set.right_map);
        
     // still nothing of course.
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_L_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)
@@ -1029,7 +1029,7 @@ public class TestJoiner extends BaseJoinTest {
     
     // extra tags now hash to something different.
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_L_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)
@@ -1078,7 +1078,7 @@ public class TestJoiner extends BaseJoinTest {
     
     // extra tags now hash to something different.
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_L_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)
@@ -1123,7 +1123,7 @@ public class TestJoiner extends BaseJoinTest {
     
     // extra tags now hash to something different.
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_L_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)
@@ -1163,7 +1163,7 @@ public class TestJoiner extends BaseJoinTest {
     
     // extra tags now hash to something different.
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_L_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)
@@ -1212,7 +1212,7 @@ public class TestJoiner extends BaseJoinTest {
     
     // cross falls back to normal hashing
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_L_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)
@@ -1260,7 +1260,7 @@ public class TestJoiner extends BaseJoinTest {
     
     // cross falls back to normal hashing
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataStore.class))
+    TimeSeriesId id = BaseTimeSeriesByteId.newBuilder(mock(ReadableTimeSeriesDataStore.class))
         .setMetric(METRIC_L_BYTES)
         .addTags(HOST, WEB01)
         .addTags(OWNER, TYRION)

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
@@ -59,7 +59,7 @@ import net.opentsdb.query.pojo.FillPolicy;
 import net.opentsdb.query.processor.expressions.ExpressionParseNode.ExpressionOp;
 import net.opentsdb.query.processor.expressions.ExpressionParseNode.OperandType;
 import net.opentsdb.stats.Span;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.utils.UnitTestException;
 
 public class TestBinaryExpressionNode {
@@ -263,7 +263,7 @@ public class TestBinaryExpressionNode {
     });
     TimeSeries ts = mock(TimeSeries.class);
     TimeSeriesByteId id = mock(TimeSeriesByteId.class);
-    TimeSeriesDataStore store = mock(TimeSeriesDataStore.class);
+    ReadableTimeSeriesDataStore store = mock(ReadableTimeSeriesDataStore.class);
     when(ts.id()).thenReturn(id);
     when(id.dataStore()).thenReturn(store);
     when(id.type()).thenAnswer(new Answer<TypeToken<?>>() {
@@ -351,7 +351,7 @@ public class TestBinaryExpressionNode {
     });
     TimeSeries ts = mock(TimeSeries.class);
     TimeSeriesByteId id = mock(TimeSeriesByteId.class);
-    TimeSeriesDataStore store = mock(TimeSeriesDataStore.class);
+    ReadableTimeSeriesDataStore store = mock(ReadableTimeSeriesDataStore.class);
     when(ts.id()).thenReturn(id);
     when(id.dataStore()).thenReturn(store);
     when(id.type()).thenAnswer(new Answer<TypeToken<?>>() {
@@ -439,7 +439,7 @@ public class TestBinaryExpressionNode {
     });
     TimeSeries ts = mock(TimeSeries.class);
     TimeSeriesByteId id = mock(TimeSeriesByteId.class);
-    TimeSeriesDataStore store = mock(TimeSeriesDataStore.class);
+    ReadableTimeSeriesDataStore store = mock(ReadableTimeSeriesDataStore.class);
     when(ts.id()).thenReturn(id);
     when(id.dataStore()).thenReturn(store);
     when(id.type()).thenAnswer(new Answer<TypeToken<?>>() {
@@ -505,7 +505,7 @@ public class TestBinaryExpressionNode {
     });
     TimeSeries ts = mock(TimeSeries.class);
     TimeSeriesByteId id = mock(TimeSeriesByteId.class);
-    TimeSeriesDataStore store = mock(TimeSeriesDataStore.class);
+    ReadableTimeSeriesDataStore store = mock(ReadableTimeSeriesDataStore.class);
     when(ts.id()).thenReturn(id);
     when(id.dataStore()).thenReturn(store);
     when(id.type()).thenAnswer(new Answer<TypeToken<?>>() {
@@ -582,7 +582,7 @@ public class TestBinaryExpressionNode {
     });
     TimeSeries ts = mock(TimeSeries.class);
     TimeSeriesByteId id = mock(TimeSeriesByteId.class);
-    TimeSeriesDataStore store = mock(TimeSeriesDataStore.class);
+    ReadableTimeSeriesDataStore store = mock(ReadableTimeSeriesDataStore.class);
     when(ts.id()).thenReturn(id);
     when(id.dataStore()).thenReturn(store);
     when(id.type()).thenAnswer(new Answer<TypeToken<?>>() {
@@ -658,7 +658,7 @@ public class TestBinaryExpressionNode {
     });
     TimeSeries ts = mock(TimeSeries.class);
     TimeSeriesByteId id = mock(TimeSeriesByteId.class);
-    TimeSeriesDataStore store = mock(TimeSeriesDataStore.class);
+    ReadableTimeSeriesDataStore store = mock(ReadableTimeSeriesDataStore.class);
     when(ts.id()).thenReturn(id);
     when(id.dataStore()).thenReturn(store);
     when(id.type()).thenAnswer(new Answer<TypeToken<?>>() {
@@ -723,7 +723,7 @@ public class TestBinaryExpressionNode {
     });
     TimeSeries ts = mock(TimeSeries.class);
     TimeSeriesByteId id = mock(TimeSeriesByteId.class);
-    TimeSeriesDataStore store = mock(TimeSeriesDataStore.class);
+    ReadableTimeSeriesDataStore store = mock(ReadableTimeSeriesDataStore.class);
     when(ts.id()).thenReturn(id);
     when(id.dataStore()).thenReturn(store);
     when(id.type()).thenAnswer(new Answer<TypeToken<?>>() {
@@ -798,7 +798,7 @@ public class TestBinaryExpressionNode {
     });
     TimeSeries ts = mock(TimeSeries.class);
     TimeSeriesByteId id = mock(TimeSeriesByteId.class);
-    TimeSeriesDataStore store = mock(TimeSeriesDataStore.class);
+    ReadableTimeSeriesDataStore store = mock(ReadableTimeSeriesDataStore.class);
     when(ts.id()).thenReturn(id);
     when(id.dataStore()).thenReturn(store);
     when(id.type()).thenAnswer(new Answer<TypeToken<?>>() {

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupBy.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupBy.java
@@ -61,7 +61,7 @@ import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
 import net.opentsdb.query.pojo.FillPolicy;
 import net.opentsdb.stats.Span;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.utils.UnitTestException;
 
 @RunWith(PowerMockRunner.class)
@@ -173,7 +173,7 @@ public class TestGroupBy {
       }
     });
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesDataStore datastore = mock(TimeSeriesDataStore.class);
+    ReadableTimeSeriesDataStore datastore = mock(ReadableTimeSeriesDataStore.class);
     TimeSeriesByteId id =  BaseTimeSeriesByteId.newBuilder(datastore)
         .setMetric(new byte[] { 0, 0, 1 })
         .addTags(new byte[] { 0, 0, 1 }, new byte[] { 0, 0, 1 })
@@ -214,7 +214,7 @@ public class TestGroupBy {
       }
     });
     TimeSeries ts = mock(TimeSeries.class);
-    TimeSeriesDataStore datastore = mock(TimeSeriesDataStore.class);
+    ReadableTimeSeriesDataStore datastore = mock(ReadableTimeSeriesDataStore.class);
     TimeSeriesByteId id =  BaseTimeSeriesByteId.newBuilder(datastore)
         .setMetric(new byte[] { 0, 0, 1 })
         .addTags(new byte[] { 0, 0, 1 }, new byte[] { 0, 0, 1 })

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByResult.java
@@ -39,7 +39,7 @@ import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
 import net.opentsdb.query.pojo.FillPolicy;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 
 public class TestGroupByResult {
   
@@ -388,7 +388,7 @@ public class TestGroupByResult {
   }
   
   private void setupBytes() {
-    final TimeSeriesDataStore data_store = mock(TimeSeriesDataStore.class);
+    final ReadableTimeSeriesDataStore data_store = mock(ReadableTimeSeriesDataStore.class);
     config = (GroupByConfig) GroupByConfig.newBuilder()
         .setAggregator("sum")
         .addTagKey("dc")

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchemaFactory.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchemaFactory.java
@@ -32,7 +32,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import net.opentsdb.core.TSDB;
-import net.opentsdb.storage.TimeSeriesDataStore;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ SchemaFactory.class })
@@ -61,7 +61,7 @@ public class TestSchemaFactory extends SchemaBase {
     assertNull(factory.default_schema);
     assertTrue(factory.schemas.isEmpty());
     
-    TimeSeriesDataStore store = factory.newInstance(tsdb, null);
+    ReadableTimeSeriesDataStore store = factory.newInstance(tsdb, null);
     assertSame(store, factory.default_schema);
     assertTrue(factory.schemas.isEmpty());
     assertNull(store.id());
@@ -86,7 +86,7 @@ public class TestSchemaFactory extends SchemaBase {
     assertNull(factory.default_schema);
     assertTrue(factory.schemas.isEmpty());
     
-    TimeSeriesDataStore store = factory.newInstance(tsdb, "id1");
+    ReadableTimeSeriesDataStore store = factory.newInstance(tsdb, "id1");
     assertNull(factory.default_schema);
     assertEquals(1, factory.schemas.size());
     assertSame(store, factory.schemas.get("id1"));

--- a/implementation/protobuf/src/main/java/net/opentsdb/data/PBufNumericIterator.java
+++ b/implementation/protobuf/src/main/java/net/opentsdb/data/PBufNumericIterator.java
@@ -22,7 +22,6 @@ import com.google.common.base.Strings;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import net.opentsdb.data.pbuf.NumericSegmentPB.NumericSegment;
-import net.opentsdb.data.pbuf.TimeSeriesDataPB;
 import net.opentsdb.data.types.numeric.MutableNumericValue;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.exceptions.SerdesException;
@@ -44,7 +43,7 @@ public class PBufNumericIterator implements
   Iterator<TimeSeriesValue<? extends TimeSeriesDataType>> {
 
   /** The encoded source. */
-  private final TimeSeriesDataPB.TimeSeriesData source;
+  private final TimeSeriesData source;
   
   /** The data point updated and returned during iteration. */
   private final MutableNumericValue dp;

--- a/implementation/protobuf/src/main/java/net/opentsdb/data/PBufNumericSummaryIterator.java
+++ b/implementation/protobuf/src/main/java/net/opentsdb/data/PBufNumericSummaryIterator.java
@@ -24,7 +24,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.protobuf.InvalidProtocolBufferException;
 
-import net.opentsdb.data.pbuf.TimeSeriesDataPB;
 import net.opentsdb.data.pbuf.NumericSummarySegmentPB.NumericSummarySegment;
 import net.opentsdb.data.pbuf.NumericSummarySegmentPB.NumericSummarySegment.NumericSummary;
 import net.opentsdb.data.pbuf.TimeSeriesDataPB.TimeSeriesData;
@@ -49,7 +48,7 @@ public class PBufNumericSummaryIterator implements
   Iterator<TimeSeriesValue<? extends TimeSeriesDataType>> {
 
   /** The encoded source. */
-  private final TimeSeriesDataPB.TimeSeriesData source;
+  private final TimeSeriesData source;
   
   /** The data point updated and returned during iteration. */
   private final MutableNumericSummaryValue dp;

--- a/implementation/protobuf/src/main/java/net/opentsdb/data/PBufTimeSeries.java
+++ b/implementation/protobuf/src/main/java/net/opentsdb/data/PBufTimeSeries.java
@@ -25,7 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
 
-import net.opentsdb.data.pbuf.TimeSeriesDataPB;
+import net.opentsdb.data.pbuf.TimeSeriesDataPB.TimeSeriesData;
 import net.opentsdb.data.pbuf.TimeSeriesPB;
 import net.opentsdb.exceptions.SerdesException;
 import net.opentsdb.query.serdes.PBufIteratorSerdes;
@@ -48,7 +48,7 @@ public class PBufTimeSeries implements TimeSeries {
   private PBufTimeSeriesId id;
   
   /** A map of data types to parsed time series. */
-  private Map<TypeToken<?>, TimeSeriesDataPB.TimeSeriesData> data;
+  private Map<TypeToken<?>, TimeSeriesData> data;
   
   /**
    * Default ctor.
@@ -66,8 +66,7 @@ public class PBufTimeSeries implements TimeSeries {
     this.factory = factory;
     this.time_series = time_series;
     data = Maps.newHashMapWithExpectedSize(time_series.getDataCount());
-    for (final TimeSeriesDataPB.TimeSeriesData data : 
-          time_series.getDataList()) {
+    for (final TimeSeriesData data : time_series.getDataList()) {
       try {
         final Class<?> clazz = Class.forName(data.getType());
         final TypeToken<?> type = TypeToken.of(clazz);
@@ -90,7 +89,7 @@ public class PBufTimeSeries implements TimeSeries {
   @Override
   public Optional<Iterator<TimeSeriesValue<? extends TimeSeriesDataType>>> iterator(
       final TypeToken<?> type) {
-    TimeSeriesDataPB.TimeSeriesData series = data.get(type);
+    TimeSeriesData series = data.get(type);
     if (series == null) {
       return Optional.empty();
     }
@@ -108,7 +107,7 @@ public class PBufTimeSeries implements TimeSeries {
   public Collection<Iterator<TimeSeriesValue<? extends TimeSeriesDataType>>> iterators() {
     List<Iterator<TimeSeriesValue<? extends TimeSeriesDataType>>> iterators = 
         Lists.newArrayListWithCapacity(data.size());
-    for (final Entry<TypeToken<?>, TimeSeriesDataPB.TimeSeriesData> entry : 
+    for (final Entry<TypeToken<?>, TimeSeriesData> entry : 
           data.entrySet()) {
       PBufIteratorSerdes serdes = factory.serdesForType(entry.getKey());
       if (serdes == null) {

--- a/implementation/protobuf/src/main/java/net/opentsdb/query/serdes/PBufIteratorSerdes.java
+++ b/implementation/protobuf/src/main/java/net/opentsdb/query/serdes/PBufIteratorSerdes.java
@@ -20,7 +20,7 @@ import com.google.common.reflect.TypeToken;
 
 import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesValue;
-import net.opentsdb.data.pbuf.TimeSeriesDataPB;
+import net.opentsdb.data.pbuf.TimeSeriesDataPB.TimeSeriesData;
 import net.opentsdb.data.pbuf.TimeSeriesPB;
 import net.opentsdb.query.QueryContext;
 import net.opentsdb.query.QueryResult;
@@ -43,7 +43,7 @@ public interface PBufIteratorSerdes {
   /**
    * The method that serializes the data. A non-null time series builder
    * is given and the serialization method must create zero or more 
-   * segments to be stored in a {@link TimeSeriesData} proto that is
+   * segments to be stored in a {@link TimeSeriesDatumIterable} proto that is
    * added to the ts_builder. If there isn't any data for the iterator,
    * just populate the builder with an empty data object for the given
    * type.
@@ -75,5 +75,5 @@ public interface PBufIteratorSerdes {
    * @throws SerdesException If something goes wrong during deserialization.
    */
   public Iterator<TimeSeriesValue<? extends TimeSeriesDataType>> 
-    deserialize(final TimeSeriesDataPB.TimeSeriesData series);
+    deserialize(final TimeSeriesData series);
 }


### PR DESCRIPTION
- Add TimeSeriesDatum interfaces for IDs and values. These will be used for
  writes as we only need namespace, metric and tags. Not the aggregated or
  disjoint tags.
- Add TimeSeriesDatumStringWrapperId that wraps a datum Id and returns a
  time series ID. This is useful for data stores.
- Add the TimeSeriesDatumIterable class, representing an iterable set of
  datum for writes as in a batched write request.
- Add the WritableTimeSeriesDataStore interface and rename the
  TimeSeriesDataStore to ReadableTimeSeriesDataStore. Some stores me be
  read-only for TSDB and others write-only so it make sense to break this
  up.

CORE:
- Add BaseTimeSeriesDatumStringId as a base class for the datum IDs.