### PR TITLE
CORE:

### DIFF
--- a/common/src/main/java/net/opentsdb/data/SecondTimeStamp.java
+++ b/common/src/main/java/net/opentsdb/data/SecondTimeStamp.java
@@ -1,0 +1,226 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2012018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAmount;
+
+import net.opentsdb.common.Const;
+
+/**
+ * Simple implementation of a timestamp that is stored as a {@link Long} 
+ * in Unix Epoch seconds. Always returns the UTC time zone.
+ * <p>
+ * <b>Notes on {@link #snapToPreviousInterval(long, ChronoUnit, DayOfWeek)}:</b>
+ * <p>
+ * @since 3.0
+ */
+public class SecondTimeStamp implements TimeStamp {
+  /** The timestamp. */
+  private long timestamp;
+  
+  /**
+   * Ctor, initializes the timestamp.
+   * @param timestamp A timestamp in Unix epoch seconds.
+   */
+  public SecondTimeStamp(final long timestamp) {
+    this.timestamp = timestamp;
+  }
+  
+  @Override
+  public long nanos() {
+    return 0;
+  }
+  
+  @Override
+  public long msEpoch() {
+    return timestamp * 1000L;
+  }
+
+  @Override
+  public long epoch() {
+    return timestamp;
+  }
+
+  @Override
+  public TimeStamp getCopy() {
+    return new SecondTimeStamp(timestamp);
+  }
+
+  @Override
+  public void updateMsEpoch(final long timestamp) {
+    this.timestamp = timestamp / 1000;
+  }
+
+  @Override
+  public void updateEpoch(final long timestamp) {
+    this.timestamp = timestamp;
+  }
+  
+  @Override
+  public void update(final TimeStamp timestamp) {
+    if (timestamp == null) {
+      throw new IllegalArgumentException("Timestamp cannot be null.");
+    }
+    if (timestamp instanceof SecondTimeStamp) {
+      this.timestamp = ((SecondTimeStamp) timestamp).timestamp;
+    } else {
+      this.timestamp = timestamp.epoch();
+    }
+  }
+
+  @Override
+  public void update(final long epoch, final long nano) {
+    timestamp = epoch;
+  }
+  
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null) {
+      return false;
+    }
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof TimeStamp)) {
+      return false;
+    }
+    return compare(Op.EQ, (TimeStamp) o);
+  }
+  
+  @Override
+  public boolean compare(final Op comparator, 
+      final TimeStamp compareTo) {
+    if (compareTo == null) {
+      throw new IllegalArgumentException("Timestamp cannot be null.");
+    }
+    if (comparator == null) {
+      throw new IllegalArgumentException("Comparator cannot be null.");
+    }
+    switch (comparator) {
+    case LT:
+      if (epoch() == compareTo.epoch()) {
+        if (nanos() < compareTo.nanos()) {
+          return true;
+        }
+      } else if (epoch() < compareTo.epoch()) {
+        return true;
+      }
+      return false;
+    case LTE:
+      if (epoch() == compareTo.epoch()) {
+        if (nanos() <= compareTo.nanos()) {
+          return true;
+        }
+      } else if (epoch() <= compareTo.epoch()) {
+        return true;
+      }
+      return false;
+    case GT:
+      if (epoch() == compareTo.epoch()) {
+        if (nanos() > compareTo.nanos()) {
+          return true;
+        }
+      } else if (epoch() > compareTo.epoch()) {
+        return true;
+      }
+      return false;
+    case GTE:
+      if (epoch() == compareTo.epoch()) {
+        if (nanos() >= compareTo.nanos()) {
+          return true;
+        }
+      } else if (epoch() >= compareTo.epoch()) {
+        return true;
+      }
+      return false;
+    case EQ:
+      return epoch() == compareTo.epoch() && 
+             nanos() == compareTo.nanos();
+    case NE:
+      return epoch() != compareTo.epoch() || 
+             nanos() != compareTo.nanos();
+    default:
+      throw new UnsupportedOperationException("Unknown comparator: " + comparator);
+    }
+  }
+
+  @Override
+  public void setMax() {
+    timestamp = Long.MAX_VALUE;
+  }
+
+  @Override
+  public String toString() {
+    return new StringBuilder()
+        .append("timestamp=")
+        .append(timestamp)
+        .append(", utc=")
+        .append(Instant.ofEpochMilli(timestamp))
+        .append(", epoch=")
+        .append(epoch())
+        .append(", nanos=")
+        .append(nanos())
+        .append(", msEpoch=")
+        .append(msEpoch())
+        .toString();
+  }
+
+  @Override
+  public ChronoUnit units() {
+    return ChronoUnit.SECONDS;
+  }
+  
+  @Override
+  public ZoneId timezone() {
+    return ZoneId.of("UTC");
+  }
+
+  @Override
+  public void add(final TemporalAmount amount) {
+    if (amount == null) {
+      throw new IllegalArgumentException("Amount cannot be null.");
+    }
+    if (amount instanceof Duration) {
+      timestamp += ((Duration) amount).getSeconds();
+    } else {
+      // can't shortcut easily here since we don't *know* the number of days in 
+      // a month. So snap to a calendar
+      final ZonedDateTime zdt = ZonedDateTime.ofInstant(
+          Instant.ofEpochSecond(timestamp), Const.UTC);
+      timestamp = Instant.from(zdt.plus(amount)).getEpochSecond();
+    }
+  }
+
+  @Override
+  public void snapToPreviousInterval(final long interval, final ChronoUnit units) {
+    snapToPreviousInterval(interval, units, DayOfWeek.SUNDAY);
+  }
+
+  @Override
+  public void snapToPreviousInterval(final long interval, 
+                                     final ChronoUnit units,
+                                     final DayOfWeek day_of_week) {
+    final TimeStamp snapper = new ZonedNanoTimeStamp(timestamp * 1000, Const.UTC);
+    snapper.snapToPreviousInterval(interval, units, day_of_week);
+    timestamp = snapper.epoch();
+  }
+  
+}

--- a/common/src/main/java/net/opentsdb/data/TimeSeriesDatum.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesDatum.java
@@ -35,4 +35,38 @@ public interface TimeSeriesDatum {
    */
   public TimeSeriesValue<? extends TimeSeriesDataType> value();
   
+  /**
+   * A wrapper around an existing ID and value. This is useful for 
+   * testing and one-off uses but for high performance writes, the 
+   * interface should be implemented on existing data.
+   * 
+   * @param id The non-null ID to wrap.
+   * @param value The non-null value to wrap.
+   * @return A wrapped datum object.
+   * @throws IllegalArgumentException if the ID or value were null.
+   */
+  public static TimeSeriesDatum wrap(
+      final TimeSeriesDatumId id, 
+      final TimeSeriesValue<? extends TimeSeriesDataType> value) {
+    if (id == null) {
+      throw new IllegalArgumentException("ID cannot be null.");
+    }
+    if (value == null) {
+      throw new IllegalArgumentException("Value cannot be null.");
+    }
+    
+    return new TimeSeriesDatum() {
+
+      @Override
+      public TimeSeriesDatumId id() {
+        return id;
+      }
+
+      @Override
+      public TimeSeriesValue<? extends TimeSeriesDataType> value() {
+        return value;
+      }
+      
+    };
+  }
 }

--- a/common/src/test/java/net/opentsdb/data/TestSecondTimeStamp.java
+++ b/common/src/test/java/net/opentsdb/data/TestSecondTimeStamp.java
@@ -1,0 +1,607 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2017  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.Test;
+
+import net.opentsdb.data.TimeStamp.Op;
+
+public class TestSecondTimeStamp {
+  // Fri, 15 May 2015 14:21:13 UTC
+  final static long TS = 1431699673L;
+ 
+  @Test
+  public void ctors() throws Exception {
+    TimeStamp ts = new SecondTimeStamp(1531847231);
+    assertEquals(1531847231000L, ts.msEpoch());
+    assertEquals(1531847231, ts.epoch());
+    assertEquals(0, ts.nanos());
+    assertEquals(ChronoUnit.SECONDS, ts.units());
+    assertEquals(ZoneId.of("UTC"), ts.timezone());
+    
+    ts = new SecondTimeStamp(-1000);
+    assertEquals(-1000000L, ts.msEpoch());
+    assertEquals(-1000, ts.epoch());
+    assertEquals(0, ts.nanos());
+    assertEquals(ChronoUnit.SECONDS, ts.units());
+    
+    ts = new SecondTimeStamp(60);
+    assertEquals(60000L, ts.msEpoch());
+    assertEquals(60, ts.epoch());
+    assertEquals(0, ts.nanos());
+    assertEquals(ChronoUnit.SECONDS, ts.units());
+  }
+  
+  @Test
+  public void getCopy() throws Exception {
+    TimeStamp ts = new SecondTimeStamp(1531847231);
+    assertEquals(1531847231000L, ts.msEpoch());
+    assertEquals(1531847231, ts.epoch());
+    
+    TimeStamp copy = ts.getCopy();
+    assertNotSame(ts, copy);
+    assertEquals(1531847231000L, ts.msEpoch());
+    assertEquals(1531847231, ts.epoch());
+  }
+  
+  @Test
+  public void update() throws Exception {
+    TimeStamp ts = new SecondTimeStamp(1000);
+    ts.updateMsEpoch(2000000);
+    assertEquals(2000000, ts.msEpoch());
+    assertEquals(2000, ts.epoch());
+    assertEquals(0, ts.nanos());
+    
+    ts.updateEpoch(3);
+    assertEquals(3000, ts.msEpoch());
+    assertEquals(3, ts.epoch());
+    assertEquals(0, ts.nanos());
+    
+    ts.update(5, 500);
+    assertEquals(5000, ts.msEpoch());
+    assertEquals(5, ts.epoch());
+    assertEquals(0, ts.nanos());
+    
+    ts.update(6, 600400500);
+    assertEquals(6000, ts.msEpoch());
+    assertEquals(6, ts.epoch());
+    assertEquals(0, ts.nanos());
+    
+    TimeStamp copy_into = new SecondTimeStamp(1000);
+    assertEquals(1000000, copy_into.msEpoch());
+    assertEquals(1000, copy_into.epoch());
+    assertEquals(0, copy_into.nanos());
+    
+    copy_into.update(ts);
+    assertEquals(6000, copy_into.msEpoch());
+    assertEquals(6, copy_into.epoch());
+    assertEquals(0, copy_into.nanos());
+  }
+  
+  @Test
+  public void compare() throws Exception {
+    final TimeStamp ts1 = new SecondTimeStamp(1000);
+    TimeStamp ts2 = new SecondTimeStamp(2000);
+    
+    assertTrue(ts1.compare(Op.LT, ts2));
+    assertTrue(ts1.compare(Op.LTE, ts2));
+    assertFalse(ts1.compare(Op.GT, ts2));
+    assertFalse(ts1.compare(Op.GTE, ts2));
+    assertFalse(ts1.compare(Op.EQ, ts2));
+    assertTrue(ts1.compare(Op.NE, ts2));
+    
+    ts2.updateEpoch(1000);
+    assertTrue(ts1.compare(Op.EQ, ts2));
+    
+    // compare to something with a higher resolution
+    ts2 = new ZonedNanoTimeStamp(1000, 500, ZoneId.of("UTC"));
+    
+    assertTrue(ts1.compare(Op.LT, ts2));
+    assertTrue(ts1.compare(Op.LTE, ts2));
+    assertFalse(ts1.compare(Op.GT, ts2));
+    assertFalse(ts1.compare(Op.GTE, ts2));
+    assertFalse(ts1.compare(Op.EQ, ts2));
+    assertTrue(ts1.compare(Op.NE, ts2));
+    
+    assertFalse(ts2.compare(Op.LT, ts1));
+    assertFalse(ts2.compare(Op.LTE, ts1));
+    assertTrue(ts2.compare(Op.GT, ts1));
+    assertTrue(ts2.compare(Op.GTE, ts1));
+    assertFalse(ts2.compare(Op.EQ, ts1));
+    assertTrue(ts2.compare(Op.NE, ts1));
+    
+    try {
+      ts1.compare(Op.LT, null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      ts1.compare(null, ts2);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void setMax() throws Exception {
+    TimeStamp ts = new SecondTimeStamp(1000);
+    assertEquals(1000000, ts.msEpoch());
+    assertEquals(1000, ts.epoch());
+    
+    ts.setMax();
+    assertEquals(-1000, ts.msEpoch());
+    assertEquals(Long.MAX_VALUE, ts.epoch());
+  }
+
+  @Test
+  public void add() throws Exception {
+    TimeStamp ts = new SecondTimeStamp(1);
+    ts.add(Period.ofYears(1));
+    assertEquals(31536001000L, ts.msEpoch());
+    assertEquals(31536001, ts.epoch());
+    assertEquals(0, ts.nanos());
+    
+    ts = new SecondTimeStamp(1);
+    ts.add(Period.ofMonths(1));
+    assertEquals(2678401000L, ts.msEpoch());
+    assertEquals(2678401, ts.epoch());
+    assertEquals(0, ts.nanos());
+    
+    ts = new SecondTimeStamp(1);
+    ts.add(Period.ofWeeks(1));
+    assertEquals(604801000, ts.msEpoch());
+    assertEquals(604801, ts.epoch());
+    assertEquals(0, ts.nanos());
+    
+    ts = new SecondTimeStamp(1);
+    ts.add(Duration.of(1, ChronoUnit.DAYS));
+    assertEquals(86401000, ts.msEpoch());
+    assertEquals(86401, ts.epoch());
+    assertEquals(0, ts.nanos());
+    
+    ts = new SecondTimeStamp(1);
+    ts.add(Duration.of(2, ChronoUnit.HOURS));
+    assertEquals(7201000, ts.msEpoch());
+    assertEquals(7201, ts.epoch());
+    assertEquals(0, ts.nanos());
+    
+    ts = new SecondTimeStamp(1);
+    ts.add(Duration.of(14, ChronoUnit.SECONDS));
+    assertEquals(15000, ts.msEpoch());
+    assertEquals(15, ts.epoch());
+    assertEquals(0, ts.nanos());
+    
+    // no-ops
+    ts = new SecondTimeStamp(1);
+    ts.add(Duration.of(25, ChronoUnit.MILLIS));
+    assertEquals(1000, ts.msEpoch());
+    assertEquals(1, ts.epoch());
+    assertEquals(0, ts.nanos());
+    
+    ts = new SecondTimeStamp(1);
+    ts.add(Duration.of(100, ChronoUnit.MICROS));
+    assertEquals(1000, ts.msEpoch());
+    assertEquals(1, ts.epoch());
+    assertEquals(0, ts.nanos());
+    
+    ts = new SecondTimeStamp(1);
+    ts.add(Duration.of(100, ChronoUnit.NANOS));
+    assertEquals(1000, ts.msEpoch());
+    assertEquals(1, ts.epoch());
+    assertEquals(0, ts.nanos());
+  }
+
+  @Test
+  public void snapToPreviousIntervalNanos() throws Exception {
+    SecondTimeStamp ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1, ChronoUnit.NANOS);
+    assertEquals(TS, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(239, ChronoUnit.NANOS);
+    assertEquals(TS, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(999, ChronoUnit.NANOS);
+    assertEquals(TS, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1000000, ChronoUnit.NANOS);
+    assertEquals(TS, ts.epoch());
+    
+    // still the same second
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1000000000, ChronoUnit.NANOS);
+    assertEquals(TS, ts.epoch());
+    
+    // snap to hour
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(3600 * 1000000000L, ChronoUnit.NANOS);
+    assertEquals(1431698400L, ts.epoch());
+  }
+  
+  @Test
+  public void snapToPreviousIntervalMicros() throws Exception {
+    SecondTimeStamp ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1, ChronoUnit.MICROS);
+    assertEquals(TS, ts.epoch());
+   
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(500, ChronoUnit.MICROS);
+    assertEquals(TS, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1000, ChronoUnit.MICROS);
+    assertEquals(TS, ts.epoch());
+    
+    // finally making a difference
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(289, ChronoUnit.MICROS);
+    assertEquals(1431699673L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(999, ChronoUnit.MICROS);
+    assertEquals(1431699673L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1000000, ChronoUnit.MICROS);
+    assertEquals(1431699673L, ts.epoch());
+    
+    // just a bizarre case
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(6843581857L, ChronoUnit.MICROS);
+    assertEquals(1431695905L, ts.epoch());
+    
+    // snap to hour
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(3600 * 1000000L, ChronoUnit.MICROS);
+    assertEquals(1431698400L, ts.epoch());
+  }
+  
+  @Test
+  public void snapToPreviousIntervalMillis() throws Exception {
+    SecondTimeStamp ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1, ChronoUnit.MILLIS);
+    assertEquals(TS, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(5, ChronoUnit.MILLIS);
+    assertEquals(1431699673L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(10, ChronoUnit.MILLIS);
+    assertEquals(1431699673L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(20, ChronoUnit.MILLIS);
+    assertEquals(1431699673L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(200, ChronoUnit.MILLIS);
+    assertEquals(1431699673L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(250, ChronoUnit.MILLIS);
+    assertEquals(1431699673L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(500, ChronoUnit.MILLIS);
+    assertEquals(1431699673L, ts.epoch());
+    
+    // funky intervals based on seconds
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(750, ChronoUnit.MILLIS);
+    assertEquals(1431699672L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(289, ChronoUnit.MILLIS);
+    assertEquals(1431699672L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(3, ChronoUnit.MILLIS);
+    assertEquals(1431699672L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(999, ChronoUnit.MILLIS);
+    assertEquals(1431699672L, ts.epoch());
+    
+    // over the interval
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1000, ChronoUnit.MILLIS);
+    assertEquals(1431699673L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(5000, ChronoUnit.MILLIS);
+    assertEquals(1431699670L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1234, ChronoUnit.MILLIS);
+    assertEquals(1431699672L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(60000, ChronoUnit.MILLIS);
+    assertEquals(1431699660L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(6843581857L, ChronoUnit.MILLIS);
+    assertEquals(1426913981L, ts.epoch());
+  }
+  
+  @Test
+  public void snapToPreviousIntervalSeconds() throws Exception {
+    SecondTimeStamp ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1, ChronoUnit.SECONDS);
+    assertEquals(1431699673L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(3, ChronoUnit.SECONDS);
+    assertEquals(1431699672L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(5, ChronoUnit.SECONDS);
+    assertEquals(1431699670L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(10, ChronoUnit.SECONDS);
+    assertEquals(1431699670L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(15, ChronoUnit.SECONDS);
+    assertEquals(1431699660L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(30, ChronoUnit.SECONDS);
+    assertEquals(1431699660L, ts.epoch());
+    
+    // funky intervals based on minutes
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(45, ChronoUnit.SECONDS);
+    assertEquals(1431699660L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(7, ChronoUnit.SECONDS);
+    assertEquals(1431699667L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(25, ChronoUnit.SECONDS);
+    assertEquals(1431699650L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(59, ChronoUnit.SECONDS);
+    assertEquals(1431699639L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(60, ChronoUnit.SECONDS);
+    assertEquals(1431699660L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(61, ChronoUnit.SECONDS);
+    assertEquals(1431699620L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1234, ChronoUnit.SECONDS);
+    assertEquals(1431699634L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(120, ChronoUnit.SECONDS);
+    assertEquals(1431699600L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(3600, ChronoUnit.SECONDS);
+    assertEquals(1431698400L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(86400, ChronoUnit.SECONDS);
+    assertEquals(1431648000L, ts.epoch());
+  }
+  
+  @Test
+  public void snapToPreviousIntervalMinutes() throws Exception {
+    SecondTimeStamp ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1, ChronoUnit.MINUTES);
+    assertEquals(1431699660L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(2, ChronoUnit.MINUTES);
+    assertEquals(1431699600L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(3, ChronoUnit.MINUTES);
+    assertEquals(1431699660L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(5, ChronoUnit.MINUTES);
+    assertEquals(1431699600L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(10, ChronoUnit.MINUTES);
+    assertEquals(1431699600L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(15, ChronoUnit.MINUTES);
+    assertEquals(1431699300L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(30, ChronoUnit.MINUTES);
+    assertEquals(1431698400L, ts.epoch());
+    
+    // funky intervals based on hours
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(45, ChronoUnit.MINUTES);
+    assertEquals(1431699300L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(7, ChronoUnit.MINUTES);
+    assertEquals(1431699660L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(25, ChronoUnit.MINUTES);
+    assertEquals(1431699000L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(59, ChronoUnit.MINUTES);
+    assertEquals(1431697560L, ts.epoch());
+    
+    // over the interval
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(60, ChronoUnit.MINUTES);
+    assertEquals(1431698400L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(61, ChronoUnit.MINUTES);
+    assertEquals(1431699240L, ts.epoch());
+    
+    // another bizarre case
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1234, ChronoUnit.MINUTES);
+    assertEquals(1431697080L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(120, ChronoUnit.MINUTES);
+    assertEquals(1431698400L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1440, ChronoUnit.MINUTES);
+    assertEquals(1431648000L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(2880, ChronoUnit.MINUTES);
+    assertEquals(1431648000L, ts.epoch());
+  }
+  
+  @Test
+  public void snapToPreviousIntervalHours() throws Exception {
+    SecondTimeStamp ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1, ChronoUnit.HOURS);
+    assertEquals(1431698400L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(2, ChronoUnit.HOURS);
+    assertEquals(1431698400L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(3, ChronoUnit.HOURS);
+    assertEquals(1431691200L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(4, ChronoUnit.HOURS);
+    assertEquals(1431691200L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(6, ChronoUnit.HOURS);
+    assertEquals(1431691200L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(12, ChronoUnit.HOURS);
+    assertEquals(1431691200L, ts.epoch());
+    
+    // funky intervals based on days
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(18, ChronoUnit.HOURS);
+    assertEquals(1431669600L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(5, ChronoUnit.HOURS);
+    assertEquals(1431698400L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(23, ChronoUnit.HOURS);
+    assertEquals(1431680400L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(24, ChronoUnit.HOURS);
+    assertEquals(1431648000L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(48, ChronoUnit.HOURS);
+    assertEquals(1431648000L, ts.epoch());
+    
+    // just a bizarre case
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(1234, ChronoUnit.HOURS);
+    assertEquals(1428955200L, ts.epoch());
+    
+    // weekly, so we pass into that case.
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(168, ChronoUnit.HOURS);
+    assertEquals(1431216000L, ts.epoch());
+    
+    ts = new SecondTimeStamp(TS);
+    ts.snapToPreviousInterval(336, ChronoUnit.HOURS);
+    assertEquals(1431216000L, ts.epoch());
+  }
+  
+  // For other snap tos, see the ZonedNanoTimestamp class.
+  
+  @Test
+  public void snapToPreviousIntervalErrors() throws Exception {
+    SecondTimeStamp ts = new SecondTimeStamp(TS);
+    try {
+      ts.snapToPreviousInterval(0, ChronoUnit.WEEKS, DayOfWeek.SATURDAY);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      ts.snapToPreviousInterval(-42, ChronoUnit.WEEKS, DayOfWeek.SATURDAY);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      ts.snapToPreviousInterval(1, null, DayOfWeek.SATURDAY);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      ts.snapToPreviousInterval(1, ChronoUnit.WEEKS, null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      ts.snapToPreviousInterval(1, ChronoUnit.HALF_DAYS);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void equals() throws Exception {
+    TimeStamp ts = new SecondTimeStamp(1);
+    TimeStamp ts2 = null;
+    
+    assertFalse(ts.equals(ts2));
+    assertFalse(ts.equals("not a ts"));
+    assertTrue(ts.equals(ts));
+    
+    ts2 = new SecondTimeStamp(1);
+    assertTrue(ts.equals(ts2));
+    
+    ts2.add(Duration.of(1, ChronoUnit.DAYS));
+    assertFalse(ts.equals(ts2));
+    
+    ts2 = new ZonedNanoTimeStamp(1000L, ZoneId.of("UTC"));
+    assertTrue(ts.equals(ts2));
+  }
+  
+}

--- a/common/src/test/java/net/opentsdb/data/TestTimeSeriesDatum.java
+++ b/common/src/test/java/net/opentsdb/data/TestTimeSeriesDatum.java
@@ -1,0 +1,45 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+public class TestTimeSeriesDatum {
+
+  @Test
+  public void wrap() throws Exception {
+    final TimeSeriesDatumId id = mock(TimeSeriesDatumId.class);
+    final TimeSeriesValue<? extends TimeSeriesDataType> value = 
+        mock(TimeSeriesValue.class);
+    
+    TimeSeriesDatum wrapped = TimeSeriesDatum.wrap(id, value);
+    assertSame(id, wrapped.id());
+    assertSame(value, wrapped.value());
+    
+    try {
+      TimeSeriesDatum.wrap(null, value);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      TimeSeriesDatum.wrap(id, null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+}

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Codec.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Codec.java
@@ -17,6 +17,9 @@ package net.opentsdb.storage.schemas.tsdb1x;
 import com.google.common.reflect.TypeToken;
 
 import net.opentsdb.data.TimeSeriesDataType;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.rollup.RollupInterval;
+import net.opentsdb.utils.Pair;
 
 /**
  * A class that will return a storage object that can be populated
@@ -47,4 +50,20 @@ public interface Codec {
    * @return A new row sequence.
    */
   public RowSeq newRowSeq(final long base_time);
+
+  /**
+   * Encodes the given value into a qualifier and value to send to the
+   * key/value column store.  
+   * @param value A non-null value to encode.
+   * @param append_format Whether or not to generate the append format.
+   * @param base_time The base time in Unix epoch seconds.
+   * @param rollup_interval An optional rollup interval.
+   * @return A non-null pair where the key is the qualifier and the value
+   * is the column value.
+   */
+  public Pair<byte[], byte[]> encode(
+      final TimeSeriesValue<? extends TimeSeriesDataType> value,
+      final boolean append_format,
+      final int base_time,
+      final RollupInterval rollup_interval);
 }

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/NumericSummaryCodec.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/NumericSummaryCodec.java
@@ -17,7 +17,10 @@ package net.opentsdb.storage.schemas.tsdb1x;
 import com.google.common.reflect.TypeToken;
 
 import net.opentsdb.data.TimeSeriesDataType;
+import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
+import net.opentsdb.rollup.RollupInterval;
+import net.opentsdb.utils.Pair;
 
 /**
  * A codec for handling TSDB 2.x rollup data points.
@@ -43,4 +46,13 @@ public class NumericSummaryCodec implements Codec {
         + "sequences.");
   }
 
+  @Override
+  public Pair<byte[], byte[]> encode(
+      final TimeSeriesValue<? extends TimeSeriesDataType> value,
+      final boolean append_format,
+      final int base_time,
+      final RollupInterval rollup_interval) {
+    // TODO - implement
+    throw new UnsupportedOperationException("Not implemented yet.");
+  }
 }

--- a/core/src/main/java/net/opentsdb/uid/UniqueId.java
+++ b/core/src/main/java/net/opentsdb/uid/UniqueId.java
@@ -22,6 +22,8 @@ import javax.xml.bind.DatatypeConverter;
 import com.google.common.base.Strings;
 import com.stumbleupon.async.Deferred;
 
+import net.opentsdb.auth.AuthState;
+import net.opentsdb.data.TimeSeriesDatumId;
 import net.opentsdb.data.TimeSeriesStringId;
 import net.opentsdb.stats.Span;
 import net.opentsdb.utils.Bytes;
@@ -167,29 +169,36 @@ public interface UniqueId {
    * <p>
    * The length of the byte array is fixed in advance by the implementation.
    *
+   * @param auth A non-null auth state to perform authorization with.
    * @param name The name to lookup in the table or to assign an ID to.
+   * @param id A non-null datum ID to use in debugging.
    * @param span An optional tracing span.
-   * @return a deferred resolving to a UID if found or created or an exception
-   * from storage if something went wrong.
+   * @return A deferred resolving to an IdOrError object reflecting if 
+   * the resolution/creation was successful or not.
    * @since 3.0
    */
-  public Deferred<byte[]> getOrCreateId(final String name, final Span span);
+  public Deferred<IdOrError> getOrCreateId(final AuthState auth,
+                                           final String name, 
+                                           final TimeSeriesDatumId id,
+                                           final Span span);
   
   /**
    * Finds the IDs associated with an array of names or creates them.
    * <p>
    * The length of the byte array is fixed in advance by the implementation.
    *
+   * @param auth A non-null auth state to perform authorization with.
    * @param names The names to lookup in the table or to assign IDs to.
+   * @param id A non-null datum ID to use in debugging.
    * @param span An optional tracing span.
-   * @return a deferred resolving to an array of UIDs if found or created or an 
-   * exception from storage if something went wrong with any of the UID lookups
-   * or assignments. Also note that the array returned will have the same size
-   * and order of the list of names.
+   * @return A deferred resolving to IdOrError objects reflecting if 
+   * the resolution/creation was successful or not.
    * @since 3.0
    */
-  public Deferred<List<byte[]>> getOrCreateIds(final List<String> names, 
-                                               final Span span);
+  public Deferred<List<IdOrError>> getOrCreateIds(final AuthState auth,
+                                                  final List<String> names, 
+                                                  final TimeSeriesDatumId id,
+                                                  final Span span);
   
   /**
    * Attempts to find suggestions of names given a search term.

--- a/core/src/main/java/net/opentsdb/uid/UniqueIdStore.java
+++ b/core/src/main/java/net/opentsdb/uid/UniqueIdStore.java
@@ -19,7 +19,8 @@ import java.util.List;
 
 import com.stumbleupon.async.Deferred;
 
-import net.opentsdb.data.TimeSeriesId;
+import net.opentsdb.auth.AuthState;
+import net.opentsdb.data.TimeSeriesDatumId;
 import net.opentsdb.stats.Span;
 
 /**
@@ -61,37 +62,45 @@ public interface UniqueIdStore {
   
   /**
    * Converts the given string to it's UID value based on the type. If 
-   * the string didn't have an assigned UID in storage, creates it.
+   * the string didn't have an assigned UID in storage, attempts to
+   * create it given that the user has permission.
    * 
+   * @param auth The non-null auth state to parse.
    * @param type A non-null UID type.
    * @param name A non-null and non-empty string.
    * @param id A non-null ID for logging and abuse prevention purposes.   
    * @param span An optional tracing span.
-   * @return A deferred resolving to the UID if successful or an exception.
+   * @return A deferred resolving to an IdOrError object reflecting if 
+   * the resolution/creation was successful or not.
    * @throws IllegalArgumentException if the type was null or the string
    * was null or empty.
    */
-  public Deferred<byte[]> getOrCreateId(final UniqueIdType type, 
-                                        final String name,
-                                        final TimeSeriesId id,
-                                        final Span span);
+  public Deferred<IdOrError> getOrCreateId(final AuthState auth,
+                                           final UniqueIdType type, 
+                                           final String name,
+                                           final TimeSeriesDatumId id,
+                                           final Span span);
   
   /**
    * Converts the given strings to their UID values based on the type. If 
-   * the strings didn't have assigned UIDs in storage, they're assigned.
+   * the strings didn't have assigned UIDs in storage, they're assigned
+   * if the user has permission.
    * 
+   * @param auth The non-null auth state to parse.
    * @param type A non-null UID type.
    * @param names A non-null and non-empty list of strings.
    * @param id A non-null ID for logging and abuse prevention purposes.   
    * @param span An optional tracing span.
-   * @return A deferred resolving to the UIDs if successful or an exception.
+   * @return A deferred resolving to IdOrError objectss reflecting if 
+   * the resolution/creation was successful or not.
    * @throws IllegalArgumentException if the type was null or the string
    * was null or empty.
    */
-  public Deferred<List<byte[]>> getOrCreateIds(final UniqueIdType type, 
-                                              final List<String> names,
-                                              final TimeSeriesId id,
-                                              final Span span);
+  public Deferred<List<IdOrError>> getOrCreateIds(final AuthState auth,
+                                                  final UniqueIdType type, 
+                                                  final List<String> names,
+                                                  final TimeSeriesDatumId id,
+                                                  final Span span);
   
   /**
    * Converts the UID to the equivalent string name.
@@ -126,6 +135,10 @@ public interface UniqueIdStore {
                                          final List<byte[]> ids,
                                          final Span span);
   
-  /** @return The non-null characterset used for en/decoding. */
-  public Charset characterSet();
+  /**
+   * Fetch the character set for the given type.
+   * @param type A non-null ID type.
+   * @return The non-null character set.
+   */
+  public Charset characterSet(final UniqueIdType type);
 }

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/SchemaBase.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/SchemaBase.java
@@ -287,23 +287,23 @@ public class SchemaBase {
     final int tk = schema.tagkWidth();
     final int tv = schema.tagvWidth();
     
-    final byte[] key = new byte[Const.SALT_WIDTH() + m + 4 
+    final byte[] key = new byte[schema.salt_width + m + 4 
        + (tags.length / 2) * tk + (tags.length / 2) * tv];
     byte[] uid = metrics.getId(metric, null).join();
     
     // metrics first
     if (uid != null) {
-      System.arraycopy(uid, 0, key, Const.SALT_WIDTH(), m);
+      System.arraycopy(uid, 0, key, schema.salt_width, m);
     } else {
       throw new IllegalArgumentException("No METRIC UID was mocked for: " + metric);
     }
     
     // timestamp
-    System.arraycopy(Bytes.fromInt(base_time), 0, key, Const.SALT_WIDTH() + m, 
+    System.arraycopy(Bytes.fromInt(base_time), 0, key, schema.salt_width + m, 
         Const.TIMESTAMP_BYTES);
     
     // shortcut for offsets
-    final int pl = Const.SALT_WIDTH() + m + Const.TIMESTAMP_BYTES;
+    final int pl = schema.salt_width + m + Const.TIMESTAMP_BYTES;
     int ctr = 0;
     int offset = 0;
     for (final String tag : tags) {

--- a/core/src/test/java/net/opentsdb/uid/MockUIDStore.java
+++ b/core/src/test/java/net/opentsdb/uid/MockUIDStore.java
@@ -24,7 +24,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.stumbleupon.async.Deferred;
 
-import net.opentsdb.data.TimeSeriesId;
+import net.opentsdb.auth.AuthState;
+import net.opentsdb.data.TimeSeriesDatumId;
 import net.opentsdb.stats.Span;
 import net.opentsdb.storage.StorageException;
 import net.opentsdb.utils.ByteSet;
@@ -131,15 +132,21 @@ public class MockUIDStore implements UniqueIdStore {
   }
   
   @Override
-  public Deferred<byte[]> getOrCreateId(UniqueIdType type, String name,
-      TimeSeriesId id, Span span) {
+  public Deferred<IdOrError> getOrCreateId(final AuthState auth,
+      final UniqueIdType type, 
+      final String name,
+      final TimeSeriesDatumId id,
+      final Span span) {
     // TODO Auto-generated method stub
     return null;
   }
   
   @Override
-  public Deferred<List<byte[]>> getOrCreateIds(UniqueIdType type,
-      List<String> names, TimeSeriesId id, Span span) {
+  public Deferred<List<IdOrError>> getOrCreateIds(final AuthState auth,
+      final UniqueIdType type, 
+      final List<String> names,
+      final TimeSeriesDatumId id,
+      final Span span) {
     // TODO Auto-generated method stub
     return null;
   }
@@ -166,7 +173,7 @@ public class MockUIDStore implements UniqueIdStore {
   }
   
   @Override
-  public Charset characterSet() {
+  public Charset characterSet(final UniqueIdType type) {
     return charset;
   }
   

--- a/core/src/test/java/net/opentsdb/uid/MockUIDStore.java
+++ b/core/src/test/java/net/opentsdb/uid/MockUIDStore.java
@@ -137,8 +137,16 @@ public class MockUIDStore implements UniqueIdStore {
       final String name,
       final TimeSeriesDatumId id,
       final Span span) {
-    // TODO Auto-generated method stub
-    return null;
+    if (name_to_ex.get(type).contains(name)) {
+      return Deferred.fromError(new StorageException("Boo!"));
+    }
+    
+    final byte[] uid = name_to_id.get(type).get(name);
+    if (uid != null) {
+      return Deferred.fromResult(IdOrError.wrapId(uid));
+    }
+    
+    return Deferred.fromResult(IdOrError.wrapRejected("Mock can't assign: " + name));
   }
   
   @Override
@@ -147,8 +155,19 @@ public class MockUIDStore implements UniqueIdStore {
       final List<String> names,
       final TimeSeriesDatumId id,
       final Span span) {
-    // TODO Auto-generated method stub
-    return null;
+    final List<IdOrError> uids = Lists.newArrayListWithCapacity(names.size());
+    for (final String name : names) {
+      if (name_to_ex.get(type).contains(name)) {
+        return Deferred.fromError(new StorageException("Boo!"));
+      }
+      final byte[] uid = name_to_id.get(type).get(name);
+      if (uid != null) {
+        uids.add(IdOrError.wrapId(uid));
+      } else {
+        uids.add(IdOrError.wrapRejected("Mock can't assign: " + name));
+      }
+    }
+    return Deferred.fromResult(uids);
   }
   
   @Override

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xUniqueIdStore.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xUniqueIdStore.java
@@ -16,8 +16,11 @@ package net.opentsdb.storage;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -29,10 +32,12 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -45,18 +50,30 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.stumbleupon.async.Callback;
 import com.stumbleupon.async.Deferred;
+import com.stumbleupon.async.TimeoutException;
 
+import io.netty.util.Timer;
 import net.opentsdb.core.Const;
+import net.opentsdb.core.MockTSDB;
+import net.opentsdb.core.MockTSDB.FakeTaskTimer;
 import net.opentsdb.core.TSDB;
+import net.opentsdb.data.BaseTimeSeriesDatumStringId;
+import net.opentsdb.data.TimeSeriesDatumId;
+import net.opentsdb.data.TimeSeriesDatumStringId;
 import net.opentsdb.stats.MockTrace;
 import net.opentsdb.stats.Span;
 import net.opentsdb.stats.Span.SpanBuilder;
+import net.opentsdb.auth.AuthState;
 import net.opentsdb.configuration.Configuration;
 import net.opentsdb.configuration.UnitTestConfiguration;
 import net.opentsdb.query.filter.TagVFilter;
 import net.opentsdb.query.pojo.Filter;
 import net.opentsdb.storage.MockBase;
+import net.opentsdb.storage.WriteStatus.WriteState;
 import net.opentsdb.storage.schemas.tsdb1x.ResolvedFilter;
+import net.opentsdb.uid.IdOrError;
+import net.opentsdb.uid.RandomUniqueId;
+import net.opentsdb.uid.UniqueIdAssignmentAuthorizer;
 import net.opentsdb.uid.UniqueIdType;
 import net.opentsdb.utils.Config;
 import net.opentsdb.utils.UnitTestException;
@@ -76,14 +93,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.mockito.ArgumentMatcher;
-import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 @RunWith(PowerMockRunner.class)
 // "Classloader hell"...  It's real.  Tell PowerMock to ignore these classes
@@ -91,27 +107,160 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PowerMockIgnore({"javax.management.*", "javax.xml.*",
                   "ch.qos.*", "org.slf4j.*",
                   "com.sum.*", "org.xml.*"})
-@PrepareForTest({ HBaseClient.class, TSDB.class, Config.class, Scanner.class, 
-  /**RandomUniqueId.class,*/ Const.class, Deferred.class })
+@PrepareForTest({ HBaseClient.class, TSDB.class, Config.class, 
+  Scanner.class, RandomUniqueId.class, Const.class, Deferred.class })
 public class TestTsdb1xUniqueIdStore extends UTBase {
   
   private static final String UNI_STRING = "\u00a5123";
   private static final byte[] UNI_BYTES = new byte[] { 0, 0, 6 };
+  private static final String ASSIGNED_ID_NAME = "foo";
+  private static final byte[] ASSIGNED_ID = { 0, 'a', 0x42 };
+  
+  private static final String UNASSIGNED_ID_NAME = "new.metric";
+  private static final byte[] UNASSIGNED_ID = new byte[] { 0, 0, 0x2B };
+  
+  private static final String ASSIGNED_TAGV_NAME = "db01";
+  private static final byte[] ASSIGNED_TAGV = new byte[] { 0, 0, 8 };
+  private static final String UNASSIGNED_TAGV_NAME = "tyrion";
+  private static final byte[] UNASSIGNED_TAGV = new byte[] { 0, 0, 0x2B };
+  
+  private static TimeSeriesDatumStringId ASSIGNED_DATUM_ID;
+  private static TimeSeriesDatumStringId UNASSIGNED_DATUM_ID;
+  
+  private UniqueIdAssignmentAuthorizer filter;
+  private FakeTaskTimer timer;
   
   @BeforeClass
   public static void beforeClassLocal() throws Exception {
     // UTF-8 Encoding
-    storage.addColumn(UID_TABLE, UNI_STRING.getBytes(Const.UTF8_CHARSET), 
-        Tsdb1xUniqueIdStore.ID_FAMILY, Tsdb1xUniqueIdStore.METRICS_QUAL, 
+    storage.addColumn(UID_TABLE, 
+        UNI_STRING.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL, 
         UNI_BYTES);
-    storage.addColumn(UID_TABLE, UNI_BYTES, Tsdb1xUniqueIdStore.NAME_FAMILY, 
+    storage.addColumn(UID_TABLE, 
+        UNI_BYTES, 
+        Tsdb1xUniqueIdStore.NAME_FAMILY, 
         Tsdb1xUniqueIdStore.METRICS_QUAL, 
         UNI_STRING.getBytes(Const.UTF8_CHARSET));
+    
+    ASSIGNED_DATUM_ID = BaseTimeSeriesDatumStringId.newBuilder()
+        .setMetric(ASSIGNED_ID_NAME)
+        .addTags("host", ASSIGNED_TAGV_NAME)
+        .addTags("owner", UNASSIGNED_TAGV_NAME)
+        .build();
+    
+    UNASSIGNED_DATUM_ID = BaseTimeSeriesDatumStringId.newBuilder()
+        .setMetric(UNASSIGNED_ID_NAME)
+        .addTags("host", ASSIGNED_TAGV_NAME)
+        .addTags("owner", UNASSIGNED_TAGV_NAME)
+        .build();
   }
 
   @Before
   public void before() throws Exception {
     resetConfig();
+  }
+  
+  @Test
+  public void ctorDefaults() throws Exception {
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    assertFalse(uid.assign_and_retry);
+    assertFalse(uid.randomize_metric_ids);
+    assertFalse(uid.randomize_tagk_ids);
+    assertFalse(uid.randomize_tagv_ids);
+    
+    assertEquals(Tsdb1xUniqueIdStore.DEFAULT_ATTEMPTS_ASSIGN_ID, 
+        uid.max_attempts_assign);
+    assertEquals(Tsdb1xUniqueIdStore.DEFAULT_ATTEMPTS_ASSIGN_RANDOM_ID, 
+        uid.max_attempts_assign_random);
+    
+    assertEquals(Charset.forName("ISO-8859-1"), 
+        uid.characterSet(UniqueIdType.METRIC));
+    assertEquals(Charset.forName("ISO-8859-1"), 
+        uid.characterSet(UniqueIdType.TAGK));
+    assertEquals(Charset.forName("ISO-8859-1"), 
+        uid.characterSet(UniqueIdType.TAGV));
+    
+    assertEquals(UniqueIdType.values().length, uid.pending_assignments.size());
+    
+    try {
+      new Tsdb1xUniqueIdStore(null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void ctorOverrides() throws Exception {
+    MockTSDB tsdb = new MockTSDB();
+    Tsdb1xHBaseDataStore data_store = mock(Tsdb1xHBaseDataStore.class);
+    when(data_store.tsdb()).thenReturn(tsdb);
+    when(data_store.getConfigKey(anyString())).then(new Answer<String>() {
+      @Override
+      public String answer(InvocationOnMock invocation) throws Throwable {
+        return (String) invocation.getArguments()[0];
+      }
+    });
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    
+    // now we're assured they're registered, override
+    tsdb.config.override(data_store.getConfigKey(
+        Tsdb1xUniqueIdStore.CONFIG_PREFIX.get(UniqueIdType.METRIC) + 
+        Tsdb1xUniqueIdStore.CHARACTER_SET_KEY), 
+        "UTF8");
+    tsdb.config.override(data_store.getConfigKey(
+        Tsdb1xUniqueIdStore.CONFIG_PREFIX.get(UniqueIdType.TAGK) + 
+        Tsdb1xUniqueIdStore.CHARACTER_SET_KEY), 
+        "UTF8");
+    tsdb.config.override(data_store.getConfigKey(
+        Tsdb1xUniqueIdStore.CONFIG_PREFIX.get(UniqueIdType.TAGV) + 
+        Tsdb1xUniqueIdStore.CHARACTER_SET_KEY), 
+        "UTF8");
+    
+    tsdb.config.override(data_store.getConfigKey(
+        Tsdb1xUniqueIdStore.CONFIG_PREFIX.get(UniqueIdType.METRIC) + 
+        Tsdb1xUniqueIdStore.RANDOM_ASSIGNMENT_KEY), 
+        "true");
+    tsdb.config.override(data_store.getConfigKey(
+        Tsdb1xUniqueIdStore.CONFIG_PREFIX.get(UniqueIdType.TAGK) + 
+        Tsdb1xUniqueIdStore.RANDOM_ASSIGNMENT_KEY), 
+        "true");
+    tsdb.config.override(data_store.getConfigKey(
+        Tsdb1xUniqueIdStore.CONFIG_PREFIX.get(UniqueIdType.TAGV) + 
+        Tsdb1xUniqueIdStore.RANDOM_ASSIGNMENT_KEY), 
+        "true");
+    
+    tsdb.config.override(data_store.getConfigKey(
+        Tsdb1xUniqueIdStore.ASSIGN_AND_RETRY_KEY), 
+        "true");
+    tsdb.config.override(data_store.getConfigKey(
+        Tsdb1xUniqueIdStore.ATTEMPTS_KEY), 
+        "42");
+    tsdb.config.override(data_store.getConfigKey(
+        Tsdb1xUniqueIdStore.RANDOM_ATTEMPTS_KEY), 
+        "128");
+    
+    uid = new Tsdb1xUniqueIdStore(data_store);
+    
+    assertTrue(uid.assign_and_retry);
+    assertTrue(uid.randomize_metric_ids);
+    assertTrue(uid.randomize_tagk_ids);
+    assertTrue(uid.randomize_tagv_ids);
+    
+    assertEquals(42, 
+        uid.max_attempts_assign);
+    assertEquals(128, 
+        uid.max_attempts_assign_random);
+    
+    assertEquals(Charset.forName("UTF8"), 
+        uid.characterSet(UniqueIdType.METRIC));
+    assertEquals(Charset.forName("UTF8"), 
+        uid.characterSet(UniqueIdType.TAGK));
+    assertEquals(Charset.forName("UTF8"), 
+        uid.characterSet(UniqueIdType.TAGV));
+    
+    assertNull(uid.authorizer);
+    assertEquals(UniqueIdType.values().length, uid.pending_assignments.size());
   }
   
 //  @Test(expected=IllegalArgumentException.class)
@@ -159,7 +308,9 @@ public class TestTsdb1xUniqueIdStore extends UTBase {
     
     // now try it with UTF8
     tsdb.config.override(
-        data_store.getConfigKey(Tsdb1xUniqueIdStore.CHARACTER_SET_KEY), "UTF-8");
+        data_store.getConfigKey(
+            Tsdb1xUniqueIdStore.CONFIG_PREFIX.get(UniqueIdType.METRIC) + 
+            Tsdb1xUniqueIdStore.CHARACTER_SET_KEY), "UTF-8");
     uid = new Tsdb1xUniqueIdStore(data_store);
     
     assertEquals(METRIC_STRING, uid.getName(UniqueIdType.METRIC, METRIC_BYTES, null).join());
@@ -325,7 +476,9 @@ public class TestTsdb1xUniqueIdStore extends UTBase {
     
     // UTF8
     tsdb.config.override(
-        data_store.getConfigKey(Tsdb1xUniqueIdStore.CHARACTER_SET_KEY), "UTF-8");
+        data_store.getConfigKey(
+            Tsdb1xUniqueIdStore.CONFIG_PREFIX.get(UniqueIdType.METRIC) + 
+            Tsdb1xUniqueIdStore.CHARACTER_SET_KEY), "UTF-8");
     uid = new Tsdb1xUniqueIdStore(data_store);
     
     names = uid.getNames(UniqueIdType.METRIC, 
@@ -491,7 +644,9 @@ public class TestTsdb1xUniqueIdStore extends UTBase {
     
     // now try it with UTF8
     tsdb.config.override(
-        data_store.getConfigKey(Tsdb1xUniqueIdStore.CHARACTER_SET_KEY), "UTF-8");
+        data_store.getConfigKey(
+            Tsdb1xUniqueIdStore.CONFIG_PREFIX.get(UniqueIdType.METRIC) + 
+            Tsdb1xUniqueIdStore.CHARACTER_SET_KEY), "UTF-8");
     uid = new Tsdb1xUniqueIdStore(data_store);
     
     assertArrayEquals(METRIC_BYTES, uid.getId(UniqueIdType.METRIC, METRIC_STRING, null).join());
@@ -656,7 +811,9 @@ public class TestTsdb1xUniqueIdStore extends UTBase {
     
     // UTF8
     tsdb.config.override(
-        data_store.getConfigKey(Tsdb1xUniqueIdStore.CHARACTER_SET_KEY), "UTF-8");
+        data_store.getConfigKey(
+            Tsdb1xUniqueIdStore.CONFIG_PREFIX.get(UniqueIdType.METRIC) + 
+            Tsdb1xUniqueIdStore.CHARACTER_SET_KEY), "UTF-8");
     uid = new Tsdb1xUniqueIdStore(data_store);
     
     ids = uid.getIds(UniqueIdType.METRIC, 
@@ -829,602 +986,813 @@ public class TestTsdb1xUniqueIdStore extends UTBase {
 //
 //    uid.getId("foo");
 //  }
-//
-//  @Test(expected=NoSuchUniqueName.class)
-//  public void getIdForNonexistentName() {
-//    uid = new UniqueId(client, table, METRIC, 3);
-//
-//    when(client.get(anyGet()))      // null  =>  ID doesn't exist.
-//      .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//    // Watch this! ______,^   I'm writing C++ in Java!
-//
-//    uid.getId("foo");
-//  }
-//
-//  @Test
-//  public void getOrCreateIdWithExistingId() {
-//    uid = new UniqueId(client, table, METRIC, 3);
-//    final byte[] id = { 0, 'a', 0x42 };
-//    final byte[] byte_name = { 'f', 'o', 'o' };
-//
-//    ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
-//    kvs.add(new KeyValue(byte_name, ID, METRIC_ARRAY, id));
-//    when(client.get(anyGet()))
-//      .thenReturn(Deferred.fromResult(kvs));
-//
-//    assertArrayEquals(id, uid.getOrCreateId("foo"));
-//    // Should be a cache hit ...
-//    assertArrayEquals(id, uid.getOrCreateId("foo"));
-//    assertEquals(1, uid.cacheHits());
-//    assertEquals(1, uid.cacheMisses());
-//    assertEquals(2, uid.cacheSize());
-//
-//    // ... so verify there was only one HBase Get.
-//    verify(client).get(anyGet());
-//  }
-//
-//  @Test  // Test the creation of an ID with no problem.
-//  public void getOrCreateIdAssignFilterOK() {
-//    uid = new UniqueId(client, table, METRIC, 3);
-//    final byte[] id = { 0, 0, 5 };
-//    final Config config = mock(Config.class);
-//    when(config.enable_realtime_uid()).thenReturn(false);
-//    final TSDB tsdb = mock(TSDB.class);
-//    when(tsdb.getConfig()).thenReturn(config);
-//    uid.setTSDB(tsdb);
-//    final UniqueIdFilterPlugin filter = mock(UniqueIdFilterPlugin.class);
-//    when(filter.fillterUIDAssignments()).thenReturn(true);
-//    when(filter.allowUIDAssignment(any(UniqueIdType.class), anyString(), 
-//        anyString(), anyMapOf(String.class, String.class)))
-//      .thenReturn(Deferred.fromResult(true));
-//    when(tsdb.getUidFilter()).thenReturn(filter);
-//    
-//    when(client.get(anyGet()))      // null  =>  ID doesn't exist.
-//      .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//    // Watch this! ______,^   I'm writing C++ in Java!
-//
-//    when(client.atomicIncrement(incrementForRow(MAXID)))
-//      .thenReturn(Deferred.fromResult(5L));
-//
-//    when(client.compareAndSet(anyPut(), emptyArray()))
-//      .thenReturn(Deferred.fromResult(true))
-//      .thenReturn(Deferred.fromResult(true));
-//
-//    assertArrayEquals(id, uid.getOrCreateId("foo"));
-//    // Should be a cache hit since we created that entry.
-//    assertArrayEquals(id, uid.getOrCreateId("foo"));
-//    // Should be a cache hit too for the same reason.
-//    assertEquals("foo", uid.getName(id));
-//
-//    verify(client).get(anyGet()); // Initial Get.
-//    verify(client).atomicIncrement(incrementForRow(MAXID));
-//    // Reverse + forward mappings.
-//    verify(client, times(2)).compareAndSet(anyPut(), emptyArray());
-//    verify(filter, times(1)).allowUIDAssignment(any(UniqueIdType.class), anyString(), 
-//        anyString(), anyMapOf(String.class, String.class));
-//  }
-//
-//  @Test (expected = FailedToAssignUniqueIdException.class)
-//  public void getOrCreateIdAssignFilterBlocked() {
-//    uid = new UniqueId(client, table, METRIC, 3);
-//    final Config config = mock(Config.class);
-//    when(config.enable_realtime_uid()).thenReturn(false);
-//    final TSDB tsdb = mock(TSDB.class);
-//    when(tsdb.getConfig()).thenReturn(config);
-//    uid.setTSDB(tsdb);
-//    final UniqueIdFilterPlugin filter = mock(UniqueIdFilterPlugin.class);
-//    when(filter.fillterUIDAssignments()).thenReturn(true);
-//    when(filter.allowUIDAssignment(any(UniqueIdType.class), anyString(), 
-//        anyString(), anyMapOf(String.class, String.class)))
-//      .thenReturn(Deferred.fromResult(false));
-//    when(tsdb.getUidFilter()).thenReturn(filter);
-//    
-//    when(client.get(anyGet()))      // null  =>  ID doesn't exist.
-//            .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//    // Watch this! ______,^   I'm writing C++ in Java!
-//
-//    when(client.atomicIncrement(incrementForRow(MAXID)))
-//            .thenReturn(Deferred.fromResult(5L));
-//
-//    when(client.compareAndSet(anyPut(), emptyArray()))
-//            .thenReturn(Deferred.fromResult(true))
-//            .thenReturn(Deferred.fromResult(true));
-//
-//    uid.getOrCreateId("foo");
-//  }
-//
-//  @Test(expected = RuntimeException.class)
-//  public void getOrCreateIdAssignFilterReturnException() {
-//    uid = new UniqueId(client, table, METRIC, 3);
-//    final Config config = mock(Config.class);
-//    when(config.enable_realtime_uid()).thenReturn(false);
-//    final TSDB tsdb = mock(TSDB.class);
-//    when(tsdb.getConfig()).thenReturn(config);
-//    uid.setTSDB(tsdb);
-//    final UniqueIdFilterPlugin filter = mock(UniqueIdFilterPlugin.class);
-//    when(filter.fillterUIDAssignments()).thenReturn(true);
-//    when(filter.allowUIDAssignment(any(UniqueIdType.class), anyString(), 
-//        anyString(), anyMapOf(String.class, String.class)))
-//      .thenReturn(Deferred.<Boolean>fromError(new UnitTestException()));
-//    when(tsdb.getUidFilter()).thenReturn(filter);
-//
-//    when(client.get(anyGet()))      // null  =>  ID doesn't exist.
-//            .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//    // Watch this! ______,^   I'm writing C++ in Java!
-//
-//    when(client.atomicIncrement(incrementForRow(MAXID)))
-//            .thenReturn(Deferred.fromResult(5L));
-//
-//    when(client.compareAndSet(anyPut(), emptyArray()))
-//            .thenReturn(Deferred.fromResult(true))
-//            .thenReturn(Deferred.fromResult(true));
-//
-//    uid.getOrCreateId("foo");
-//  }
-//  
-//  @Test(expected = RuntimeException.class)
-//  public void getOrCreateIdAssignFilterThrowsException() {
-//    uid = new UniqueId(client, table, METRIC, 3);
-//    final Config config = mock(Config.class);
-//    when(config.enable_realtime_uid()).thenReturn(false);
-//    final TSDB tsdb = mock(TSDB.class);
-//    when(tsdb.getConfig()).thenReturn(config);
-//    uid.setTSDB(tsdb);
-//    final UniqueIdFilterPlugin filter = mock(UniqueIdFilterPlugin.class);
-//    when(filter.fillterUIDAssignments()).thenReturn(true);
-//    when(filter.allowUIDAssignment(any(UniqueIdType.class), anyString(), 
-//        anyString(), anyMapOf(String.class, String.class)))
-//      .thenThrow(new UnitTestException());
-//    when(tsdb.getUidFilter()).thenReturn(filter);
-//
-//    when(client.get(anyGet()))      // null  =>  ID doesn't exist.
-//            .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//    // Watch this! ______,^   I'm writing C++ in Java!
-//
-//    when(client.atomicIncrement(incrementForRow(MAXID)))
-//            .thenReturn(Deferred.fromResult(5L));
-//
-//    when(client.compareAndSet(anyPut(), emptyArray()))
-//            .thenReturn(Deferred.fromResult(true))
-//            .thenReturn(Deferred.fromResult(true));
-//
-//    uid.getOrCreateId("foo");
-//  }
-//
-//  @Test
-//  public void getOrCreateIdAsyncAssignFilterOK() throws Exception {
-//    uid = new UniqueId(client, table, METRIC, 3);
-//    final byte[] id = { 0, 0, 5 };
-//    final Config config = mock(Config.class);
-//    when(config.enable_realtime_uid()).thenReturn(false);
-//    final TSDB tsdb = mock(TSDB.class);
-//    when(tsdb.getConfig()).thenReturn(config);
-//    uid.setTSDB(tsdb);
-//    final UniqueIdFilterPlugin filter = mock(UniqueIdFilterPlugin.class);
-//    when(filter.fillterUIDAssignments()).thenReturn(true);
-//    when(filter.allowUIDAssignment(any(UniqueIdType.class), anyString(), 
-//        anyString(), anyMapOf(String.class, String.class)))
-//      .thenReturn(Deferred.fromResult(true));
-//    when(tsdb.getUidFilter()).thenReturn(filter);
-//    when(client.get(anyGet()))      // null  =>  ID doesn't exist.
-//      .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//    // Watch this! ______,^   I'm writing C++ in Java!
-//
-//    when(client.atomicIncrement(incrementForRow(MAXID)))
-//      .thenReturn(Deferred.fromResult(5L));
-//
-//    when(client.compareAndSet(anyPut(), emptyArray()))
-//      .thenReturn(Deferred.fromResult(true))
-//      .thenReturn(Deferred.fromResult(true));
-//
-//    assertArrayEquals(id, uid.getOrCreateIdAsync("foo").join());
-//    // Should be a cache hit since we created that entry.
-//    assertArrayEquals(id, uid.getOrCreateIdAsync("foo").join());
-//    // Should be a cache hit too for the same reason.
-//    assertEquals("foo", uid.getName(id));
-//    
-//    verify(client).get(anyGet()); // Initial Get.
-//    verify(client).atomicIncrement(incrementForRow(MAXID));
-//    // Reverse + forward mappings.
-//    verify(client, times(2)).compareAndSet(anyPut(), emptyArray());
-//    verify(filter, times(1)).allowUIDAssignment(any(UniqueIdType.class), anyString(), 
-//        anyString(), anyMapOf(String.class, String.class));
-//  }
-//  
-//  @Test (expected = FailedToAssignUniqueIdException.class)
-//  public void getOrCreateIdAsyncAssignFilterBlocked() throws Exception {
-//    uid = new UniqueId(client, table, METRIC, 3);
-//    final Config config = mock(Config.class);
-//    when(config.enable_realtime_uid()).thenReturn(false);
-//    final TSDB tsdb = mock(TSDB.class);
-//    when(tsdb.getConfig()).thenReturn(config);
-//    uid.setTSDB(tsdb);
-//    final UniqueIdFilterPlugin filter = mock(UniqueIdFilterPlugin.class);
-//    when(filter.fillterUIDAssignments()).thenReturn(true);
-//    when(filter.allowUIDAssignment(any(UniqueIdType.class), anyString(), 
-//        anyString(), anyMapOf(String.class, String.class)))
-//      .thenReturn(Deferred.fromResult(false));
-//    when(tsdb.getUidFilter()).thenReturn(filter);
-//    when(client.get(anyGet()))      // null  =>  ID doesn't exist.
-//      .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//
-//    when(client.atomicIncrement(incrementForRow(MAXID)))
-//      .thenReturn(Deferred.fromResult(5L));
-//
-//    when(client.compareAndSet(anyPut(), emptyArray()))
-//      .thenReturn(Deferred.fromResult(true))
-//      .thenReturn(Deferred.fromResult(true));
-//
-//    uid.getOrCreateIdAsync("foo").join();
-//  }
-//  
-//  @Test (expected = UnitTestException.class)
-//  public void getOrCreateIdAsyncAssignFilterReturnException() throws Exception {
-//    uid = new UniqueId(client, table, METRIC, 3);
-//    final Config config = mock(Config.class);
-//    when(config.enable_realtime_uid()).thenReturn(false);
-//    final TSDB tsdb = mock(TSDB.class);
-//    when(tsdb.getConfig()).thenReturn(config);
-//    uid.setTSDB(tsdb);
-//    final UniqueIdFilterPlugin filter = mock(UniqueIdFilterPlugin.class);
-//    when(filter.fillterUIDAssignments()).thenReturn(true);
-//    when(filter.allowUIDAssignment(any(UniqueIdType.class), anyString(), 
-//        anyString(), anyMapOf(String.class, String.class)))
-//      .thenReturn(Deferred.<Boolean>fromError(new UnitTestException()));
-//    when(tsdb.getUidFilter()).thenReturn(filter);
-//    when(client.get(anyGet()))      // null  =>  ID doesn't exist.
-//      .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//
-//    when(client.atomicIncrement(incrementForRow(MAXID)))
-//      .thenReturn(Deferred.fromResult(5L));
-//
-//    when(client.compareAndSet(anyPut(), emptyArray()))
-//      .thenReturn(Deferred.fromResult(true))
-//      .thenReturn(Deferred.fromResult(true));
-//
-//    uid.getOrCreateIdAsync("foo").join();
-//  }
-//  
-//  @Test (expected = UnitTestException.class)
-//  public void getOrCreateIdAsyncAssignFilterThrowsException() throws Exception {
-//    uid = new UniqueId(client, table, METRIC, 3);
-//    final Config config = mock(Config.class);
-//    when(config.enable_realtime_uid()).thenReturn(false);
-//    final TSDB tsdb = mock(TSDB.class);
-//    when(tsdb.getConfig()).thenReturn(config);
-//    uid.setTSDB(tsdb);
-//    final UniqueIdFilterPlugin filter = mock(UniqueIdFilterPlugin.class);
-//    when(filter.fillterUIDAssignments()).thenReturn(true);
-//    when(filter.allowUIDAssignment(any(UniqueIdType.class), anyString(), 
-//        anyString(),anyMapOf(String.class, String.class)))
-//      .thenThrow(new UnitTestException());
-//    when(tsdb.getUidFilter()).thenReturn(filter);
-//    when(client.get(anyGet()))      // null  =>  ID doesn't exist.
-//      .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//
-//    when(client.atomicIncrement(incrementForRow(MAXID)))
-//      .thenReturn(Deferred.fromResult(5L));
-//
-//    when(client.compareAndSet(anyPut(), emptyArray()))
-//      .thenReturn(Deferred.fromResult(true))
-//      .thenReturn(Deferred.fromResult(true));
-//
-//    uid.getOrCreateIdAsync("foo").join();
-//  }
-//  
-//  @Test  // Test the creation of an ID when unable to increment MAXID
-//  public void getOrCreateIdUnableToIncrementMaxId() throws Exception {
-//    PowerMockito.mockStatic(Thread.class);
-//
-//    uid = new UniqueId(client, table, METRIC, 3);
-//
-//    when(client.get(anyGet()))      // null  =>  ID doesn't exist.
-//      .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//    // Watch this! ______,^   I'm writing C++ in Java!
-//
-//    HBaseException hbe = fakeHBaseException();
-//    when(client.atomicIncrement(incrementForRow(MAXID)))
-//      .thenThrow(hbe);
-//    PowerMockito.doNothing().when(Thread.class); Thread.sleep(anyInt());
-//
-//    try {
-//      uid.getOrCreateId("foo");
-//      fail("HBaseException should have been thrown!");
-//    } catch (HBaseException e) {
-//      assertSame(hbe, e);
-//    }
-//  }
-//
-//  @Test  // Test the creation of an ID with a race condition.
-//  public void getOrCreateIdAssignIdWithRaceCondition() {
-//    // Simulate a race between client A and client B.
-//    // A does a Get and sees that there's no ID for this name.
-//    // B does a Get and sees that there's no ID too, and B actually goes
-//    // through the entire process to create the ID.
-//    // Then A attempts to go through the process and should discover that the
-//    // ID has already been assigned.
-//
-//    uid = new UniqueId(client, table, METRIC, 3); // Used by client A.
-//    HBaseClient client_b = mock(HBaseClient.class); // For client B.
-//    final UniqueId uid_b = new UniqueId(client_b, table, METRIC, 3);
-//
-//    final byte[] id = { 0, 0, 5 };
-//    final byte[] byte_name = { 'f', 'o', 'o' };
-//    final ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
-//    kvs.add(new KeyValue(byte_name, ID, METRIC_ARRAY, id));
-//    
-//    final Deferred<ArrayList<KeyValue>> d = 
-//      PowerMockito.spy(new Deferred<ArrayList<KeyValue>>());
-//    when(client.get(anyGet()))
-//      .thenReturn(d)
-//      .thenReturn(Deferred.fromResult(kvs));
-//
-//    final Answer<byte[]> the_race = new Answer<byte[]>() {
-//      public byte[] answer(final InvocationOnMock unused_invocation) throws Exception {
-//        // While answering A's first Get, B doest a full getOrCreateId.
-//        assertArrayEquals(id, uid_b.getOrCreateId("foo"));
-//        d.callback(null);
-//        return (byte[]) ((Deferred) d).join();
-//      }
-//    };
-//
-//    // Start the race when answering A's first Get.
-//    try {
-//      PowerMockito.doAnswer(the_race).when(d).joinUninterruptibly();
-//    } catch (Exception e) {
-//      fail("Should never happen: " + e);
-//    }
-//
-//    when(client_b.get(anyGet())) // null => ID doesn't exist.
-//      .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//    // Watch this! ______,^ I'm writing C++ in Java!
-//
-//    when(client_b.atomicIncrement(incrementForRow(MAXID)))
-//      .thenReturn(Deferred.fromResult(5L));
-//
-//    when(client_b.compareAndSet(anyPut(), emptyArray()))
-//      .thenReturn(Deferred.fromResult(true))
-//      .thenReturn(Deferred.fromResult(true));
-//
-//    // Now that B is finished, A proceeds and allocates a UID that will be
-//    // wasted, and creates the reverse mapping, but fails at creating the
-//    // forward mapping.
-//    when(client.atomicIncrement(incrementForRow(MAXID)))
-//      .thenReturn(Deferred.fromResult(6L));
-//
-//    when(client.compareAndSet(anyPut(), emptyArray()))
-//      .thenReturn(Deferred.fromResult(true)) // Orphan reverse mapping.
-//      .thenReturn(Deferred.fromResult(false)); // Already CAS'ed by A.
-//
-//    // Start the execution.
-//    assertArrayEquals(id, uid.getOrCreateId("foo"));
-//
-//    // Verify the order of execution too.
-//    final InOrder order = inOrder(client, client_b);
-//    order.verify(client).get(anyGet()); // 1st Get for A.
-//    order.verify(client_b).get(anyGet()); // 1st Get for B.
-//    order.verify(client_b).atomicIncrement(incrementForRow(MAXID));
-//    order.verify(client_b, times(2)).compareAndSet(anyPut(), // both mappings.
-//                                                   emptyArray());
-//    order.verify(client).atomicIncrement(incrementForRow(MAXID));
-//    order.verify(client, times(2)).compareAndSet(anyPut(), // both mappings.
-//                                                 emptyArray());
-//    order.verify(client).get(anyGet()); // A retries and gets it.
-//  }
-//
-//  @Test
-//  // Test the creation of an ID when all possible IDs are already in use
-//  public void getOrCreateIdWithOverflow() {
-//    uid = new UniqueId(client, table, METRIC, 1);  // IDs are only on 1 byte.
-//
-//    when(client.get(anyGet()))      // null  =>  ID doesn't exist.
-//      .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//    // Watch this! ______,^   I'm writing C++ in Java!
-//
-//    // Update once HBASE-2292 is fixed:
-//    when(client.atomicIncrement(incrementForRow(MAXID)))
-//      .thenReturn(Deferred.fromResult(256L));
-//
-//    try {
-//      final byte[] id = uid.getOrCreateId("foo");
-//      fail("IllegalArgumentException should have been thrown but instead "
-//           + " this was returned id=" + Arrays.toString(id));
-//    } catch (IllegalStateException e) {
-//      // OK.
-//    }
-//
-//    verify(client, times(1)).get(anyGet());  // Initial Get.
-//    verify(client).atomicIncrement(incrementForRow(MAXID));
-//  }
-//
-//  @Test  // ICV throws an exception, we can't get an ID.
-//  public void getOrCreateIdWithICVFailure() {
-//    uid = new UniqueId(client, table, METRIC, 3);
-//    final Config config = mock(Config.class);
-//    when(config.enable_realtime_uid()).thenReturn(false);
-//    final TSDB tsdb = mock(TSDB.class);
-//    when(tsdb.getConfig()).thenReturn(config);
-//    uid.setTSDB(tsdb);
-//    
-//    when(client.get(anyGet()))      // null  =>  ID doesn't exist.
-//      .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//    // Watch this! ______,^   I'm writing C++ in Java!
-//
-//    // Update once HBASE-2292 is fixed:
-//    HBaseException hbe = fakeHBaseException();
-//    when(client.atomicIncrement(incrementForRow(MAXID)))
-//      .thenReturn(Deferred.<Long>fromError(hbe))
-//      .thenReturn(Deferred.fromResult(5L));
-//
-//    when(client.compareAndSet(anyPut(), emptyArray()))
-//      .thenReturn(Deferred.fromResult(true))
-//      .thenReturn(Deferred.fromResult(true));
-//
-//    final byte[] id = { 0, 0, 5 };
-//    assertArrayEquals(id, uid.getOrCreateId("foo"));
-//    verify(client, times(1)).get(anyGet()); // Initial Get.
-//    // First increment (failed) + retry.
-//    verify(client, times(2)).atomicIncrement(incrementForRow(MAXID));
-//    // Reverse + forward mappings.
-//    verify(client, times(2)).compareAndSet(anyPut(), emptyArray());
-//  }
-//
-//  @Test  // Test that the reverse mapping is created before the forward one.
-//  public void getOrCreateIdPutsReverseMappingFirst() {
-//    uid = new UniqueId(client, table, METRIC, 3);
-//    final Config config = mock(Config.class);
-//    when(config.enable_realtime_uid()).thenReturn(false);
-//    final TSDB tsdb = mock(TSDB.class);
-//    when(tsdb.getConfig()).thenReturn(config);
-//    uid.setTSDB(tsdb);
-//    
-//    when(client.get(anyGet()))      // null  =>  ID doesn't exist.
-//      .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//    // Watch this! ______,^   I'm writing C++ in Java!
-//
-//    when(client.atomicIncrement(incrementForRow(MAXID)))
-//      .thenReturn(Deferred.fromResult(6L));
-//
-//    when(client.compareAndSet(anyPut(), emptyArray()))
-//      .thenReturn(Deferred.fromResult(true))
-//      .thenReturn(Deferred.fromResult(true));
-//
-//    final byte[] id = { 0, 0, 6 };
-//    final byte[] row = { 'f', 'o', 'o' };
-//    assertArrayEquals(id, uid.getOrCreateId("foo"));
-//
-//    final InOrder order = inOrder(client);
-//    order.verify(client).get(anyGet());            // Initial Get.
-//    order.verify(client).atomicIncrement(incrementForRow(MAXID));
-//    order.verify(client).compareAndSet(putForRow(id), emptyArray());
-//    order.verify(client).compareAndSet(putForRow(row), emptyArray());
-//  }
-//  
-//  @Test
-//  public void getOrCreateIdRandom() {
-//    PowerMockito.mockStatic(RandomUniqueId.class);
-//    uid = new UniqueId(client, table, METRIC, 3, true);
-//    final long id = 42L;
-//    final byte[] id_array = { 0, 0, 0x2A };
-//
-//    when(RandomUniqueId.getRandomUID()).thenReturn(id);
-//    when(client.get(any(GetRequest.class)))
-//      .thenReturn(Deferred.<ArrayList<KeyValue>>fromResult(null));
-//    
-//    when(client.compareAndSet(any(PutRequest.class), any(byte[].class)))
-//      .thenReturn(Deferred.fromResult(true))
-//      .thenReturn(Deferred.fromResult(true));
-//
-//    assertArrayEquals(id_array, uid.getOrCreateId("foo"));
-//    // Should be a cache hit ...
-//    assertArrayEquals(id_array, uid.getOrCreateId("foo"));
-//    assertEquals(1, uid.cacheHits());
-//    assertEquals(1, uid.cacheMisses());
-//    assertEquals(2, uid.cacheSize());
-//    assertEquals(0, uid.randomIdCollisions());
-//    // ... so verify there was only one HBase Get.
-//    verify(client).get(any(GetRequest.class));
-//  }
-//  
-//  @Test
-//  public void getOrCreateIdRandomCollision() {
-//    PowerMockito.mockStatic(RandomUniqueId.class);
-//    uid = new UniqueId(client, table, METRIC, 3, true);
-//    final long id = 42L;
-//    final byte[] id_array = { 0, 0, 0x2A };
-//
-//    when(RandomUniqueId.getRandomUID()).thenReturn(24L).thenReturn(id);
-//    
-//    when(client.get(any(GetRequest.class)))
-//      .thenReturn(Deferred.fromResult((ArrayList<KeyValue>)null));
-//    
-//    when(client.compareAndSet(anyPut(), any(byte[].class)))
-//      .thenReturn(Deferred.fromResult(false))
-//      .thenReturn(Deferred.fromResult(true))
-//      .thenReturn(Deferred.fromResult(true));
-//
-//    assertArrayEquals(id_array, uid.getOrCreateId("foo"));
-//    // Should be a cache hit ...
-//    assertArrayEquals(id_array, uid.getOrCreateId("foo"));
-//    assertEquals(1, uid.cacheHits());
-//    assertEquals(1, uid.cacheMisses());
-//    assertEquals(2, uid.cacheSize());
-//    assertEquals(1, uid.randomIdCollisions());
-//
-//    // ... so verify there was only one HBase Get.
-//    verify(client).get(anyGet());
-//  }
-//  
-//  @Test
-//  public void getOrCreateIdRandomCollisionTooManyAttempts() {
-//    PowerMockito.mockStatic(RandomUniqueId.class);
-//    uid = new UniqueId(client, table, METRIC, 3, true);
-//    final long id = 42L;
-//
-//    when(RandomUniqueId.getRandomUID()).thenReturn(24L).thenReturn(id);
-//    
-//    when(client.get(any(GetRequest.class)))
-//      .thenReturn(Deferred.fromResult((ArrayList<KeyValue>)null));
-//    
-//    when(client.compareAndSet(any(PutRequest.class), any(byte[].class)))
-//      .thenReturn(Deferred.fromResult(false))
-//      .thenReturn(Deferred.fromResult(false))
-//      .thenReturn(Deferred.fromResult(false))
-//      .thenReturn(Deferred.fromResult(false))
-//      .thenReturn(Deferred.fromResult(false))
-//      .thenReturn(Deferred.fromResult(false))
-//      .thenReturn(Deferred.fromResult(false))
-//      .thenReturn(Deferred.fromResult(false))
-//      .thenReturn(Deferred.fromResult(false))
-//      .thenReturn(Deferred.fromResult(false));
-//
-//    try {
-//      final byte[] assigned_id = uid.getOrCreateId("foo");
-//      fail("FailedToAssignUniqueIdException should have been thrown but instead "
-//           + " this was returned id=" + Arrays.toString(assigned_id));
-//    } catch (FailedToAssignUniqueIdException e) {
-//      // OK
-//    }
-//    assertEquals(0, uid.cacheHits());
-//    assertEquals(1, uid.cacheMisses());
-//    assertEquals(0, uid.cacheSize());
-//    assertEquals(9, uid.randomIdCollisions());
-//
-//    // ... so verify there was only one HBase Get.
-//    verify(client).get(any(GetRequest.class));
-//  }
-//  
-//  @Test
-//  public void getOrCreateIdRandomWithRaceCondition() {
-//    PowerMockito.mockStatic(RandomUniqueId.class);
-//    uid = new UniqueId(client, table, METRIC, 3, true);
-//    final long id = 24L;
-//    final byte[] id_array = { 0, 0, 0x2A };
-//    final byte[] byte_name = { 'f', 'o', 'o' };
-//    
-//    ArrayList<KeyValue> kvs = new ArrayList<KeyValue>(1);
-//    kvs.add(new KeyValue(byte_name, ID, METRIC_ARRAY, id_array));
-//    
-//    when(RandomUniqueId.getRandomUID()).thenReturn(id);
-//    
-//    when(client.get(any(GetRequest.class)))
-//      .thenReturn(Deferred.fromResult((ArrayList<KeyValue>)null))
-//      .thenReturn(Deferred.fromResult(kvs));
-//    
-//    when(client.compareAndSet(any(PutRequest.class), any(byte[].class)))
-//      .thenReturn(Deferred.fromResult(true))
-//      .thenReturn(Deferred.fromResult(false));
-//
-//    assertArrayEquals(id_array, uid.getOrCreateId("foo"));
-//    assertEquals(0, uid.cacheHits());
-//    assertEquals(2, uid.cacheMisses());
-//    assertEquals(2, uid.cacheSize());
-//    assertEquals(1, uid.randomIdCollisions());
-//
-//    // ... so verify there was only one HBase Get.
-//    verify(client, times(2)).get(any(GetRequest.class));
-//  }
-//  
+  
+  @Test
+  public void getOrCreateIdWithExistingId() throws Exception {
+    resetAssignmentState();
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    IdOrError result = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        ASSIGNED_ID_NAME, 
+        ASSIGNED_DATUM_ID, 
+        null).join();
+    assertArrayEquals(ASSIGNED_ID, result.id());
+    assertNull(result.error());
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+
+  @Test  // Test the creation of an ID with no problem.
+  public void getOrCreateIdAssignFilterOK() throws Exception {
+    resetAssignmentState();
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    IdOrError result = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null).join();
+    assertArrayEquals(UNASSIGNED_ID, result.id());
+    assertNull(result.error());
+    assertArrayEquals(UNASSIGNED_ID, storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertArrayEquals(UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        storage.getColumn(data_store.uidTable(), 
+            UNASSIGNED_ID, 
+            Tsdb1xUniqueIdStore.NAME_FAMILY, 
+            Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+
+  @Test
+  public void getOrCreateIdAssignFilterBlocked() throws Exception {
+    resetAssignmentState();
+    when(filter.allowUIDAssignment(any(AuthState.class), any(UniqueIdType.class), anyString(), 
+        any(TimeSeriesDatumId.class)))
+      .thenReturn(Deferred.fromResult("Nope!"));
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    IdOrError result = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null).join();
+    assertNull(result.id());
+    assertEquals("Nope!", result.error());
+    assertEquals(WriteState.REJECTED, result.state());
+    assertNull(storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertNull(storage.getColumn(data_store.uidTable(), 
+            UNASSIGNED_ID, 
+            Tsdb1xUniqueIdStore.NAME_FAMILY, 
+            Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+
+  @Test
+  public void getOrCreateIdAssignFilterReturnException() throws Exception{
+    resetAssignmentState();
+    when(filter.allowUIDAssignment(any(AuthState.class), any(UniqueIdType.class), anyString(), 
+        any(TimeSeriesDatumId.class))).thenAnswer(new Answer<Deferred<String>>() {
+          @Override
+          public Deferred<String> answer(InvocationOnMock invocation)
+              throws Throwable {
+            return Deferred.fromError(new UnitTestException());
+          }
+        });
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    Deferred<IdOrError> deferred = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null);
+    try {
+      deferred.join();
+      fail("Expected UnitTestException");
+    } catch (UnitTestException e) { }
+    assertNull(storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertNull(storage.getColumn(data_store.uidTable(), 
+            UNASSIGNED_ID, 
+            Tsdb1xUniqueIdStore.NAME_FAMILY, 
+            Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test
+  public void getOrCreateIdAssignFilterThrowsException() throws Exception {
+    resetAssignmentState();
+    when(filter.allowUIDAssignment(any(AuthState.class), any(UniqueIdType.class), anyString(), 
+        any(TimeSeriesDatumId.class))).thenThrow(new UnitTestException());
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    Deferred<IdOrError> deferred = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null);
+    try {
+      deferred.join();
+      fail("Expected UnitTestException");
+    } catch (UnitTestException e) { }
+    assertNull(storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertNull(storage.getColumn(data_store.uidTable(), 
+            UNASSIGNED_ID, 
+            Tsdb1xUniqueIdStore.NAME_FAMILY, 
+            Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+
+  @Test  // Test the creation of an ID when unable to increment MAXID
+  public void getOrCreateIdUnableToIncrementMaxId() throws Exception {
+    resetAssignmentState();
+    storage.addColumn(UID_TABLE, 
+        Tsdb1xUniqueIdStore.MAXID_ROW,
+        Tsdb1xUniqueIdStore.ID_FAMILY,
+        Tsdb1xUniqueIdStore.METRICS_QUAL, 
+        new byte[] { 0, 0, 0, 0, 0, (byte) 255, (byte) 255, (byte) 255 });
+    
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    Deferred<IdOrError> deferred = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null);
+    try {
+      deferred.join();
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException e) { }
+    assertNull(storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertNull(storage.getColumn(data_store.uidTable(), 
+            UNASSIGNED_ID, 
+            Tsdb1xUniqueIdStore.NAME_FAMILY, 
+            Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test  // Failure due to negative id.
+  public void getOrCreateIdUnableToIncrementRolledID() throws Exception {
+    resetAssignmentState();
+    storage.addColumn(UID_TABLE, 
+        Tsdb1xUniqueIdStore.MAXID_ROW,
+        Tsdb1xUniqueIdStore.ID_FAMILY,
+        Tsdb1xUniqueIdStore.METRICS_QUAL, 
+        Bytes.fromLong(Long.MAX_VALUE));
+    
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    Deferred<IdOrError> deferred = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null);
+    try {
+      deferred.join();
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException e) { }
+    assertNull(storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertNull(storage.getColumn(data_store.uidTable(), 
+            UNASSIGNED_ID, 
+            Tsdb1xUniqueIdStore.NAME_FAMILY, 
+            Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test  // Failure due to negative id.
+  public void getOrCreateIdUnableToIncrementCorruptId() throws Exception {
+    resetAssignmentState();
+    storage.addColumn(UID_TABLE, 
+        Tsdb1xUniqueIdStore.MAXID_ROW,
+        Tsdb1xUniqueIdStore.ID_FAMILY,
+        Tsdb1xUniqueIdStore.METRICS_QUAL, 
+        new byte[] { 0, 0 });
+    
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    Deferred<IdOrError> deferred = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null);
+    try {
+      deferred.join();
+      // TODO - fix this in asynchbase.
+      fail("Expected StorageException");
+    } catch (StorageException e) { }
+    assertNull(storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertNull(storage.getColumn(data_store.uidTable(), 
+            UNASSIGNED_ID, 
+            Tsdb1xUniqueIdStore.NAME_FAMILY, 
+            Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test  // Test the creation of an ID with a race condition.
+  public void getOrCreateIdAssignIdWithRaceConditionReverseMap() throws Exception {
+    resetAssignmentState();
+    Tsdb1xHBaseDataStore data_store_a = mock(Tsdb1xHBaseDataStore.class);
+    HBaseClient client = mock(HBaseClient.class);
+    when(data_store_a.client()).thenReturn(client);
+    when(data_store_a.schema()).thenReturn(schema);
+    when(data_store_a.tsdb()).thenReturn(tsdb);
+    when(data_store_a.getConfigKey(anyString())).then(new Answer<String>() {
+      @Override
+      public String answer(InvocationOnMock invocation) throws Throwable {
+        return (String) invocation.getArguments()[0];
+      }
+    });
+    when(data_store_a.uidTable()).thenReturn(UID_TABLE);
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store_a);
+    
+    when(client.get(anyGet()))
+      .thenReturn(Deferred.fromResult(null));
+    
+    when(client.atomicIncrement(any(AtomicIncrementRequest.class)))
+      .thenReturn(Deferred.fromResult(5L))
+      .thenReturn(Deferred.fromResult(6L));
+    
+    when(client.compareAndSet(anyPut(), emptyArray()))
+      .thenReturn(Deferred.fromResult(false))
+      .thenReturn(Deferred.fromResult(true))
+      .thenReturn(Deferred.fromResult(true));
+    
+    Deferred<IdOrError> deferred = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null);
+    try {
+      deferred.join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertNotNull(timer.pausedTask);
+    timer.continuePausedTask();
+    
+    IdOrError result = deferred.join();
+    assertArrayEquals(new byte[] { 0, 0, 6 }, result.id());
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test  // Test the creation of an ID with a race condition.
+  public void getOrCreateIdAssignIdWithRaceConditionForwardMap() throws Exception {
+    resetAssignmentState();
+    Tsdb1xHBaseDataStore data_store_a = mock(Tsdb1xHBaseDataStore.class);
+    HBaseClient client = mock(HBaseClient.class);
+    when(data_store_a.client()).thenReturn(client);
+    when(data_store_a.schema()).thenReturn(schema);
+    when(data_store_a.tsdb()).thenReturn(tsdb);
+    when(data_store_a.getConfigKey(anyString())).then(new Answer<String>() {
+      @Override
+      public String answer(InvocationOnMock invocation) throws Throwable {
+        return (String) invocation.getArguments()[0];
+      }
+    });
+    when(data_store_a.uidTable()).thenReturn(UID_TABLE);
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store_a);
+    
+    when(client.get(anyGet()))
+      .thenReturn(Deferred.fromResult(null))
+      .thenReturn(Deferred.fromResult(
+          Lists.newArrayList(new KeyValue(UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+              Tsdb1xUniqueIdStore.ID_FAMILY, 
+              Tsdb1xUniqueIdStore.METRICS_QUAL, 
+              new byte[] { 0, 0, 5 }))));
+    
+    when(client.atomicIncrement(any(AtomicIncrementRequest.class)))
+      .thenReturn(Deferred.fromResult(5L));
+    
+    when(client.compareAndSet(anyPut(), emptyArray()))
+      .thenReturn(Deferred.fromResult(true))
+      .thenReturn(Deferred.fromResult(false));
+    
+    IdOrError result = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null).join();
+    assertArrayEquals(new byte[] { 0, 0, 5 }, result.id());
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test  // Test the creation of an ID with a race condition.
+  public void getOrCreateIdTooManyAttempts() throws Exception {
+    resetAssignmentState();
+    Tsdb1xHBaseDataStore data_store_a = mock(Tsdb1xHBaseDataStore.class);
+    HBaseClient client = mock(HBaseClient.class);
+    when(data_store_a.client()).thenReturn(client);
+    when(data_store_a.schema()).thenReturn(schema);
+    when(data_store_a.tsdb()).thenReturn(tsdb);
+    when(data_store_a.getConfigKey(anyString())).then(new Answer<String>() {
+      @Override
+      public String answer(InvocationOnMock invocation) throws Throwable {
+        return (String) invocation.getArguments()[0];
+      }
+    });
+    when(data_store_a.uidTable()).thenReturn(UID_TABLE);
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store_a);
+    
+    when(client.get(anyGet()))
+      .thenReturn(Deferred.fromResult(null));
+    
+    when(client.atomicIncrement(any(AtomicIncrementRequest.class)))
+      .thenReturn(Deferred.fromResult(5L))
+      .thenReturn(Deferred.fromResult(6L))
+      .thenReturn(Deferred.fromResult(7L))
+      .thenReturn(Deferred.fromResult(8L));
+    
+    when(client.compareAndSet(anyPut(), emptyArray()))
+      .thenReturn(Deferred.fromResult(false))
+      .thenReturn(Deferred.fromResult(false))
+      .thenReturn(Deferred.fromResult(false))
+      .thenReturn(Deferred.fromResult(false));
+    
+    Deferred<IdOrError> deferred = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null);
+    
+    try {
+      deferred.join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertNotNull(timer.pausedTask);
+    timer.continuePausedTask();
+    
+    IdOrError result = deferred.join();
+    assertNull(result.id());
+    assertEquals(WriteState.RETRY, result.state());
+    assertNotNull(result.error());
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test  // Test the creation of an ID with a race condition.
+  public void getOrCreateIdIncException() throws Exception {
+    resetAssignmentState();
+    Tsdb1xHBaseDataStore data_store_a = mock(Tsdb1xHBaseDataStore.class);
+    HBaseClient client = mock(HBaseClient.class);
+    when(data_store_a.client()).thenReturn(client);
+    when(data_store_a.schema()).thenReturn(schema);
+    when(data_store_a.tsdb()).thenReturn(tsdb);
+    when(data_store_a.getConfigKey(anyString())).then(new Answer<String>() {
+      @Override
+      public String answer(InvocationOnMock invocation) throws Throwable {
+        return (String) invocation.getArguments()[0];
+      }
+    });
+    when(data_store_a.uidTable()).thenReturn(UID_TABLE);
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store_a);
+    
+    when(client.get(anyGet()))
+      .thenReturn(Deferred.fromResult(null));
+    
+    when(client.atomicIncrement(any(AtomicIncrementRequest.class)))
+      .thenReturn(Deferred.fromError(new UnitTestException()));
+    
+    when(client.compareAndSet(anyPut(), emptyArray()))
+      .thenReturn(Deferred.fromResult(true));
+    
+    Deferred<IdOrError> deferred = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null);
+    try {
+      deferred.join();
+      fail("Expected UnitTestException");
+    } catch (UnitTestException e) { }
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test  // Test the creation of an ID with a race condition.
+  public void getOrCreateIdCASException() throws Exception {
+    resetAssignmentState();
+    Tsdb1xHBaseDataStore data_store_a = mock(Tsdb1xHBaseDataStore.class);
+    HBaseClient client = mock(HBaseClient.class);
+    when(data_store_a.client()).thenReturn(client);
+    when(data_store_a.schema()).thenReturn(schema);
+    when(data_store_a.tsdb()).thenReturn(tsdb);
+    when(data_store_a.getConfigKey(anyString())).then(new Answer<String>() {
+      @Override
+      public String answer(InvocationOnMock invocation) throws Throwable {
+        return (String) invocation.getArguments()[0];
+      }
+    });
+    when(data_store_a.uidTable()).thenReturn(UID_TABLE);
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store_a);
+    
+    when(client.get(anyGet()))
+      .thenReturn(Deferred.fromResult(null));
+    
+    when(client.atomicIncrement(any(AtomicIncrementRequest.class)))
+      .thenReturn(Deferred.fromResult(5L));
+    
+    when(client.compareAndSet(anyPut(), emptyArray()))
+      .thenReturn(Deferred.fromError(new UnitTestException()));
+    
+    Deferred<IdOrError> deferred = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null);
+    try {
+      deferred.join();
+      fail("Expected UnitTestException");
+    } catch (UnitTestException e) { }
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test
+  public void getOrCreateIdRandom() throws Exception {
+    resetAssignmentState();
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    Whitebox.setInternalState(uid, "randomize_metric_ids", true);
+    IdOrError result = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID,
+        null).join();
+    assertTrue(Bytes.memcmp(UNASSIGNED_ID, result.id()) != 0);
+    assertEquals(3, result.id().length);
+    assertNull(result.error());
+
+    assertArrayEquals(result.id(), storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertArrayEquals(UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        storage.getColumn(data_store.uidTable(), 
+            result.id(), 
+            Tsdb1xUniqueIdStore.NAME_FAMILY, 
+            Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test
+  public void getOrCreateIdRandomCollision() throws Exception {
+    resetAssignmentState();
+    
+    PowerMockito.mockStatic(RandomUniqueId.class);
+    when(RandomUniqueId.getRandomUID(anyInt()))
+      .thenReturn(24898L)
+      .thenReturn(42L);
+    
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    Whitebox.setInternalState(uid, "randomize_metric_ids", true);
+    
+    Deferred<IdOrError> deferred = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID,
+        null);
+    
+    try {
+      deferred.join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertNotNull(timer.pausedTask);
+    timer.continuePausedTask();
+    
+    IdOrError result = deferred.join();
+    assertTrue(Bytes.memcmp(UNASSIGNED_ID, result.id()) != 0);
+    assertEquals(3, result.id().length);
+    assertNull(result.error());
+
+    assertArrayEquals(result.id(), storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertArrayEquals(UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        storage.getColumn(data_store.uidTable(), 
+            result.id(), 
+            Tsdb1xUniqueIdStore.NAME_FAMILY, 
+            Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test
+  public void getOrCreateIdRandomCollisionTooManyAttempts() throws Exception {
+    resetAssignmentState();
+    
+    PowerMockito.mockStatic(RandomUniqueId.class);
+    when(RandomUniqueId.getRandomUID(anyInt()))
+      .thenReturn(24898L)
+      .thenReturn(24898L)
+      .thenReturn(24898L);
+    
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    Whitebox.setInternalState(uid, "randomize_metric_ids", true);
+    Whitebox.setInternalState(uid, "max_attempts_assign_random", (short) 3); 
+    Deferred<IdOrError> deferred = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID,
+        null);
+    
+    try {
+      deferred.join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertNotNull(timer.pausedTask);
+    timer.continuePausedTask();
+    
+    IdOrError result = deferred.join();
+    assertNull(result.id());
+    assertEquals(WriteState.RETRY, result.state());
+    assertNotNull(result.error());
+
+    assertNull(storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test
+  public void getOrCreateIdRandomWithRaceConditionReverseMap() throws Exception {
+    resetAssignmentState();
+    
+    PowerMockito.mockStatic(RandomUniqueId.class);
+    when(RandomUniqueId.getRandomUID(anyInt()))
+      .thenReturn(1L)
+      .thenReturn(42L);
+    
+    resetAssignmentState();
+    Tsdb1xHBaseDataStore data_store_a = mock(Tsdb1xHBaseDataStore.class);
+    HBaseClient client = mock(HBaseClient.class);
+    when(data_store_a.client()).thenReturn(client);
+    when(data_store_a.schema()).thenReturn(schema);
+    when(data_store_a.tsdb()).thenReturn(tsdb);
+    when(data_store_a.getConfigKey(anyString())).then(new Answer<String>() {
+      @Override
+      public String answer(InvocationOnMock invocation) throws Throwable {
+        return (String) invocation.getArguments()[0];
+      }
+    });
+    when(data_store_a.uidTable()).thenReturn(UID_TABLE);
+    
+    when(client.get(anyGet()))
+      .thenReturn(Deferred.fromResult(null));
+    
+    when(client.compareAndSet(anyPut(), emptyArray()))
+      .thenReturn(Deferred.fromResult(false))
+      .thenReturn(Deferred.fromResult(true))
+      .thenReturn(Deferred.fromResult(true));
+    
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store_a);
+    Whitebox.setInternalState(uid, "randomize_metric_ids", true);
+    
+    Deferred<IdOrError> deferred = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID,
+        null);
+    
+    try {
+      deferred.join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    assertNotNull(timer.pausedTask);
+    timer.continuePausedTask();
+    
+    IdOrError result = deferred.join();
+    assertTrue(Bytes.memcmp(UNASSIGNED_ID, result.id()) != 0);
+    assertEquals(3, result.id().length);
+    assertNull(result.error());
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test
+  public void getOrCreateIdRandomWithRaceConditionForwardMap() throws Exception {
+    resetAssignmentState();
+    
+    PowerMockito.mockStatic(RandomUniqueId.class);
+    when(RandomUniqueId.getRandomUID(anyInt()))
+      .thenReturn(1L);
+    
+    resetAssignmentState();
+    Tsdb1xHBaseDataStore data_store_a = mock(Tsdb1xHBaseDataStore.class);
+    HBaseClient client = mock(HBaseClient.class);
+    when(data_store_a.client()).thenReturn(client);
+    when(data_store_a.schema()).thenReturn(schema);
+    when(data_store_a.tsdb()).thenReturn(tsdb);
+    when(data_store_a.getConfigKey(anyString())).then(new Answer<String>() {
+      @Override
+      public String answer(InvocationOnMock invocation) throws Throwable {
+        return (String) invocation.getArguments()[0];
+      }
+    });
+    when(data_store_a.uidTable()).thenReturn(UID_TABLE);
+    
+    when(client.get(anyGet()))
+      .thenReturn(Deferred.fromResult(null))
+      .thenReturn(Deferred.fromResult(
+          Lists.newArrayList(new KeyValue(UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+              Tsdb1xUniqueIdStore.ID_FAMILY, 
+              Tsdb1xUniqueIdStore.METRICS_QUAL, 
+              new byte[] { 0, 0, 1 }))));
+    
+    when(client.compareAndSet(anyPut(), emptyArray()))
+      .thenReturn(Deferred.fromResult(true))
+      .thenReturn(Deferred.fromResult(false))
+      .thenReturn(Deferred.fromResult(true));
+    
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store_a);
+    Whitebox.setInternalState(uid, "randomize_metric_ids", true);
+    
+    IdOrError result = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID,
+        null).join();
+    assertArrayEquals(new byte[] { 0, 0, 1 }, result.id());
+    assertEquals(3, result.id().length);
+    assertNull(result.error());
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+  
+  @Test
+  public void getOrCreateIdAlreadyWaiting() throws Exception {
+    resetAssignmentState();
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    Map<String, Deferred<IdOrError>> waiting = 
+        uid.pending_assignments.get(UniqueIdType.METRIC); 
+    Deferred<IdOrError> deferred = new Deferred<IdOrError>();
+    waiting.put(UNASSIGNED_ID_NAME, deferred);
+    
+    Deferred<IdOrError> assign1 = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null);
+    
+    try {
+      assign1.join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    Deferred<IdOrError> assign2 = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null);
+    try {
+      assign2.join(1);
+      fail("Expected TimeoutException");
+    } catch (TimeoutException e) { }
+    
+    deferred.callback(IdOrError.wrapId(UNASSIGNED_ID));
+    
+    IdOrError result = assign1.join();
+    assertArrayEquals(UNASSIGNED_ID, result.id());
+    assertNull(result.error());
+    
+    result = assign2.join();
+    assertArrayEquals(UNASSIGNED_ID, result.id());
+    assertNull(result.error());
+  }
+  
+  @Test
+  public void getOrCreateIdAssignAndRetry() throws Exception {
+    resetAssignmentState();
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    Whitebox.setInternalState(uid, "assign_and_retry", true);
+    IdOrError result = uid.getOrCreateId(null, 
+        UniqueIdType.METRIC, 
+        UNASSIGNED_ID_NAME, 
+        UNASSIGNED_DATUM_ID, 
+        null).join();
+    assertNull(result.id());
+    assertEquals(WriteState.RETRY, result.state());
+    assertSame(Tsdb1xUniqueIdStore.ASSIGN_AND_RETRY, result.error());
+    
+    // still assigns
+    assertArrayEquals(UNASSIGNED_ID, storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertArrayEquals(UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        storage.getColumn(data_store.uidTable(), 
+            UNASSIGNED_ID, 
+            Tsdb1xUniqueIdStore.NAME_FAMILY, 
+            Tsdb1xUniqueIdStore.METRICS_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.METRIC).isEmpty());
+  }
+
+  @Test
+  public void getOrCreateIdsAssignOne() throws Exception {
+    resetAssignmentState();
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    
+    List<String> names = Lists.newArrayList(ASSIGNED_TAGV_NAME,
+        UNASSIGNED_TAGV_NAME);
+    List<IdOrError> result = uid.getOrCreateIds(null, 
+        UniqueIdType.TAGV, 
+        names, 
+        ASSIGNED_DATUM_ID, 
+        null).join();
+    
+    assertEquals(2, result.size());
+    assertArrayEquals(ASSIGNED_TAGV, result.get(0).id());
+    assertNull(result.get(0).error());
+    assertArrayEquals(UNASSIGNED_TAGV, result.get(1).id());
+    assertNull(result.get(1).error());
+    
+    assertArrayEquals(UNASSIGNED_TAGV, storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_TAGV_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.TAG_VALUE_QUAL));
+    assertArrayEquals(UNASSIGNED_TAGV_NAME.getBytes(Const.UTF8_CHARSET), 
+        storage.getColumn(data_store.uidTable(), 
+            UNASSIGNED_TAGV, 
+            Tsdb1xUniqueIdStore.NAME_FAMILY, 
+            Tsdb1xUniqueIdStore.TAG_VALUE_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.TAGV).isEmpty());
+  }
+  
+  @Test
+  public void getOrCreateIdsAssignAndRetry() throws Exception {
+    resetAssignmentState();
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    Whitebox.setInternalState(uid, "assign_and_retry", true);
+    
+    List<String> names = Lists.newArrayList(ASSIGNED_TAGV_NAME,
+        UNASSIGNED_TAGV_NAME);
+    List<IdOrError> result = uid.getOrCreateIds(null, 
+        UniqueIdType.TAGV, 
+        names, 
+        ASSIGNED_DATUM_ID, 
+        null).join();
+    
+    assertEquals(2, result.size());
+    assertArrayEquals(ASSIGNED_TAGV, result.get(0).id());
+    assertNull(result.get(0).error());
+    assertNull(result.get(1).id());
+    assertEquals(WriteState.RETRY, result.get(1).state());
+    assertSame(Tsdb1xUniqueIdStore.ASSIGN_AND_RETRY, result.get(1).error());
+    
+    assertArrayEquals(UNASSIGNED_TAGV, storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_TAGV_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.TAG_VALUE_QUAL));
+    assertArrayEquals(UNASSIGNED_TAGV_NAME.getBytes(Const.UTF8_CHARSET), 
+        storage.getColumn(data_store.uidTable(), 
+            UNASSIGNED_TAGV, 
+            Tsdb1xUniqueIdStore.NAME_FAMILY, 
+            Tsdb1xUniqueIdStore.TAG_VALUE_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.TAGV).isEmpty());
+  }
+  
+  @Test
+  public void getOrCreateIdsAssignException() throws Exception {
+    resetAssignmentState();
+    Tsdb1xUniqueIdStore uid = new Tsdb1xUniqueIdStore(data_store);
+    
+    List<String> names = Lists.newArrayList(TAGV_STRING_EX,
+        UNASSIGNED_TAGV_NAME);
+    List<IdOrError> result = uid.getOrCreateIds(null, 
+        UniqueIdType.TAGV, 
+        names, 
+        ASSIGNED_DATUM_ID, 
+        null).join();
+    
+    assertEquals(2, result.size());
+    assertNull(result.get(0).id());
+    assertNotNull(result.get(0).error());
+    assertNotNull(result.get(0).exception());
+    assertArrayEquals(UNASSIGNED_TAGV, result.get(1).id());
+    assertNull(result.get(1).error());
+    assertNull(result.get(1).exception());
+    
+    assertArrayEquals(UNASSIGNED_TAGV, storage.getColumn(data_store.uidTable(), 
+        UNASSIGNED_TAGV_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.TAG_VALUE_QUAL));
+    assertArrayEquals(UNASSIGNED_TAGV_NAME.getBytes(Const.UTF8_CHARSET), 
+        storage.getColumn(data_store.uidTable(), 
+            UNASSIGNED_TAGV, 
+            Tsdb1xUniqueIdStore.NAME_FAMILY, 
+            Tsdb1xUniqueIdStore.TAG_VALUE_QUAL));
+    assertTrue(uid.pending_assignments.get(UniqueIdType.TAGV).isEmpty());
+  }
+  
 //  @Test
 //  public void suggestWithNoMatch() {
 //    uid = new UniqueId(client, table, METRIC, 3);
@@ -2370,15 +2738,78 @@ public class TestTsdb1xUniqueIdStore extends UTBase {
       .thenReturn("fake exception");
     return hbe;
   }
-
-  private static final byte[] MAXID = { 0 };
-
+  
   private static void resetConfig() {
     final UnitTestConfiguration c = tsdb.config;
-    if (c.hasProperty(data_store.getConfigKey(Tsdb1xUniqueIdStore.CHARACTER_SET_KEY))) {
-      c.override(data_store.getConfigKey(Tsdb1xUniqueIdStore.CHARACTER_SET_KEY), 
-          Tsdb1xUniqueIdStore.CHARACTER_SET_DEFAULT);
+    if (c.hasProperty(data_store.getConfigKey(
+        Tsdb1xUniqueIdStore.CONFIG_PREFIX.get(UniqueIdType.METRIC) + 
+        Tsdb1xUniqueIdStore.CHARACTER_SET_KEY))) {
+      // restore
+      tsdb.config.override(
+          data_store.getConfigKey(
+              Tsdb1xUniqueIdStore.CONFIG_PREFIX.get(UniqueIdType.METRIC) + 
+              Tsdb1xUniqueIdStore.CHARACTER_SET_KEY), Tsdb1xUniqueIdStore.CHARACTER_SET_DEFAULT);
     }
+  }
+  
+  private void resetAssignmentState() {
+    filter = mock(UniqueIdAssignmentAuthorizer.class);
+    when(filter.fillterUIDAssignments()).thenReturn(true);
+    when(filter.allowUIDAssignment(any(AuthState.class), any(UniqueIdType.class), anyString(), 
+        any(TimeSeriesDatumId.class)))
+      .thenReturn(Deferred.fromResult(null))
+      .thenReturn(Deferred.fromResult(null));
+    
+    timer = new FakeTaskTimer();
+    tsdb.timer = timer;
+    
+    when(tsdb.registry.getDefaultPlugin(
+        UniqueIdAssignmentAuthorizer.class)).thenReturn(filter);
+    
+    // clean out the UID table.
+    storage.flushRow(UID_TABLE, ASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET));
+    storage.flushRow(UID_TABLE, ASSIGNED_ID);
+    storage.flushRow(UID_TABLE, ASSIGNED_TAGV_NAME.getBytes(Const.UTF8_CHARSET));
+    storage.flushRow(UID_TABLE, ASSIGNED_TAGV);
+    storage.flushRow(UID_TABLE, UNASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET));
+    storage.flushRow(UID_TABLE, UNASSIGNED_ID);
+    storage.flushRow(UID_TABLE, UNASSIGNED_TAGV_NAME.getBytes(Const.UTF8_CHARSET));
+    storage.flushRow(UID_TABLE, UNASSIGNED_TAGV);
+    
+    storage.addColumn(UID_TABLE, 
+        ASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL, 
+        ASSIGNED_ID);
+    storage.addColumn(UID_TABLE, 
+        ASSIGNED_ID, 
+        Tsdb1xUniqueIdStore.NAME_FAMILY, 
+        Tsdb1xUniqueIdStore.METRICS_QUAL, 
+        ASSIGNED_ID_NAME.getBytes(Const.UTF8_CHARSET));
+    
+    storage.addColumn(UID_TABLE, 
+        ASSIGNED_TAGV_NAME.getBytes(Const.UTF8_CHARSET), 
+        Tsdb1xUniqueIdStore.ID_FAMILY, 
+        Tsdb1xUniqueIdStore.TAG_VALUE_QUAL, 
+        ASSIGNED_TAGV);
+    storage.addColumn(UID_TABLE, 
+        ASSIGNED_TAGV, 
+        Tsdb1xUniqueIdStore.NAME_FAMILY, 
+        Tsdb1xUniqueIdStore.TAG_VALUE_QUAL, 
+        ASSIGNED_TAGV_NAME.getBytes(Const.UTF8_CHARSET));
+    
+    // set an atomic long for metrics and tag values
+    storage.addColumn(UID_TABLE, 
+        Tsdb1xUniqueIdStore.MAXID_ROW,
+        Tsdb1xUniqueIdStore.ID_FAMILY,
+        Tsdb1xUniqueIdStore.METRICS_QUAL, 
+        Bytes.fromLong(42));
+    
+    storage.addColumn(UID_TABLE, 
+        Tsdb1xUniqueIdStore.MAXID_ROW,
+        Tsdb1xUniqueIdStore.ID_FAMILY,
+        Tsdb1xUniqueIdStore.TAG_VALUE_QUAL, 
+        Bytes.fromLong(42));
   }
   
   static void verifySpan(final String name) {
@@ -2404,7 +2835,12 @@ public class TestTsdb1xUniqueIdStore extends UTBase {
     when(data_store.client()).thenReturn(local_client);
     when(data_store.tsdb()).thenReturn(tsdb);
     when(data_store.uidTable()).thenReturn(UID_TABLE);
-    when(data_store.getConfigKey(anyString())).thenReturn("foo");
+    when(data_store.getConfigKey(anyString())).then(new Answer<String>() {
+      @Override
+      public String answer(InvocationOnMock invocation) throws Throwable {
+        return (String) invocation.getArguments()[0];
+      }
+    });
     return data_store;
   }
 }


### PR DESCRIPTION
- Add the WriteState to IdOrError so we can figure out how to handle UID assignment
  failures.
- Restore the UID assignment to Tsdb1xUniqueIdStore using the old UniqueIdAllocator.
  However it now returns the IdOrError and also incorporate retry backoff using the
  same schema as AsyncHBase.