### PR TITLE
CORE:

### DIFF
--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/MockBase.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/MockBase.java
@@ -855,25 +855,30 @@ public final class MockBase {
    * all byte arrays hex encoded
    */
   public void dumpToSystemOut() {
-    dumpToSystemOut(false);
+    dumpToSystemOut(null, false);
   }
 
   /**
    * Dumps the entire storage hash to stdout in a sort of tree style format
+   * @param table An optional table, if null, print them all.
    * @param ascii Whether or not the values should be converted to ascii
    */
-  public void dumpToSystemOut(final boolean ascii) {
+  public void dumpToSystemOut(final byte[] table, final boolean ascii) {
     if (storage.isEmpty()) {
       System.out.println("Storage is Empty");
       return;
     }
 
-    for (Entry<byte[], ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>>> table :
+    for (Entry<byte[], ByteMap<ByteMap<ByteMap<TreeMap<Long, byte[]>>>>> db_table :
       storage.entrySet()) {
-      System.out.println("[Table] " + new String(table.getKey(), Const.ASCII_CHARSET));
+      if (table != null && Bytes.memcmp(table, db_table.getKey()) != 0) {
+        continue;
+      }
+      
+      System.out.println("[Table] " + new String(db_table.getKey(), Const.ASCII_CHARSET));
 
       for (Entry<byte[], ByteMap<ByteMap<TreeMap<Long, byte[]>>>> cf :
-        table.getValue().entrySet()) {
+        db_table.getValue().entrySet()) {
         System.out.println("  [CF] " + new String(cf.getKey(), Const.ASCII_CHARSET));
 
         for (Entry<byte[], ByteMap<TreeMap<Long, byte[]>>> row :

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xHBaseDataStore.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xHBaseDataStore.java
@@ -15,55 +15,120 @@
 package net.opentsdb.storage;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.hbase.async.HBaseClient;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 import net.opentsdb.common.Const;
 import net.opentsdb.configuration.Configuration;
 import net.opentsdb.configuration.UnitTestConfiguration;
 import net.opentsdb.core.DefaultRegistry;
 import net.opentsdb.core.DefaultTSDB;
+import net.opentsdb.data.BaseTimeSeriesDatumStringId;
+import net.opentsdb.data.MillisecondTimeStamp;
+import net.opentsdb.data.SecondTimeStamp;
+import net.opentsdb.data.TimeSeriesDatum;
+import net.opentsdb.data.TimeSeriesDatumStringId;
+import net.opentsdb.data.types.numeric.MutableNumericValue;
+import net.opentsdb.storage.WriteStatus.WriteState;
+import net.opentsdb.storage.schemas.tsdb1x.NumericCodec;
 import net.opentsdb.storage.schemas.tsdb1x.Schema;
 import net.opentsdb.storage.schemas.tsdb1x.Tsdb1xDataStoreFactory;
 import net.opentsdb.uid.UniqueIdStore;
 
-public class TestTsdb1xHBaseDataStore {
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ Tsdb1xHBaseDataStore.class, HBaseClient.class })
+public class TestTsdb1xHBaseDataStore extends UTBase {
 
   private Tsdb1xHBaseFactory factory;
-  private DefaultTSDB tsdb;
-  private Configuration config;
-  private DefaultRegistry registry;
+//  private DefaultTSDB tsdb;
+//  private Configuration config;
+//  private DefaultRegistry registry;
   
   @Before
   public void before() throws Exception {
     factory = mock(Tsdb1xHBaseFactory.class);
-    tsdb = mock(DefaultTSDB.class);
-    config = UnitTestConfiguration.getConfiguration();
-    registry = mock(DefaultRegistry.class);
-    when(tsdb.getConfig()).thenReturn(config);
-    when(tsdb.getRegistry()).thenReturn(registry);
+//    tsdb = mock(DefaultTSDB.class);
+//    config = UnitTestConfiguration.getConfiguration();
+//    registry = mock(DefaultRegistry.class);
+//    when(tsdb.getConfig()).thenReturn(config);
+//    when(tsdb.getRegistry()).thenReturn(registry);
     when(factory.tsdb()).thenReturn(tsdb);
+    PowerMockito.whenNew(HBaseClient.class).withAnyArguments().thenReturn(client);
+    storage.flushStorage("tsdb".getBytes(Const.ASCII_US_CHARSET));
   }
   
   @Test
   public void ctorDefault() throws Exception {
     final Tsdb1xHBaseDataStore store = 
-        new Tsdb1xHBaseDataStore(factory, "UT", mock(Schema.class));
+        new Tsdb1xHBaseDataStore(factory, "UT", schema);
     assertArrayEquals("tsdb".getBytes(Const.ISO_8859_CHARSET), store.dataTable());
     assertArrayEquals("tsdb-uid".getBytes(Const.ISO_8859_CHARSET), store.uidTable());
     assertSame(tsdb, store.tsdb());
     assertNotNull(store.uidStore());
-    verify(registry, times(1)).registerSharedObject(eq("UT_uidstore"), 
+    verify(tsdb.registry, atLeastOnce()).registerSharedObject(eq("UT_uidstore"), 
         any(UniqueIdStore.class));
   }
   
+  @Test
+  public void write() throws Exception {
+    MutableNumericValue value = 
+        new MutableNumericValue(new SecondTimeStamp(1262304000), 42);
+    TimeSeriesDatumStringId id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setMetric(METRIC_STRING)
+        .addTags(TAGK_STRING, TAGV_STRING)
+        .build();
+    
+    Tsdb1xHBaseDataStore store = 
+        new Tsdb1xHBaseDataStore(factory, "UT", schema);
+    WriteStatus state = store.write(null, TimeSeriesDatum.wrap(id, value), null).join();
+    assertEquals(WriteState.OK, state.state());
+    byte[] row_key = new byte[] { 0, 0, 1, 75, 61, 59, 0, 0, 0, 1, 0, 0, 1 };
+    assertArrayEquals(new byte[] { 42 }, storage.getColumn(
+        store.dataTable(), row_key, Tsdb1xHBaseDataStore.DATA_FAMILY, 
+        new byte[] { 0, 0 }));
+    storage.dumpToSystemOut(store.dataTable(), false);
+    
+    // appends
+    Whitebox.setInternalState(store, "enable_appends", true);
+    state = store.write(null, TimeSeriesDatum.wrap(id, value), null).join();
+    assertEquals(WriteState.OK, state.state());
+    assertArrayEquals(new byte[] { 0, 0, 42 }, storage.getColumn(
+        store.dataTable(), row_key, Tsdb1xHBaseDataStore.DATA_FAMILY, 
+        NumericCodec.APPEND_QUALIFIER));
+    
+    Whitebox.setInternalState(store, "enable_appends", false);
+    Whitebox.setInternalState(store, "enable_appends_coproc", true);
+    value.resetValue(1);
+    state = store.write(null, TimeSeriesDatum.wrap(id, value), null).join();
+    assertEquals(WriteState.OK, state.state());
+    // overwrites
+    assertArrayEquals(new byte[] { 0, 0, 1 }, storage.getColumn(
+        store.dataTable(), row_key, Tsdb1xHBaseDataStore.DATA_FAMILY, 
+        NumericCodec.APPEND_QUALIFIER));
+    
+    // bad metric
+    id = BaseTimeSeriesDatumStringId.newBuilder()
+        .setMetric(METRIC_STRING_EX)
+        .addTags(TAGK_STRING, TAGV_STRING)
+        .build();
+    state = store.write(null, TimeSeriesDatum.wrap(id, value), null).join();
+    assertEquals(WriteState.ERROR, state.state());
+  }
 }


### PR DESCRIPTION
- Add the encode() method to Schema to encode a value into qualifier and
  value byte arrays using the proper codecs.

STORAGE:
- Implement the write method in the HBase data store. Works for regular old
  numerics.