### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/QueryNodeFactory.java
+++ b/common/src/main/java/net/opentsdb/query/QueryNodeFactory.java
@@ -14,6 +14,11 @@
 // limitations under the License.
 package net.opentsdb.query;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import net.opentsdb.core.TSDB;
+
 /**
  * The factory used to generate a {@link QueryNode} for a new query execution.
  * Implementations can be single or multi-node.
@@ -27,8 +32,15 @@ public interface QueryNodeFactory {
    * @return A non-null unique ID of the factory.
    */
   public String id();
- 
-  /** @return A class to use for serdes for configuring nodes of this
-   * type. */
-  public Class<? extends QueryNodeConfig> nodeConfigClass();
+  
+  /**
+   * Parse the given JSON or YAML into the proper node config.
+   * @param mapper A non-null mapper to use for parsing.
+   * @param tsdb The non-null TSD to pull factories from.
+   * @param node The non-null node to parse.
+   * @return An instantiated node config if successful.
+   */
+  public QueryNodeConfig parseConfig(final ObjectMapper mapper,
+                                     final TSDB tsdb, 
+                                     final JsonNode node);
 }

--- a/common/src/main/java/net/opentsdb/query/execution/graph/ExecutionGraph.java
+++ b/common/src/main/java/net/opentsdb/query/execution/graph/ExecutionGraph.java
@@ -337,15 +337,8 @@ public class ExecutionGraph implements Comparable<ExecutionGraph> {
                 + "for node type: " + id);
           }
         }
-        try {
-          final QueryNodeConfig node_config = 
-              mapper.treeToValue(config, factory.nodeConfigClass());
-          node_builder.setConfig(node_config);
-          
-        } catch (JsonProcessingException e) {
-          throw new QueryExecutionException("Failed to parse config: " 
-              + node, 0, e);
-        }
+        final QueryNodeConfig node_config = factory.parseConfig(mapper, tsdb, config);
+        node_builder.setConfig(node_config);
       }
       
       builder.addNode(node_builder.build());

--- a/common/src/main/java/net/opentsdb/query/filter/ChainFilter.java
+++ b/common/src/main/java/net/opentsdb/query/filter/ChainFilter.java
@@ -56,7 +56,7 @@ public class ChainFilter implements QueryFilter {
     }
   }
   
-  /** @return The operator to use for logical comparisson. */
+  /** @return The operator to use for logical comparison. */
   public FilterOp getOp() {
     return op;
   }

--- a/common/src/main/java/net/opentsdb/query/filter/ChainFilterFactory.java
+++ b/common/src/main/java/net/opentsdb/query/filter/ChainFilterFactory.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.core.TSDB;
 import net.opentsdb.exceptions.QueryExecutionException;
@@ -80,6 +81,26 @@ public class ChainFilterFactory implements QueryFilterFactory {
       builder.addFilter(factory.parse(tsdb, mapper, filter));
     }
     return builder.build();
+  }
+
+  @Override
+  public String id() {
+    return "Chain";
+  }
+
+  @Override
+  public Deferred<Object> initialize(final TSDB tsdb) {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
   }
 
 }

--- a/common/src/main/java/net/opentsdb/query/filter/NotFilterFactory.java
+++ b/common/src/main/java/net/opentsdb/query/filter/NotFilterFactory.java
@@ -17,6 +17,7 @@ package net.opentsdb.query.filter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.core.TSDB;
 
@@ -63,6 +64,26 @@ public class NotFilterFactory implements QueryFilterFactory {
     return (QueryFilter) NotFilter.newBuilder()
         .setFilter(factory.parse(tsdb, mapper, filter))
         .build();
+  }
+
+  @Override
+  public String id() {
+    return "Not";
+  }
+
+  @Override
+  public Deferred<Object> initialize(TSDB tsdb) {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
   }
 
 }

--- a/common/src/main/java/net/opentsdb/query/filter/QueryFilterFactory.java
+++ b/common/src/main/java/net/opentsdb/query/filter/QueryFilterFactory.java
@@ -18,13 +18,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import net.opentsdb.core.TSDB;
+import net.opentsdb.core.TSDBPlugin;
 
 /**
  * A factory used to generate {@link QueryFilter}s.
  * 
  * @since 3.0
  */
-public interface QueryFilterFactory {
+public interface QueryFilterFactory extends TSDBPlugin {
   
   /**
    * The descriptive and unique ID of the factory used during registration.

--- a/common/src/test/java/net/opentsdb/query/execution/graph/TestExecutionGraph.java
+++ b/common/src/test/java/net/opentsdb/query/execution/graph/TestExecutionGraph.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -557,10 +558,14 @@ public class TestExecutionGraph {
     }
 
     @Override
-    public Class<? extends QueryNodeConfig> nodeConfigClass() {
-      return MockConfigA.class;
+    public QueryNodeConfig parseConfig(ObjectMapper mapper, TSDB tsdb,
+        JsonNode node) {
+      try {
+        return (QueryNodeConfig) mapper.treeToValue(node, MockConfigA.class);
+      } catch (JsonProcessingException e) {
+        throw new IllegalArgumentException("Failed to parse TagValueLiteralOr", e);
+      }
     }
-    
   }
   
   @JsonInclude(Include.NON_NULL)
@@ -663,12 +668,16 @@ public class TestExecutionGraph {
     public String id() {
       return "MockFactoryB";
     }
-
-    @Override
-    public Class<? extends QueryNodeConfig> nodeConfigClass() {
-      return MockConfigB.class;
-    }
     
+    @Override
+    public QueryNodeConfig parseConfig(ObjectMapper mapper, TSDB tsdb,
+        JsonNode node) {
+      try {
+        return (QueryNodeConfig) mapper.treeToValue(node, MockConfigB.class);
+      } catch (JsonProcessingException e) {
+        throw new IllegalArgumentException("Failed to parse TagValueLiteralOr", e);
+      }
+    }
   }
   
 }

--- a/common/src/test/java/net/opentsdb/query/filter/UTFilterFactory.java
+++ b/common/src/test/java/net/opentsdb/query/filter/UTFilterFactory.java
@@ -17,6 +17,7 @@ package net.opentsdb.query.filter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.core.TSDB;
 
@@ -50,6 +51,26 @@ public class UTFilterFactory implements QueryFilterFactory {
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("Failed to parse UTQueryFilter", e);
     }
+  }
+
+  @Override
+  public String id() {
+    return "UTFilter";
+  }
+
+  @Override
+  public Deferred<Object> initialize(TSDB tsdb) {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
   }
   
   

--- a/core/src/main/java/net/opentsdb/core/PluginsConfig.java
+++ b/core/src/main/java/net/opentsdb/core/PluginsConfig.java
@@ -103,6 +103,7 @@ public class PluginsConfig extends Validatable {
   public static final List<String> DEFAULT_TYPES = Lists.newArrayList();
   static {
     DEFAULT_TYPES.add("net.opentsdb.query.QueryNodeFactory");
+    DEFAULT_TYPES.add("net.opentsdb.query.filter.QueryFilterFactory");
     DEFAULT_TYPES.add("net.opentsdb.stats.StatsCollector");
     DEFAULT_TYPES.add("net.opentsdb.query.interpolation.QueryInterpolatorFactory");
     DEFAULT_TYPES.add("net.opentsdb.storage.DatumIdValidator");

--- a/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
+++ b/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
@@ -14,11 +14,17 @@
 // limitations under the License.
 package net.opentsdb.query;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.core.TSDB;
 import net.opentsdb.core.TSDBPlugin;
 import net.opentsdb.exceptions.QueryExecutionException;
+import net.opentsdb.query.filter.MetricFilter;
+import net.opentsdb.query.filter.QueryFilter;
+import net.opentsdb.query.filter.QueryFilterFactory;
 import net.opentsdb.storage.ReadableTimeSeriesDataStore;
 import net.opentsdb.storage.TimeSeriesDataStoreFactory;
 
@@ -64,12 +70,7 @@ public class QueryDataSourceFactory implements SingleQueryNodeFactory, TSDBPlugi
   public String id() {
     return "datasource";
   }
-
-  @Override
-  public Class<? extends QueryNodeConfig> nodeConfigClass() {
-    return QuerySourceConfig.class;
-  }
-
+  
   @Override
   public Deferred<Object> initialize(final TSDB tsdb) {
     this.tsdb = tsdb;
@@ -84,6 +85,84 @@ public class QueryDataSourceFactory implements SingleQueryNodeFactory, TSDBPlugi
   @Override
   public String version() {
     return "3.0.0";
+  }
+
+  
+  @Override
+  public QueryNodeConfig parseConfig(final ObjectMapper mapper, 
+                                     final TSDB tsdb,
+                                     final JsonNode node) {
+    QuerySourceConfig.Builder builder = QuerySourceConfig.newBuilder();
+    JsonNode n = node.get("start");
+    if (n == null) {
+      throw new IllegalArgumentException("Start field is required.");
+    }
+    builder.setStart(n.asText());
+    
+    n = node.get("end");
+    if (n != null) {
+      builder.setEnd(n.asText());
+    }
+    
+    n = node.get("timezone");
+    if (n != null) {
+      builder.setTimezone(n.asText());
+    }
+    
+    // TODO - types
+    
+    n = node.get("metric");
+    if (n == null) {
+      throw new IllegalArgumentException("Missing the metric field.");
+    }
+    JsonNode type_node = n.get("type");
+    if (type_node == null) {
+      throw new IllegalArgumentException("Missing the metric type field.");
+    }
+    String type = type_node.asText();
+    if (Strings.isNullOrEmpty(type)) {
+      throw new IllegalArgumentException("Metric type field cannot be null or empty.");
+    }
+    QueryFilterFactory factory = tsdb.getRegistry().getPlugin(QueryFilterFactory.class, type);
+    if (factory == null) {
+      throw new IllegalArgumentException("No query filter factory found for: " + type);
+    }
+    QueryFilter filter = factory.parse(tsdb, mapper, n);
+    if (filter == null || !(filter instanceof MetricFilter)) {
+      throw new IllegalArgumentException("Metric query filter was not "
+          + "an instanceof MetricFilter: " + filter.getClass());
+    }
+    builder.setMetric((MetricFilter) filter);
+    
+    n = node.get("filterId");
+    if (n != null && !Strings.isNullOrEmpty(n.asText())) {
+      builder.setFilterId(n.asText());
+    } else {
+      n = node.get("filter");
+      if (n != null) {
+        type_node = n.get("type");
+        if (type_node == null) {
+          throw new IllegalArgumentException("Missing the filter type field.");
+        }
+        
+        type = type_node.asText();
+        if (Strings.isNullOrEmpty(type)) {
+          throw new IllegalArgumentException("Filter type field cannot be null or empty.");
+        }
+        
+        factory = tsdb.getRegistry().getPlugin(QueryFilterFactory.class, type);
+        if (factory == null) {
+          throw new IllegalArgumentException("No query filter factory found for: " + type);
+        }
+        filter = factory.parse(tsdb, mapper, n);
+        if (filter == null) {
+          throw new IllegalArgumentException("Unable to parse filter config.");
+        }
+        builder.setQueryFilter(filter);
+      }
+    }
+    
+    return builder.build();
   }
 
 }

--- a/core/src/main/java/net/opentsdb/query/QuerySourceConfig.java
+++ b/core/src/main/java/net/opentsdb/query/QuerySourceConfig.java
@@ -18,6 +18,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Strings;
 import com.google.common.collect.ComparisonChain;
@@ -27,6 +29,7 @@ import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 
 import net.opentsdb.core.Const;
+import net.opentsdb.core.TSDB;
 import net.opentsdb.data.MillisecondTimeStamp;
 import net.opentsdb.data.TimeStamp;
 import net.opentsdb.query.filter.MetricFilter;

--- a/core/src/main/java/net/opentsdb/query/SemanticQuery.java
+++ b/core/src/main/java/net/opentsdb/query/SemanticQuery.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -30,7 +31,6 @@ import net.opentsdb.query.filter.DefaultNamedFilter;
 import net.opentsdb.query.filter.NamedFilter;
 import net.opentsdb.query.filter.QueryFilter;
 import net.opentsdb.query.filter.QueryFilterFactory;
-import net.opentsdb.query.pojo.Filter;
 import net.opentsdb.query.serdes.SerdesOptions;
 import net.opentsdb.utils.JSON;
 

--- a/core/src/main/java/net/opentsdb/query/execution/CachingQueryExecutor.java
+++ b/core/src/main/java/net/opentsdb/query/execution/CachingQueryExecutor.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
@@ -117,10 +119,10 @@ public class CachingQueryExecutor implements QuerySourceFactory {
     throw new UnsupportedOperationException("Not implemented yet");
   }
   
-  @Override
-  public Class<? extends QueryNodeConfig> nodeConfigClass() {
-    return Config.class;
-  }
+//  @Override
+//  public Class<? extends QueryNodeConfig> nodeConfigClass() {
+//    return Config.class;
+//  }
   
   @Override
   public TimeSeriesDataSource newNode(final QueryPipelineContext context,
@@ -773,6 +775,13 @@ public class CachingQueryExecutor implements QuerySourceFactory {
   @VisibleForTesting
   TimeSeriesCacheKeyGenerator keyGenerator() {
     return key_generator;
+  }
+
+  @Override
+  public QueryNodeConfig parseConfig(ObjectMapper mapper, TSDB tsdb,
+      JsonNode node) {
+    // TODO Auto-generated method stub
+    return null;
   }
 
   

--- a/core/src/main/java/net/opentsdb/query/filter/ExplicitTagsFilterFactory.java
+++ b/core/src/main/java/net/opentsdb/query/filter/ExplicitTagsFilterFactory.java
@@ -17,6 +17,7 @@ package net.opentsdb.query.filter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.core.TSDB;
 
@@ -63,6 +64,26 @@ public class ExplicitTagsFilterFactory implements QueryFilterFactory {
     return (QueryFilter) NotFilter.newBuilder()
         .setFilter(factory.parse(tsdb, mapper, filter))
         .build();
+  }
+
+  @Override
+  public String id() {
+    return "ExplicitTags";
+  }
+
+  @Override
+  public Deferred<Object> initialize(TSDB tsdb) {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
   }
 
 }

--- a/core/src/main/java/net/opentsdb/query/filter/MetricLiteralFactory.java
+++ b/core/src/main/java/net/opentsdb/query/filter/MetricLiteralFactory.java
@@ -17,6 +17,7 @@ package net.opentsdb.query.filter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.core.TSDB;
 
@@ -43,5 +44,25 @@ public class MetricLiteralFactory implements QueryFilterFactory {
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("Failed to parse MetricLiteral", e);
     }
+  }
+
+  @Override
+  public String id() {
+    return "MetricLiteral";
+  }
+
+  @Override
+  public Deferred<Object> initialize(TSDB tsdb) {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
   }
 }

--- a/core/src/main/java/net/opentsdb/query/filter/TagValueLiteralOrFactory.java
+++ b/core/src/main/java/net/opentsdb/query/filter/TagValueLiteralOrFactory.java
@@ -17,6 +17,7 @@ package net.opentsdb.query.filter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.core.TSDB;
 
@@ -43,5 +44,25 @@ public class TagValueLiteralOrFactory implements QueryFilterFactory {
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("Failed to parse TagValueLiteralOr", e);
     }
+  }
+
+  @Override
+  public String id() {
+    return "TagValueLiteralOr";
+  }
+
+  @Override
+  public Deferred<Object> initialize(TSDB tsdb) {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
   }
 }

--- a/core/src/main/java/net/opentsdb/query/filter/TagValueRegexFactory.java
+++ b/core/src/main/java/net/opentsdb/query/filter/TagValueRegexFactory.java
@@ -17,6 +17,7 @@ package net.opentsdb.query.filter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.core.TSDB;
 
@@ -43,5 +44,25 @@ public class TagValueRegexFactory implements QueryFilterFactory {
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("Failed to parse TagValueRegexFilter", e);
     }
+  }
+
+  @Override
+  public String id() {
+    return "TagValueRegex";
+  }
+
+  @Override
+  public Deferred<Object> initialize(TSDB tsdb) {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
   }
 }

--- a/core/src/main/java/net/opentsdb/query/filter/TagValueWildcardFactory.java
+++ b/core/src/main/java/net/opentsdb/query/filter/TagValueWildcardFactory.java
@@ -17,6 +17,7 @@ package net.opentsdb.query.filter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.core.TSDB;
 
@@ -43,5 +44,25 @@ public class TagValueWildcardFactory implements QueryFilterFactory {
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("Failed to parse TagValueWildcard", e);
     }
+  }
+
+  @Override
+  public String id() {
+    return "TagValueWildcard";
+  }
+
+  @Override
+  public Deferred<Object> initialize(TSDB tsdb) {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
   }
 }

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleFactory.java
@@ -18,9 +18,13 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 
+import net.opentsdb.core.TSDB;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
@@ -64,10 +68,16 @@ public class DownsampleFactory extends BaseQueryNodeFactory {
     // TODO Auto-generated method stub
     return null;
   }
-
+  
   @Override
-  public Class<? extends QueryNodeConfig> nodeConfigClass() {
-    return DownsampleConfig.class;
+  public QueryNodeConfig parseConfig(final ObjectMapper mapper,
+                                     final TSDB tsdb,
+                                     final JsonNode node) {
+    try {
+      return mapper.treeToValue(node, DownsampleConfig.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Unable to parse config", e);
+    }
   }
   
   /**

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionFactory.java
@@ -19,10 +19,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 
+import net.opentsdb.core.TSDB;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
@@ -130,12 +134,18 @@ public class ExpressionFactory extends BaseMultiQueryNodeFactory {
     }
     return query_nodes;
   }
-
+  
   @Override
-  public Class<? extends QueryNodeConfig> nodeConfigClass() {
-    return ExpressionConfig.class;
+  public QueryNodeConfig parseConfig(final ObjectMapper mapper, 
+                                     final TSDB tsdb,
+                                     final JsonNode node) {
+    try {
+      return mapper.treeToValue(node, ExpressionConfig.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Unable to parse config", e);
+    }
   }
-
+  
   static String validate2(final ExpressionParseNode node, 
                           final boolean left, 
                           final List<ExecutionGraphNode> nodes, 

--- a/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByFactory.java
@@ -18,9 +18,13 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 
+import net.opentsdb.core.TSDB;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
@@ -67,8 +71,14 @@ public class GroupByFactory extends BaseQueryNodeFactory {
   }
   
   @Override
-  public Class<? extends QueryNodeConfig> nodeConfigClass() {
-    return GroupByConfig.class;
+  public QueryNodeConfig parseConfig(final ObjectMapper mapper, 
+                                     final TSDB tsdb,
+                                     final JsonNode node) {
+    try {
+      return mapper.treeToValue(node, GroupByConfig.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Unable to parse config", e);
+    }
   }
   
   /**

--- a/core/src/main/java/net/opentsdb/query/processor/rate/RateFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/rate/RateFactory.java
@@ -18,9 +18,13 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 
+import net.opentsdb.core.TSDB;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.types.numeric.NumericType;
@@ -58,14 +62,21 @@ public class RateFactory extends BaseQueryNodeFactory {
   }
 
   @Override
-  public QueryNode newNode(QueryPipelineContext context, String id) {
+  public QueryNode newNode(final QueryPipelineContext context, 
+                           final String id) {
     // TODO Auto-generated method stub
     return null;
   }
-
+  
   @Override
-  public Class<? extends QueryNodeConfig> nodeConfigClass() {
-    return RateOptions.class;
+  public QueryNodeConfig parseConfig(final ObjectMapper mapper, 
+                                     final TSDB tsdb,
+                                     final JsonNode node) {
+    try {
+      return mapper.treeToValue(node, RateOptions.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Unable to parse config", e);
+    }
   }
   
   /**

--- a/core/src/main/java/net/opentsdb/query/processor/topn/TopNFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/topn/TopNFactory.java
@@ -14,6 +14,11 @@
 // limitations under the License.
 package net.opentsdb.query.processor.topn;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import net.opentsdb.core.TSDB;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
@@ -62,10 +67,16 @@ public class TopNFactory extends BaseQueryNodeFactory {
                            final QueryNodeConfig config) {
     return new TopN(this, context, id, (TopNConfig) config);
   }
-
+  
   @Override
-  public Class<? extends QueryNodeConfig> nodeConfigClass() {
-    return TopNConfig.class;
+  public QueryNodeConfig parseConfig(final ObjectMapper mapper, 
+                                     final TSDB tsdb,
+                                     final JsonNode node) {
+    try {
+      return mapper.treeToValue(node, TopNConfig.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Unable to parse config", e);
+    }
   }
   
 }

--- a/core/src/test/java/net/opentsdb/query/TestAbstractQueryPipelineContext.java
+++ b/core/src/test/java/net/opentsdb/query/TestAbstractQueryPipelineContext.java
@@ -39,6 +39,8 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -1371,7 +1373,8 @@ public class TestAbstractQueryPipelineContext {
     }
 
     @Override
-    public Class<? extends QueryNodeConfig> nodeConfigClass() {
+    public QueryNodeConfig parseConfig(ObjectMapper mapper, TSDB tsdb,
+        JsonNode node) {
       return null;
     }
     
@@ -1431,7 +1434,8 @@ public class TestAbstractQueryPipelineContext {
     }
 
     @Override
-    public Class<? extends QueryNodeConfig> nodeConfigClass() {
+    public QueryNodeConfig parseConfig(ObjectMapper mapper, TSDB tsdb,
+        JsonNode node) {
       return null;
     }
     
@@ -1491,7 +1495,8 @@ public class TestAbstractQueryPipelineContext {
     }
 
     @Override
-    public Class<? extends QueryNodeConfig> nodeConfigClass() {
+    public QueryNodeConfig parseConfig(ObjectMapper mapper, TSDB tsdb,
+        JsonNode node) {
       return null;
     }
     
@@ -1550,7 +1555,8 @@ public class TestAbstractQueryPipelineContext {
     }
 
     @Override
-    public Class<? extends QueryNodeConfig> nodeConfigClass() {
+    public QueryNodeConfig parseConfig(ObjectMapper mapper, TSDB tsdb,
+        JsonNode node) {
       return null;
     }
 

--- a/core/src/test/java/net/opentsdb/query/processor/TestBaseMultiQueryNodeFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/TestBaseMultiQueryNodeFactory.java
@@ -31,9 +31,12 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import net.opentsdb.core.TSDB;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesValue;
@@ -198,8 +201,8 @@ public class TestBaseMultiQueryNodeFactory {
     }
     
     @Override
-    public Class<? extends QueryNodeConfig> nodeConfigClass() {
-      // TODO Auto-generated method stub
+    public QueryNodeConfig parseConfig(ObjectMapper mapper, TSDB tsdb,
+        JsonNode node) {
       return null;
     }
     

--- a/core/src/test/java/net/opentsdb/query/processor/TestBaseQueryNodeFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/TestBaseQueryNodeFactory.java
@@ -30,9 +30,12 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import net.opentsdb.core.TSDB;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesValue;
@@ -201,8 +204,8 @@ public class TestBaseQueryNodeFactory {
     }
 
     @Override
-    public Class<? extends QueryNodeConfig> nodeConfigClass() {
-      // TODO Auto-generated method stub
+    public QueryNodeConfig parseConfig(ObjectMapper mapper, TSDB tsdb,
+        JsonNode node) {
       return null;
     }
     


### PR DESCRIPTION
- Switch the QueryNodeFactory to return a config given the Jackson parse tree
  node instead of just returning the class. QuerySourceConfig needs the
  factories to parse filters properly.
- Make the QueryFilterFactory a TSDBPlugin so they're loaded on startup.
- Tweak all the filters to implement the plugin.

CORE:
- Tweak the QueryDataSourceFactory to parse the JSON properly now.
- Tweak all the filters to implement the plugin.