### PR TITLE
CORE:

### DIFF
--- a/common/src/main/java/net/opentsdb/auth/AuthState.java
+++ b/common/src/main/java/net/opentsdb/auth/AuthState.java
@@ -76,4 +76,20 @@ public interface AuthState {
    * be null.
    */
   public byte[] getToken();
+  
+  /**
+   * Whether or not the subject has the rights to take on the requested
+   * role for Role Based Access Control.
+   * @param role The non-null and non-empty role string.
+   * @return True if the subject has the rights, false if not.
+   */
+  public boolean hasRole(final String role);
+  
+  /**
+   * Whether or not the subject has permission to perform the given
+   * action for Role Based Access Control.
+   * @param action The non-null and non-empty action string.
+   * @return True if the subject has permission, false if not.
+   */
+  public boolean hasPermission(final String action);
 }

--- a/common/src/main/java/net/opentsdb/core/Registry.java
+++ b/common/src/main/java/net/opentsdb/core/Registry.java
@@ -16,8 +16,10 @@ package net.opentsdb.core;
 
 import java.util.concurrent.ExecutorService;
 
+import com.google.common.reflect.TypeToken;
 import com.stumbleupon.async.Deferred;
 
+import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.query.QueryIteratorFactory;
 import net.opentsdb.query.interpolation.QueryInterpolatorFactory;
 import net.opentsdb.query.QueryNodeFactory;
@@ -120,6 +122,35 @@ public interface Registry {
    * @return The factory if found, null if such an iterator does not exist.
    */
   public QueryIteratorFactory getQueryIteratorFactory(final String id);
+  
+  /**
+   * Registers the data type with the given name. Uses the provided name
+   * and if successful, will also register under the class name returned
+   * by {@code type.toString().toLowerCase()}.
+   * @param type A non-null type not registered yet.
+   * @param name A non-null and non-empty name to register under.
+   * @param is_default_name Whether or not this is the default name.
+   * @throws IllegalArgumentException if the name was already mapped to
+   * a different type.
+   */
+  public void registerType(final TypeToken<? extends TimeSeriesDataType> type, 
+                           final String name,
+                           final boolean is_default_name);
+  
+  /**
+   * Returns the data type associated with the given name.
+   * @param name A non-null and non-empty name.
+   * @return The type if found, null if not.
+   */
+  public TypeToken<? extends TimeSeriesDataType> getType(final String name);
+  
+  /**
+   * Returns the default name associated with the given type.
+   * @param type The non-null type.
+   * @return A non-null and non-empty string if the type is registered, 
+   * null if the type is not.
+   */
+  public String getDefaultTypeName(final TypeToken<? extends TimeSeriesDataType> type);
   
   public ReadableTimeSeriesDataStore getDefaultStore();
   

--- a/common/src/main/java/net/opentsdb/stats/BlackholeTracer.java
+++ b/common/src/main/java/net/opentsdb/stats/BlackholeTracer.java
@@ -1,0 +1,169 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.stats;
+
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.core.TSDB;
+
+/**
+ * When a tracing plugin is not loaded, this class should be passed
+ * around so that we avoid a ton of {@code if (span != null)...} 
+ * checks.
+ * 
+ * @since 3.0
+ */
+public class BlackholeTracer implements Tracer, Trace, Span, Span.SpanBuilder {
+
+  @Override
+  public void finish() { }
+
+  @Override
+  public void finish(final long duration) {  }
+
+  @Override
+  public Span setSuccessTags() {
+    return this;
+  }
+
+  @Override
+  public Span setErrorTags() {
+    return this;
+  }
+
+  @Override
+  public Span setErrorTags(final Throwable t) {
+    return this;
+  }
+
+  @Override
+  public Span setTag(final String key, final String value) {
+    return this;
+  }
+
+  @Override
+  public Span setTag(final String key, final Number value) {
+    return this;
+  }
+
+  @Override
+  public Span log(final String key, final Throwable t) {
+    return this;
+  }
+
+  @Override
+  public Object implementationSpan() {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder newChild(final String id) {
+    return this;
+  }
+
+  @Override
+  public boolean isDebug() {
+    return false;
+  }
+
+  @Override
+  public SpanBuilder asChildOf(final Span parent) {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder withTag(final String key, final String value) {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder withTag(final String key, final Number value) {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder buildSpan(final String id) {
+    return this;
+  }
+
+  @Override
+  public Span start() {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder newSpan(final String id) {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder newSpan(final String id, final String... tags) {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder newSpanWithThread(final String id) {
+    return this;
+  }
+
+  @Override
+  public SpanBuilder newSpanWithThread(final String id, 
+                                       final String... tags) {
+    return this;
+  }
+
+  @Override
+  public String traceId() {
+    return "Null";
+  }
+
+  @Override
+  public Span firstSpan() {
+    return this;
+  }
+
+  @Override
+  public String id() {
+    return "BlackholeTracer";
+  }
+
+  @Override
+  public Deferred<Object> initialize(final TSDB tsdb) {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
+  }
+
+  @Override
+  public Trace newTrace(final boolean report, final boolean debug) {
+    return this;
+  }
+
+  @Override
+  public Trace newTrace(final boolean report, 
+                        final boolean debug, 
+                        final String service_name) {
+    return this;
+  }
+
+}

--- a/common/src/main/java/net/opentsdb/storage/BlackHoleWriter.java
+++ b/common/src/main/java/net/opentsdb/storage/BlackHoleWriter.java
@@ -1,0 +1,81 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.storage;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.auth.AuthState;
+import net.opentsdb.core.TSDB;
+import net.opentsdb.core.TSDBPlugin;
+import net.opentsdb.data.TimeSeriesDatum;
+import net.opentsdb.data.TimeSeriesSharedTagsAndTimeData;
+import net.opentsdb.stats.Span;
+
+/**
+ * Simple writer that just dumps the data into the bit-bucket in the sky.
+ * 
+ * @since 3.0
+ */
+public class BlackHoleWriter implements WritableTimeSeriesDataStore, TSDBPlugin {
+
+  /**
+   * Default ctor.
+   */
+  public BlackHoleWriter() {
+    
+  }
+  
+  @Override
+  public String id() {
+    return "BlackHoleWriter";
+  }
+
+  @Override
+  public Deferred<Object> initialize(final TSDB tsdb) {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
+  }
+
+  @Override
+  public Deferred<WriteStatus> write(final AuthState state, 
+                                     final TimeSeriesDatum datum,
+                                     final Span span) {
+    return Deferred.fromResult(WriteStatus.OK);
+  }
+
+  @Override
+  public Deferred<List<WriteStatus>> write(final AuthState state,
+                                           final TimeSeriesSharedTagsAndTimeData data, 
+                                           final Span span) {
+    final List<WriteStatus> list = Lists.newArrayListWithExpectedSize(data.size());
+    for (int i = 0; i < data.size(); i++) {
+      list.add(WriteStatus.OK);
+    }
+    return Deferred.fromResult(list);
+  }
+
+}

--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
@@ -147,7 +147,7 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes, TSDBPlugin {
             json.writeNumberField("start", result.timeSpecification().start().epoch());
             json.writeNumberField("end", result.timeSpecification().end().epoch());
             json.writeStringField("intervalISO", result.timeSpecification().interval().toString());
-            json.writeNumberField("intervalNumeric", result.timeSpecification().interval().get(result.timeSpecification().units()));
+            //json.writeNumberField("intervalNumeric", result.timeSpecification().interval().get(result.timeSpecification().units()));
             if (result.timeSpecification().timezone() != null) {
               json.writeStringField("timeZone", result.timeSpecification().timezone().toString());
             }
@@ -253,7 +253,7 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes, TSDBPlugin {
                 }
                 
                 if (value.value() == null) {
-                  json.writeNull();;
+                  json.writeNull();
                 } else if (type == NumericType.TYPE) {
                   if (((TimeSeriesValue<NumericType>) value).value().isInteger()) {
                     json.writeNumber( 
@@ -278,6 +278,9 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes, TSDBPlugin {
           }
           // end of the data array
           json.writeEndArray();
+          
+          // TODO - flag
+          //json.writeObjectField("executionGraph", context.query());
           
           // final end of the object.
           json.writeEndObject();

--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
@@ -1,0 +1,332 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.execution.serdes;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.temporal.TemporalUnit;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Map.Entry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+import com.stumbleupon.async.DeferredGroupException;
+
+import net.opentsdb.common.Const;
+import net.opentsdb.core.TSDB;
+import net.opentsdb.core.TSDBPlugin;
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesByteId;
+import net.opentsdb.data.TimeSeriesDataType;
+import net.opentsdb.data.TimeSeriesStringId;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.TimeStamp.Op;
+import net.opentsdb.data.types.numeric.NumericSummaryType;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.exceptions.QueryExecutionException;
+import net.opentsdb.query.QueryContext;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.serdes.SerdesOptions;
+import net.opentsdb.query.serdes.TimeSeriesSerdes;
+import net.opentsdb.stats.Span;
+import net.opentsdb.utils.Exceptions;
+import net.opentsdb.utils.JSON;
+
+public class JsonV3QuerySerdes implements TimeSeriesSerdes, TSDBPlugin {
+  private static final Logger LOG = LoggerFactory.getLogger(
+      JsonV3QuerySerdes.class);
+  
+  @Override
+  public String id() {
+    return "V3";
+  }
+
+  @Override
+  public Deferred<Object> initialize(TSDB tsdb) {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
+  }
+
+  @Override
+  public Deferred<Object> serialize(final QueryContext context, 
+                                    final SerdesOptions options,
+                                    final OutputStream stream, 
+                                    final QueryResult result, 
+                                    final Span span) {
+    if (stream == null) {
+      throw new IllegalArgumentException("Output stream may not be null.");
+    }
+    if (result == null) {
+      throw new IllegalArgumentException("Data may not be null.");
+    }
+    final JsonV2QuerySerdesOptions opts;
+    if (options == null) {
+      throw new IllegalArgumentException("Options cannot be null.");
+    }
+     if (!(options instanceof JsonV2QuerySerdesOptions)) {
+      throw new IllegalArgumentException("Options were of the wrong type: " 
+          + options.getClass());
+    }
+    opts = (JsonV2QuerySerdesOptions) options;
+    
+    final JsonGenerator json;
+    try {
+      json = JSON.getFactory().createGenerator(stream);
+    } catch (IOException e) {
+      throw new RuntimeException("WTF?", e);
+    }
+    
+    try {
+      json.writeStartObject();
+      
+    } catch (IOException e) {
+      throw new RuntimeException("WTF?", e);
+    }
+    
+    final List<TimeSeries> series;
+    final List<Deferred<TimeSeriesStringId>> deferreds;
+    if (result.idType() == Const.TS_BYTE_ID) {
+      series = Lists.newArrayList(result.timeSeries());
+      deferreds = Lists.newArrayListWithCapacity(series.size());
+      for (final TimeSeries ts : result.timeSeries()) {
+        deferreds.add(((TimeSeriesByteId) ts.id()).decode(false, 
+            null /* TODO - implement tracing */));
+      }
+    } else {
+      series = null;
+      deferreds = null;
+    }
+    
+    /**
+     * Performs the serialization after determining if the serializations
+     * need to resolve series IDs.
+     */
+    class ResolveCB implements Callback<Object, ArrayList<TimeSeriesStringId>> {
+
+      @Override
+      public Object call(final ArrayList<TimeSeriesStringId> ids) 
+            throws Exception {
+        try {
+          // serdes time spec if present
+          if (result.timeSpecification() != null) {
+            json.writeObjectFieldStart("timeSpecification");
+            // TODO - ms, second, nanos, etc
+            json.writeNumberField("start", result.timeSpecification().start().epoch());
+            json.writeNumberField("end", result.timeSpecification().end().epoch());
+            json.writeStringField("intervalISO", result.timeSpecification().interval().toString());
+            json.writeNumberField("intervalNumeric", result.timeSpecification().interval().get(result.timeSpecification().units()));
+            if (result.timeSpecification().timezone() != null) {
+              json.writeStringField("timeZone", result.timeSpecification().timezone().toString());
+            }
+            json.writeStringField("units", result.timeSpecification().units().toString());
+            json.writeEndObject();
+          }
+          
+          json.writeArrayFieldStart("data");
+          int idx = 0;
+          for (final TimeSeries series : 
+            series != null ? series : result.timeSeries()) {
+            
+            final TypeToken<? extends TimeSeriesDataType> type;
+            Optional<Iterator<TimeSeriesValue<?>>> optional = 
+                series.iterator(NumericType.TYPE);
+            if (!optional.isPresent()) {
+              continue;
+            } else {
+              type = NumericType.TYPE;
+            }
+            
+            final Iterator<TimeSeriesValue<?>> iterator = optional.get();
+            if (!iterator.hasNext()) {
+              continue;
+            }
+            TimeSeriesValue<? extends TimeSeriesDataType> value = 
+                (TimeSeriesValue<TimeSeriesDataType>) iterator.next();
+            while (value != null && value.timestamp().compare(
+                Op.LT, opts.start)) {
+              if (iterator.hasNext()) {
+                value = (TimeSeriesValue<NumericType>) iterator.next();
+              } else {
+                value = null;
+              }
+            }
+            
+            if (value == null) {
+              continue;
+            }
+            if (value.timestamp().compare(Op.LT, opts.start()) ||
+                value.timestamp().compare(Op.GT, opts.end)) {
+              continue;
+            }
+            
+            json.writeStartObject();
+            
+            final TimeSeriesStringId id;
+            if (ids != null) {
+              id = (ids.get(idx++));
+            } else {
+              id = (TimeSeriesStringId) series.id();
+            }
+            
+            json.writeStringField("metric", id.metric());
+            json.writeObjectFieldStart("tags");
+            for (final Entry<String, String> entry : id.tags().entrySet()) {
+              json.writeStringField(entry.getKey(), entry.getValue());
+            }
+            json.writeEndObject();
+            json.writeArrayFieldStart("aggregateTags");
+            for (final String tag : id.aggregatedTags()) {
+              json.writeString(tag);
+            }
+            json.writeEndArray();
+            if (result.timeSpecification() == null) {
+              json.writeObjectFieldStart("NumericType");
+              
+              long ts = 0;
+              while (value != null) {
+                if (value.timestamp().compare(Op.GT, opts.end())) {
+                  break;
+                }
+                
+                ts = (opts != null && opts.msResolution()) 
+                    ? value.timestamp().msEpoch() 
+                    : value.timestamp().msEpoch() / 1000;
+                final String ts_string = Long.toString(ts);
+                if (value.value() == null) {
+                  json.writeNullField(ts_string);
+                } else if (type == NumericType.TYPE) {
+                  if (((TimeSeriesValue<NumericType>) value).value().isInteger()) {
+                    json.writeNumberField(ts_string, 
+                        ((TimeSeriesValue<NumericType>) value).value().longValue());
+                  } else {
+                    json.writeNumberField(ts_string, 
+                        ((TimeSeriesValue<NumericType>) value).value().doubleValue());
+                  }
+                }
+                
+                if (iterator.hasNext()) {
+                  value = (TimeSeriesValue<NumericType>) iterator.next();
+                } else {
+                  value = null;
+                }
+              }
+              json.writeEndObject();
+            } else {
+              // just write the values.
+              json.writeArrayFieldStart("NumericType");
+              while (value != null) {
+                if (value.timestamp().compare(Op.GT, opts.end())) {
+                  break;
+                }
+                
+                if (value.value() == null) {
+                  json.writeNull();;
+                } else if (type == NumericType.TYPE) {
+                  if (((TimeSeriesValue<NumericType>) value).value().isInteger()) {
+                    json.writeNumber( 
+                        ((TimeSeriesValue<NumericType>) value).value().longValue());
+                  } else {
+                    json.writeNumber(
+                        ((TimeSeriesValue<NumericType>) value).value().doubleValue());
+                  }
+                }
+                
+                if (iterator.hasNext()) {
+                  value = (TimeSeriesValue<NumericType>) iterator.next();
+                } else {
+                  value = null;
+                }
+              }
+              json.writeEndArray();
+            }
+            
+            json.writeEndObject();
+            json.flush();
+          }
+          // end of the data array
+          json.writeEndArray();
+          
+          // final end of the object.
+          json.writeEndObject();
+          json.close();
+          
+        } catch (Exception e) {
+          LOG.error("Unexpected exception", e);
+          return Deferred.fromError(new QueryExecutionException(
+              "Unexpected exception "
+              + "serializing: " + result, 500, e));
+        }
+        return Deferred.fromResult(null);
+      }
+      
+    }
+    
+    class ErrorCB implements Callback<Object, Exception> {
+      @Override
+      public Object call(final Exception ex) throws Exception {
+        if (ex instanceof DeferredGroupException) {
+          throw (Exception) Exceptions.getCause((DeferredGroupException) ex);
+        }
+        throw ex;
+      }
+    }
+    
+    try {
+      if (deferreds != null) {
+        return Deferred.group(deferreds)
+          .addCallback(new ResolveCB())
+          .addErrback(new ErrorCB());
+      } else {
+        return Deferred.fromResult(new ResolveCB().call(null));
+      }
+    } catch (InterruptedException e) {
+      throw new QueryExecutionException("Failed to resolve IDs", 500, e);
+    } catch (Exception e) {
+      LOG.error("Unexpected exception", e);
+      throw new QueryExecutionException("Failed to resolve IDs", 500, e);
+    }
+  }
+
+  @Override
+  public void deserialize(final SerdesOptions options, 
+                          final InputStream stream,
+                          final QueryNode node, 
+                          final Span span) {
+    node.onError(new UnsupportedOperationException("Not implemented for this "
+        + "class: " + getClass().getCanonicalName()));
+  }
+
+}

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/Downsample.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/Downsample.java
@@ -14,7 +14,9 @@
 // limitations under the License.
 package net.opentsdb.query.processor.downsample;
 
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAmount;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -128,7 +130,7 @@ public class Downsample extends AbstractQueryNode {
    * A downsample result that's a member class of the main node so that we share
    * the references to the config and node.
    */
-  class DownsampleResult implements QueryResult {
+  class DownsampleResult implements QueryResult, TimeSpecification {
     /** Countdown latch for closing the result set based on the upstreams. */
     private final CountDownLatch latch;
     
@@ -216,7 +218,7 @@ public class Downsample extends AbstractQueryNode {
     
     @Override
     public TimeSpecification timeSpecification() {
-      return results.timeSpecification(); // TODO - return the config;
+      return this;
     }
 
     @Override
@@ -285,12 +287,29 @@ public class Downsample extends AbstractQueryNode {
       }
     }
     
-    TimeStamp start() {
+    @Override
+    public TimeStamp start() {
       return start;
     }
     
-    TimeStamp end() {
+    @Override
+    public TimeStamp end() {
       return end;
+    }
+    
+    @Override
+    public TemporalAmount interval() {
+      return config.interval();
+    }
+
+    @Override
+    public ChronoUnit units() {
+      return config.units();
+    }
+
+    @Override
+    public ZoneId timezone() {
+      return config.timezone();
     }
     
     /**
@@ -362,6 +381,8 @@ public class Downsample extends AbstractQueryNode {
       }
       
     }
+
+    
   }
   
 }

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsample.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsample.java
@@ -210,6 +210,9 @@ public class TestDownsample {
     ds.initialize(null);
     dr = ds.new DownsampleResult(result);
     assertEquals(ChronoUnit.SECONDS, dr.resolution());
+    assertEquals(3600, dr.start().epoch());
+    assertEquals(43200, dr.end().epoch());
+    assertEquals(ChronoUnit.HOURS, dr.units());
     
     config = (DownsampleConfig) DownsampleConfig.newBuilder()
         .setAggregator("sum")
@@ -222,6 +225,9 @@ public class TestDownsample {
     ds.initialize(null);
     dr = ds.new DownsampleResult(result);
     assertEquals(ChronoUnit.MILLIS, dr.resolution());
+    assertEquals(1, dr.start().epoch());
+    assertEquals(43200, dr.end().epoch());
+    assertEquals(ChronoUnit.MILLIS, dr.units());
     
     config = (DownsampleConfig) DownsampleConfig.newBuilder()
         .setAggregator("sum")
@@ -234,6 +240,9 @@ public class TestDownsample {
     ds.initialize(null);
     dr = ds.new DownsampleResult(result);
     assertEquals(ChronoUnit.NANOS, dr.resolution());
+    assertEquals(1, dr.start().epoch());
+    assertEquals(43200, dr.end().epoch());
+    assertEquals(ChronoUnit.MICROS, dr.units());
     
     config = (DownsampleConfig) DownsampleConfig.newBuilder()
         .setAggregator("sum")
@@ -246,6 +255,9 @@ public class TestDownsample {
     ds.initialize(null);
     dr = ds.new DownsampleResult(result);
     assertEquals(ChronoUnit.NANOS, dr.resolution());
+    assertEquals(1, dr.start().epoch());
+    assertEquals(43200, dr.end().epoch());
+    assertEquals(ChronoUnit.NANOS, dr.units());
   }
   
   @Test

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/RawQueryRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/RawQueryRpc.java
@@ -46,6 +46,7 @@ import net.opentsdb.query.SemanticQueryContext;
 import net.opentsdb.query.TSQuery;
 import net.opentsdb.query.execution.serdes.JsonV2QuerySerdes;
 import net.opentsdb.query.execution.serdes.JsonV2QuerySerdesOptions;
+import net.opentsdb.query.execution.serdes.JsonV3QuerySerdes;
 import net.opentsdb.query.pojo.TimeSeriesQuery;
 import net.opentsdb.query.serdes.SerdesFactory;
 import net.opentsdb.query.serdes.SerdesOptions;
@@ -332,7 +333,7 @@ public class RawQueryRpc {
 //              .start();
 //        }
 
-        final JsonV2QuerySerdes serdes = new JsonV2QuerySerdes();
+        final JsonV3QuerySerdes serdes = new JsonV3QuerySerdes();
         try {
           // TODO - ug ug ugggg!!!
           serdes.serialize(context, options, output, result, serdes_span).join();


### PR DESCRIPTION
- Start the JsonV3QuerySerdes serializer. This will do a lot of neat, new
  stuff. For now it just handles numerics and drops timestamps for
  downsampled data so we save a TON of bandwidth. Lots of changes coming
  though.
- Fix the Downsampler node to return the time spec.

SERVLET:
- Tweak RawQueryRpc to use the new v3 serdes.