### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/filter/ChainFilter.java
+++ b/common/src/main/java/net/opentsdb/query/filter/ChainFilter.java
@@ -44,9 +44,9 @@ public class ChainFilter implements QueryFilter {
    * @param builder The non-null builder.
    */
   protected ChainFilter(final Builder builder) {
-    if (builder.filters == null || builder.filters.size() < 2) {
+    if (builder.filters == null || builder.filters.size() < 1) {
       throw new IllegalArgumentException("Filters list cannot be null "
-          + "or have fewer than 2 filters.");
+          + "or have fewer than 1 filter.");
     }
     filters = builder.filters;
     if (builder.op == null) {

--- a/common/src/main/java/net/opentsdb/storage/WritableTimeSeriesDataStoreFactory.java
+++ b/common/src/main/java/net/opentsdb/storage/WritableTimeSeriesDataStoreFactory.java
@@ -1,0 +1,38 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.storage;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.core.TSDBPlugin;
+
+/**
+ * The interface used for implementing a data store that can accept 
+ * writes via the OpenTSDB APIs.
+ * 
+ * @since 3.0
+ */
+public interface WritableTimeSeriesDataStoreFactory extends TSDBPlugin{
+  
+  /**
+   * Returns a reference to a specific data store instance with the 
+   * given ID. If the ID is null or empty it's the "default" instance.
+   * @param tsdb A non-null TSD to pull configs from.
+   * @param id An optional ID.
+   * @return An instantiated time series data store.
+   */
+  public WritableTimeSeriesDataStore newStoreInstance(final TSDB tsdb, 
+                                                      final String id);
+  
+}

--- a/common/src/test/java/net/opentsdb/query/filter/TestChainFilterAndFactory.java
+++ b/common/src/test/java/net/opentsdb/query/filter/TestChainFilterAndFactory.java
@@ -67,15 +67,6 @@ public class TestChainFilterAndFactory {
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
     
-    // only one filter.
-    json = "{\"type\":\"chain\",\"filters\":["
-        + "{\"type\":\"UTQueryFilter\",\"tag\":\"host\",\"filter\":\"web01|web02\"}]}";
-    node = MAPPER.readTree(json);
-    try {
-      chain_factory.parse(tsdb, MAPPER, node);
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
-    
     // no type
     json = "{\"type\":\"chain\",\"filters\":["
         + "{\"type\":\"TagValueLiteralOr\",\"tagKey\":\"host\",\"filter\":\"web01|web02\"},"
@@ -112,14 +103,6 @@ public class TestChainFilterAndFactory {
         filter.getFilters().get(0)).filter);
     assertEquals("tyrion", ((UTQueryFilter) 
         filter.getFilters().get(1)).filter);
-    
-    try {
-      ChainFilter.newBuilder()
-          .setOp(FilterOp.OR)
-          .addFilter(new UTQueryFilter("host", "web01|web02"))
-          .build();
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
     
     try {
       ChainFilter.newBuilder()

--- a/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
+++ b/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.stumbleupon.async.Deferred;
 
+import net.opentsdb.core.DefaultRegistry;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.core.TSDBPlugin;
 import net.opentsdb.exceptions.QueryExecutionException;
@@ -52,18 +53,17 @@ public class QueryDataSourceFactory implements SingleQueryNodeFactory, TSDBPlugi
   public QueryNode newNode(final QueryPipelineContext context, 
                            final String id,
                            final QueryNodeConfig config) {
-    final TimeSeriesDataStoreFactory factory = tsdb.getRegistry()
-        .getDefaultPlugin(TimeSeriesDataStoreFactory.class);
-      if (factory == null) {
-        throw new RuntimeException("No factory!");
-      }
+//    final TimeSeriesDataStoreFactory factory = tsdb.getRegistry()
+//        .getDefaultPlugin(TimeSeriesDataStoreFactory.class);
+//      if (factory == null) {
+//        throw new RuntimeException("No factory!");
+//      }
       
-      final ReadableTimeSeriesDataStore store = factory.newInstance(tsdb, null);
-      if (store == null) {
-        throw new QueryExecutionException("Unable to get a data store "
-            + "instance from factory: " + factory.id(), 0);
-      }
-      return store.newNode(context, id, config);
+    final ReadableTimeSeriesDataStore store = ((DefaultRegistry) tsdb.getRegistry()).getDefaultStore();
+    if (store == null) {
+      throw new QueryExecutionException("Unable to get a data store!", 0);
+    }
+    return store.newNode(context, id, config);
   }
 
   @Override

--- a/core/src/test/java/net/opentsdb/query/TestTSDBV2QueryContextBuilder.java
+++ b/core/src/test/java/net/opentsdb/query/TestTSDBV2QueryContextBuilder.java
@@ -38,6 +38,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import com.stumbleupon.async.Deferred;
 import com.stumbleupon.async.TimeoutException;
 
+import net.opentsdb.core.DefaultRegistry;
 import net.opentsdb.core.MockTSDB;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesStringId;
@@ -76,6 +77,7 @@ public class TestTSDBV2QueryContextBuilder {
   @BeforeClass
   public static void beforeClass() throws Exception {
     TSDB = new MockTSDB();
+    TSDB.registry = mock(DefaultRegistry.class);
     STORE_FACTORY = new MockDataStoreFactory();
     TSDB.config.register("MockDataStore.timestamp", 1483228800000L, false, "UT");
     
@@ -110,8 +112,8 @@ public class TestTSDBV2QueryContextBuilder {
           return factory;
         }
       });
-    when(TSDB.registry.getDefaultPlugin(TimeSeriesDataStoreFactory.class))
-      .thenReturn(STORE_FACTORY);
+    when(((DefaultRegistry) TSDB.registry).getDefaultStore())
+      .thenReturn(new MockDataStore(TSDB, null));
     SOURCE_FACTORY = new QueryDataSourceFactory();
     SOURCE_FACTORY.initialize(TSDB).join();
   }

--- a/storage/googlepubsub/src/main/java/net/opentsdb/storage/PubSubConsumer.java
+++ b/storage/googlepubsub/src/main/java/net/opentsdb/storage/PubSubConsumer.java
@@ -37,6 +37,7 @@ import com.google.pubsub.v1.PubsubMessage;
 import com.stumbleupon.async.Callback;
 import com.stumbleupon.async.Deferred;
 
+import net.opentsdb.core.DefaultRegistry;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.data.TimeSeriesDatum;
 import net.opentsdb.data.TimeSeriesSharedTagsAndTimeData;
@@ -120,8 +121,7 @@ public class PubSubConsumer implements TimeSeriesDataConsumer, MessageReceiver {
           "Serdes can't be null."));
     }
     
-    data_store = tsdb.getRegistry().getDefaultPlugin(
-        WritableTimeSeriesDataStore.class);
+    data_store = ((DefaultRegistry) tsdb.getRegistry()).getDefaultWriteStore();
     if (data_store == null) {
       return Deferred.fromError(new IllegalArgumentException(
           "No default data store found."));


### PR DESCRIPTION
- Add WritableTimeSeriesDataStoreFactory.

CORE:
- Register the write and read stores in the default registry again. This may
  still need more tweaking as it's ugly as heck.
- Rework the order of default registrations in the plugin config as we need
  to load the built-ins first before named classes.
- Schema now implements the WritableTimeSeriesDataStore and registers the
  read writes.

PROTOBUF:
- Implement millisecond encoding for timestamps and fix zoned encoding.

BIGTABLE:
- Clean out some old printlns.
- Set the thread pool to be a fixed size. Cached can blow up the heap
  due to all of the async calls.

PUBSUB:
- Get the default write store for now.