### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/data/TimeSpecification.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSpecification.java
@@ -49,6 +49,9 @@ public interface TimeSpecification {
    */
   public TemporalAmount interval();
   
+  /** @return The non-null string interval representing {@link #interval()}. */
+  public String stringInterval();
+  
   /**
    * The units of time the interval represents.
    * @return A non-null unit.

--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
@@ -147,6 +147,7 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes, TSDBPlugin {
             json.writeNumberField("start", result.timeSpecification().start().epoch());
             json.writeNumberField("end", result.timeSpecification().end().epoch());
             json.writeStringField("intervalISO", result.timeSpecification().interval().toString());
+            json.writeStringField("interval", result.timeSpecification().stringInterval());
             //json.writeNumberField("intervalNumeric", result.timeSpecification().interval().get(result.timeSpecification().units()));
             if (result.timeSpecification().timezone() != null) {
               json.writeStringField("timeZone", result.timeSpecification().timezone().toString());

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/Downsample.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/Downsample.java
@@ -211,7 +211,7 @@ public class Downsample extends AbstractQueryNode {
     
     @Override
     public TimeSpecification timeSpecification() {
-      return this;
+      return config.fill() ? this : results.timeSpecification();
     }
 
     @Override
@@ -295,6 +295,11 @@ public class Downsample extends AbstractQueryNode {
       return config.interval();
     }
 
+    @Override
+    public String stringInterval() {
+      return config.intervalAsString();
+    }
+    
     @Override
     public ChronoUnit units() {
       return config.units();


### PR DESCRIPTION
- Add stringInterval() to the TimeSpecification for downsampling so we get
  the simple string, e.g. "1m" instead of the ISO "PT1M".

CORE:
- Fix Downsample to return the time spec ONLY if fill was enabled.