### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/interpolation/QueryInterpolatorConfig.java
+++ b/common/src/main/java/net/opentsdb/query/interpolation/QueryInterpolatorConfig.java
@@ -15,10 +15,10 @@
 package net.opentsdb.query.interpolation;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.google.common.hash.HashCode;
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.data.TimeSeriesDataType;
 
 /**
  * A configuration class for an iterator interpolator.
@@ -26,11 +26,6 @@ import com.google.common.hash.HashCode;
  * @since 3.0
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(use = Id.NAME,
-  include = JsonTypeInfo.As.PROPERTY,
-  property = "configType",
-  visible = true)
-@JsonTypeIdResolver(QueryInterpolatorConfigResolver.class)
 public interface QueryInterpolatorConfig extends 
     Comparable<QueryInterpolatorConfig>{
 
@@ -47,12 +42,11 @@ public interface QueryInterpolatorConfig extends
    * of a data type.
    * @return A non-null data type name.
    */
-  public String dataType();
-  
-  /** @return The non-null class of the configuration implementation. */
-  public String configType();
+  public String interpolatorType();
   
   /** @return A non-null deterministic hash code for the object. */
   public HashCode buildHashCode();
   
+  /** @return The data type for this config. */
+  public TypeToken<? extends TimeSeriesDataType> type();
 }

--- a/common/src/main/java/net/opentsdb/query/interpolation/QueryInterpolatorConfigParser.java
+++ b/common/src/main/java/net/opentsdb/query/interpolation/QueryInterpolatorConfigParser.java
@@ -1,0 +1,41 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.interpolation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import net.opentsdb.core.TSDB;
+
+/**
+ * Parses text into an interpolator config.
+ * 
+ * @since 3.0
+ */
+public interface QueryInterpolatorConfigParser {
+
+  /**
+   * Parses the node.
+   * @param mapper A non-null mapper.
+   * @param tsdb The non-null TSDB to fetch the registry from.
+   * @param node The root config node.
+   * @return A parsed interpolator config on success or an exception
+   * if something went wrong.
+   */
+  public QueryInterpolatorConfig parse(final ObjectMapper mapper,
+                                       final TSDB tsdb, 
+                                       final JsonNode node);
+  
+}

--- a/common/src/main/java/net/opentsdb/query/interpolation/QueryInterpolatorFactory.java
+++ b/common/src/main/java/net/opentsdb/query/interpolation/QueryInterpolatorFactory.java
@@ -16,15 +16,18 @@ package net.opentsdb.query.interpolation;
 
 import java.util.Iterator;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.reflect.TypeToken;
 
+import net.opentsdb.core.TSDB;
 import net.opentsdb.core.TSDBPlugin;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesValue;
 
 /**
- * A factory interface for generating interator interpolators.
+ * A factory interface for generating iterator interpolators.
  * 
  * @since 3.0
  */
@@ -65,7 +68,20 @@ public interface QueryInterpolatorFactory extends TSDBPlugin {
    * @param clazz A non-null class with a constructor accepting the 
    * following parameters: "TimeSeries, QueryInterpolatorConfig" or 
    * "Iterator<TimeSeriesValue<? extends TimeSeriesDataType>>, QueryInterpolatorConfig".
+   * @param parser A config parser.
    */
   public void register(final TypeToken<? extends TimeSeriesDataType> type,
-                       final Class<? extends QueryInterpolator<?>> clazz); 
+                       final Class<? extends QueryInterpolator<?>> clazz,
+                       final QueryInterpolatorConfigParser parser); 
+
+  /**
+   * Parse the given JSON or YAML into the proper node config.
+   * @param mapper A non-null mapper to use for parsing.
+   * @param tsdb The non-null TSD to pull factories from.
+   * @param node The non-null node to parse.
+   * @return An instantiated node config if successful.
+   */
+  public QueryInterpolatorConfig parseConfig(final ObjectMapper mapper,
+                                             final TSDB tsdb, 
+                                             final JsonNode node);
 }

--- a/core/src/main/java/net/opentsdb/core/PluginsConfig.java
+++ b/core/src/main/java/net/opentsdb/core/PluginsConfig.java
@@ -119,13 +119,13 @@ public class PluginsConfig extends Validatable {
   }
   
   public static final Map<String, String> DEFAULT_IMPLEMENTATIONS = 
-      Maps.newHashMap();
+      Maps.newLinkedHashMap();
   static {
-    DEFAULT_IMPLEMENTATIONS.put("net.opentsdb.storage.TimeSeriesDataStoreFactory", 
-        "net.opentsdb.storage.schemas.tsdb1x.SchemaFactory");
     DEFAULT_IMPLEMENTATIONS.put(
         "net.opentsdb.storage.schemas.tsdb1x.Tsdb1xDataStoreFactory", 
         "net.opentsdb.storage.Tsdb1xHBaseFactory");
+    DEFAULT_IMPLEMENTATIONS.put("net.opentsdb.storage.TimeSeriesDataStoreFactory", 
+        "net.opentsdb.storage.schemas.tsdb1x.SchemaFactory");
     DEFAULT_IMPLEMENTATIONS.put("net.opentsdb.query.serdes.TimeSeriesSerdes", 
         "net.opentsdb.query.serdes.PBufSerdes");
     DEFAULT_IMPLEMENTATIONS.put("net.opentsdb.query.interpolation.QueryInterpolatorFactory", 
@@ -844,9 +844,9 @@ public class PluginsConfig extends Validatable {
   
   /** Loads the {@link #DEFAULT_IMPLEMENTATIONS} */
   void loadDefaultInstances() {
-    final List<PluginConfig> config_clones = 
-        Lists.newArrayListWithExpectedSize(configs == null ? DEFAULT_IMPLEMENTATIONS.size() :
-          configs.size() + DEFAULT_IMPLEMENTATIONS.size());
+    if (configs == null) {
+      configs = Lists.newArrayListWithExpectedSize(DEFAULT_IMPLEMENTATIONS.size());
+    }
     for (final Entry<String, String> type : DEFAULT_IMPLEMENTATIONS.entrySet()) {
       final PluginConfig config = PluginConfig.newBuilder()
           .setType(type.getKey())
@@ -858,13 +858,9 @@ public class PluginsConfig extends Validatable {
           LOG.debug("Will try to load default plugin implementation: " 
               + type.getValue());
         }
-        config_clones.add(config);
+        configs.add(config);
       }
     }
-    if (configs != null) {
-      config_clones.addAll(configs);
-    }
-    configs = config_clones;
   }
   
   /**

--- a/core/src/main/java/net/opentsdb/query/BaseQueryNodeConfigWithInterpolators.java
+++ b/core/src/main/java/net/opentsdb/query/BaseQueryNodeConfigWithInterpolators.java
@@ -60,21 +60,11 @@ public abstract class BaseQueryNodeConfigWithInterpolators
       interpolator_configs = Maps.newHashMapWithExpectedSize(
           builder.interpolatorConfigs.size());
       for (final QueryInterpolatorConfig config : builder.interpolatorConfigs) {
-        // TODO - may need to put this in the registry AND we want to 
-        // figure out if the name is a full string or not.
-        final Class<?> clazz;
-        try {
-          clazz = Class.forName(config.dataType());
-        } catch (ClassNotFoundException e) {
-          throw new IllegalArgumentException("No data type found for: " 
-              + config.dataType());
-        }
-        final TypeToken<?> type = TypeToken.of(clazz);
-        if (interpolator_configs.containsKey(type)) {
+        if (interpolator_configs.containsKey(config.type())) {
           throw new IllegalArgumentException("Already have an "
-              + "interpolator configuration for: " + type);
+              + "interpolator configuration for: " + config.type());
         }
-        interpolator_configs.put(type, config);
+        interpolator_configs.put(config.type(), config);
       }
     } else {
       interpolator_configs = null;

--- a/core/src/main/java/net/opentsdb/query/interpolation/BaseInterpolatorConfig.java
+++ b/core/src/main/java/net/opentsdb/query/interpolation/BaseInterpolatorConfig.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
 
 /**
- * Base class for interpolator configs. Validates that the type is set.
+ * Base class for interpolator configs. If the type is null, we assume a default.
  * 
  * @since 3.0
  */
@@ -28,23 +28,23 @@ public abstract class BaseInterpolatorConfig implements QueryInterpolatorConfig 
   protected final String id;
   
   /** The non-null data type ID. */
-  protected final String type;
+  protected final String interpolator_type;
   
   /** The class name of the config for parsing. */
-  protected final String config_type;
+  protected final String data_type;
   
   /**
    * Default ctor.
    * @param builder A non-null builder
-   * @throws IllegalArgumentException if the type was null or empty.
    */
   protected BaseInterpolatorConfig(final Builder builder) {
-    if (Strings.isNullOrEmpty(builder.type)) {
-      throw new IllegalArgumentException("Type cannot be null.");
+    if (Strings.isNullOrEmpty(builder.dataType)) {
+      throw new IllegalArgumentException("Data type cannot be null "
+          + "or empty.");
     }
     id = builder.id;
-    type = builder.type;
-    config_type = builder.configType;
+    interpolator_type = builder.type;
+    data_type = builder.dataType;
   }
   
   /** @return The ID. */
@@ -55,23 +55,17 @@ public abstract class BaseInterpolatorConfig implements QueryInterpolatorConfig 
   
   /** @return The data type for this config. */
   @Override
-  public String dataType() {
-    return type;
+  public String interpolatorType() {
+    return interpolator_type;
   }
-  
-  /** @return The class name of the config for parsing. */
-  @Override
-  public String configType() {
-    return config_type;
-  }
-  
+    
   public static abstract class Builder {
     @JsonProperty
     protected String id;
     @JsonProperty
     protected String type;
     @JsonProperty
-    protected String configType;
+    protected String dataType;
     
     public Builder setId(final String id) {
       this.id = id;
@@ -83,8 +77,8 @@ public abstract class BaseInterpolatorConfig implements QueryInterpolatorConfig 
       return this;
     }
     
-    public Builder setConfigType(final String config_type) {
-      this.configType = config_type;
+    public Builder setDataType(final String data_type) {
+      this.dataType = data_type;
       return this;
     }
     

--- a/core/src/main/java/net/opentsdb/query/interpolation/DefaultInterpolatorFactory.java
+++ b/core/src/main/java/net/opentsdb/query/interpolation/DefaultInterpolatorFactory.java
@@ -20,7 +20,9 @@ import net.opentsdb.core.TSDB;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolator;
+import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorParser;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolator;
+import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorParser;
 
 /**
  * The default interpolation factory stored as the default plugin with
@@ -40,8 +42,10 @@ public class DefaultInterpolatorFactory extends BaseQueryIntperolatorFactory {
   @Override
   public Deferred<Object> initialize(final TSDB tsdb) {
     // Add defaults for the built-in types
-    register(NumericType.TYPE, NumericInterpolator.class);
-    register(NumericSummaryType.TYPE, NumericSummaryInterpolator.class);
+    register(NumericType.TYPE, NumericInterpolator.class, 
+        new NumericInterpolatorParser());
+    register(NumericSummaryType.TYPE, NumericSummaryInterpolator.class, 
+        new NumericSummaryInterpolatorParser());
     return Deferred.fromResult(null);
   }
 
@@ -54,5 +58,5 @@ public class DefaultInterpolatorFactory extends BaseQueryIntperolatorFactory {
   public String version() {
     return "3.0.0";
   }
-
+  
 }

--- a/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/LERPFactory.java
+++ b/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/LERPFactory.java
@@ -40,7 +40,8 @@ public class LERPFactory extends BaseQueryIntperolatorFactory {
 
   @Override
   public Deferred<Object> initialize(final TSDB tsdb) {
-    register(NumericType.TYPE, NumericLERP.class);
+    register(NumericType.TYPE, NumericLERP.class, 
+        new NumericInterpolatorParser());
     return Deferred.fromResult(null);
   }
 
@@ -58,4 +59,5 @@ public class LERPFactory extends BaseQueryIntperolatorFactory {
   Map<TypeToken<?>, Pair<Constructor<?>, Constructor<?>>> types() {
     return types;
   }
+  
 }

--- a/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericInterpolatorConfig.java
+++ b/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericInterpolatorConfig.java
@@ -26,8 +26,10 @@ import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Ordering;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hasher;
+import com.google.common.reflect.TypeToken;
 
 import net.opentsdb.core.Const;
+import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.types.numeric.BaseNumericFillPolicy;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryFillPolicy;
@@ -84,11 +86,17 @@ public class NumericInterpolatorConfig extends BaseInterpolatorConfig {
   }
   
   @Override
+  public TypeToken<? extends TimeSeriesDataType> type() {
+    return NumericType.TYPE;
+  }
+  
+  @Override
   public HashCode buildHashCode() {
     final Hasher hasher = Const.HASH_FUNCTION().newHasher()
         .putString(id != null ? id : "null", Const.UTF8_CHARSET)
-        .putString(type, Const.ASCII_CHARSET)
-        .putString(config_type != null ? config_type : "null", Const.ASCII_CHARSET)
+        .putString(interpolator_type != null ? interpolator_type : "null", 
+            Const.ASCII_CHARSET)
+        .putString(data_type != null ? data_type : "null", Const.ASCII_CHARSET)
         .putInt(fillPolicy.ordinal())
         .putInt(realFillPolicy.ordinal());
     return hasher.hash();
@@ -109,8 +117,10 @@ public class NumericInterpolatorConfig extends BaseInterpolatorConfig {
     return ComparisonChain.start()
         .compare(id, ((NumericInterpolatorConfig) o).id,
             Ordering.natural().nullsFirst())
-        .compare(type, ((NumericInterpolatorConfig) o).type)
-        .compare(config_type, ((NumericInterpolatorConfig) o).config_type,
+        .compare(interpolator_type, 
+            ((NumericInterpolatorConfig) o).interpolator_type,
+            Ordering.natural().nullsFirst())
+        .compare(data_type, ((NumericInterpolatorConfig) o).data_type,
             Ordering.natural().nullsFirst())
         .compare(fillPolicy, ((NumericInterpolatorConfig) o).fillPolicy)
         .compare(realFillPolicy, ((NumericInterpolatorConfig) o).realFillPolicy)
@@ -131,8 +141,8 @@ public class NumericInterpolatorConfig extends BaseInterpolatorConfig {
     
     final NumericInterpolatorConfig other = (NumericInterpolatorConfig) o;
     return Objects.equals(id, other.id) &&
-           Objects.equals(type, other.type) &&
-           Objects.equals(config_type, other.config_type) && 
+           Objects.equals(interpolator_type, other.interpolator_type) &&
+           Objects.equals(data_type, other.data_type) && 
            Objects.equals(fillPolicy, other.fillPolicy) &&
            Objects.equals(realFillPolicy, other.realFillPolicy);
   }
@@ -146,8 +156,8 @@ public class NumericInterpolatorConfig extends BaseInterpolatorConfig {
   public String toString() {
     return new StringBuilder()
         .append("{id=").append(id)
-        .append(", type=").append(type)
-        .append(", configType=").append(config_type)
+        .append(", type=").append(interpolator_type)
+        .append(", dataType=").append(data_type)
         .append(", fill=").append(fillPolicy)
         .append(", realFill=").append(realFillPolicy)
         .append("}")

--- a/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericInterpolatorParser.java
+++ b/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericInterpolatorParser.java
@@ -1,0 +1,52 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.interpolation.types.numeric;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.query.interpolation.QueryInterpolatorConfig;
+import net.opentsdb.query.interpolation.QueryInterpolatorConfigParser;
+import net.opentsdb.query.pojo.FillPolicy;
+
+/**
+ * Parser that will return a scalar or plain interpolator config.
+ * 
+ * @since 3.0
+ */
+public class NumericInterpolatorParser implements QueryInterpolatorConfigParser {
+
+  @Override
+  public QueryInterpolatorConfig parse(final ObjectMapper mapper, 
+                                       final TSDB tsdb,
+                                       final JsonNode node) {
+    try {
+      final JsonNode fill_node = node.get("fillPolicy");
+      if (fill_node != null) {
+        final FillPolicy fill = mapper.treeToValue(fill_node, FillPolicy.class);
+        if (fill == FillPolicy.SCALAR) {
+          return mapper.treeToValue(node, ScalarNumericInterpolatorConfig.class);
+        }
+      }
+      
+      return mapper.treeToValue(node, NumericInterpolatorConfig.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Failed to parse the config", e);
+    }
+  }
+
+}

--- a/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericSummaryInterpolatorConfig.java
+++ b/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericSummaryInterpolatorConfig.java
@@ -27,8 +27,10 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hasher;
+import com.google.common.reflect.TypeToken;
 
 import net.opentsdb.core.Const;
+import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.types.numeric.BaseNumericFillPolicy;
 import net.opentsdb.data.types.numeric.BaseNumericSummaryFillPolicy;
 import net.opentsdb.data.types.numeric.NumericAggregator;
@@ -89,7 +91,7 @@ public class NumericSummaryInterpolatorConfig extends BaseInterpolatorConfig {
     if (builder.real_fill == null) {
       throw new IllegalArgumentException("Default real fill policy cannot be null.");
     }
-    if (!type.equals(NumericSummaryType.TYPE.toString())) {
+    if (!data_type.equals(NumericSummaryType.TYPE.toString())) {
       throw new IllegalArgumentException("Type must be " + NumericSummaryType.TYPE);
     }
     fill_policy = builder.fill_policy;
@@ -150,10 +152,11 @@ public class NumericSummaryInterpolatorConfig extends BaseInterpolatorConfig {
    * @return
    */
   public QueryFillPolicy<NumericType> queryFill(final int summary) {
-    final NumericInterpolatorConfig config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
+    final NumericInterpolatorConfig config = 
+        (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(fillPolicy(summary))
         .setRealFillPolicy(realFillPolicy(summary))
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     return new BaseNumericFillPolicy(config);
   }
@@ -179,11 +182,17 @@ public class NumericSummaryInterpolatorConfig extends BaseInterpolatorConfig {
   }
   
   @Override
+  public TypeToken<? extends TimeSeriesDataType> type() {
+    return NumericSummaryType.TYPE;
+  }
+  
+  @Override
   public HashCode buildHashCode() {
     final Hasher hasher = Const.HASH_FUNCTION().newHasher()
         .putString(id, Const.UTF8_CHARSET)
-        .putString(type, Const.ASCII_CHARSET)
-        .putString(config_type, Const.ASCII_CHARSET)
+        .putString(interpolator_type == null ? "" : interpolator_type, 
+            Const.ASCII_CHARSET)
+        .putString(data_type, Const.ASCII_CHARSET)
         .putInt(fill_policy.ordinal())
         .putInt(real_fill.ordinal())
         .putBoolean(sync);
@@ -228,8 +237,10 @@ public class NumericSummaryInterpolatorConfig extends BaseInterpolatorConfig {
     
     return ComparisonChain.start()
         .compare(id, ((NumericSummaryInterpolatorConfig) o).id)
-        .compare(type, ((NumericSummaryInterpolatorConfig) o).type)
-        .compare(config_type, ((NumericSummaryInterpolatorConfig) o).config_type)
+        .compare(interpolator_type, 
+            ((NumericSummaryInterpolatorConfig) o).interpolator_type,
+            Ordering.<String>natural().nullsFirst())
+        .compare(data_type, ((NumericSummaryInterpolatorConfig) o).data_type)
         .compare(fill_policy, ((NumericSummaryInterpolatorConfig) o).fill_policy)
         .compare(real_fill, ((NumericSummaryInterpolatorConfig) o).real_fill)
         .compare(sync, ((NumericSummaryInterpolatorConfig) o).sync)
@@ -258,8 +269,8 @@ public class NumericSummaryInterpolatorConfig extends BaseInterpolatorConfig {
     
     final NumericSummaryInterpolatorConfig other = (NumericSummaryInterpolatorConfig) o;
     return Objects.equals(id, other.id) &&
-           Objects.equals(type, other.type) &&
-           Objects.equals(config_type, other.config_type) && 
+           Objects.equals(interpolator_type, other.interpolator_type) &&
+           Objects.equals(data_type, other.data_type) && 
            Objects.equals(fill_policy, other.fill_policy) &&
            Objects.equals(real_fill, other.real_fill) && 
            Objects.equals(sync, other.sync) && 

--- a/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericSummaryInterpolatorParser.java
+++ b/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericSummaryInterpolatorParser.java
@@ -1,0 +1,44 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.interpolation.types.numeric;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.query.interpolation.QueryInterpolatorConfig;
+import net.opentsdb.query.interpolation.QueryInterpolatorConfigParser;
+
+/**
+ * Returns a Numeric Summary Interpolator config.
+ * TODO - handle scalars
+ * 
+ * @since 3.0
+ */
+public class NumericSummaryInterpolatorParser implements QueryInterpolatorConfigParser {
+
+  @Override
+  public QueryInterpolatorConfig parse(final ObjectMapper mapper, 
+                                       final TSDB tsdb,
+                                       final JsonNode node) {
+    try {
+      return mapper.treeToValue(node, NumericSummaryInterpolatorConfig.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Failed to parse the config", e);
+    }
+  }
+
+}

--- a/core/src/main/java/net/opentsdb/query/pojo/TimeSeriesQuery.java
+++ b/core/src/main/java/net/opentsdb/query/pojo/TimeSeriesQuery.java
@@ -727,7 +727,7 @@ public class TimeSeriesQuery extends Validatable
                     .setFillPolicy(FillPolicy.NONE) // TODO
                     .setRealFillPolicy(FillWithRealPolicy.NONE)
                     .setId("LERP")
-                    .setType(NumericType.TYPE.toString())
+                    .setDataType(NumericType.TYPE.toString())
                     .build())
                 .setId(expression.getId())
                 .build())
@@ -768,7 +768,7 @@ public class TimeSeriesQuery extends Validatable
                   .setFillPolicy(policy)
                   .setRealFillPolicy(FillWithRealPolicy.NONE)
                   .setId(interpolator)
-                  .setType(NumericType.TYPE.toString())
+                  .setDataType(NumericType.TYPE.toString())
                   .build());
     if (!Strings.isNullOrEmpty(downsampler.getTimezone())) {
       ds.setTimeZone(downsampler.getTimezone());
@@ -833,7 +833,7 @@ public class TimeSeriesQuery extends Validatable
                     .setFillPolicy(policy)
                     .setRealFillPolicy(FillWithRealPolicy.NONE)
                     .setId(interpolator)
-                    .setType(NumericType.TYPE.toString())
+                    .setDataType(NumericType.TYPE.toString())
                     .build())
                 .setId(metric.getId() + "_GroupBy");
           }
@@ -861,7 +861,7 @@ public class TimeSeriesQuery extends Validatable
               .setFillPolicy(policy)
               .setRealFillPolicy(FillWithRealPolicy.NONE)
               .setId(interpolator)
-              .setType(NumericType.TYPE.toString())
+              .setDataType(NumericType.TYPE.toString())
               .build())
           .setId(metric.getId() + "_GroupBy");
           

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleFactory.java
@@ -73,11 +73,7 @@ public class DownsampleFactory extends BaseQueryNodeFactory {
   public QueryNodeConfig parseConfig(final ObjectMapper mapper,
                                      final TSDB tsdb,
                                      final JsonNode node) {
-    try {
-      return mapper.treeToValue(node, DownsampleConfig.class);
-    } catch (JsonProcessingException e) {
-      throw new IllegalArgumentException("Unable to parse config", e);
-    }
+    return DownsampleConfig.parse(mapper, tsdb, node);
   }
   
   /**

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericIterator.java
@@ -147,7 +147,7 @@ public class DownsampleNumericIterator implements QueryIterator {
                                         interpolator_config.id());
     if (factory == null) {
       throw new IllegalArgumentException("No interpolator factory found for: " + 
-          interpolator_config.dataType() == null ? "Default" : interpolator_config.dataType());
+          interpolator_config.interpolatorType() == null ? "Default" : interpolator_config.interpolatorType());
     }
     
     final QueryInterpolator<?> interp = factory.newInterpolator(
@@ -156,7 +156,7 @@ public class DownsampleNumericIterator implements QueryIterator {
         interpolator_config);
     if (interp == null) {
       throw new IllegalArgumentException("No interpolator implementation found for: " + 
-          interpolator_config.dataType() == null ? "Default" : interpolator_config.dataType());
+          interpolator_config.interpolatorType() == null ? "Default" : interpolator_config.interpolatorType());
     }
     interpolator = (QueryInterpolator<NumericType>) interp;
     interval_ts = this.result.start().getCopy();

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericSummaryIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericSummaryIterator.java
@@ -124,7 +124,7 @@ public class DownsampleNumericSummaryIterator implements QueryIterator {
             DefaultRollupConfig.queryToRollupAggregation(config.aggregator())));
       }
       interpolator_config = nsic
-          .setType(NumericSummaryType.TYPE.toString())
+          .setDataType(NumericSummaryType.TYPE.toString())
           .build();
     }
     this.interpolator_config = (NumericSummaryInterpolatorConfig) interpolator_config;
@@ -133,7 +133,7 @@ public class DownsampleNumericSummaryIterator implements QueryIterator {
         interpolator_config.id());
     if (factory == null) {
       throw new IllegalArgumentException("No interpolator factory found for: " + 
-          interpolator_config.dataType() == null ? "Default" : interpolator_config.dataType());
+          interpolator_config.interpolatorType() == null ? "Default" : interpolator_config.interpolatorType());
     }
     
     QueryInterpolator<?> interp = factory.newInterpolator(
@@ -142,7 +142,7 @@ public class DownsampleNumericSummaryIterator implements QueryIterator {
         interpolator_config);
     if (interp == null) {
       throw new IllegalArgumentException("No interpolator implementation found for: " + 
-          interpolator_config.dataType() == null ? "Default" : interpolator_config.dataType());
+          interpolator_config.interpolatorType() == null ? "Default" : interpolator_config.interpolatorType());
     }
     interpolator = (QueryInterpolator<NumericSummaryType>) interp;
     interval_ts = this.result.start().getCopy();

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionConfig.java
@@ -132,7 +132,7 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators {
       final List<QueryInterpolatorConfig> configs = variable_interpolators.get(variable);
       if (configs != null) {
         for (final QueryInterpolatorConfig cfg : configs) {
-          if (cfg.dataType().equals(type.toString())) {
+          if (cfg.type() == type) {
             config = cfg;
             break;
           }

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionNumericSummaryIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionNumericSummaryIterator.java
@@ -112,7 +112,7 @@ public class ExpressionNumericSummaryIterator extends
           nsic.addExpectedSummary(summary);
         }
         interpolator_config = nsic
-            .setType(NumericSummaryType.TYPE.toString())
+            .setDataType(NumericSummaryType.TYPE.toString())
             .setId(null)
             .build();
       }
@@ -176,7 +176,7 @@ public class ExpressionNumericSummaryIterator extends
           nsic.addExpectedSummary(summary);
         }
         interpolator_config = nsic
-            .setType(NumericSummaryType.TYPE.toString())
+            .setDataType(NumericSummaryType.TYPE.toString())
             .setId(null)
             .build();
       }

--- a/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByFactory.java
@@ -74,11 +74,7 @@ public class GroupByFactory extends BaseQueryNodeFactory {
   public QueryNodeConfig parseConfig(final ObjectMapper mapper, 
                                      final TSDB tsdb,
                                      final JsonNode node) {
-    try {
-      return mapper.treeToValue(node, GroupByConfig.class);
-    } catch (JsonProcessingException e) {
-      throw new IllegalArgumentException("Unable to parse config", e);
-    }
+    return GroupByConfig.parse(mapper, tsdb, node);
   }
   
   /**

--- a/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByNumericSummaryIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByNumericSummaryIterator.java
@@ -156,7 +156,7 @@ public class GroupByNumericSummaryIterator implements QueryIterator,
                 ((GroupByConfig) node.config()).getAggregator())));
       }
       interpolator_config = nsic
-          .setType(NumericSummaryType.TYPE.toString())
+          .setDataType(NumericSummaryType.TYPE.toString())
           .setId(null).build();
     }
     config = (NumericSummaryInterpolatorConfig) interpolator_config;
@@ -165,7 +165,7 @@ public class GroupByNumericSummaryIterator implements QueryIterator,
         interpolator_config.id());
     if (factory == null) {
       throw new IllegalArgumentException("No interpolator factory found for: " + 
-          interpolator_config.dataType() == null ? "Default" : interpolator_config.dataType());
+          interpolator_config.interpolatorType() == null ? "Default" : interpolator_config.interpolatorType());
     }
     
     for (final TimeSeries source : sources) {

--- a/core/src/test/java/net/opentsdb/data/types/numeric/TestBaseNumericFillPolicy.java
+++ b/core/src/test/java/net/opentsdb/data/types/numeric/TestBaseNumericFillPolicy.java
@@ -34,7 +34,7 @@ public class TestBaseNumericFillPolicy {
         new BaseNumericFillPolicy(NumericInterpolatorConfig.newBuilder()
             .setFillPolicy(FillPolicy.NOT_A_NUMBER)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build());
     assertTrue(Double.isNaN(fill.fill().doubleValue()));
     
@@ -52,7 +52,7 @@ public class TestBaseNumericFillPolicy {
         NumericInterpolatorConfig.newBuilder()
           .setFillPolicy(FillPolicy.NOT_A_NUMBER)
           .setRealFillPolicy(FillWithRealPolicy.NONE)
-          .setType(NumericType.TYPE.toString())
+          .setDataType(NumericType.TYPE.toString())
           .build());
     assertFalse(fill.isInteger());
     assertTrue(Double.isNaN(fill.fill().doubleValue()));
@@ -62,7 +62,7 @@ public class TestBaseNumericFillPolicy {
     fill = new BaseNumericFillPolicy(NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.ZERO)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build());
     assertTrue(fill.isInteger());
     try {
@@ -75,7 +75,7 @@ public class TestBaseNumericFillPolicy {
     fill = new BaseNumericFillPolicy(NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NONE)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build());
     assertFalse(fill.isInteger());
     assertNull(fill.fill());
@@ -83,7 +83,7 @@ public class TestBaseNumericFillPolicy {
     fill = new BaseNumericFillPolicy(NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NULL)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build());
     assertFalse(fill.isInteger());
     assertNull(fill.fill());
@@ -91,7 +91,7 @@ public class TestBaseNumericFillPolicy {
     fill = new BaseNumericFillPolicy(NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.SCALAR)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build());
     assertFalse(fill.isInteger());
     try {
@@ -102,7 +102,7 @@ public class TestBaseNumericFillPolicy {
     fill = new BaseNumericFillPolicy(NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.MAX)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build());
     assertFalse(fill.isInteger());
     assertEquals(Double.MAX_VALUE, fill.fill().doubleValue(), 0.00001);
@@ -110,7 +110,7 @@ public class TestBaseNumericFillPolicy {
     fill = new BaseNumericFillPolicy(NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.MIN)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build());
     assertFalse(fill.isInteger());
     assertEquals(Double.MIN_VALUE, fill.fill().doubleValue(), 0.00001);

--- a/core/src/test/java/net/opentsdb/data/types/numeric/TestBaseNumericSummaryFillPolicy.java
+++ b/core/src/test/java/net/opentsdb/data/types/numeric/TestBaseNumericSummaryFillPolicy.java
@@ -36,7 +36,7 @@ public class TestBaseNumericSummaryFillPolicy {
             .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
             .addExpectedSummary(0)
             .addExpectedSummary(2)
-            .setType(NumericSummaryType.TYPE.toString())
+            .setDataType(NumericSummaryType.TYPE.toString())
             .build());
     final NumericSummaryType value = fill.fill();
     assertEquals(2, value.summariesAvailable().size());
@@ -61,7 +61,7 @@ public class TestBaseNumericSummaryFillPolicy {
             .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
             .addExpectedSummary(0)
             .addExpectedSummary(2)
-            .setType(NumericSummaryType.TYPE.toString())
+            .setDataType(NumericSummaryType.TYPE.toString())
             .build());
     NumericSummaryType value = fill.fill();
     assertEquals(2, value.summariesAvailable().size());
@@ -75,7 +75,7 @@ public class TestBaseNumericSummaryFillPolicy {
             .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
             .addExpectedSummary(0)
             .addExpectedSummary(2)
-            .setType(NumericSummaryType.TYPE.toString())
+            .setDataType(NumericSummaryType.TYPE.toString())
             .build());
     value = fill.fill();
     assertEquals(2, value.summariesAvailable().size());
@@ -89,7 +89,7 @@ public class TestBaseNumericSummaryFillPolicy {
             .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
             .addExpectedSummary(0)
             .addExpectedSummary(2)
-            .setType(NumericSummaryType.TYPE.toString())
+            .setDataType(NumericSummaryType.TYPE.toString())
             .build());
     assertNull(fill.fill());
     
@@ -98,7 +98,7 @@ public class TestBaseNumericSummaryFillPolicy {
             .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
             .addExpectedSummary(0)
             .addExpectedSummary(2)
-            .setType(NumericSummaryType.TYPE.toString())
+            .setDataType(NumericSummaryType.TYPE.toString())
             .build());
     assertNull(fill.fill());
     
@@ -107,7 +107,7 @@ public class TestBaseNumericSummaryFillPolicy {
             .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
             .addExpectedSummary(0)
             .addExpectedSummary(2)
-            .setType(NumericSummaryType.TYPE.toString())
+            .setDataType(NumericSummaryType.TYPE.toString())
             .build());
     try {
       fill.fill();
@@ -119,7 +119,7 @@ public class TestBaseNumericSummaryFillPolicy {
             .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
             .addExpectedSummary(0)
             .addExpectedSummary(2)
-            .setType(NumericSummaryType.TYPE.toString())
+            .setDataType(NumericSummaryType.TYPE.toString())
             .build());
     value = fill.fill();
     assertEquals(2, value.summariesAvailable().size());
@@ -133,7 +133,7 @@ public class TestBaseNumericSummaryFillPolicy {
             .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
             .addExpectedSummary(0)
             .addExpectedSummary(2)
-            .setType(NumericSummaryType.TYPE.toString())
+            .setDataType(NumericSummaryType.TYPE.toString())
             .build());
     value = fill.fill();
     assertEquals(2, value.summariesAvailable().size());

--- a/core/src/test/java/net/opentsdb/data/types/numeric/TestScalarNumericFillPolicy.java
+++ b/core/src/test/java/net/opentsdb/data/types/numeric/TestScalarNumericFillPolicy.java
@@ -34,7 +34,7 @@ public class TestScalarNumericFillPolicy {
           .setValue(42)
           .setFillPolicy(FillPolicy.NOT_A_NUMBER)
           .setRealFillPolicy(FillWithRealPolicy.NONE)
-          .setType(NumericType.TYPE.toString())
+          .setDataType(NumericType.TYPE.toString())
           .build());
     assertTrue(policy.fill().isInteger());
     assertEquals(42, policy.fill().longValue());
@@ -49,7 +49,7 @@ public class TestScalarNumericFillPolicy {
           .setValue(42.5D)
           .setFillPolicy(FillPolicy.NOT_A_NUMBER)
           .setRealFillPolicy(FillWithRealPolicy.NONE)
-          .setType(NumericType.TYPE.toString())
+          .setDataType(NumericType.TYPE.toString())
           .build());
     assertFalse(policy.fill().isInteger());
     try {

--- a/core/src/test/java/net/opentsdb/query/TestBaseQueryNodeConfigWithInterpolators.java
+++ b/core/src/test/java/net/opentsdb/query/TestBaseQueryNodeConfigWithInterpolators.java
@@ -22,7 +22,9 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 import com.google.common.hash.HashCode;
+import com.google.common.reflect.TypeToken;
 
+import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.types.annotation.AnnotationType;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
@@ -36,10 +38,10 @@ public class TestBaseQueryNodeConfigWithInterpolators {
     TestConfig node = (TestConfig) new TestConfig.Builder()
         .setId("foo")
         .addInterpolatorConfig(new TestInterpolatorConfig.Builder()
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .addInterpolatorConfig(new TestInterpolatorConfig.Builder()
-            .setType(AnnotationType.TYPE.toString())
+            .setDataType(AnnotationType.TYPE.toString())
             .build())
         .build();
     assertEquals("foo", node.getId());
@@ -62,10 +64,10 @@ public class TestBaseQueryNodeConfigWithInterpolators {
       new TestConfig.Builder()
       .setId("foo")
       .addInterpolatorConfig(new TestInterpolatorConfig.Builder()
-          .setType(NumericType.TYPE.toString())
+          .setDataType(NumericType.TYPE.toString())
           .build())
       .addInterpolatorConfig(new TestInterpolatorConfig.Builder()
-          .setType("nosuchtype")
+          .setDataType("nosuchtype")
           .build())
       .build();
       fail("Expected IllegalArgumentException");
@@ -119,6 +121,19 @@ public class TestBaseQueryNodeConfigWithInterpolators {
     public int compareTo(QueryInterpolatorConfig o) {
       // TODO Auto-generated method stub
       return 0;
+    }
+
+   
+    @Override
+    public TypeToken<? extends TimeSeriesDataType> type() {
+      if (data_type.endsWith("NumericType")) {
+        return NumericType.TYPE;
+      } else if (data_type.endsWith("NumericSummaryType")) {
+        return NumericSummaryType.TYPE;
+      } else if (data_type.endsWith("AnnotationType")) {
+        return AnnotationType.TYPE;
+      }
+      throw new IllegalArgumentException("No type!");
     }
   }
 }

--- a/core/src/test/java/net/opentsdb/query/TestTSDBV2QueryContextBuilder.java
+++ b/core/src/test/java/net/opentsdb/query/TestTSDBV2QueryContextBuilder.java
@@ -287,7 +287,7 @@ public class TestTSDBV2QueryContextBuilder {
                     .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
                       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
                       .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-                      .setType(NumericType.TYPE.toString())
+                      .setDataType(NumericType.TYPE.toString())
                       .build())
                     .build()))
             .build())

--- a/core/src/test/java/net/opentsdb/query/interpolation/TestBaseInterpolatorConfig.java
+++ b/core/src/test/java/net/opentsdb/query/interpolation/TestBaseInterpolatorConfig.java
@@ -21,6 +21,9 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 import com.google.common.hash.HashCode;
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.data.TimeSeriesDataType;
 
 public class TestBaseInterpolatorConfig {
 
@@ -28,30 +31,27 @@ public class TestBaseInterpolatorConfig {
   public void builder() throws Exception {
     QueryInterpolatorConfig config = TestInterpolatorConfig.newBuilder()
         .setId("myid")
-        .setType("numeric")
+        .setDataType("numeric")
         .build();
     assertEquals("myid", config.id());
-    assertEquals("numeric", config.dataType());
+    assertNull(config.interpolatorType());
+    assertNull(config.type());
     
     config = TestInterpolatorConfig.newBuilder()
-        .setType("numeric")
+        .setType("LERP")
+        .setDataType("numeric")
         .build();
     assertNull(config.id());
-    assertEquals("numeric", config.dataType());
+    assertEquals("LERP", config.interpolatorType());
+    assertNull(config.type());
     
     config = TestInterpolatorConfig.newBuilder()
         .setId("")
-        .setType("numeric")
+        .setDataType("numeric")
         .build();
     assertEquals("", config.id());
-    assertEquals("numeric", config.dataType());
-    
-    try {
-      TestInterpolatorConfig.newBuilder()
-        .setId("myid")
-        .build();
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
+    assertNull(config.interpolatorType());
+    assertNull(config.type());
     
     try {
       TestInterpolatorConfig.newBuilder()
@@ -91,6 +91,12 @@ public class TestBaseInterpolatorConfig {
     public int compareTo(QueryInterpolatorConfig o) {
       // TODO Auto-generated method stub
       return 0;
+    }
+
+    @Override
+    public TypeToken<? extends TimeSeriesDataType> type() {
+      // TODO Auto-generated method stub
+      return null;
     }
   }
 }

--- a/core/src/test/java/net/opentsdb/query/interpolation/TestDefaultInterpolatorFactory.java
+++ b/core/src/test/java/net/opentsdb/query/interpolation/TestDefaultInterpolatorFactory.java
@@ -45,6 +45,8 @@ public class TestDefaultInterpolatorFactory {
     assertNull(factory.initialize(mock(TSDB.class)).join());
     assertEquals(2, factory.types.size());
     
+    assertEquals(2, factory.parsers.size());
+    
     TimeSeries time_series = mock(TimeSeries.class);
     when(time_series.iterator(NumericType.TYPE)).thenReturn(Optional.empty());
     when(time_series.iterator(NumericSummaryType.TYPE)).thenReturn(Optional.empty());

--- a/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestNumericInterpolator.java
+++ b/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestNumericInterpolator.java
@@ -55,7 +55,7 @@ public class TestNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
   }
   
@@ -240,7 +240,7 @@ public class TestNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREVIOUS_ONLY)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -288,7 +288,7 @@ public class TestNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -336,7 +336,7 @@ public class TestNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_PREVIOUS)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -384,7 +384,7 @@ public class TestNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -432,7 +432,7 @@ public class TestNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NONE)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -480,7 +480,7 @@ public class TestNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NULL)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -528,7 +528,7 @@ public class TestNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.ZERO)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -576,7 +576,7 @@ public class TestNumericInterpolator {
         .setValue(42)
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestNumericInterpolatorConfig.java
+++ b/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestNumericInterpolatorConfig.java
@@ -37,7 +37,7 @@ public class TestNumericInterpolatorConfig {
         NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     assertEquals(FillPolicy.NOT_A_NUMBER, config.fillPolicy());
     assertEquals(FillWithRealPolicy.PREFER_NEXT, config.realFillPolicy());
@@ -46,7 +46,7 @@ public class TestNumericInterpolatorConfig {
       NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(null)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
@@ -55,7 +55,7 @@ public class TestNumericInterpolatorConfig {
       NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         //.setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
@@ -64,7 +64,7 @@ public class TestNumericInterpolatorConfig {
       NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(null)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
@@ -73,7 +73,7 @@ public class TestNumericInterpolatorConfig {
       NumericInterpolatorConfig.newBuilder()
         //.setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
@@ -93,7 +93,7 @@ public class TestNumericInterpolatorConfig {
         NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     QueryFillPolicy<NumericType> fill = config.queryFill();
     assertTrue(Double.isNaN(fill.fill().doubleValue()));
@@ -101,7 +101,7 @@ public class TestNumericInterpolatorConfig {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NONE)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     fill = config.queryFill();
     assertNull(fill.fill());
@@ -109,7 +109,7 @@ public class TestNumericInterpolatorConfig {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NULL)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     fill = config.queryFill();
     assertNull(fill.fill());
@@ -117,7 +117,7 @@ public class TestNumericInterpolatorConfig {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.ZERO)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     fill = config.queryFill();
     assertEquals(0, fill.fill().longValue());
@@ -129,8 +129,7 @@ public class TestNumericInterpolatorConfig {
         NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
-        .setConfigType(NumericInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericType.TYPE.toString())
         .setId("ni")
         .build();
     
@@ -138,8 +137,7 @@ public class TestNumericInterpolatorConfig {
         NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
-        .setConfigType(NumericInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericType.TYPE.toString())
         .setId("ni")
         .build();
     assertEquals(c1.hashCode(), c2.hashCode());
@@ -150,8 +148,7 @@ public class TestNumericInterpolatorConfig {
         NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.MAX) // <-- DIFF
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
-        .setConfigType(NumericInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericType.TYPE.toString())
         .setId("ni")
         .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());
@@ -162,8 +159,7 @@ public class TestNumericInterpolatorConfig {
         NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_PREVIOUS) // <-- DIFF
-        .setType(NumericType.TYPE.toString())
-        .setConfigType(NumericInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericType.TYPE.toString())
         .setId("ni")
         .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());
@@ -174,8 +170,7 @@ public class TestNumericInterpolatorConfig {
         NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericSummaryType.TYPE.toString()) // <-- DIFF
-        .setConfigType(NumericInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericSummaryType.TYPE.toString()) // <-- DIFF
         .setId("ni")
         .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());
@@ -186,20 +181,7 @@ public class TestNumericInterpolatorConfig {
         NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
-        .setConfigType(NumericInterpolatorConfig.class.getSimpleName()) // <-- DIFF
-        .setId("ni")
-        .build();
-    assertNotEquals(c1.hashCode(), c2.hashCode());
-    assertNotEquals(c1, c2);
-    assertEquals(1, c1.compareTo(c2));
-    
-    c2 = (NumericInterpolatorConfig) 
-        NumericInterpolatorConfig.newBuilder()
-        .setFillPolicy(FillPolicy.NOT_A_NUMBER)
-        .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
-        .setConfigType(NumericInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericType.TYPE.toString())
         .setId("foo") // <-- DIFF
         .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());

--- a/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestNumericLERP.java
+++ b/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestNumericLERP.java
@@ -54,7 +54,7 @@ public class TestNumericLERP {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
   }
   
@@ -323,7 +323,7 @@ public class TestNumericLERP {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREVIOUS_ONLY)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -371,7 +371,7 @@ public class TestNumericLERP {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -419,7 +419,7 @@ public class TestNumericLERP {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_PREVIOUS)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -467,7 +467,7 @@ public class TestNumericLERP {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -515,7 +515,7 @@ public class TestNumericLERP {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NONE)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -563,7 +563,7 @@ public class TestNumericLERP {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NONE)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -611,7 +611,7 @@ public class TestNumericLERP {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.ZERO)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()
@@ -659,7 +659,7 @@ public class TestNumericLERP {
         .setValue(42)
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     NumericMillisecondShard source = new NumericMillisecondShard(
         BaseTimeSeriesStringId.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestNumericSummaryInterpolator.java
+++ b/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestNumericSummaryInterpolator.java
@@ -53,7 +53,7 @@ public class TestNumericSummaryInterpolator {
         .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
         .addExpectedSummary(0)
         .addExpectedSummary(2)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     
     source = new MockTimeSeries(
@@ -193,7 +193,7 @@ public class TestNumericSummaryInterpolator {
         .addExpectedSummary(0)
         .addExpectedSummary(2)
         .setSync(true)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     
     NumericSummaryInterpolator interpolator = 
@@ -594,7 +594,7 @@ public class TestNumericSummaryInterpolator {
         .addExpectedSummary(0)
         .addExpectedSummary(2)
         .setSync(true)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     
     NumericSummaryInterpolator interpolator = 
@@ -712,7 +712,7 @@ public class TestNumericSummaryInterpolator {
         .addExpectedSummary(0)
         .addExpectedSummary(2)
         .setSync(true)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     
     source.clear();

--- a/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestNumericSummaryInterpolatorConfig.java
+++ b/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestNumericSummaryInterpolatorConfig.java
@@ -54,7 +54,7 @@ public class TestNumericSummaryInterpolatorConfig {
       .setSync(true)
       .setComponentAggregator(Aggregators.SUM)
       .setId("myId")
-      .setType(NumericSummaryType.TYPE.toString())
+      .setDataType(NumericSummaryType.TYPE.toString())
       .build();
     assertEquals(FillPolicy.NOT_A_NUMBER, config.defaultFillPolicy());
     assertEquals(FillWithRealPolicy.NEXT_ONLY, config.defaultRealFillPolicy());
@@ -68,7 +68,7 @@ public class TestNumericSummaryInterpolatorConfig {
     assertTrue(config.sync());
     assertSame(Aggregators.SUM, config.componentAggregator());
     assertEquals("myId", config.id());
-    assertEquals(NumericSummaryType.TYPE.toString(), config.dataType());
+    assertEquals(NumericSummaryType.TYPE, config.type());
     
     // adders where proper
     config = (NumericSummaryInterpolatorConfig) NumericSummaryInterpolatorConfig.newBuilder()
@@ -80,7 +80,7 @@ public class TestNumericSummaryInterpolatorConfig {
         .addExpectedSummary(1)
         .setSync(true)
         .setComponentAggregator(Aggregators.SUM)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     assertEquals(FillPolicy.NOT_A_NUMBER, config.defaultFillPolicy());
     assertEquals(FillWithRealPolicy.NEXT_ONLY, config.defaultRealFillPolicy());
@@ -94,14 +94,14 @@ public class TestNumericSummaryInterpolatorConfig {
     assertTrue(config.sync());
     assertSame(Aggregators.SUM, config.componentAggregator());
     assertNull(config.id());
-    assertEquals(NumericSummaryType.TYPE.toString(), config.dataType());
+    assertEquals(NumericSummaryType.TYPE, config.type());
     
     // just the bare minimums.
     config = (NumericSummaryInterpolatorConfig) NumericSummaryInterpolatorConfig.newBuilder()
         .setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setDefaultRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
         .addExpectedSummary(0)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     assertEquals(FillPolicy.NOT_A_NUMBER, config.defaultFillPolicy());
     assertEquals(FillWithRealPolicy.NEXT_ONLY, config.defaultRealFillPolicy());
@@ -117,7 +117,7 @@ public class TestNumericSummaryInterpolatorConfig {
           //.setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
           .setDefaultRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
           .addExpectedSummary(0)
-          .setType(NumericSummaryType.TYPE.toString())
+          .setDataType(NumericSummaryType.TYPE.toString())
           .build();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
@@ -127,7 +127,7 @@ public class TestNumericSummaryInterpolatorConfig {
           .setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
           //.setDefaultRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
           .addExpectedSummary(0)
-          .setType(NumericSummaryType.TYPE.toString())
+          .setDataType(NumericSummaryType.TYPE.toString())
           .build();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
@@ -137,7 +137,7 @@ public class TestNumericSummaryInterpolatorConfig {
           .setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
           .setDefaultRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
           //.addExpectedSummary(0)
-          .setType(NumericSummaryType.TYPE.toString())
+          .setDataType(NumericSummaryType.TYPE.toString())
           .build();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
@@ -167,7 +167,7 @@ public class TestNumericSummaryInterpolatorConfig {
     .setExpectedSummaries(Lists.newArrayList(0, 1, 2))
     .setSync(true)
     .setComponentAggregator(Aggregators.SUM)
-    .setType(NumericSummaryType.TYPE.toString())
+    .setDataType(NumericSummaryType.TYPE.toString())
     .build();
     
     assertEquals(FillPolicy.ZERO, config.fillPolicy(0));
@@ -196,7 +196,7 @@ public class TestNumericSummaryInterpolatorConfig {
     .setExpectedSummaries(Lists.newArrayList(0, 1, 2))
     .setSync(true)
     .setComponentAggregator(Aggregators.SUM)
-    .setType(NumericSummaryType.TYPE.toString())
+    .setDataType(NumericSummaryType.TYPE.toString())
     .build();
     
     QueryFillPolicy<NumericType> fill = config.queryFill(0);
@@ -242,8 +242,7 @@ public class TestNumericSummaryInterpolatorConfig {
       .setSync(true)
       .setComponentAggregator(Aggregators.SUM)
       .setId("myId")
-      .setType(NumericSummaryType.TYPE.toString())
-      .setConfigType(NumericSummaryInterpolatorConfig.class.getCanonicalName())
+      .setDataType(NumericSummaryType.TYPE.toString())
       .build();
     
     NumericSummaryInterpolatorConfig c2 = 
@@ -260,8 +259,7 @@ public class TestNumericSummaryInterpolatorConfig {
       .setSync(true)
       .setComponentAggregator(Aggregators.SUM)
       .setId("myId")
-      .setType(NumericSummaryType.TYPE.toString())
-      .setConfigType(NumericSummaryInterpolatorConfig.class.getCanonicalName())
+      .setDataType(NumericSummaryType.TYPE.toString())
       .build();
     assertEquals(c1.hashCode(), c2.hashCode());
     assertEquals(c1, c2);
@@ -280,8 +278,7 @@ public class TestNumericSummaryInterpolatorConfig {
       .setSync(true)
       .setComponentAggregator(Aggregators.SUM)
       .setId("myId")
-      .setType(NumericSummaryType.TYPE.toString())
-      .setConfigType(NumericSummaryInterpolatorConfig.class.getCanonicalName())
+      .setDataType(NumericSummaryType.TYPE.toString())
       .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());
     assertNotEquals(c1, c2);
@@ -300,8 +297,7 @@ public class TestNumericSummaryInterpolatorConfig {
         .setSync(true)
         .setComponentAggregator(Aggregators.SUM)
         .setId("myId")
-        .setType(NumericSummaryType.TYPE.toString())
-        .setConfigType(NumericSummaryInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());
     assertNotEquals(c1, c2);
@@ -320,8 +316,7 @@ public class TestNumericSummaryInterpolatorConfig {
         .setSync(true)
         .setComponentAggregator(Aggregators.SUM)
         .setId("myId")
-        .setType(NumericSummaryType.TYPE.toString())
-        .setConfigType(NumericSummaryInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());
     assertNotEquals(c1, c2);
@@ -340,8 +335,7 @@ public class TestNumericSummaryInterpolatorConfig {
         .setSync(true)
         .setComponentAggregator(Aggregators.SUM)
         .setId("myId")
-        .setType(NumericSummaryType.TYPE.toString())
-        .setConfigType(NumericSummaryInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());
     assertNotEquals(c1, c2);
@@ -360,8 +354,7 @@ public class TestNumericSummaryInterpolatorConfig {
         .setSync(true)
         .setComponentAggregator(Aggregators.SUM)
         .setId("myId")
-        .setType(NumericSummaryType.TYPE.toString())
-        .setConfigType(NumericSummaryInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());
     assertNotEquals(c1, c2);
@@ -380,8 +373,7 @@ public class TestNumericSummaryInterpolatorConfig {
         .setSync(true)
         .setComponentAggregator(Aggregators.SUM)
         .setId("myId")
-        .setType(NumericSummaryType.TYPE.toString())
-        .setConfigType(NumericSummaryInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());
     assertNotEquals(c1, c2);
@@ -400,8 +392,7 @@ public class TestNumericSummaryInterpolatorConfig {
         .setSync(true)
         .setComponentAggregator(Aggregators.SUM)
         .setId("myId")
-        .setType(NumericSummaryType.TYPE.toString())
-        .setConfigType(NumericSummaryInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     assertEquals(c1.hashCode(), c2.hashCode());
     assertEquals(c1, c2);
@@ -420,8 +411,7 @@ public class TestNumericSummaryInterpolatorConfig {
         .setSync(true)
         .setComponentAggregator(Aggregators.SUM)
         .setId("myId")
-        .setType(NumericSummaryType.TYPE.toString())
-        .setConfigType(NumericSummaryInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());
     assertNotEquals(c1, c2);
@@ -440,8 +430,7 @@ public class TestNumericSummaryInterpolatorConfig {
         .setSync(true)
         .setComponentAggregator(Aggregators.SUM)
         .setId("myId")
-        .setType(NumericSummaryType.TYPE.toString())
-        .setConfigType(NumericSummaryInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());
     assertNotEquals(c1, c2);
@@ -460,8 +449,7 @@ public class TestNumericSummaryInterpolatorConfig {
         //.setSync(true) 
         .setComponentAggregator(Aggregators.SUM)
         .setId("myId")
-        .setType(NumericSummaryType.TYPE.toString())
-        .setConfigType(NumericSummaryInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());
     assertNotEquals(c1, c2);
@@ -480,31 +468,10 @@ public class TestNumericSummaryInterpolatorConfig {
         .setSync(true)
         .setComponentAggregator(Aggregators.SUM)
         .setId("other") // <--DIFF
-        .setType(NumericSummaryType.TYPE.toString())
-        .setConfigType(NumericSummaryInterpolatorConfig.class.getCanonicalName())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     assertNotEquals(c1.hashCode(), c2.hashCode());
     assertNotEquals(c1, c2);
     assertEquals(-1, c1.compareTo(c2));
-    
-    c2 = (NumericSummaryInterpolatorConfig) NumericSummaryInterpolatorConfig.newBuilder()
-        .setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
-        .setDefaultRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
-        .setFillPolicyOverrides(ImmutableMap.<Integer, FillPolicy>builder()
-            .put(0, FillPolicy.ZERO)
-            .build())
-        .setRealFillPolicyOverrides(ImmutableMap.<Integer, FillWithRealPolicy>builder()
-            .put(1, FillWithRealPolicy.PREFER_NEXT)
-            .build())
-        .setExpectedSummaries(Lists.newArrayList(0, 1))
-        .setSync(true)
-        .setComponentAggregator(Aggregators.SUM)
-        .setId("myId")
-        .setType(NumericSummaryType.TYPE.toString())
-        .setConfigType(NumericSummaryInterpolatorConfig.class.getSimpleName()) // <-- DIFF
-        .build();
-    assertNotEquals(c1.hashCode(), c2.hashCode());
-    assertNotEquals(c1, c2);
-    assertEquals(1, c1.compareTo(c2));
   }
 }

--- a/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestReadAheadNumericInterpolator.java
+++ b/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestReadAheadNumericInterpolator.java
@@ -47,7 +47,7 @@ public class TestReadAheadNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     fill_policy = new BaseNumericFillPolicy(config);
   }
@@ -201,7 +201,7 @@ public class TestReadAheadNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     fill_policy = new BaseNumericFillPolicy(config);
     
@@ -256,7 +256,7 @@ public class TestReadAheadNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREVIOUS_ONLY)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     fill_policy = new BaseNumericFillPolicy(config);
     
@@ -311,7 +311,7 @@ public class TestReadAheadNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_PREVIOUS)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     fill_policy = new BaseNumericFillPolicy(config);
     
@@ -366,7 +366,7 @@ public class TestReadAheadNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     fill_policy = new BaseNumericFillPolicy(config);
     
@@ -421,7 +421,7 @@ public class TestReadAheadNumericInterpolator {
     config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     fill_policy = new BaseNumericFillPolicy(config);
     

--- a/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestScalarNumericInterpolatorConfig.java
+++ b/core/src/test/java/net/opentsdb/query/interpolation/types/numeric/TestScalarNumericInterpolatorConfig.java
@@ -36,7 +36,7 @@ public class TestScalarNumericInterpolatorConfig {
         .setValue(42)
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     assertTrue(((ScalarNumericInterpolatorConfig) config).isInteger());
     assertEquals(42, ((ScalarNumericInterpolatorConfig) config).longValue());
@@ -46,7 +46,7 @@ public class TestScalarNumericInterpolatorConfig {
         .setValue(42.5D)
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     assertFalse(((ScalarNumericInterpolatorConfig) config).isInteger());
     assertEquals(42.5, ((ScalarNumericInterpolatorConfig) config).doubleValue(), 0.01);
@@ -56,7 +56,7 @@ public class TestScalarNumericInterpolatorConfig {
         //.setValue(42) <== defaults to 0
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     assertTrue(((ScalarNumericInterpolatorConfig) config).isInteger());
     assertEquals(0, ((ScalarNumericInterpolatorConfig) config).longValue());
@@ -67,7 +67,7 @@ public class TestScalarNumericInterpolatorConfig {
         .setValue(42)
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(null)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
@@ -77,7 +77,7 @@ public class TestScalarNumericInterpolatorConfig {
         .setValue(42)
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         //.setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
@@ -87,7 +87,7 @@ public class TestScalarNumericInterpolatorConfig {
         .setValue(42)
         .setFillPolicy(null)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
@@ -97,7 +97,7 @@ public class TestScalarNumericInterpolatorConfig {
         .setValue(42)
         //.setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }

--- a/core/src/test/java/net/opentsdb/query/pojo/TestTimeSeriesQuery.java
+++ b/core/src/test/java/net/opentsdb/query/pojo/TestTimeSeriesQuery.java
@@ -642,7 +642,6 @@ public class TestTimeSeriesQuery {
     SemanticQuery.Builder builder = 
         JSON.parseToObject(json, TimeSeriesQuery.class).convert();
     SemanticQuery query = builder.build();
-    System.out.println(query.getExecutionGraph());
     assertEquals(4, query.getExecutionGraph().getNodes().size());
     
     ExecutionGraphNode node = query.getExecutionGraph().getNodes().get(0);

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsample.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsample.java
@@ -77,7 +77,7 @@ public class TestDownsample {
           (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     NumericSummaryInterpolatorConfig summary_config = 
@@ -85,7 +85,7 @@ public class TestDownsample {
       .setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setDefaultRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
       .addExpectedSummary(0)
-      .setType(NumericSummaryType.TYPE.toString())
+      .setDataType(NumericSummaryType.TYPE.toString())
       .build();
     
     config = (DownsampleConfig) DownsampleConfig.newBuilder()
@@ -184,7 +184,7 @@ public class TestDownsample {
           (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-      .setType(NumericSummaryType.TYPE.toString())
+      .setDataType(NumericSummaryType.TYPE.toString())
       .build();
     
     config = (DownsampleConfig) DownsampleConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleConfig.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleConfig.java
@@ -46,7 +46,7 @@ public class TestDownsampleConfig {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
     .setFillPolicy(FillPolicy.NOT_A_NUMBER)
     .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-    .setType(NumericType.TYPE.toString())
+    .setDataType(NumericType.TYPE.toString())
     .build();
     
     summary_config = 
@@ -55,7 +55,7 @@ public class TestDownsampleConfig {
       .setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setDefaultRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
       .addExpectedSummary(0)
-      .setType(NumericSummaryType.TYPE.toString())
+      .setDataType(NumericSummaryType.TYPE.toString())
       .build();
   }
   

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleFactory.java
@@ -99,7 +99,7 @@ public class TestDownsampleFactory {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
     .setFillPolicy(FillPolicy.NOT_A_NUMBER)
     .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-    .setType(NumericType.TYPE.toString())
+    .setDataType(NumericType.TYPE.toString())
     .build();
     
     NumericSummaryInterpolatorConfig summary_config = 
@@ -107,7 +107,7 @@ public class TestDownsampleFactory {
     .setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
     .setDefaultRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
     .addExpectedSummary(0)
-    .setType(NumericSummaryType.TYPE.toString())
+    .setDataType(NumericSummaryType.TYPE.toString())
     .build();
     
     DownsampleConfig config = (DownsampleConfig) DownsampleConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericIterator.java
@@ -47,8 +47,8 @@ import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.SemanticQuery;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.execution.graph.ExecutionGraph;
-import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.QueryInterpolatorFactory;
+import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.ScalarNumericInterpolatorConfig;
 import net.opentsdb.query.pojo.FillPolicy;
@@ -83,7 +83,7 @@ public class TestDownsampleNumericIterator {
     numeric_config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NONE)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
   }
   
@@ -2527,7 +2527,7 @@ public class TestDownsampleNumericIterator {
     numeric_config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     
     config = (DownsampleConfig) DownsampleConfig.newBuilder()
@@ -2617,7 +2617,7 @@ public class TestDownsampleNumericIterator {
     numeric_config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NULL)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     
     config = (DownsampleConfig) DownsampleConfig.newBuilder()
@@ -2707,7 +2707,7 @@ public class TestDownsampleNumericIterator {
     numeric_config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.ZERO)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     
     config = (DownsampleConfig) DownsampleConfig.newBuilder()
@@ -2798,7 +2798,7 @@ public class TestDownsampleNumericIterator {
         .setValue(42)
         .setFillPolicy(FillPolicy.SCALAR)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     
     config = (DownsampleConfig) DownsampleConfig.newBuilder()
@@ -2888,7 +2888,7 @@ public class TestDownsampleNumericIterator {
     numeric_config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NONE)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     
     config = (DownsampleConfig) DownsampleConfig.newBuilder()
@@ -2978,7 +2978,7 @@ public class TestDownsampleNumericIterator {
     numeric_config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NONE)
         .setRealFillPolicy(FillWithRealPolicy.PREFER_PREVIOUS)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     
     config = (DownsampleConfig) DownsampleConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericSummaryIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericSummaryIterator.java
@@ -43,8 +43,8 @@ import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.SemanticQuery;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.execution.graph.ExecutionGraph;
-import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.QueryInterpolatorFactory;
+import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
 import net.opentsdb.query.pojo.FillPolicy;
@@ -3370,7 +3370,7 @@ public class TestDownsampleNumericSummaryIterator {
         .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
                 .setFillPolicy(FillPolicy.NOT_A_NUMBER)
                 .setRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
-                .setType(NumericType.TYPE.toString())
+                .setDataType(NumericType.TYPE.toString())
                 .build())
         .build();
     when(node.config()).thenReturn(config);
@@ -3430,7 +3430,7 @@ public class TestDownsampleNumericSummaryIterator {
                 .setDefaultRealFillPolicy(real)
                 .addExpectedSummary(0)
                 .addExpectedSummary(2)
-                .setType(NumericSummaryType.TYPE.toString())
+                .setDataType(NumericSummaryType.TYPE.toString())
                 .build())
         .build();
     when(node.config()).thenReturn(config);

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/BaseNumericSummaryTest.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/BaseNumericSummaryTest.java
@@ -36,8 +36,8 @@ import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
-import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.QueryInterpolatorFactory;
+import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
 import net.opentsdb.query.joins.JoinConfig;
@@ -76,7 +76,7 @@ public class BaseNumericSummaryTest {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.ZERO)
       .setRealFillPolicy(FillWithRealPolicy.NONE)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     NUMERIC_SUMMARY_CONFIG = 
@@ -84,7 +84,7 @@ public class BaseNumericSummaryTest {
       .setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
       .setExpectedSummaries(Lists.newArrayList(0, 2))
-      .setType(NumericSummaryType.TYPE.toString())
+      .setDataType(NumericSummaryType.TYPE.toString())
       .build();
     
     JOIN_CONFIG = (JoinConfig) JoinConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/BaseNumericTest.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/BaseNumericTest.java
@@ -30,8 +30,8 @@ import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
-import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.QueryInterpolatorFactory;
+import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.joins.JoinConfig;
 import net.opentsdb.query.joins.Joiner;
@@ -66,7 +66,7 @@ public class BaseNumericTest {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.NONE)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     JOIN_CONFIG = (JoinConfig) JoinConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
@@ -84,7 +84,7 @@ public class TestBinaryExpressionNode {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     join_config = (JoinConfig) JoinConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionConfig.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionConfig.java
@@ -38,7 +38,7 @@ public class TestExpressionConfig {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     ExpressionConfig config = (ExpressionConfig) 
@@ -150,14 +150,14 @@ public class TestExpressionConfig {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     NumericInterpolatorConfig numeric_config2 = 
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.NEXT_ONLY) // <-- DIFF
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     final ExpressionConfig c1 = (ExpressionConfig) 
@@ -335,14 +335,14 @@ public class TestExpressionConfig {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     NumericInterpolatorConfig numeric_config2 = 
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.ZERO)
       .setRealFillPolicy(FillWithRealPolicy.NONE)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     ExpressionConfig config = (ExpressionConfig) 

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionFactory.java
@@ -60,7 +60,7 @@ public class TestExpressionFactory {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.NONE)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     JOIN_CONFIG = (JoinConfig) JoinConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorAdditive.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorAdditive.java
@@ -530,7 +530,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NONE)
       .setRealFillPolicy(FillWithRealPolicy.NONE)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     ExpressionConfig exp_config = (ExpressionConfig) ExpressionConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorDivide.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorDivide.java
@@ -337,7 +337,7 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NONE)
       .setRealFillPolicy(FillWithRealPolicy.NONE)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     ExpressionConfig exp_config = (ExpressionConfig) ExpressionConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorLogical.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorLogical.java
@@ -542,7 +542,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NONE)
       .setRealFillPolicy(FillWithRealPolicy.NONE)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     ExpressionConfig exp_config = (ExpressionConfig) ExpressionConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorMod.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorMod.java
@@ -337,7 +337,7 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NONE)
       .setRealFillPolicy(FillWithRealPolicy.NONE)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     ExpressionConfig exp_config = (ExpressionConfig) ExpressionConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorMultiply.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorMultiply.java
@@ -337,7 +337,7 @@ public class TestExpressionNumericIteratorMultiply extends BaseNumericTest {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NONE)
       .setRealFillPolicy(FillWithRealPolicy.NONE)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     ExpressionConfig exp_config = (ExpressionConfig) ExpressionConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorRelational.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorRelational.java
@@ -1161,7 +1161,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NONE)
       .setRealFillPolicy(FillWithRealPolicy.NONE)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     ExpressionConfig exp_config = (ExpressionConfig) ExpressionConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericSummaryIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericSummaryIterator.java
@@ -374,7 +374,7 @@ public class TestExpressionNumericSummaryIterator
       .setDefaultFillPolicy(FillPolicy.NONE)
       .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
       .setExpectedSummaries(Lists.newArrayList(0, 2))
-      .setType(NumericSummaryType.TYPE.toString())
+      .setDataType(NumericSummaryType.TYPE.toString())
       .build();
     
     ExpressionConfig exp_config = (ExpressionConfig) ExpressionConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionParser.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionParser.java
@@ -46,7 +46,7 @@ public class TestExpressionParser {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.NONE)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     JOIN_CONFIG = (JoinConfig) JoinConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionResult.java
@@ -64,7 +64,7 @@ public class TestExpressionResult {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     join_config = (JoinConfig) JoinConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionTimeSeries.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionTimeSeries.java
@@ -110,7 +110,7 @@ public class TestExpressionTimeSeries {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.NONE)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     config = (ExpressionConfig) ExpressionConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupBy.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupBy.java
@@ -82,7 +82,7 @@ public class TestGroupBy {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
     .setFillPolicy(FillPolicy.NOT_A_NUMBER)
     .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-    .setType(NumericType.TYPE.toString())
+    .setDataType(NumericType.TYPE.toString())
     .build();
     
     NumericSummaryInterpolatorConfig summary_config = 
@@ -90,7 +90,7 @@ public class TestGroupBy {
     .setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
     .setDefaultRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
     .addExpectedSummary(0)
-    .setType(NumericSummaryType.TYPE.toString())
+    .setDataType(NumericSummaryType.TYPE.toString())
     .build();
     
     config = (GroupByConfig) GroupByConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByConfig.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByConfig.java
@@ -43,7 +43,7 @@ public class TestGroupByConfig {
           (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     summary_config = 
@@ -51,7 +51,7 @@ public class TestGroupByConfig {
       .setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setDefaultRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
       .addExpectedSummary(0)
-      .setType(NumericSummaryType.TYPE.toString())
+      .setDataType(NumericSummaryType.TYPE.toString())
       .build();
   }
   

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByFactory.java
@@ -48,8 +48,8 @@ import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
-import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.QueryInterpolatorFactory;
+import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
 import net.opentsdb.query.pojo.FillPolicy;
@@ -92,7 +92,7 @@ public class TestGroupByFactory {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
     .setFillPolicy(FillPolicy.NOT_A_NUMBER)
     .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-    .setType(NumericType.TYPE.toString())
+    .setDataType(NumericType.TYPE.toString())
     .build();
     
     NumericSummaryInterpolatorConfig summary_config = 
@@ -100,7 +100,7 @@ public class TestGroupByFactory {
     .setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
     .setDefaultRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
     .addExpectedSummary(0)
-    .setType(NumericSummaryType.TYPE.toString())
+    .setDataType(NumericSummaryType.TYPE.toString())
     .build();
     
     final GroupByConfig config = (GroupByConfig) GroupByConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByNumericIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByNumericIterator.java
@@ -54,8 +54,8 @@ import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
-import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.QueryInterpolatorFactory;
+import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.ScalarNumericInterpolatorConfig;
 import net.opentsdb.query.pojo.FillPolicy;
@@ -79,7 +79,7 @@ public class TestGroupByNumericIterator {
     numeric_config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NONE)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     
     config = (GroupByConfig) GroupByConfig.newBuilder()
@@ -302,7 +302,7 @@ public class TestGroupByNumericIterator {
         .setValue(42)
         .setFillPolicy(FillPolicy.SCALAR)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     
     config = (GroupByConfig) GroupByConfig.newBuilder()
@@ -589,7 +589,7 @@ public class TestGroupByNumericIterator {
     numeric_config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     
     config = (GroupByConfig) GroupByConfig.newBuilder()
@@ -649,7 +649,7 @@ public class TestGroupByNumericIterator {
     numeric_config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NULL)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     
     config = (GroupByConfig) GroupByConfig.newBuilder()
@@ -709,7 +709,7 @@ public class TestGroupByNumericIterator {
     numeric_config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     
     config = (GroupByConfig) GroupByConfig.newBuilder()
@@ -769,7 +769,7 @@ public class TestGroupByNumericIterator {
     numeric_config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     
     config = (GroupByConfig) GroupByConfig.newBuilder()
@@ -836,7 +836,7 @@ public class TestGroupByNumericIterator {
     numeric_config = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
         .setFillPolicy(FillPolicy.NOT_A_NUMBER)
         .setRealFillPolicy(FillWithRealPolicy.NONE)
-        .setType(NumericType.TYPE.toString())
+        .setDataType(NumericType.TYPE.toString())
         .build();
     
     config = (GroupByConfig) GroupByConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByNumericSummaryIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByNumericSummaryIterator.java
@@ -41,8 +41,8 @@ import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
-import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.QueryInterpolatorFactory;
+import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
 import net.opentsdb.query.pojo.FillPolicy;
@@ -88,7 +88,7 @@ public class TestGroupByNumericSummaryIterator {
         .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
         .addExpectedSummary(0)
         .addExpectedSummary(2)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     config = (GroupByConfig) GroupByConfig.newBuilder()
         .setAggregator("sum")
@@ -329,7 +329,7 @@ public class TestGroupByNumericSummaryIterator {
         .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
         .addExpectedSummary(0)
         .addExpectedSummary(2)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     config = (GroupByConfig) GroupByConfig.newBuilder()
         .setAggregator("sum")
@@ -376,7 +376,7 @@ public class TestGroupByNumericSummaryIterator {
         .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
         .addExpectedSummary(0)
         .addExpectedSummary(2)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     config = (GroupByConfig) GroupByConfig.newBuilder()
         .setAggregator("sum")
@@ -423,7 +423,7 @@ public class TestGroupByNumericSummaryIterator {
         .setDefaultRealFillPolicy(FillWithRealPolicy.NONE)
         .addExpectedSummary(0)
         .addExpectedSummary(2)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     config = (GroupByConfig) GroupByConfig.newBuilder()
         .setAggregator("sum")
@@ -496,7 +496,7 @@ public class TestGroupByNumericSummaryIterator {
         .addExpectedSummary(0)
         .addExpectedSummary(2)
         .setComponentAggregator(Aggregators.SUM)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     config = (GroupByConfig) GroupByConfig.newBuilder()
         .setAggregator("avg")
@@ -534,7 +534,7 @@ public class TestGroupByNumericSummaryIterator {
         .addExpectedSummary(0)
         .addExpectedSummary(2)
         .setComponentAggregator(Aggregators.SUM)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     config = (GroupByConfig) GroupByConfig.newBuilder()
         .setAggregator("avg")
@@ -563,7 +563,7 @@ public class TestGroupByNumericSummaryIterator {
         .addExpectedSummary(0)
         .addExpectedSummary(2)
         .setComponentAggregator(Aggregators.SUM)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     config = (GroupByConfig) GroupByConfig.newBuilder()
         .setAggregator("avg")
@@ -601,7 +601,7 @@ public class TestGroupByNumericSummaryIterator {
         .addExpectedSummary(0)
         .addExpectedSummary(2)
         .setComponentAggregator(Aggregators.SUM)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     config = (GroupByConfig) GroupByConfig.newBuilder()
         .setAggregator("avg")
@@ -639,7 +639,7 @@ public class TestGroupByNumericSummaryIterator {
         .addExpectedSummary(0)
         .addExpectedSummary(2)
         .setComponentAggregator(Aggregators.SUM)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     config = (GroupByConfig) GroupByConfig.newBuilder()
         .setAggregator("avg")
@@ -683,7 +683,7 @@ public class TestGroupByNumericSummaryIterator {
         .addExpectedSummary(0)
         .addExpectedSummary(2)
         .setComponentAggregator(Aggregators.SUM)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     config = (GroupByConfig) GroupByConfig.newBuilder()
         .setAggregator("avg")
@@ -724,7 +724,7 @@ public class TestGroupByNumericSummaryIterator {
         .addExpectedSummary(0)
         .addExpectedSummary(2)
         .setComponentAggregator(Aggregators.SUM)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     config = (GroupByConfig) GroupByConfig.newBuilder()
         .setAggregator("avg")
@@ -765,7 +765,7 @@ public class TestGroupByNumericSummaryIterator {
         .addExpectedSummary(0)
         .addExpectedSummary(2)
         .setComponentAggregator(Aggregators.SUM)
-        .setType(NumericSummaryType.TYPE.toString())
+        .setDataType(NumericSummaryType.TYPE.toString())
         .build();
     config = (GroupByConfig) GroupByConfig.newBuilder()
         .setAggregator("avg")
@@ -807,7 +807,7 @@ public class TestGroupByNumericSummaryIterator {
         .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build();
     
@@ -840,7 +840,7 @@ public class TestGroupByNumericSummaryIterator {
         .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build();
     

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByResult.java
@@ -60,7 +60,7 @@ public class TestGroupByResult {
           (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-      .setType(NumericType.TYPE.toString())
+      .setDataType(NumericType.TYPE.toString())
       .build();
     
     summary_config = 
@@ -68,7 +68,7 @@ public class TestGroupByResult {
       .setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
       .setDefaultRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
       .addExpectedSummary(0)
-      .setType(NumericSummaryType.TYPE.toString())
+      .setDataType(NumericSummaryType.TYPE.toString())
       .build();
     
     config = (GroupByConfig) GroupByConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByTimeSeries.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByTimeSeries.java
@@ -47,8 +47,8 @@ import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
-import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.QueryInterpolatorFactory;
+import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
 import net.opentsdb.query.pojo.FillPolicy;
@@ -70,7 +70,7 @@ public class TestGroupByTimeSeries {
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
     .setFillPolicy(FillPolicy.NOT_A_NUMBER)
     .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
-    .setType(NumericType.TYPE.toString())
+    .setDataType(NumericType.TYPE.toString())
     .build();
     
     NumericSummaryInterpolatorConfig summary_config = 
@@ -78,7 +78,7 @@ public class TestGroupByTimeSeries {
     .setDefaultFillPolicy(FillPolicy.NOT_A_NUMBER)
     .setDefaultRealFillPolicy(FillWithRealPolicy.NEXT_ONLY)
     .addExpectedSummary(0)
-    .setType(NumericSummaryType.TYPE.toString())
+    .setDataType(NumericSummaryType.TYPE.toString())
     .build();
     
     factory = new GroupByFactory();

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xMultiGet.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xMultiGet.java
@@ -266,7 +266,7 @@ public class TestTsdb1xMultiGet extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("avg");
@@ -352,7 +352,7 @@ public class TestTsdb1xMultiGet extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("sum");
@@ -447,7 +447,7 @@ public class TestTsdb1xMultiGet extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("max");
@@ -1342,7 +1342,7 @@ public class TestTsdb1xMultiGet extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("avg");

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xQueryNode.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xQueryNode.java
@@ -249,7 +249,7 @@ public class TestTsdb1xQueryNode extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(context.upstreamOfType(any(QueryNode.class), eq(Downsample.class)))

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xScanners.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xScanners.java
@@ -270,7 +270,7 @@ public class TestTsdb1xScanners extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("avg");
@@ -376,7 +376,7 @@ public class TestTsdb1xScanners extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("max");
@@ -394,7 +394,7 @@ public class TestTsdb1xScanners extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     scanners = new Tsdb1xScanners(node, source_config);
@@ -452,7 +452,7 @@ public class TestTsdb1xScanners extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("avg");
@@ -470,7 +470,7 @@ public class TestTsdb1xScanners extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("avg");
@@ -2538,7 +2538,7 @@ public class TestTsdb1xScanners extends UTBase {
               .setFillPolicy(FillPolicy.NONE)
               .setRealFillPolicy(FillWithRealPolicy.NONE)
               .setId("interp")
-              .setType(NumericType.TYPE.toString())
+              .setDataType(NumericType.TYPE.toString())
               .build())
           .build());
       when(node.rollupAggregation()).thenReturn(ds);

--- a/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableMultiGet.java
+++ b/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableMultiGet.java
@@ -274,7 +274,7 @@ public class TestTsdb1xBigtableMultiGet extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("avg");
@@ -378,7 +378,7 @@ public class TestTsdb1xBigtableMultiGet extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("sum");
@@ -487,7 +487,7 @@ public class TestTsdb1xBigtableMultiGet extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("max");
@@ -1349,7 +1349,7 @@ public class TestTsdb1xBigtableMultiGet extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("avg");

--- a/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableQueryNode.java
+++ b/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableQueryNode.java
@@ -250,7 +250,7 @@ public class TestTsdb1xBigtableQueryNode extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(context.upstreamOfType(any(QueryNode.class), eq(Downsample.class)))

--- a/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableScanners.java
+++ b/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableScanners.java
@@ -279,7 +279,7 @@ public class TestTsdb1xBigtableScanners extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("avg");
@@ -385,7 +385,7 @@ public class TestTsdb1xBigtableScanners extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("max");
@@ -403,7 +403,7 @@ public class TestTsdb1xBigtableScanners extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     scanners = new Tsdb1xBigtableScanners(node, source_config);
@@ -461,7 +461,7 @@ public class TestTsdb1xBigtableScanners extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("avg");
@@ -479,7 +479,7 @@ public class TestTsdb1xBigtableScanners extends UTBase {
             .setFillPolicy(FillPolicy.NONE)
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setId("interp")
-            .setType(NumericType.TYPE.toString())
+            .setDataType(NumericType.TYPE.toString())
             .build())
         .build());
     when(node.rollupAggregation()).thenReturn("avg");
@@ -2487,7 +2487,7 @@ public class TestTsdb1xBigtableScanners extends UTBase {
               .setFillPolicy(FillPolicy.NONE)
               .setRealFillPolicy(FillWithRealPolicy.NONE)
               .setId("interp")
-              .setType(NumericType.TYPE.toString())
+              .setDataType(NumericType.TYPE.toString())
               .build())
           .build());
       when(node.rollupAggregation()).thenReturn(ds);


### PR DESCRIPTION
- Tweak the QueryInterpolatorConfig so it returns a data type and the old
  config type is now the interpolator type. And we don't need the deserializer
  any more as we'll do it manually.
- Add the QueryInterpolatorConfigParser interface.
- Include a parser in the QueryInterpolatorFactory interface.

CORE:
- Restore the registry loading of default implementations. That should be at
  the end, not the beginning.
- Add parsers for the interpolators and rename the getters per the main
  interface. And use the new parsers. We can now parse out scalars in the
  raw queries.