### PR TITLE
Fix builds on the next branch

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -93,10 +93,13 @@ tsdb_SRC := \
 	src/core/WritableDataPoints.java	\
 	src/core/WriteableDataPointFilterPlugin.java	\
 	src/graph/Plot.java	\
-	src/auth/AuthenticationChannelHandler.java \
-	src/auth/Authentication.java \
-	src/auth/Authorization.java \
-	src/auth/AuthState.java \
+	src/auth/AllowAllAuthenticatingAuthorizer.java	\
+	src/auth/AuthenticationChannelHandler.java	\
+	src/auth/Authentication.java	\
+	src/auth/Authorization.java	\
+	src/auth/AuthState.java	\
+	src/auth/Permissions.java	\
+	src/auth/Roles.java	\
 	src/meta/Annotation.java	\
 	src/meta/MetaDataCache.java	\
 	src/meta/TSMeta.java	\


### PR DESCRIPTION
Adds missing source files for authentication features to Makefile.am to repair build

It is not possible to do a clean build of the next branch currently because a few java source files are missing from Makefile.am

steps to reproduce

```
mkdir clean-checkout && cd clean-checkout
git clone https://github.com/OpenTSDB/opentsdb.git
git checkout next
sh build.sh
```

results in

```
../src/auth/Authorization.java:77: error: cannot find symbol
  public abstract AuthState hasPermission(final AuthState state, final Permissions permission);
                                                                       ^
  symbol:   class Permissions
  location: interface Authorization
```