### PR TITLE
CORE:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/QueryPipelineContext.java
+++ b/common/src/main/java/net/opentsdb/query/QueryPipelineContext.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 
 import net.opentsdb.core.TSDB;
 import net.opentsdb.data.TimeSeriesDataSource;
+import net.opentsdb.query.execution.graph.ExecutionGraph;
 import net.opentsdb.stats.Span;
 
 /**
@@ -118,6 +119,11 @@ public interface QueryPipelineContext extends QueryNode {
    * @return A non-null and non-empty collection of root query nodes.
    */
   public Collection<QueryNode> roots();
+  
+  /**
+   * @return The execution graph associated with this pipeline.
+   */
+  public ExecutionGraph executionGraph();
   
   /**
    * Releases all resources held by the query graph.

--- a/common/src/main/java/net/opentsdb/query/execution/graph/ExecutionGraph.java
+++ b/common/src/main/java/net/opentsdb/query/execution/graph/ExecutionGraph.java
@@ -14,10 +14,8 @@
 // limitations under the License.
 package net.opentsdb.query.execution.graph;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.jgrapht.experimental.dag.DirectedAcyclicGraph;
 import org.jgrapht.experimental.dag.DirectedAcyclicGraph.CycleFoundException;
@@ -36,7 +34,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
@@ -69,10 +66,6 @@ public class ExecutionGraph implements Comparable<ExecutionGraph> {
   
   /** The list of nodes given by the user or config. */
   protected List<ExecutionGraphNode> nodes;
-
-  /** A set of optional node configs manually de-serialized. Not counted
-   * in the equals, hash code or comparable. */
-  protected Map<String, QueryNodeConfig> node_configs;
   
   /**
    * Protected ctor that sets up maps but doesn't generate the graph.
@@ -94,58 +87,6 @@ public class ExecutionGraph implements Comparable<ExecutionGraph> {
   /** @return The list of nodes configured in this graph. */
   public List<ExecutionGraphNode> getNodes() {
     return Collections.unmodifiableList(nodes);
-  }
-  
-  /** @return An optional map of node configs. */
-  public Map<String, QueryNodeConfig> nodeConfigs() {
-    return node_configs != null ? node_configs : Collections.emptyMap();
-  }
-  
-  /**
-   * Overrides the list of node configs with those given in the collection.
-   * Uses the {@link QueryNodeConfig#getId()} as the ID of a specific
-   * node or the name of node types. 
-   * @param configs A non-null list of node configs. May be empty.
-   * @throws IllegalArgumentException if the collection was null.
-   */
-  public void setNodeConfigs(final Collection<QueryNodeConfig> configs) {
-    if (configs == null) {
-      throw new IllegalArgumentException("Configs cannot be null.");
-    }
-    if (node_configs != null) {
-      node_configs.clear();
-    }
-    for (final QueryNodeConfig config : configs) {
-      addNodeConfig(config);
-    }
-  }
-  
-  /**
-   * Adds the given node config to the map using the 
-   * {@link QueryNodeConfig#getId()} as the unique key of config. This 
-   * may map to a node type to be used as the default for all nodes of 
-   * that type or it may be a specific node ID. It may not be null.
-   * @param config A non-null config.
-   * @throws IllegalArgumentException if the config was null or the 
-   * id of the config was null or empty or if a config with the same
-   * ID was already present.
-   */
-  public void addNodeConfig(final QueryNodeConfig config) {
-    if (config == null) {
-      throw new IllegalArgumentException("Config cannot be null.");
-    }
-    if (Strings.isNullOrEmpty(config.getId())) {
-      throw new IllegalArgumentException("Config ID cannot be null or "
-          + "empty.");
-    }
-    if (node_configs == null) {
-      node_configs = Maps.newHashMap();
-    }
-    if (node_configs.containsKey(config.getId())) {
-      throw new IllegalArgumentException("Duplicate config ID found "
-          + "for:  " + config.getId());
-    }
-    node_configs.put(config.getId(), config);
   }
   
   @Override
@@ -195,8 +136,6 @@ public class ExecutionGraph implements Comparable<ExecutionGraph> {
         .append(id)
         .append(", nodes=")
         .append(nodes)
-        .append(", nodeConfigs=")
-        .append(node_configs)
         .toString();
   }
   

--- a/common/src/main/java/net/opentsdb/query/execution/graph/ExecutionGraphNode.java
+++ b/common/src/main/java/net/opentsdb/query/execution/graph/ExecutionGraphNode.java
@@ -81,6 +81,9 @@ public class ExecutionGraphNode implements Comparable<ExecutionGraphNode> {
     }
     id = builder.id;
     sources = builder.sources;
+    if (sources != null) {
+      Collections.sort(sources);
+    }
     config = builder.config;
   }
   
@@ -135,7 +138,6 @@ public class ExecutionGraphNode implements Comparable<ExecutionGraphNode> {
           Lists.newArrayListWithCapacity(sources.size() + 
               (config != null ? 2 : 1));
       hashes.add(hc);
-      Collections.sort(sources);
       for (final String source : sources) {
         hashes.add(Const.HASH_FUNCTION().newHasher().putString(
             source, Const.UTF8_CHARSET).hash());

--- a/common/src/test/java/net/opentsdb/data/MockTimeSeries.java
+++ b/common/src/test/java/net/opentsdb/data/MockTimeSeries.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 import com.google.common.collect.Lists;
@@ -90,15 +91,18 @@ public class MockTimeSeries implements TimeSeries {
       return Optional.empty();
     }
     Collections.sort(types, new TimeSeriesValue.TimeSeriesValueComparator());
-    return Optional.of(new MockTimeSeriesIterator(types.iterator()));
+    return Optional.of(new MockTimeSeriesIterator(types.iterator(),
+        (TypeToken<? extends TimeSeriesDataType>) type));
   }
 
   @Override
   public Collection<TypedIterator<TimeSeriesValue<? extends TimeSeriesDataType>>> iterators() {
     final List<TypedIterator<TimeSeriesValue<? extends TimeSeriesDataType>>> iterators
       = Lists.newArrayListWithCapacity(data.size());
-    for (final List<TimeSeriesValue<?>> types : data.values()) {
-      iterators.add(new MockTimeSeriesIterator(types.iterator()));
+    for (final Entry<TypeToken<?>, List<TimeSeriesValue<?>>> entry : data.entrySet()) {
+      
+      iterators.add(new MockTimeSeriesIterator(entry.getValue().iterator(),
+          (TypeToken<? extends TimeSeriesDataType>) entry.getKey()));
     }
     return iterators;
   }
@@ -123,8 +127,9 @@ public class MockTimeSeries implements TimeSeries {
   class MockTimeSeriesIterator extends TypedIterator<TimeSeriesValue<?>> {
     private final Iterator<TimeSeriesValue<?>> iterator;
     
-    MockTimeSeriesIterator(final Iterator<TimeSeriesValue<?>> iterator) {
-      super(iterator, new MockTimeSeriesDataType().type());
+    MockTimeSeriesIterator(final Iterator<TimeSeriesValue<?>> iterator,
+                           final TypeToken<? extends TimeSeriesDataType> type) {
+      super(iterator, type);
       this.iterator = iterator;
     }
     
@@ -138,16 +143,6 @@ public class MockTimeSeries implements TimeSeries {
       return iterator.next();
     }
     
-  }
-
-  class MockTimeSeriesDataType implements TimeSeriesDataType {
-
-    TypeToken<MockTimeSeriesDataType> TYPE = TypeToken.of(MockTimeSeriesDataType.class);
-
-    @Override
-    public TypeToken<? extends TimeSeriesDataType> type() {
-      return TYPE;
-    }
   }
   
 }

--- a/common/src/test/java/net/opentsdb/query/execution/graph/TestExecutionGraph.java
+++ b/common/src/test/java/net/opentsdb/query/execution/graph/TestExecutionGraph.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -42,7 +41,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.collect.Lists;
 import com.google.common.hash.HashCode;
 
 import net.opentsdb.configuration.Configuration;
@@ -253,74 +251,6 @@ public class TestExecutionGraph {
     assertEquals(g1.hashCode(), g2.hashCode());
     assertEquals(g1, g2);
     assertEquals(0, g1.compareTo(g2));
-  }
-  
-  @Test
-  public void addNodeConfig() throws Exception {
-    ExecutionGraph graph = ExecutionGraph.newBuilder()
-        .setId("Graph1")
-        .addNode(ExecutionGraphNode.newBuilder()
-          .setId("N1")
-          .setType("MockFactoryA")
-          .addSource("S1")
-          .addSource("S2"))
-        .addNode(ExecutionGraphNode.newBuilder()
-          .setId("S1")
-          .setType("MockSourceFactory"))
-        .addNode(ExecutionGraphNode.newBuilder()
-          .setId("S2")
-          .setType("MockSourceFactory"))
-        .build();
-    
-    QueryNodeConfig config1 = mock(QueryNodeConfig.class);
-    when(config1.getId()).thenReturn("config1");
-    QueryNodeConfig config2 = mock(QueryNodeConfig.class);
-    when(config2.getId()).thenReturn("config2");
-    
-    graph.addNodeConfig(config1);
-    assertEquals(1, graph.nodeConfigs().size());
-    assertSame(config1, graph.nodeConfigs().get("config1"));
-    
-    graph.addNodeConfig(config2);
-    assertEquals(2, graph.nodeConfigs().size());
-    assertSame(config1, graph.nodeConfigs().get("config1"));
-    assertSame(config2, graph.nodeConfigs().get("config2"));
-    
-    graph.setNodeConfigs(Lists.newArrayList(config2));
-    assertEquals(1, graph.nodeConfigs().size());
-    assertSame(config2, graph.nodeConfigs().get("config2"));
-    
-    try {
-      graph.addNodeConfig(config2);
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
-    
-    graph.node_configs.clear();
-    when(config2.getId()).thenReturn(null);
-    try {
-      graph.addNodeConfig(config2);
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
-    assertTrue(graph.nodeConfigs().isEmpty());
-    
-    when(config2.getId()).thenReturn("");
-    try {
-      graph.addNodeConfig(config2);
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
-    assertTrue(graph.nodeConfigs().isEmpty());
-    
-    try {
-      graph.addNodeConfig(null);
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
-    assertTrue(graph.nodeConfigs().isEmpty());
-    
-    try {
-      graph.setNodeConfigs(null);
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
-    assertTrue(graph.nodeConfigs().isEmpty());
   }
   
   @Test

--- a/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
+++ b/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
@@ -18,20 +18,14 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-import org.jgrapht.experimental.dag.DirectedAcyclicGraph;
-import org.jgrapht.experimental.dag.DirectedAcyclicGraph.CycleFoundException;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.traverse.BreadthFirstIterator;
-import org.jgrapht.traverse.DepthFirstIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 
@@ -41,10 +35,9 @@ import net.opentsdb.data.TimeSeriesDataSource;
 import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.TimeSpecification;
 import net.opentsdb.query.execution.graph.ExecutionGraph;
-import net.opentsdb.query.execution.graph.ExecutionGraphNode;
+import net.opentsdb.query.plan.DefaultQueryPlanner;
 import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.Span;
-import net.opentsdb.utils.Pair;
 
 /**
  * A useful base class for {@link QueryPipelineContext}s that stores references
@@ -59,7 +52,7 @@ import net.opentsdb.utils.Pair;
  * 
  * <b>Invariants:</b>
  * <ul>
- * <li>Each {@link ExecutionGraphNode} must have a unique ID within the graph.</li>
+ * <li>Each {@link ExecutionGraphNode} must have a unique ID within the plan.graph().</li>
  * <li>The graph must have at most one sink that will be used to execution a
  * query.</li>
  * <li>The graph must be a non-cyclical DAG.</li>
@@ -79,21 +72,12 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
   
   /** The upstream query context this pipeline context belongs to. */
   protected final QueryContext context;
-  
-  /** The original user defined execution graph. */
-  protected final ExecutionGraph execution_graph;
-  
-  /** A mutable copy of the nodes. */
-  protected final List<ExecutionGraphNode> nodes;
+
+  /** The query plan. */
+  protected DefaultQueryPlanner plan;
   
   /** The set of query sinks. */
   protected final Collection<QuerySink> sinks;
-  
-  /** The set of node roots to link to the sinks. */
-  protected Set<QueryNode> roots;
-  
-  /** The list of source nodes. */
-  protected List<TimeSeriesDataSource> sources;
   
   /** The cumulative result object when operating in {@link QueryMode#SINGLE}. */
   protected CumulativeQueryResult single_results;
@@ -112,11 +96,6 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
   /** Used in a sync streaming mode to track how many sinks are done. */
   protected int completed_sinks;
   
-  /** The graph of query nodes. 
-   * PRIVATE so that we can swap out the graph implementation at a later date.
-   */
-  protected DirectedAcyclicGraph<QueryNode, DefaultEdge> graph;
-  
   /**
    * Default ctor.
    * @param tsdb A non-null TSDB to work with.
@@ -128,7 +107,6 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
   public AbstractQueryPipelineContext(final TSDB tsdb, 
                                       final TimeSeriesQuery query, 
                                       final QueryContext context,
-                                      final ExecutionGraph execution_graph,
                                       final Collection<QuerySink> sinks) {
     if (tsdb == null) {
       throw new IllegalArgumentException("TSDB object cannot be null.");
@@ -139,22 +117,14 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
     if (context == null) {
       throw new IllegalArgumentException("The context cannot be null.");
     }
-    if (execution_graph == null) {
-      throw new IllegalArgumentException("Execution graph cannot be null.");
-    }
     if (sinks == null || sinks.isEmpty()) {
       throw new IllegalArgumentException("The sinks cannot be null or empty");
     }
     this.tsdb = tsdb;
     this.query = query;
     this.context = context;
-    this.execution_graph = execution_graph;
     this.sinks = sinks;
-    graph = new DirectedAcyclicGraph<QueryNode, DefaultEdge>(DefaultEdge.class);
-    graph.addVertex(this);
-    roots = Sets.newHashSet();
-    sources = Lists.newArrayList();
-    nodes = Lists.newArrayList(execution_graph.getNodes());
+    plan = new DefaultQueryPlanner(this, Lists.newArrayList((QueryNode) this));
   }
   
   @Override
@@ -173,22 +143,27 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
   }
   
   @Override
+  public ExecutionGraph executionGraph() {
+    return query.getExecutionGraph();
+  }
+  
+  @Override
   public Collection<QueryNode> upstream(final QueryNode node) {
     if (node == null) {
       throw new IllegalArgumentException("Node cannot be null.");
     }
-    if (!graph.containsVertex(node)) {
+    if (!plan.graph().containsVertex(node)) {
       throw new IllegalArgumentException("The given node wasn't in this graph: " 
           + node);
     }
-    final Set<DefaultEdge> upstream = graph.incomingEdgesOf(node);
+    final Set<DefaultEdge> upstream = plan.graph().incomingEdgesOf(node);
     if (upstream.isEmpty()) {
       return Collections.emptyList();
     }
     final List<QueryNode> listeners = Lists.newArrayListWithCapacity(
         upstream.size());
     for (final DefaultEdge e : upstream) {
-      listeners.add(graph.getEdgeSource(e));
+      listeners.add(plan.graph().getEdgeSource(e));
     }
     return listeners;
   }
@@ -198,18 +173,18 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
     if (node == null) {
       throw new IllegalArgumentException("Node cannot be null.");
     }
-    if (!graph.containsVertex(node)) {
+    if (!plan.graph().containsVertex(node)) {
       throw new IllegalArgumentException("The given node wasn't in this graph: " 
           + node);
     }
-    final Set<DefaultEdge> downstream = graph.outgoingEdgesOf(node);
+    final Set<DefaultEdge> downstream = plan.graph().outgoingEdgesOf(node);
     if (downstream.isEmpty()) {
       return Collections.emptyList();
     }
     final List<QueryNode> downstreams = Lists.newArrayListWithCapacity(
         downstream.size());
     for (final DefaultEdge e : downstream) {
-      downstreams.add(graph.getEdgeTarget(e));
+      downstreams.add(plan.graph().getEdgeTarget(e));
     }
     return downstreams;
   }
@@ -219,18 +194,18 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
     if (node == null) {
       throw new IllegalArgumentException("Node cannot be null.");
     }
-    if (!graph.containsVertex(node)) {
+    if (!plan.graph().containsVertex(node)) {
       throw new IllegalArgumentException("The given node wasn't in this graph: " 
           + node);
     }
-    final Set<DefaultEdge> downstream = graph.outgoingEdgesOf(node);
+    final Set<DefaultEdge> downstream = plan.graph().outgoingEdgesOf(node);
     if (downstream.isEmpty()) {
       return Collections.emptyList();
     }
     final Set<TimeSeriesDataSource> downstreams = Sets.newHashSetWithExpectedSize(
         downstream.size());
     for (final DefaultEdge e : downstream) {
-      final QueryNode target = graph.getEdgeTarget(e);
+      final QueryNode target = plan.graph().getEdgeTarget(e);
       if (downstreams.contains(target)) {
         continue;
       }
@@ -253,19 +228,19 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
     if (type == null) {
       throw new IllegalArgumentException("Type cannot be null.");
     }
-    if (!graph.containsVertex(node)) {
+    if (!plan.graph().containsVertex(node)) {
       throw new IllegalArgumentException("The given node wasn't in this graph: " 
           + node);
     }
     
-    final Set<DefaultEdge> upstream = graph.incomingEdgesOf(node);
+    final Set<DefaultEdge> upstream = plan.graph().incomingEdgesOf(node);
     if (upstream.isEmpty()) {
       return Collections.emptyList();
     }
     
     List<QueryNode> upstreams = null;
     for (final DefaultEdge e : upstream) {
-      final QueryNode source = graph.getEdgeSource(e);
+      final QueryNode source = plan.graph().getEdgeSource(e);
       if (source.getClass().equals(type)) {
         if (upstreams == null) {
           upstreams = Lists.newArrayList();
@@ -294,19 +269,19 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
     if (type == null) {
       throw new IllegalArgumentException("Type cannot be null.");
     }
-    if (!graph.containsVertex(node)) {
+    if (!plan.graph().containsVertex(node)) {
       throw new IllegalArgumentException("The given node wasn't in this graph: " 
           + node);
     }
     
-    final Set<DefaultEdge> downstream = graph.outgoingEdgesOf(node);
+    final Set<DefaultEdge> downstream = plan.graph().outgoingEdgesOf(node);
     if (downstream.isEmpty()) {
       return Collections.emptyList();
     }
     
     List<QueryNode> downstreams = null;
     for (final DefaultEdge e : downstream) {
-      final QueryNode target = graph.getEdgeTarget(e);
+      final QueryNode target = plan.graph().getEdgeTarget(e);
       if (target.getClass().equals(type)) {
         if (downstreams == null) {
           downstreams = Lists.newArrayList();
@@ -333,7 +308,7 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
   
   @Override
   public Collection<QueryNode> roots() {
-    return roots;
+    return plan.roots();
   }
   
   @Override
@@ -344,7 +319,7 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
   @Override
   public void close() {
     final BreadthFirstIterator<QueryNode, DefaultEdge> bf_iterator = 
-        new BreadthFirstIterator<QueryNode, DefaultEdge>(graph);
+        new BreadthFirstIterator<QueryNode, DefaultEdge>(plan.graph());
     while (bf_iterator.hasNext()) {
       final QueryNode node = bf_iterator.next();
       if (node == this) {
@@ -365,7 +340,7 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
         context.mode() == QueryMode.CONTINOUS_SERVER_SYNC_STREAM ||
         context.mode() == QueryMode.BOUNDED_SERVER_ASYNC_STREAM ||
         context.mode() == QueryMode.CONTINOUS_SERVER_ASYNC_STREAM) {
-      for (final TimeSeriesDataSource source : sources) {
+      for (final TimeSeriesDataSource source : plan.sources()) {
         try {
           source.fetchNext(span);
         } catch (Exception e) {
@@ -379,14 +354,14 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
     }
     
     synchronized(this) {
-      if (source_idx >= sources.size()) {
+      if (source_idx >= plan.sources().size()) {
         source_idx = 0;
       }
       try {
-        sources.get(source_idx++).fetchNext(span);
+        plan.sources().get(source_idx++).fetchNext(span);
       } catch (Exception e) {
         LOG.error("Failed to fetch next from source: " 
-            + sources.get(source_idx - 1), e);
+            + plan.sources().get(source_idx - 1), e);
         onError(e);
       }
     }
@@ -452,6 +427,11 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
     return null;
   }
   
+  /** @return The planner. */
+  public DefaultQueryPlanner plan() {
+    return plan;
+  }
+  
   /**
    * A helper to initialize the nodes in depth-first order.
    */
@@ -459,157 +439,14 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
     final Span child;
     if (span != null) {
       child = span.newChild(getClass() + ".initializeGraph")
-                  .withTag("graphId", execution_graph.getId() == null ? "null" : execution_graph.getId())
-                  .start();
+        .withTag("graphId", 
+            query.getExecutionGraph().getId() == null ? 
+                "null" : query.getExecutionGraph().getId())
+        .start();
     } else {
       child = null;
     }
-    
-    final Map<String, QueryNodeConfig> node_configs = 
-        execution_graph.nodeConfigs();
-    final Map<String, QueryNode> map = 
-        Maps.newHashMapWithExpectedSize(execution_graph.getNodes().size());
-    final Set<String> unique_ids = 
-        Sets.newHashSetWithExpectedSize(execution_graph.getNodes().size());
-    List<Pair<MultiQueryNodeFactory, ExecutionGraphNode>> multis = null;
-    
-    // first pass to instantiate the nodes.
-    for (final ExecutionGraphNode node : nodes) {
-      if (unique_ids.contains(node.getId())) {
-        throw new IllegalArgumentException("The node id \"" 
-            + node.getId() + "\" appeared more than once in the "
-            + "graph. It must be unique.");
-      }
-      unique_ids.add(node.getId());
-      
-      final QueryNodeFactory factory;
-      if (!Strings.isNullOrEmpty(node.getType())) {
-        factory = tsdb.getRegistry().getQueryNodeFactory(node.getType().toLowerCase());
-      } else {
-        factory = tsdb.getRegistry().getQueryNodeFactory(node.getId().toLowerCase());
-      }
-      if (factory == null) {
-        throw new IllegalArgumentException("No node factory found for "
-            + "configuration " + node);
-      }
-      
-      // we can only handle singles here, multis we run through in a second
-      // pass.
-      if (!(factory instanceof SingleQueryNodeFactory)) {
-        if (multis == null) {
-          multis = Lists.newArrayList();
-        }
-        multis.add(new Pair<MultiQueryNodeFactory, ExecutionGraphNode>(
-            (MultiQueryNodeFactory) factory, node));
-        continue;
-      }
-      
-      final QueryNode query_node;
-      QueryNodeConfig node_config = node.getConfig() != null ? 
-          node.getConfig() : node_configs.get(node.getId());
-      if (node_config == null) {
-        node_config = node_configs.get(node.getType());
-      }
-      if (node_config != null) {
-        query_node = ((SingleQueryNodeFactory) factory)
-            .newNode(this, node.getId(), node_config);
-      } else {
-        query_node = ((SingleQueryNodeFactory) factory)
-            .newNode(this, node.getId());
-      }
-      if (query_node == null) {
-        throw new IllegalStateException("Factory returned a null "
-            + "instance for " + node);
-      }
-      
-      map.put(node.getId(), query_node);
-      
-      graph.addVertex(query_node);
-    }
-    
-    // if there are multis that change the DAG, let's set em up now
-    if (multis != null) {
-      for (final Pair<MultiQueryNodeFactory, ExecutionGraphNode> pair : multis) {
-        QueryNodeConfig node_config = pair.getValue().getConfig() != null ? 
-            pair.getValue().getConfig() : node_configs.get(pair.getValue().getId());
-        if (node_config == null) {
-          node_config = node_configs.get(pair.getValue().getType());
-        }
-        if (node_config == null) {
-          throw new IllegalArgumentException("No config supplied for "
-              + "node: " + pair.getValue().getId());
-        }
-        
-        final Collection<QueryNode> query_nodes = pair.getKey().newNodes(
-            this, pair.getValue().getId(), node_config, nodes);
-        if (query_nodes == null || query_nodes.isEmpty()) {
-          throw new IllegalStateException("Factory returned a null or "
-              + "empty list of nodes for " + pair.getValue().getId());
-        }
-        for (final QueryNode node : query_nodes) {
-          if (node == null) {
-            throw new IllegalStateException("Factory returned a null "
-                + "node for " + pair.getValue().getId());
-          }
-          
-          map.put(node.id(), node);
-          graph.addVertex(node);
-        }
-        
-        // Important! We have to remove the original node config for
-        // debugging so we know it was replaced.
-        nodes.remove(pair.getValue());
-      }
-    }
-    
-    // second (or third) pass to build the graph.
-    for (final ExecutionGraphNode node : nodes) {
-      if (node != null && 
-          node.getSources() != null && 
-          !node.getSources().isEmpty()) {
-        final QueryNode query_node = map.get(node.getId());
-        for (final String source : node.getSources()) {
-          try {
-            graph.addDagEdge(query_node, map.get(source));
-          } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Failed to add node: " 
-                + node, e);
-          } catch (CycleFoundException e) {
-            throw new IllegalArgumentException("A cycle was detected "
-                + "adding node: " + node, e);
-          }
-        }
-      }
-    }
-    
-    // depth first initiation of the executors since we have to init
-    // the ones without any downstream dependencies first.
-    final DepthFirstIterator<QueryNode, DefaultEdge> iterator = 
-        new DepthFirstIterator<QueryNode, DefaultEdge>(graph);
-    final Set<TimeSeriesDataSource> source_set = Sets.newHashSet();
-    while (iterator.hasNext()) {
-      final QueryNode node = iterator.next();
-      
-      final Set<DefaultEdge> incoming = graph.incomingEdgesOf(node);
-      if (incoming.size() == 0 && node != this) {
-        try {
-          graph.addDagEdge(this, node);
-        } catch (CycleFoundException e) {
-          throw new IllegalArgumentException(
-              "Invalid graph configuration", e);
-        }
-        roots.add(node);
-      }
-      
-      if (node instanceof TimeSeriesDataSource) {
-        source_set.add((TimeSeriesDataSource) node);
-      }
-      
-      if (node != this) {
-        node.initialize(child);
-      }
-    }
-    sources.addAll(source_set);
+    plan.plan(child);
     if (child != null) {
       child.setSuccessTags().finish();
     }
@@ -622,7 +459,7 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
    */
   protected void checkComplete() {
     if (completed_sinks >= total_sequences &&
-        completed_downstream >= roots.size()) {
+        completed_downstream >= plan.roots().size()) {
       for (final QuerySink sink : sinks) {
         if (context.mode() == QueryMode.SINGLE && single_results != null) {
           try {

--- a/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
+++ b/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
@@ -62,7 +62,8 @@ public class QueryDataSourceFactory implements SingleQueryNodeFactory, TSDBPlugi
 //        throw new RuntimeException("No factory!");
 //      }
       
-    final ReadableTimeSeriesDataStore store = ((DefaultRegistry) tsdb.getRegistry()).getDefaultStore();
+    final ReadableTimeSeriesDataStore store = ((DefaultRegistry) 
+        tsdb.getRegistry()).getDefaultStore();
     if (store == null) {
       throw new QueryExecutionException("Unable to get a data store!", 0);
     }

--- a/core/src/main/java/net/opentsdb/query/SemanticQuery.java
+++ b/core/src/main/java/net/opentsdb/query/SemanticQuery.java
@@ -121,12 +121,6 @@ public class SemanticQuery implements TimeSeriesQuery {
         ((QuerySourceConfig) node.getConfig()).setTimeSeriesQuery(this);
       }
     }
-    for (final QueryNodeConfig config : execution_graph.nodeConfigs().values()) {
-      if (config instanceof QuerySourceConfig &&
-          ((QuerySourceConfig) config).getQuery() == null) {
-        ((QuerySourceConfig) config).setTimeSeriesQuery(this);
-      }
-    }
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/query/SemanticQueryContext.java
+++ b/core/src/main/java/net/opentsdb/query/SemanticQueryContext.java
@@ -144,7 +144,7 @@ public class SemanticQueryContext implements QueryContext {
 
     public LocalPipeline(TSDB tsdb, TimeSeriesQuery query, QueryContext context,
         ExecutionGraph execution_graph, Collection<QuerySink> sinks) {
-      super(tsdb, query, context, execution_graph, sinks);
+      super(tsdb, query, context, sinks);
     }
 
     @Override

--- a/core/src/main/java/net/opentsdb/query/TSDBV2QueryContextBuilder.java
+++ b/core/src/main/java/net/opentsdb/query/TSDBV2QueryContextBuilder.java
@@ -208,7 +208,7 @@ public class TSDBV2QueryContextBuilder implements QueryContextBuilder {
 
     public LocalPipeline(TSDB tsdb, TimeSeriesQuery query, QueryContext context,
         ExecutionGraph execution_graph, Collection<QuerySink> sinks) {
-      super(tsdb, query, context, execution_graph, sinks);
+      super(tsdb, query, context, sinks);
     }
 
     @Override

--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV2QuerySerdesOptions.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV2QuerySerdesOptions.java
@@ -40,6 +40,9 @@ public class JsonV2QuerySerdesOptions extends BaseSerdesOptions {
   /** Whether or not to show the summary. */
   private boolean show_summary;
   
+  /** The number of time series necessary to switch to parallel mode. */
+  private int parallel_threshold;
+  
   /**
    * Default ctor.
    * @param builder Non-null builder.
@@ -51,6 +54,7 @@ public class JsonV2QuerySerdesOptions extends BaseSerdesOptions {
     show_query = builder.showQuery;
     show_stats = builder.showStats;
     show_summary = builder.showSummary;
+    parallel_threshold = builder.parallelThreshold;
   }
   
   @Override
@@ -83,6 +87,10 @@ public class JsonV2QuerySerdesOptions extends BaseSerdesOptions {
     return show_summary;
   }
   
+  public int parallelThreshold() {
+    return parallel_threshold;
+  }
+  
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -98,6 +106,8 @@ public class JsonV2QuerySerdesOptions extends BaseSerdesOptions {
     private boolean showStats;
     @JsonProperty
     private boolean showSummary;
+    @JsonProperty
+    private int parallelThreshold;
     
     public Builder setShowTsuids(final boolean showTsuids) {
       this.showTsuids = showTsuids;
@@ -121,6 +131,11 @@ public class JsonV2QuerySerdesOptions extends BaseSerdesOptions {
     
     public Builder setShowSummary(final boolean showSummary) {
       this.showSummary = showSummary;
+      return this;
+    }
+    
+    public Builder setParallelThreshold(final int parallelThreshold) {
+      this.parallelThreshold = parallelThreshold;
       return this;
     }
     

--- a/core/src/main/java/net/opentsdb/query/plan/DefaultQueryPlanner.java
+++ b/core/src/main/java/net/opentsdb/query/plan/DefaultQueryPlanner.java
@@ -1,0 +1,466 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.plan;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.jgrapht.Graph;
+import org.jgrapht.experimental.dag.DirectedAcyclicGraph;
+import org.jgrapht.experimental.dag.DirectedAcyclicGraph.CycleFoundException;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.traverse.BreadthFirstIterator;
+import org.jgrapht.traverse.DepthFirstIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import net.opentsdb.data.TimeSeriesDataSource;
+import net.opentsdb.query.MultiQueryNodeFactory;
+import net.opentsdb.query.QueryDataSourceFactory;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryNodeConfig;
+import net.opentsdb.query.QueryNodeFactory;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.QuerySourceConfig;
+import net.opentsdb.query.SingleQueryNodeFactory;
+import net.opentsdb.query.execution.graph.ExecutionGraph;
+import net.opentsdb.query.execution.graph.ExecutionGraphNode;
+import net.opentsdb.storage.TimeSeriesDataStoreFactory;
+
+/**
+ * A query planner that handles push-down operations to data sources.
+ * 
+ * TODO - more work and break it into an interface like the old one.
+ * 
+ * @since 3.0
+ */
+public class DefaultQueryPlanner {
+  private static final Logger LOG = LoggerFactory.getLogger(
+      DefaultQueryPlanner.class);
+  
+  /** The context we belong to. We get the query here. */
+  private final QueryPipelineContext context;
+  
+  /** The roots (sent to sinks) of the user given graph. */
+  private List<QueryNode> roots;
+  
+  /** The sinks to report to. */
+  private List<QueryNode> sinks;
+  
+  /** The planned execution graph. */
+  private DirectedAcyclicGraph<QueryNode, DefaultEdge> graph;
+  
+  /** The list of data sources we're fetching from. */
+  private List<TimeSeriesDataSource> sources;
+  
+  /** The configuration graph. */
+  private DirectedAcyclicGraph<ExecutionGraphNode, DefaultEdge> config_graph;
+  
+  /**
+   * Default ctor.
+   * @param context The non-null context to pull the query from.
+   * @param sinks The non-null list of one or more sinks to report to.
+   */
+  public DefaultQueryPlanner(final QueryPipelineContext context,
+                             final List<QueryNode> sinks) {
+    this.context = context;
+    roots = Lists.newArrayList();
+    this.sinks = sinks;
+    sources = Lists.newArrayList();
+  }
+  
+  /**
+   * Does the hard work.
+   */
+  public void plan() {
+    final Map<String, ExecutionGraphNode> config_map = 
+        Maps.newHashMapWithExpectedSize(
+            context.query().getExecutionGraph().getNodes().size());
+    config_graph = 
+        new DirectedAcyclicGraph<ExecutionGraphNode, DefaultEdge>(
+            DefaultEdge.class);
+    
+    // the first step is to add the vertices to the graph and we'll stash
+    // the nodes in a map by node ID so we can link them later.
+    for (final ExecutionGraphNode node : 
+      context.query().getExecutionGraph().getNodes()) {
+      if (config_map.putIfAbsent(node.getId(), node) != null) {
+        throw new IllegalArgumentException("The node id \"" 
+            + node.getId() + "\" appeared more than once in the "
+            + "graph. It must be unique.");
+      }
+      config_graph.addVertex(node);
+    }
+    
+    // now link em with the edges.
+    for (final ExecutionGraphNode node : 
+        context.query().getExecutionGraph().getNodes()) {
+      if (node.getSources() != null) {
+        for (final String source : node.getSources()) {
+          try {
+            config_graph.addDagEdge(node, config_map.get(source));
+          } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Failed to add node: " 
+                + node, e);
+          } catch (CycleFoundException e) {
+            throw new IllegalArgumentException("A cycle was detected "
+                + "adding node: " + node, e);
+          }
+        }
+      }
+    }
+    
+    final Map<String, QueryNodeFactory> factory_cache = Maps.newHashMap();
+    
+    // next we walk and let the factories update the graph as needed.
+    // Note the clone to avoid concurrent modification of the graph.
+    DepthFirstIterator<ExecutionGraphNode, DefaultEdge> iterator = 
+        new DepthFirstIterator<ExecutionGraphNode, DefaultEdge>(
+            (Graph<ExecutionGraphNode, DefaultEdge>) config_graph.clone());
+    final List<ExecutionGraphNode> data_sources = Lists.newArrayList();
+    while (iterator.hasNext()) {
+      final ExecutionGraphNode node = iterator.next();
+      if (node.getConfig() != null && 
+          node.getConfig() instanceof QuerySourceConfig) {
+        data_sources.add(node);
+      }
+      
+      final String factory_id;
+      if (!Strings.isNullOrEmpty(node.getType())) {
+        factory_id = node.getType().toLowerCase();
+      } else {
+        factory_id = node.getId().toLowerCase();
+      }
+      final QueryNodeFactory factory = context.tsdb().getRegistry()
+          .getQueryNodeFactory(factory_id);
+      factory.setupGraph(context.query(), node, config_graph);
+      factory_cache.put(factory_id, factory);
+    }
+    
+    // next, push down by walking up from the data sources.
+    for (final ExecutionGraphNode node : data_sources) {
+      final QueryNodeFactory factory;
+      if (!Strings.isNullOrEmpty(node.getType())) {
+        factory = factory_cache.get(node.getType().toLowerCase());
+      } else {
+        factory = factory_cache.get(node.getId().toLowerCase());
+      }
+      
+      // TODO - cleanup the source factories. ugg!!!
+      if (factory == null || !(factory instanceof QueryDataSourceFactory)) {
+        throw new IllegalArgumentException("No node factory found for "
+            + "configuration " + node);
+      }
+      
+      final List<ExecutionGraphNode> push_downs = Lists.newArrayList();
+      for (final DefaultEdge edge : 
+        Sets.newHashSet(config_graph.incomingEdgesOf(node))) {
+        final ExecutionGraphNode n = config_graph.getEdgeSource(edge);
+        
+        // TODO - temp! Get named source.
+        final TimeSeriesDataStoreFactory source_factory = 
+            context.tsdb().getRegistry().getDefaultPlugin(
+                TimeSeriesDataStoreFactory.class);
+        if (source_factory == null) {
+          throw new IllegalArgumentException("Unable to find a default "
+              + "time series data store factory class!");
+        }
+        final DefaultEdge e = pushDown(node, node, source_factory, n, push_downs);
+        if (e != null) {
+          config_graph.removeEdge(e);
+          push_downs.add(n);
+        }
+        
+        if (config_graph.outgoingEdgesOf(n).isEmpty()) {
+          config_graph.removeVertex(n);
+        }
+      }
+      
+      if (!push_downs.isEmpty()) {
+        // now dump the push downs into this node.
+        final QuerySourceConfig new_config = QuerySourceConfig.newBuilder(
+            (QuerySourceConfig) node.getConfig())
+            .setPushDownNodes(push_downs)
+            .build();
+        final ExecutionGraphNode new_node = ExecutionGraphNode.newBuilder(node)
+            .setConfig(new_config)
+            .build();
+        ExecutionGraph.replace(node, new_node, config_graph);
+      }
+    }
+    
+    // now go and build the node graph
+    graph = new DirectedAcyclicGraph<QueryNode, DefaultEdge>(DefaultEdge.class);
+    final Map<String, QueryNode> nodes_map = Maps.newHashMap();
+    for (final QueryNode sink : sinks) {
+      graph.addVertex(sink);
+      nodes_map.put(sink.id(), sink);
+    }
+    
+    final List<Long> constructed = Lists.newArrayList();
+    final BreadthFirstIterator<ExecutionGraphNode, DefaultEdge> bfi = 
+        new BreadthFirstIterator<ExecutionGraphNode, DefaultEdge>(config_graph);
+    while (bfi.hasNext()) {
+      final ExecutionGraphNode node = bfi.next();
+      if (config_graph.incomingEdgesOf(node).isEmpty()) {
+        buildNodeGraph(context, node, constructed, nodes_map, factory_cache);
+      }
+    }
+    
+    // depth first initiation of the executors since we have to init
+    // the ones without any downstream dependencies first.
+    final DepthFirstIterator<QueryNode, DefaultEdge> node_iterator = 
+        new DepthFirstIterator<QueryNode, DefaultEdge>(graph);
+    final Set<TimeSeriesDataSource> source_set = Sets.newHashSet();
+    while (node_iterator.hasNext()) {
+      final QueryNode node = node_iterator.next();
+      if (sinks.contains(node)) {
+        continue;
+      }
+      
+      final Set<DefaultEdge> incoming = graph.incomingEdgesOf(node);
+      if (incoming.size() == 0 && node != this) {
+        try {
+          for (final QueryNode sink : sinks) {
+            graph.addDagEdge(sink, node);
+          }
+        } catch (CycleFoundException e) {
+          throw new IllegalArgumentException(
+              "Invalid graph configuration", e);
+        }
+        roots.add(node);
+      }
+      
+      if (node instanceof TimeSeriesDataSource) {
+        source_set.add((TimeSeriesDataSource) node);
+      }
+      
+      if (node != this) {
+        node.initialize(null /* TODO */);
+      }
+    }
+    sources.addAll(source_set);
+  }
+  
+  /**
+   * Recursive method extract 
+   * @param parent The parent of this node.
+   * @param source The data source node.
+   * @param factory The data source factory.
+   * @param node The current node.
+   * @param push_downs The non-null list of node configs that we'll 
+   * populate any time we can push down.
+   * @return An edge to link with if the previous node was pushed down.
+   */
+  private DefaultEdge pushDown(
+      final ExecutionGraphNode parent,
+      final ExecutionGraphNode source, 
+      final TimeSeriesDataStoreFactory factory, 
+      final ExecutionGraphNode node,
+      final List<ExecutionGraphNode> push_downs) {
+    if (!factory.supportsPushdown(node.getConfig().getClass())) {
+      if (!config_graph.containsEdge(node, parent)) {
+        try {
+          config_graph.addDagEdge(node, parent);
+        } catch (CycleFoundException e) {
+          throw new IllegalArgumentException(
+              "Invalid graph configuration", e);
+        }
+      }
+      return null;
+    }
+    
+    if (!node.getConfig().pushDown()) {
+      // reached a node config that doesn't allow push downs.
+      return null;
+    }
+    
+    final DefaultEdge delete_edge = config_graph.getEdge(node, source);
+    
+    // see if we can walk up for more
+    final Set<DefaultEdge> incoming = config_graph.incomingEdgesOf(node);
+    if (!incoming.isEmpty()) {
+      List<DefaultEdge> removals = Lists.newArrayList();
+      List<ExecutionGraphNode> nodes = Lists.newArrayList();
+      for (final DefaultEdge edge : incoming) {
+        final ExecutionGraphNode n = config_graph.getEdgeSource(edge);
+        nodes.add(n);
+        DefaultEdge e = pushDown(parent, node, factory, n, push_downs);
+        if (e != null) {
+          removals.add(e);
+        }
+      }
+      
+      if (!removals.isEmpty()) {
+        for (final DefaultEdge e : removals) {
+          config_graph.removeEdge(e);
+        }
+      }
+      
+      for (final ExecutionGraphNode n : nodes) {
+        if (config_graph.outgoingEdgesOf(n).isEmpty()) {
+          if (config_graph.removeVertex(n)) {
+            push_downs.add(n);
+          }
+        }
+      }
+    }
+    
+    // purge if we pushed everything down
+    if (config_graph.outgoingEdgesOf(node).isEmpty()) {
+      if (config_graph.removeVertex(node)) {
+        push_downs.add(node);
+      }
+    }
+    
+    return delete_edge;
+  }
+
+  /**
+   * Resursive helper to build and link the actual node graph.
+   * @param context The non-null context we're working with.
+   * @param node The current node config.
+   * @param constructed A cache to determine if we've already instantated
+   * and linked the node.
+   * @param nodes_map A map of instantiated nodes to use for linking.
+   * @param factory_cache The cache of factories so we don't have to keep
+   * looking them up.
+   * @return A node to link with.
+   */
+  private QueryNode buildNodeGraph(
+      final QueryPipelineContext context, 
+      final ExecutionGraphNode node, 
+      final List<Long> constructed,
+      final Map<String, QueryNode> nodes_map,
+      final Map<String, QueryNodeFactory> factory_cache) {
+    // short circuit initialized nodes.
+    if (constructed.contains(node.buildHashCode().asLong())) {
+      return nodes_map.get(node.getId());
+    }
+    
+    // walk up the graph.
+    final List<QueryNode> sources = Lists.newArrayList();
+    for (final DefaultEdge edge : config_graph.outgoingEdgesOf(node)) {
+      sources.add(buildNodeGraph(
+          context, 
+          config_graph.getEdgeTarget(edge), 
+          constructed, 
+          nodes_map, 
+          factory_cache));
+    }
+    
+    final QueryNodeFactory factory;
+    if (!Strings.isNullOrEmpty(node.getType())) {
+      factory = factory_cache.get(node.getType().toLowerCase());
+    } else {
+      factory = factory_cache.get(node.getId().toLowerCase());
+    }
+    if (factory == null) {
+      throw new IllegalArgumentException("No node factory found for "
+          + "configuration " + node);
+    }
+    
+    QueryNodeConfig node_config = node.getConfig() != null ? node.getConfig() : 
+          context.query().getExecutionGraph().nodeConfigs().get(node.getId());
+    if (node_config == null) {
+      node_config = context.query().getExecutionGraph().nodeConfigs()
+          .get(node.getType());
+    }
+    if (node_config == null) {
+      throw new IllegalArgumentException("No node config for " 
+          + node.getId() + " or " + node.getType());
+    }
+    
+    QueryNode query_node = null;
+    final List<ExecutionGraphNode> configs = Lists.newArrayList(
+        context.query().getExecutionGraph().getNodes());
+    if (!(factory instanceof SingleQueryNodeFactory)) {
+      final Collection<QueryNode> query_nodes = 
+          ((MultiQueryNodeFactory) factory).newNodes(
+              context, node.getId(), node_config, configs);
+      if (query_nodes == null || query_nodes.isEmpty()) {
+        throw new IllegalStateException("Factory returned a null or "
+            + "empty list of nodes for " + node.getId());
+      }
+      
+      QueryNode last = null;
+      for (final QueryNode n : query_nodes) {
+        if (n == null) {
+          throw new IllegalStateException("Factory returned a null "
+              + "node for " + node.getId());
+        }
+        if (query_node == null) {
+          query_node = n;
+        }
+        last = n;
+        
+        graph.addVertex(n);
+        nodes_map.put(n.id(), n);
+      }
+      
+      constructed.add(node.buildHashCode().asLong());
+      for (final QueryNode source : sources) {
+        try {
+          graph.addDagEdge(last, source);
+        } catch (CycleFoundException e) {
+          throw new IllegalArgumentException(
+              "Invalid graph configuration", e);
+        }
+      }
+    } else {
+      query_node = ((SingleQueryNodeFactory) factory)
+          .newNode(context, node.getId(), node_config);
+      if (query_node == null) {
+        throw new IllegalStateException("Factory returned a null "
+            + "instance for " + node);
+      }
+      
+      graph.addVertex(query_node);
+      nodes_map.put(query_node.id(), query_node);
+    }
+    
+    constructed.add(node.buildHashCode().asLong());
+    
+    for (final QueryNode source_node : sources) {
+      try {
+        graph.addDagEdge(query_node, source_node);
+      } catch (CycleFoundException e) {
+        throw new IllegalArgumentException(
+            "Invalid graph configuration", e);
+      }
+    }
+    
+    return query_node;
+  }
+
+  public List<QueryNode> roots() {
+    return roots;
+  }
+  
+  public DirectedAcyclicGraph<QueryNode, DefaultEdge> graph() {
+    return graph;
+  }
+  
+  public List<TimeSeriesDataSource> sources() {
+    return sources;
+  }
+}

--- a/core/src/main/java/net/opentsdb/query/plan/DefaultQueryPlanner.java
+++ b/core/src/main/java/net/opentsdb/query/plan/DefaultQueryPlanner.java
@@ -44,6 +44,7 @@ import net.opentsdb.query.QuerySourceConfig;
 import net.opentsdb.query.SingleQueryNodeFactory;
 import net.opentsdb.query.execution.graph.ExecutionGraph;
 import net.opentsdb.query.execution.graph.ExecutionGraphNode;
+import net.opentsdb.stats.Span;
 import net.opentsdb.storage.TimeSeriesDataStoreFactory;
 
 /**
@@ -91,7 +92,7 @@ public class DefaultQueryPlanner {
   /**
    * Does the hard work.
    */
-  public void plan() {
+  public void plan(final Span span) {
     final Map<String, ExecutionGraphNode> config_map = 
         Maps.newHashMapWithExpectedSize(
             context.query().getExecutionGraph().getNodes().size());
@@ -152,6 +153,10 @@ public class DefaultQueryPlanner {
       }
       final QueryNodeFactory factory = context.tsdb().getRegistry()
           .getQueryNodeFactory(factory_id);
+      if (factory == null) {
+        throw new IllegalArgumentException("No node factory found for: " 
+            + factory_id);
+      }
       factory.setupGraph(context.query(), node, config_graph);
       factory_cache.put(factory_id, factory);
     }
@@ -255,7 +260,7 @@ public class DefaultQueryPlanner {
       }
       
       if (node != this) {
-        node.initialize(null /* TODO */);
+        node.initialize(span);
       }
     }
     sources.addAll(source_set);

--- a/core/src/main/java/net/opentsdb/query/plan/DefaultQueryPlanner.java
+++ b/core/src/main/java/net/opentsdb/query/plan/DefaultQueryPlanner.java
@@ -37,7 +37,6 @@ import net.opentsdb.data.TimeSeriesDataSource;
 import net.opentsdb.query.MultiQueryNodeFactory;
 import net.opentsdb.query.QueryDataSourceFactory;
 import net.opentsdb.query.QueryNode;
-import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QuerySourceConfig;
@@ -384,13 +383,7 @@ public class DefaultQueryPlanner {
           + "configuration " + node);
     }
     
-    QueryNodeConfig node_config = node.getConfig() != null ? node.getConfig() : 
-          context.query().getExecutionGraph().nodeConfigs().get(node.getId());
-    if (node_config == null) {
-      node_config = context.query().getExecutionGraph().nodeConfigs()
-          .get(node.getType());
-    }
-    if (node_config == null) {
+    if (node.getConfig() == null) {
       throw new IllegalArgumentException("No node config for " 
           + node.getId() + " or " + node.getType());
     }
@@ -401,7 +394,7 @@ public class DefaultQueryPlanner {
     if (!(factory instanceof SingleQueryNodeFactory)) {
       final Collection<QueryNode> query_nodes = 
           ((MultiQueryNodeFactory) factory).newNodes(
-              context, node.getId(), node_config, configs);
+              context, node.getId(), node.getConfig(), configs);
       if (query_nodes == null || query_nodes.isEmpty()) {
         throw new IllegalStateException("Factory returned a null or "
             + "empty list of nodes for " + node.getId());
@@ -433,7 +426,7 @@ public class DefaultQueryPlanner {
       }
     } else {
       query_node = ((SingleQueryNodeFactory) factory)
-          .newNode(context, node.getId(), node_config);
+          .newNode(context, node.getId(), node.getConfig());
       if (query_node == null) {
         throw new IllegalStateException("Factory returned a null "
             + "instance for " + node);

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleConfig.java
@@ -239,6 +239,10 @@ public class DownsampleConfig extends BaseQueryNodeConfigWithInterpolators {
   /** @return The number of intervals in the downsampling window bounded
    * by {@link #startTime()} and {@link #endTime()}. */
   public int intervals() {
+    if (run_all) {
+      return 1;
+    }
+    
     if (cached_intervals < 0) {
       TimeStamp ts = start_time.getCopy();
       int intervals = 0;

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleFactory.java
@@ -94,17 +94,11 @@ public class DownsampleFactory extends BaseQueryNodeFactory {
       final DirectedAcyclicGraph<ExecutionGraphNode, DefaultEdge> graph) {
     // For downsampling we need to set the config start and end times
     // to the query start and end times. The config will then align them.
-    DownsampleConfig.Builder builder = null;
-    if (config.getConfig() == null) {
-      DownsampleConfig dscfg = (DownsampleConfig) 
-          query.getExecutionGraph().nodeConfigs().get(config.getId());
-      builder = DownsampleConfig.newBuilder(dscfg);
-    } else {
-      builder = DownsampleConfig.newBuilder((DownsampleConfig) config.getConfig());
-    }
-    builder.setStart(query.getStart())
-           .setEnd(query.getEnd())
-           .setId(config.getId());
+    DownsampleConfig.Builder builder = DownsampleConfig
+        .newBuilder((DownsampleConfig) config.getConfig())
+        .setStart(query.getStart())
+        .setEnd(query.getEnd())
+        .setId(config.getId());
     
     ExecutionGraphNode node = ExecutionGraphNode.newBuilder(config)
         .setConfig(builder.build())

--- a/core/src/test/java/net/opentsdb/query/plan/TestDefaultQueryPlanner.java
+++ b/core/src/test/java/net/opentsdb/query/plan/TestDefaultQueryPlanner.java
@@ -1,0 +1,821 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.plan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.traverse.DepthFirstIterator;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.google.common.collect.Lists;
+
+import net.opentsdb.core.DefaultRegistry;
+import net.opentsdb.core.MockTSDB;
+import net.opentsdb.core.TSDBPlugin;
+import net.opentsdb.data.TimeSeriesDataSource;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.QueryMode;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryNodeConfig;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.QuerySourceConfig;
+import net.opentsdb.query.SemanticQuery;
+import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
+import net.opentsdb.query.execution.graph.ExecutionGraph;
+import net.opentsdb.query.execution.graph.ExecutionGraphNode;
+import net.opentsdb.query.filter.MetricLiteralFilter;
+import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
+import net.opentsdb.query.pojo.FillPolicy;
+import net.opentsdb.query.processor.downsample.Downsample;
+import net.opentsdb.query.processor.downsample.DownsampleConfig;
+import net.opentsdb.query.processor.groupby.GroupBy;
+import net.opentsdb.query.processor.groupby.GroupByConfig;
+import net.opentsdb.storage.ReadableTimeSeriesDataStore;
+import net.opentsdb.storage.TimeSeriesDataStoreFactory;
+
+public class TestDefaultQueryPlanner {
+
+  private static MockTSDB TSDB;
+  private static TimeSeriesDataStoreFactory STORE_FACTORY;
+  private static ReadableTimeSeriesDataStore STORE;
+  private static NumericInterpolatorConfig NUMERIC_CONFIG;
+  private static QueryNode SINK;
+  
+  private QueryPipelineContext context;
+  private static List<TimeSeriesDataSource> STORE_NODES;
+  
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    TSDB = new MockTSDB();
+    STORE_FACTORY = mock(TimeSeriesDataStoreFactory.class);
+    STORE = mock(ReadableTimeSeriesDataStore.class);
+    //STORE_NODE = mock(TimeSeriesDataSource.class);
+    SINK = mock(QueryNode.class);
+    STORE_NODES = Lists.newArrayList();
+    
+    TSDB.registry = new DefaultRegistry(TSDB);
+    ((DefaultRegistry) TSDB.registry).initialize(true);
+    ((DefaultRegistry) TSDB.registry).registerPlugin(
+        TimeSeriesDataStoreFactory.class, null, (TSDBPlugin) STORE_FACTORY);
+    ((DefaultRegistry) TSDB.registry).registerReadStore(STORE, null);
+    
+    when(STORE_FACTORY.newInstance(TSDB, null)).thenReturn(STORE);
+    when(STORE.newNode(any(QueryPipelineContext.class), anyString(), 
+        any(QueryNodeConfig.class)))
+      .thenAnswer(new Answer<QueryNode>() {
+        @Override
+        public QueryNode answer(InvocationOnMock invocation) throws Throwable {
+          final TimeSeriesDataSource node = mock(TimeSeriesDataSource.class);
+          when(node.config()).thenReturn((QueryNodeConfig) invocation.getArguments()[2]);
+          STORE_NODES.add(node);
+          return node;
+        }
+      });
+    
+    NUMERIC_CONFIG = (NumericInterpolatorConfig) 
+        NumericInterpolatorConfig.newBuilder()
+        .setFillPolicy(FillPolicy.NOT_A_NUMBER)
+        .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
+        .setDataType(NumericType.TYPE.toString())
+        .build();
+  }
+  
+  @Before
+  public void before() throws Exception {
+    context = mock(QueryPipelineContext.class);
+    when(context.tsdb()).thenReturn(TSDB);
+    
+    STORE_NODES.clear();
+    when(STORE_FACTORY.supportsPushdown(any(Class.class)))
+      .thenReturn(false);
+  }
+  
+  @Test
+  public void oneMetricOneGraphNoPushdown() throws Exception {
+    ExecutionGraph graph = ExecutionGraph.newBuilder()
+        .setId("g1")
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m1")
+            .setType("DataSource")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.user")
+                    .build())
+                .setFilterId("f1")
+                .setId("m1")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("downsample")
+            .addSource("m1")
+            .setConfig(DownsampleConfig.newBuilder()
+                .setAggregator("sum")
+                .setInterval("1m")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("downsample")
+                .build())
+            .build())
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("groupby")
+            .addSource("downsample")
+            .setConfig(GroupByConfig.newBuilder()
+                .setAggregator("sum")
+                .addTagKey("host")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("gb")
+                .build()))
+        .build();
+    
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
+    
+    when(context.query()).thenReturn(query);
+    
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
+    planner.plan();
+    
+    // validate
+    assertSame(STORE_NODES.get(0), planner.sources().get(0));
+    assertEquals(4, planner.graph().vertexSet().size());
+    
+    DepthFirstIterator<QueryNode, DefaultEdge> iterator = 
+        new DepthFirstIterator<QueryNode, DefaultEdge>(planner.graph());
+    QueryNode node = iterator.next();
+    assertSame(SINK, node);
+    
+    node = iterator.next();
+    assertTrue(node instanceof GroupBy);
+    
+    node = iterator.next();
+    assertTrue(node instanceof Downsample);
+    assertEquals(1514764800, ((DownsampleConfig) node.config()).startTime().epoch());
+    assertEquals(1514768400, ((DownsampleConfig) node.config()).endTime().epoch());
+    
+    node = iterator.next();
+    assertSame(STORE_NODES.get(0), node);
+    
+    assertEquals(1, planner.roots().size());
+    assertTrue(planner.roots().get(0) instanceof GroupBy);
+  }
+  
+  @Test
+  public void oneMetricOneGraphPushdown() throws Exception {
+    when(STORE_FACTORY.supportsPushdown(DownsampleConfig.class))
+      .thenReturn(true);
+    
+    ExecutionGraph graph = ExecutionGraph.newBuilder()
+        .setId("g1")
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m1")
+            .setType("DataSource")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.user")
+                    .build())
+                .setFilterId("f1")
+                .setId("m1")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("downsample")
+            .addSource("m1")
+            .setConfig(DownsampleConfig.newBuilder()
+                .setAggregator("sum")
+                .setInterval("1m")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("downsample")
+                .build())
+            .build())
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("groupby")
+            .addSource("downsample")
+            .setConfig(GroupByConfig.newBuilder()
+                .setAggregator("sum")
+                .addTagKey("host")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("gb")
+                .build()))
+        .build();
+    
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
+    
+    when(context.query()).thenReturn(query);
+    
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
+    planner.plan();
+    
+    // validate
+    assertSame(STORE_NODES.get(0), planner.sources().get(0));
+    assertEquals(3, planner.graph().vertexSet().size());
+    
+    DepthFirstIterator<QueryNode, DefaultEdge> iterator = 
+        new DepthFirstIterator<QueryNode, DefaultEdge>(planner.graph());
+    QueryNode node = iterator.next();
+    assertSame(SINK, node);
+    
+    node = iterator.next();
+    assertTrue(node instanceof GroupBy);
+
+    node = iterator.next();
+    assertSame(STORE_NODES.get(0), node);
+    QuerySourceConfig source_config = (QuerySourceConfig) STORE_NODES.get(0).config();
+    assertEquals(1, source_config.pushDownNodes().size());
+    assertTrue(source_config.pushDownNodes().get(0).getConfig() instanceof DownsampleConfig);
+    assertEquals("downsample", source_config.pushDownNodes().get(0).getId());
+    
+    assertEquals(1, planner.roots().size());
+    assertTrue(planner.roots().get(0) instanceof GroupBy);
+  }
+  
+  @Test
+  public void oneMetricOneGraphPushdownAll() throws Exception {
+    when(STORE_FACTORY.supportsPushdown(DownsampleConfig.class))
+      .thenReturn(true);
+    
+    ExecutionGraph graph = ExecutionGraph.newBuilder()
+        .setId("g1")
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m1")
+            .setType("DataSource")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.user")
+                    .build())
+                .setFilterId("f1")
+                .setId("m1")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("downsample")
+            .addSource("m1")
+            .setConfig(DownsampleConfig.newBuilder()
+                .setAggregator("sum")
+                .setInterval("1m")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("downsample")
+                .build())
+            .build())
+        .build();
+    
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
+    
+    when(context.query()).thenReturn(query);
+    
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
+    planner.plan();
+    
+    // validate
+    assertSame(STORE_NODES.get(0), planner.sources().get(0));
+    assertEquals(2, planner.graph().vertexSet().size());
+    
+    DepthFirstIterator<QueryNode, DefaultEdge> iterator = 
+        new DepthFirstIterator<QueryNode, DefaultEdge>(planner.graph());
+    QueryNode node = iterator.next();
+    assertSame(SINK, node);
+    
+    node = iterator.next();
+    assertSame(STORE_NODES.get(0), node);
+    QuerySourceConfig source_config = (QuerySourceConfig) STORE_NODES.get(0).config();
+    assertEquals(1, source_config.pushDownNodes().size());
+    assertTrue(source_config.pushDownNodes().get(0).getConfig() instanceof DownsampleConfig);
+    assertEquals("downsample", source_config.pushDownNodes().get(0).getId());
+    
+    assertEquals(1, planner.roots().size());
+    assertTrue(planner.roots().get(0) instanceof TimeSeriesDataSource);
+  }
+
+  @Test
+  public void twoMetricsOneGraphNoPushdown() throws Exception {
+    ExecutionGraph graph = ExecutionGraph.newBuilder()
+        .setId("g1")
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m1")
+            .setType("DataSource")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.user")
+                    .build())
+                .setFilterId("f1")
+                .setId("m1")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m2")
+            .setType("DataSource")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.sys")
+                    .build())
+                .setFilterId("f1")
+                .setId("m2")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("downsample")
+            .addSource("m1")
+            .addSource("m2")
+            .setConfig(DownsampleConfig.newBuilder()
+                .setAggregator("sum")
+                .setInterval("1m")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("downsample")
+                .build())
+            .build())
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("groupby")
+            .addSource("downsample")
+            .setConfig(GroupByConfig.newBuilder()
+                .setAggregator("sum")
+                .addTagKey("host")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("gb")
+                .build()))
+        .build();
+    
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
+    
+    when(context.query()).thenReturn(query);
+
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
+    planner.plan();
+    
+    // validate
+    assertEquals(2, planner.sources().size());
+    assertTrue(planner.sources().contains(STORE_NODES.get(0)));
+    assertTrue(planner.sources().contains(STORE_NODES.get(1)));
+    assertEquals(5, planner.graph().vertexSet().size());
+    
+    DepthFirstIterator<QueryNode, DefaultEdge> iterator = 
+        new DepthFirstIterator<QueryNode, DefaultEdge>(planner.graph());
+    QueryNode node = iterator.next();
+    assertSame(SINK, node);
+    
+    node = iterator.next();
+    assertTrue(node instanceof GroupBy);
+    
+    node = iterator.next();
+    assertTrue(node instanceof Downsample);
+    assertEquals(1514764800, ((DownsampleConfig) node.config()).startTime().epoch());
+    assertEquals(1514768400, ((DownsampleConfig) node.config()).endTime().epoch());
+    
+    // TODO - watch this bit for ordering
+    node = iterator.next();
+    assertSame(STORE_NODES.get(1), node);
+    
+    node = iterator.next();
+    assertSame(STORE_NODES.get(0), node);
+    
+    assertEquals(1, planner.roots().size());
+    assertTrue(planner.roots().get(0) instanceof GroupBy);
+  }
+
+  @Test
+  public void twoMetricsOneGraphPushdownCommon() throws Exception {
+    when(STORE_FACTORY.supportsPushdown(DownsampleConfig.class))
+      .thenReturn(true);
+    
+    ExecutionGraph graph = ExecutionGraph.newBuilder()
+        .setId("g1")
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m1")
+            .setType("DataSource")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.user")
+                    .build())
+                .setFilterId("f1")
+                .setId("m1")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m2")
+            .setType("DataSource")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.sys")
+                    .build())
+                .setFilterId("f1")
+                .setId("m2")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("downsample")
+            .addSource("m1")
+            .addSource("m2")
+            .setConfig(DownsampleConfig.newBuilder()
+                .setAggregator("sum")
+                .setInterval("1m")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("downsample")
+                .build())
+            .build())
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("groupby")
+            .addSource("downsample")
+            .setConfig(GroupByConfig.newBuilder()
+                .setAggregator("sum")
+                .addTagKey("host")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("gb")
+                .build()))
+        .build();
+    
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
+    
+    when(context.query()).thenReturn(query);
+
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
+    planner.plan();
+    
+    // validate
+    assertEquals(2, planner.sources().size());
+    assertTrue(planner.sources().contains(STORE_NODES.get(0)));
+    assertTrue(planner.sources().contains(STORE_NODES.get(1)));
+    assertEquals(4, planner.graph().vertexSet().size());
+    
+    DepthFirstIterator<QueryNode, DefaultEdge> iterator = 
+        new DepthFirstIterator<QueryNode, DefaultEdge>(planner.graph());
+    QueryNode node = iterator.next();
+    assertSame(SINK, node);
+    
+    node = iterator.next();
+    assertTrue(node instanceof GroupBy);
+
+    // TODO - watch this bit for ordering
+    node = iterator.next();
+    assertSame(STORE_NODES.get(1), node);
+    QuerySourceConfig source_config = (QuerySourceConfig) STORE_NODES.get(1).config();
+    assertEquals(1, source_config.pushDownNodes().size());
+    assertTrue(source_config.pushDownNodes().get(0).getConfig() instanceof DownsampleConfig);
+    assertEquals("downsample", source_config.pushDownNodes().get(0).getId());
+    
+    node = iterator.next();
+    assertSame(STORE_NODES.get(0), node);
+    source_config = (QuerySourceConfig) STORE_NODES.get(0).config();
+    assertEquals(1, source_config.pushDownNodes().size());
+    assertTrue(source_config.pushDownNodes().get(0).getConfig() instanceof DownsampleConfig);
+    assertEquals("downsample", source_config.pushDownNodes().get(0).getId());
+    
+    assertEquals(1, planner.roots().size());
+    assertTrue(planner.roots().get(0) instanceof GroupBy);
+  }
+  
+  @Test
+  public void twoMetricsOneGraphPushdownNotCommon() throws Exception {
+    when(STORE_FACTORY.supportsPushdown(DownsampleConfig.class))
+      .thenReturn(true);
+    
+    ExecutionGraph graph = ExecutionGraph.newBuilder()
+        .setId("g1")
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m1")
+            .setType("DataSource")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.user")
+                    .build())
+                .setFilterId("f1")
+                .setId("m1")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m2")
+            .setType("DataSource")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.sys")
+                    .build())
+                .setFilterId("f1")
+                .setId("m2")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("downsample")
+            .addSource("m1")
+            .setConfig(DownsampleConfig.newBuilder()
+                .setAggregator("sum")
+                .setInterval("1m")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("downsample")
+                .build())
+            .build())
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("ds2")
+            .setType("downsample")
+            .addSource("m2")
+            .setConfig(DownsampleConfig.newBuilder()
+                .setAggregator("sum")
+                .setInterval("2m")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("downsample")
+                .build())
+            .build())
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("groupby")
+            .addSource("downsample")
+            .addSource("ds2")
+            .setConfig(GroupByConfig.newBuilder()
+                .setAggregator("sum")
+                .addTagKey("host")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("gb")
+                .build()))
+        .build();
+    
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
+    
+    when(context.query()).thenReturn(query);
+
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
+    planner.plan();
+    
+    // validate
+    assertEquals(2, planner.sources().size());
+    assertTrue(planner.sources().contains(STORE_NODES.get(0)));
+    assertTrue(planner.sources().contains(STORE_NODES.get(1)));
+    assertEquals(4, planner.graph().vertexSet().size());
+    
+    DepthFirstIterator<QueryNode, DefaultEdge> iterator = 
+        new DepthFirstIterator<QueryNode, DefaultEdge>(planner.graph());
+    QueryNode node = iterator.next();
+    assertSame(SINK, node);
+    
+    node = iterator.next();
+    assertTrue(node instanceof GroupBy);
+
+    // TODO - watch this bit for ordering
+    node = iterator.next();
+    assertSame(STORE_NODES.get(1), node);
+    QuerySourceConfig source_config = (QuerySourceConfig) STORE_NODES.get(1).config();
+    assertEquals(1, source_config.pushDownNodes().size());
+    assertTrue(source_config.pushDownNodes().get(0).getConfig() instanceof DownsampleConfig);
+    assertEquals("ds2", source_config.pushDownNodes().get(0).getId());
+    
+    node = iterator.next();
+    assertSame(STORE_NODES.get(0), node);
+    source_config = (QuerySourceConfig) STORE_NODES.get(0).config();
+    assertEquals(1, source_config.pushDownNodes().size());
+    assertTrue(source_config.pushDownNodes().get(0).getConfig() instanceof DownsampleConfig);
+    assertEquals("downsample", source_config.pushDownNodes().get(0).getId());
+    
+    assertEquals(1, planner.roots().size());
+    assertTrue(planner.roots().get(0) instanceof GroupBy);
+  }
+
+  @Test
+  public void twoMetricsOneGraphPushdownAll() throws Exception {
+    when(STORE_FACTORY.supportsPushdown(DownsampleConfig.class))
+      .thenReturn(true);
+    
+    ExecutionGraph graph = ExecutionGraph.newBuilder()
+        .setId("g1")
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m1")
+            .setType("DataSource")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.user")
+                    .build())
+                .setFilterId("f1")
+                .setId("m1")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m2")
+            .setType("DataSource")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.sys")
+                    .build())
+                .setFilterId("f1")
+                .setId("m2")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("downsample")
+            .addSource("m1")
+            .addSource("m2")
+            .setConfig(DownsampleConfig.newBuilder()
+                .setAggregator("sum")
+                .setInterval("1m")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("downsample")
+                .build())
+            .build())
+        .build();
+    
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
+    
+    when(context.query()).thenReturn(query);
+
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
+    planner.plan();
+    
+    // validate
+    assertEquals(2, planner.sources().size());
+    assertTrue(planner.sources().contains(STORE_NODES.get(0)));
+    assertTrue(planner.sources().contains(STORE_NODES.get(1)));
+    assertEquals(3, planner.graph().vertexSet().size());
+    
+    DepthFirstIterator<QueryNode, DefaultEdge> iterator = 
+        new DepthFirstIterator<QueryNode, DefaultEdge>(planner.graph());
+    QueryNode node = iterator.next();
+    assertSame(SINK, node);
+    
+    // TODO - watch this bit for ordering
+    node = iterator.next();
+    assertSame(STORE_NODES.get(1), node);
+    QuerySourceConfig source_config = (QuerySourceConfig) STORE_NODES.get(1).config();
+    assertEquals(1, source_config.pushDownNodes().size());
+    assertTrue(source_config.pushDownNodes().get(0).getConfig() instanceof DownsampleConfig);
+    assertEquals("downsample", source_config.pushDownNodes().get(0).getId());
+    
+    node = iterator.next();
+    assertSame(STORE_NODES.get(0), node);
+    source_config = (QuerySourceConfig) STORE_NODES.get(0).config();
+    assertEquals(1, source_config.pushDownNodes().size());
+    assertTrue(source_config.pushDownNodes().get(0).getConfig() instanceof DownsampleConfig);
+    assertEquals("downsample", source_config.pushDownNodes().get(0).getId());
+    
+    assertEquals(2, planner.roots().size());
+    assertTrue(planner.roots().get(0) instanceof TimeSeriesDataSource);
+    assertTrue(planner.roots().get(1) instanceof TimeSeriesDataSource);
+  }
+  
+  @Test
+  public void cycleFound() throws Exception {
+    ExecutionGraph graph = ExecutionGraph.newBuilder()
+        .setId("g1")
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m1")
+            .setType("DataSource")
+            .addSource("groupby")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.user")
+                    .build())
+                .setFilterId("f1")
+                .setId("m1")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("downsample")
+            .addSource("m1")
+            .setConfig(DownsampleConfig.newBuilder()
+                .setAggregator("sum")
+                .setInterval("1m")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("downsample")
+                .build())
+            .build())
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("groupby")
+            .addSource("downsample")
+            .setConfig(GroupByConfig.newBuilder()
+                .setAggregator("sum")
+                .addTagKey("host")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("gb")
+                .build()))
+        .build();
+    
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
+    
+    when(context.query()).thenReturn(query);
+    
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
+    try {
+      planner.plan();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    assertNull(planner.graph());
+  }
+  
+  @Test
+  public void duplicateNodeIds() throws Exception {
+    ExecutionGraph graph = ExecutionGraph.newBuilder()
+        .setId("g1")
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m1")
+            .setType("DataSource")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.user")
+                    .build())
+                .setFilterId("f1")
+                .setId("m1")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("m1")
+            .setType("DataSource")
+            .setConfig(QuerySourceConfig.newBuilder()
+                .setMetric(MetricLiteralFilter.newBuilder()
+                    .setMetric("sys.cpu.sys")
+                    .build())
+                .setFilterId("f1")
+                .setId("m1")
+                .build()))
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("downsample")
+            .addSource("m1")
+            .setConfig(DownsampleConfig.newBuilder()
+                .setAggregator("sum")
+                .setInterval("1m")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("downsample")
+                .build())
+            .build())
+        .addNode(ExecutionGraphNode.newBuilder()
+            .setId("groupby")
+            .addSource("downsample")
+            .setConfig(GroupByConfig.newBuilder()
+                .setAggregator("sum")
+                .addTagKey("host")
+                .addInterpolatorConfig(NUMERIC_CONFIG)
+                .setId("gb")
+                .build()))
+        .build();
+    
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
+    
+    when(context.query()).thenReturn(query);
+    
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
+    try {
+      planner.plan();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    assertNull(planner.graph());
+  }
+}

--- a/core/src/test/java/net/opentsdb/query/plan/TestDefaultQueryPlanner.java
+++ b/core/src/test/java/net/opentsdb/query/plan/TestDefaultQueryPlanner.java
@@ -166,7 +166,7 @@ public class TestDefaultQueryPlanner {
     
     DefaultQueryPlanner planner = 
         new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
-    planner.plan();
+    planner.plan(null);
     
     // validate
     assertSame(STORE_NODES.get(0), planner.sources().get(0));
@@ -241,7 +241,7 @@ public class TestDefaultQueryPlanner {
     
     DefaultQueryPlanner planner = 
         new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
-    planner.plan();
+    planner.plan(null);
     
     // validate
     assertSame(STORE_NODES.get(0), planner.sources().get(0));
@@ -306,7 +306,7 @@ public class TestDefaultQueryPlanner {
     
     DefaultQueryPlanner planner = 
         new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
-    planner.plan();
+    planner.plan(null);
     
     // validate
     assertSame(STORE_NODES.get(0), planner.sources().get(0));
@@ -385,7 +385,7 @@ public class TestDefaultQueryPlanner {
 
     DefaultQueryPlanner planner = 
         new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
-    planner.plan();
+    planner.plan(null);
     
     // validate
     assertEquals(2, planner.sources().size());
@@ -477,7 +477,7 @@ public class TestDefaultQueryPlanner {
 
     DefaultQueryPlanner planner = 
         new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
-    planner.plan();
+    planner.plan(null);
     
     // validate
     assertEquals(2, planner.sources().size());
@@ -583,7 +583,7 @@ public class TestDefaultQueryPlanner {
 
     DefaultQueryPlanner planner = 
         new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
-    planner.plan();
+    planner.plan(null);
     
     // validate
     assertEquals(2, planner.sources().size());
@@ -669,7 +669,7 @@ public class TestDefaultQueryPlanner {
 
     DefaultQueryPlanner planner = 
         new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
-    planner.plan();
+    planner.plan(null);
     
     // validate
     assertEquals(2, planner.sources().size());
@@ -750,7 +750,7 @@ public class TestDefaultQueryPlanner {
     DefaultQueryPlanner planner = 
         new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
     try {
-      planner.plan();
+      planner.plan(null);
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
     assertNull(planner.graph());
@@ -813,7 +813,7 @@ public class TestDefaultQueryPlanner {
     DefaultQueryPlanner planner = 
         new DefaultQueryPlanner(context, Lists.newArrayList(SINK));
     try {
-      planner.plan();
+      planner.plan(null);
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
     assertNull(planner.graph());

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleConfig.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleConfig.java
@@ -178,5 +178,17 @@ public class TestDownsampleConfig {
         .addInterpolatorConfig(summary_config)
         .build();
     assertEquals(240, config.intervals());
+    
+    config = (DownsampleConfig) DownsampleConfig.newBuilder()
+        .setAggregator("sum")
+        .setId("foo")
+        .setInterval("0s")
+        .setRunAll(true)
+        .setStart("1514843302")
+        .setEnd("1514846902")
+        .addInterpolatorConfig(numeric_config)
+        .addInterpolatorConfig(summary_config)
+        .build();
+    assertEquals(1, config.intervals());
   }
 }


### PR DESCRIPTION
- Start a new DefaultQueryPlanner class that will parse out the ExecutionGraph
  and handle push-down operations to the data source. This will replace the
  old planners and the abstract context planner.