### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
+++ b/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
@@ -563,10 +563,11 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
               + "specification in query result: " + next);
         }
         
-        if (!time_specification.equals(next.timeSpecification())) {
-          throw new IllegalStateException("Received a different time "
-              + "specification in query result: " + next);
-        }
+        // TODO - fix equivalence
+//        if (!time_specification.equals(next.timeSpecification())) {
+//          throw new IllegalStateException("Received a different time "
+//              + "specification in query result: " + next);
+//        }
       }
       if (next.sequenceId() > sequence_id) {
         sequence_id = next.sequenceId();

--- a/core/src/main/java/net/opentsdb/query/joins/JoinConfig.java
+++ b/core/src/main/java/net/opentsdb/query/joins/JoinConfig.java
@@ -124,7 +124,7 @@ public class JoinConfig extends BaseQueryNodeConfig {
   @Override
   public HashCode buildHashCode() {
     final Hasher hasher = Const.HASH_FUNCTION().newHasher()
-        .putString(id, Const.UTF8_CHARSET)
+        .putString(id == null ? "null" : id, Const.UTF8_CHARSET)
         .putString(type.toString(), Const.ASCII_CHARSET)
         .putBoolean(explicit_tags);
     final Map<String, String> sorted = new TreeMap<String, String>(joins);

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNode.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNode.java
@@ -77,23 +77,18 @@ public class BinaryExpressionNode extends AbstractQueryNode {
    * @param factory The factory we came from.
    * @param context The non-null context.
    * @param id The ID of this node.
-   * @param config The non-null overall expression config.
    * @param expression_config The non-null sub-expression config.
    */
   public BinaryExpressionNode(final QueryNodeFactory factory,
                               final QueryPipelineContext context, 
-                              final String id, 
-                              final ExpressionConfig config, 
+                              final String id,
                               final ExpressionParseNode expression_config) {
     super(factory, context, id);
-    if (config == null) {
-      throw new IllegalArgumentException("Config cannot be null.");
-    }
     if (expression_config == null) {
       throw new IllegalArgumentException("Expression config cannot be null.");
     }
-    this.config = config;
     this.expression_config = expression_config;
+    config = expression_config.expressionConfig();
     result = new ExpressionResult(this);
     need_two_sources = 
         (expression_config.leftType() == OperandType.SUB_EXP || 

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNodeFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNodeFactory.java
@@ -1,0 +1,140 @@
+//This file is part of OpenTSDB.
+//Copyright (C) 2018  The OpenTSDB Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+package net.opentsdb.query.processor.expressions;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.jgrapht.experimental.dag.DirectedAcyclicGraph;
+import org.jgrapht.graph.DefaultEdge;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.types.numeric.NumericSummaryType;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.QueryIteratorFactory;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryNodeConfig;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.TimeSeriesQuery;
+import net.opentsdb.query.execution.graph.ExecutionGraphNode;
+import net.opentsdb.query.processor.BaseQueryNodeFactory;
+
+/**
+ * Returns a node and iterators for a binary expression (usually created
+ * from an ExpressionConfig and factory).
+ * 
+ * @since 3.0
+ */
+public class BinaryExpressionNodeFactory extends BaseQueryNodeFactory {
+
+  /**
+   * Required empty ctor.
+   */
+  public BinaryExpressionNodeFactory() {
+    super("binaryexpression");
+    registerIteratorFactory(NumericType.TYPE, new NumericIteratorFactory());
+    registerIteratorFactory(NumericSummaryType.TYPE, 
+        new NumericSummaryIteratorFactory());
+  }
+
+  @Override
+  public QueryNode newNode(final QueryPipelineContext context, 
+                           final String id) {
+    throw new UnsupportedOperationException("Default configs are not "
+        + "allowed for Binary Expressions.");
+  }
+
+  @Override
+  public QueryNode newNode(final QueryPipelineContext context, 
+                           final String id,
+                           final QueryNodeConfig config) {
+    return new BinaryExpressionNode(this, context, id, (ExpressionParseNode) config);
+  }
+
+  @Override
+  public QueryNodeConfig parseConfig(ObjectMapper mapper, TSDB tsdb,
+      JsonNode node) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public void setupGraph(
+      final TimeSeriesQuery query, 
+      final ExecutionGraphNode config,
+      final DirectedAcyclicGraph<ExecutionGraphNode, DefaultEdge> graph) {
+    // nothing to do here.
+  }
+
+  /**
+   * The default numeric iterator factory.
+   */
+  protected class NumericIteratorFactory implements QueryIteratorFactory {
+
+    @Override
+    public Iterator<TimeSeriesValue<?>> newIterator(final QueryNode node,
+                                                    final QueryResult result,
+                                                    final Collection<TimeSeries> sources) {
+      throw new UnsupportedOperationException("Expression iterators must have a map.");
+    }
+
+    @Override
+    public Iterator<TimeSeriesValue<?>> newIterator(final QueryNode node,
+                                                    final QueryResult result,
+                                                    final Map<String, TimeSeries> sources) {
+      return new ExpressionNumericIterator(node, result, sources);
+    }
+
+    @Override
+    public Collection<TypeToken<?>> types() {
+      return Lists.newArrayList(NumericType.TYPE);
+    }
+        
+  }
+
+  /**
+   * Handles summaries.
+   */
+  protected class NumericSummaryIteratorFactory implements QueryIteratorFactory {
+
+    @Override
+    public Iterator<TimeSeriesValue<?>> newIterator(final QueryNode node,
+                                                    final QueryResult result,
+                                                    final Collection<TimeSeries> sources) {
+      throw new UnsupportedOperationException("Expression iterators must have a map.");
+    }
+
+    @Override
+    public Iterator<TimeSeriesValue<?>> newIterator(final QueryNode node,
+                                                    final QueryResult result,
+                                                    final Map<String, TimeSeries> sources) {
+      return new ExpressionNumericSummaryIterator(node, result, sources);
+    }
+    
+    @Override
+    public Collection<TypeToken<?>> types() {
+      return Lists.newArrayList(NumericSummaryType.TYPE);
+    }
+  }
+}

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParseNode.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParseNode.java
@@ -17,6 +17,7 @@ package net.opentsdb.query.processor.expressions;
 import com.google.common.base.Strings;
 import com.google.common.hash.HashCode;
 
+import net.opentsdb.common.Const;
 import net.opentsdb.query.BaseQueryNodeConfig;
 import net.opentsdb.query.QueryNodeConfig;
 
@@ -120,12 +121,18 @@ public class ExpressionParseNode extends BaseQueryNodeConfig {
   /** Whether or not we're "not"ting the output. */
   private boolean not;
   
+  /** A link to the original expression config. */
+  private final ExpressionConfig expression_config;
+  
   /**
    * Protected ctor.
    * @param builder The non-null builder.
    */
   protected ExpressionParseNode(final Builder builder) {
     super(builder);
+    if (builder.expression_config == null) {
+      throw new IllegalArgumentException("Missing parent expression config.");
+    }
     this.id = super.getId();
     left = builder.left;
     left_type = builder.left_type;
@@ -135,6 +142,7 @@ public class ExpressionParseNode extends BaseQueryNodeConfig {
     negate = builder.negate;
     not = builder.not;
     as = id;
+    expression_config = builder.expression_config;
   }
   
   /** @return The name to use for the metric. Defaults to the ID. */
@@ -197,6 +205,11 @@ public class ExpressionParseNode extends BaseQueryNodeConfig {
     right = id;
   }
   
+  /** @return The original expressionConfig. */
+  public ExpressionConfig expressionConfig() {
+    return expression_config;
+  }
+  
   @Override
   public boolean pushDown() {
     // TODO Auto-generated method stub
@@ -206,7 +219,9 @@ public class ExpressionParseNode extends BaseQueryNodeConfig {
   @Override
   public HashCode buildHashCode() {
     // TODO Auto-generated method stub
-    return null;
+    return Const.HASH_FUNCTION().newHasher()
+        .putString(id, Const.UTF8_CHARSET)
+        .hash();
   }
 
   @Override
@@ -224,7 +239,7 @@ public class ExpressionParseNode extends BaseQueryNodeConfig {
   @Override
   public int hashCode() {
     // TODO Auto-generated method stub
-    return 0;
+    return buildHashCode().asInt();
   }
   
   public String toString() {
@@ -282,6 +297,7 @@ public class ExpressionParseNode extends BaseQueryNodeConfig {
     private ExpressionOp op;
     private boolean negate;
     private boolean not;
+    private ExpressionConfig expression_config;
     
     public Builder setLeft(final Object left) {
       this.left = left;
@@ -315,6 +331,11 @@ public class ExpressionParseNode extends BaseQueryNodeConfig {
     
     public Builder setNot(final boolean not) {
       this.not = not;
+      return this;
+    }
+    
+    public Builder setExpressionConfig(final ExpressionConfig expression_config) {
+      this.expression_config = expression_config;
       return this;
     }
     

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParser.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParser.java
@@ -326,6 +326,7 @@ public class ExpressionParser extends DefaultErrorStrategy
     // here we can cleanup, e.g. merge numerics
     final ExpressionParseNode.Builder builder = ExpressionParseNode
         .newBuilder()
+        .setExpressionConfig(config)
         .setExpressionOp(op);
     setBranch(builder, left, true);
     setBranch(builder, right, false);

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionTimeSeries.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionTimeSeries.java
@@ -117,7 +117,7 @@ public class ExpressionTimeSeries implements TimeSeries {
     }
     
     final Iterator<TimeSeriesValue<? extends TimeSeriesDataType>> iterator = 
-        ((BaseMultiQueryNodeFactory) node.factory()).newTypedIterator(type, node, result,
+        ((BinaryExpressionNodeFactory) node.factory()).newTypedIterator(type, node, result,
             (Map<String, TimeSeries>) builder.build());
     if (iterator == null) {
       return Optional.empty();  
@@ -139,7 +139,7 @@ public class ExpressionTimeSeries implements TimeSeries {
     final List<TypedIterator<TimeSeriesValue<? extends TimeSeriesDataType>>> iterators =
         Lists.newArrayListWithExpectedSize(types.size());
     for (final TypeToken<?> type : types) {
-      iterators.add(((BaseMultiQueryNodeFactory) node.factory()).newTypedIterator(
+      iterators.add(((BinaryExpressionNodeFactory) node.factory()).newTypedIterator(
           type, node, result, sources));
     }
     return iterators;

--- a/core/src/test/java/net/opentsdb/query/plan/TestDefaultQueryPlanner.java
+++ b/core/src/test/java/net/opentsdb/query/plan/TestDefaultQueryPlanner.java
@@ -55,9 +55,12 @@ import net.opentsdb.query.execution.graph.ExecutionGraph;
 import net.opentsdb.query.execution.graph.ExecutionGraphNode;
 import net.opentsdb.query.filter.MetricLiteralFilter;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
+import net.opentsdb.query.joins.JoinConfig.JoinType;
+import net.opentsdb.query.joins.JoinConfig;
 import net.opentsdb.query.pojo.FillPolicy;
 import net.opentsdb.query.processor.downsample.Downsample;
 import net.opentsdb.query.processor.downsample.DownsampleConfig;
+import net.opentsdb.query.processor.expressions.ExpressionConfig;
 import net.opentsdb.query.processor.groupby.GroupBy;
 import net.opentsdb.query.processor.groupby.GroupByConfig;
 import net.opentsdb.storage.ReadableTimeSeriesDataStore;
@@ -818,4 +821,5 @@ public class TestDefaultQueryPlanner {
     } catch (IllegalArgumentException e) { }
     assertNull(planner.graph());
   }
+  
 }

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/BaseNumericSummaryTest.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/BaseNumericSummaryTest.java
@@ -127,6 +127,7 @@ public class BaseNumericSummaryTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     
     when(node.pipelineContext()).thenReturn(CONTEXT);

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/BaseNumericTest.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/BaseNumericTest.java
@@ -108,6 +108,7 @@ public class BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     
     when(node.pipelineContext()).thenReturn(CONTEXT);

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestBaseExpressionNumericIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestBaseExpressionNumericIterator.java
@@ -75,6 +75,7 @@ public class TestBaseExpressionNumericIterator extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -96,6 +97,7 @@ public class TestBaseExpressionNumericIterator extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -117,6 +119,7 @@ public class TestBaseExpressionNumericIterator extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = 

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
@@ -106,13 +106,14 @@ public class TestBinaryExpressionNode {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
   }
   
   @Test
   public void ctor() throws Exception {
     BinaryExpressionNode node = new BinaryExpressionNode(
-        factory, context, "a+b", config, expression_config);
+        factory, context, "a+b", expression_config);
     assertSame(config, node.config);
     assertSame(expression_config, node.expressionConfig());
     assertTrue(node.need_two_sources);
@@ -126,9 +127,10 @@ public class TestBinaryExpressionNode {
         .setRight("SubExp#1")
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     node = new BinaryExpressionNode(
-        factory, context, "a+b", config, expression_config);
+        factory, context, "a+b", expression_config);
     assertSame(config, node.config);
     assertSame(expression_config, node.expressionConfig());
     assertTrue(node.need_two_sources);
@@ -142,9 +144,10 @@ public class TestBinaryExpressionNode {
         .setRight("42#1")
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     node = new BinaryExpressionNode(
-        factory, context, "a+b", config, expression_config);
+        factory, context, "a+b", expression_config);
     assertSame(config, node.config);
     assertSame(expression_config, node.expressionConfig());
     assertFalse(node.need_two_sources);
@@ -153,19 +156,13 @@ public class TestBinaryExpressionNode {
     
     try {
       new BinaryExpressionNode(
-          factory, null, "a+b", config, expression_config);
+          factory, null, "a+b", expression_config);
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
     
     try {
       new BinaryExpressionNode(
-          factory, context, "a+b", null, expression_config);
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
-    
-    try {
-      new BinaryExpressionNode(
-          factory, context, "a+b", config, null);
+          factory, context, "a+b", null);
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
   }
@@ -173,7 +170,7 @@ public class TestBinaryExpressionNode {
   @Test
   public void onComplete() throws Exception {
     BinaryExpressionNode node = new BinaryExpressionNode(
-        factory, context, "a+b", config, expression_config);
+        factory, context, "a+b", expression_config);
     node.initialize(null);
     
     node.onComplete(mock(QueryNode.class), 42, 42);
@@ -188,7 +185,7 @@ public class TestBinaryExpressionNode {
   @Test
   public void onError() throws Exception {
     BinaryExpressionNode node = new BinaryExpressionNode(
-        factory, context, "a+b", config, expression_config);
+        factory, context, "a+b", expression_config);
     node.initialize(null);
     
     final UnitTestException ex = new UnitTestException();
@@ -205,7 +202,7 @@ public class TestBinaryExpressionNode {
   @Test
   public void onNextStringDouble() throws Exception {
     BinaryExpressionNode node = new BinaryExpressionNode(
-        factory, context, "a+b", config, expression_config);
+        factory, context, "a+b", expression_config);
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
@@ -228,10 +225,11 @@ public class TestBinaryExpressionNode {
         .setRight("42")
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     
     BinaryExpressionNode node = new BinaryExpressionNode(
-        factory, context, "a+b", config, expression_config);
+        factory, context, "a+b", expression_config);
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
@@ -244,7 +242,7 @@ public class TestBinaryExpressionNode {
   @Test
   public void onNextByteDouble() throws Exception {
     BinaryExpressionNode node = new BinaryExpressionNode(
-        factory, context, "a+b", config, expression_config);
+        factory, context, "a+b", expression_config);
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
@@ -329,10 +327,11 @@ public class TestBinaryExpressionNode {
         .setRight("sub")
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     
     BinaryExpressionNode node = new BinaryExpressionNode(
-        factory, context, "a+sub", config, expression_config);
+        factory, context, "a+sub", expression_config);
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
@@ -417,10 +416,11 @@ public class TestBinaryExpressionNode {
         .setRight("sub2")
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     
     BinaryExpressionNode node = new BinaryExpressionNode(
-        factory, context, "a+sub", config, expression_config);
+        factory, context, "a+sub", expression_config);
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
@@ -490,10 +490,11 @@ public class TestBinaryExpressionNode {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     
     BinaryExpressionNode node = new BinaryExpressionNode(
-        factory, context, "a+b", config, expression_config);
+        factory, context, "a+b", expression_config);
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
@@ -567,10 +568,11 @@ public class TestBinaryExpressionNode {
         .setRight("42")
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     
     BinaryExpressionNode node = new BinaryExpressionNode(
-        factory, context, "a+b", config, expression_config);
+        factory, context, "a+b", expression_config);
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
@@ -639,7 +641,7 @@ public class TestBinaryExpressionNode {
   @Test
   public void onNextByteMetricException() throws Exception {
     BinaryExpressionNode node = new BinaryExpressionNode(
-        factory, context, "a+b", config, expression_config);
+        factory, context, "a+b", expression_config);
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
@@ -704,7 +706,7 @@ public class TestBinaryExpressionNode {
   @Test
   public void onNextByteTagException() throws Exception {
     BinaryExpressionNode node = new BinaryExpressionNode(
-        factory, context, "a+b", config, expression_config);
+        factory, context, "a+b", expression_config);
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
@@ -779,7 +781,7 @@ public class TestBinaryExpressionNode {
   @Test
   public void onNextByteNullTag() throws Exception {
     BinaryExpressionNode node = new BinaryExpressionNode(
-        factory, context, "a+b", config, expression_config);
+        factory, context, "a+b", expression_config);
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorAdditive.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorAdditive.java
@@ -87,6 +87,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -130,6 +131,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .setNegate(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -162,6 +164,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .setNegate(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -228,6 +231,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -271,6 +275,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .setNegate(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -303,6 +308,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .setNegate(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -369,6 +375,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -434,6 +441,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -500,6 +508,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -581,6 +590,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -622,6 +632,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -651,6 +662,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -691,6 +703,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -720,6 +733,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -756,6 +770,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -786,6 +801,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -822,6 +838,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -851,6 +868,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -887,6 +905,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -924,6 +943,7 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorDivide.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorDivide.java
@@ -54,6 +54,7 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
   }
@@ -114,6 +115,7 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(CONFIG)
         .setNegate(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -196,6 +198,7 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(CONFIG)
         .setNegate(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -400,6 +403,7 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -441,6 +445,7 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -519,6 +524,7 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -548,6 +554,7 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -583,6 +590,7 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -612,6 +620,7 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
         .setRight(false)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -647,6 +656,7 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -684,6 +694,7 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorLogical.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorLogical.java
@@ -53,6 +53,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
   }
@@ -99,6 +100,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -142,6 +144,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -174,6 +177,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -240,6 +244,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -283,6 +288,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -315,6 +321,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -381,6 +388,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -446,6 +454,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -512,6 +521,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -593,6 +603,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -634,6 +645,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -664,6 +676,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -704,6 +717,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -733,6 +747,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -768,6 +783,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -797,6 +813,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -824,6 +841,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -851,6 +869,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -886,6 +905,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -915,6 +935,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -942,6 +963,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight(false)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -969,6 +991,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight(false)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -1004,6 +1027,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -1033,6 +1057,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -1068,6 +1093,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -1097,6 +1123,7 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorMod.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorMod.java
@@ -54,6 +54,7 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
   }
@@ -114,6 +115,7 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(CONFIG)
         .setNegate(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -196,6 +198,7 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(CONFIG)
         .setNegate(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -400,6 +403,7 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -441,6 +445,7 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -478,6 +483,7 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -507,6 +513,7 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -542,6 +549,7 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -571,6 +579,7 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
         .setRight(false)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -606,6 +615,7 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -643,6 +653,7 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorMultiply.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorMultiply.java
@@ -54,6 +54,7 @@ public class TestExpressionNumericIteratorMultiply extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MULTIPLY)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
   }
@@ -114,6 +115,7 @@ public class TestExpressionNumericIteratorMultiply extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MULTIPLY)
+        .setExpressionConfig(CONFIG)
         .setNegate(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -196,6 +198,7 @@ public class TestExpressionNumericIteratorMultiply extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MULTIPLY)
+        .setExpressionConfig(CONFIG)
         .setNegate(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -400,6 +403,7 @@ public class TestExpressionNumericIteratorMultiply extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MULTIPLY)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -441,6 +445,7 @@ public class TestExpressionNumericIteratorMultiply extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.MULTIPLY)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -478,6 +483,7 @@ public class TestExpressionNumericIteratorMultiply extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MULTIPLY)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -507,6 +513,7 @@ public class TestExpressionNumericIteratorMultiply extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MULTIPLY)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -542,6 +549,7 @@ public class TestExpressionNumericIteratorMultiply extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.MULTIPLY)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -571,6 +579,7 @@ public class TestExpressionNumericIteratorMultiply extends BaseNumericTest {
         .setRight(false)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.MULTIPLY)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -606,6 +615,7 @@ public class TestExpressionNumericIteratorMultiply extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.MULTIPLY)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -643,6 +653,7 @@ public class TestExpressionNumericIteratorMultiply extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.MULTIPLY)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorRelational.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorRelational.java
@@ -54,6 +54,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
   }
@@ -101,6 +102,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -124,6 +126,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -147,6 +150,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -170,6 +174,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -193,6 +198,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -230,6 +236,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -263,6 +270,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -287,6 +295,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -311,6 +320,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -335,6 +345,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -359,6 +370,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -420,6 +432,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -443,6 +456,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -466,6 +480,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -489,6 +504,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -512,6 +528,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -549,6 +566,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -582,6 +600,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -606,6 +625,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -630,6 +650,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -654,6 +675,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -678,6 +700,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .setNot(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -738,6 +761,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -761,6 +785,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -784,6 +809,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -807,6 +833,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -830,6 +857,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -889,6 +917,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -912,6 +941,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -935,6 +965,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -958,6 +989,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -981,6 +1013,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1041,6 +1074,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1065,6 +1099,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1089,6 +1124,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1113,6 +1149,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1137,6 +1174,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1212,6 +1250,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1235,6 +1274,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1258,6 +1298,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1281,6 +1322,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1304,6 +1346,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1339,6 +1382,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -1368,6 +1412,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1390,6 +1435,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1412,6 +1458,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1434,6 +1481,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1456,6 +1504,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1490,6 +1539,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -1519,6 +1569,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1541,6 +1592,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1563,6 +1615,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1585,6 +1638,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1607,6 +1661,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1637,6 +1692,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -1666,6 +1722,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1688,6 +1745,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1710,6 +1768,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1732,6 +1791,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1754,6 +1814,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1776,6 +1837,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -1803,6 +1865,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1825,6 +1888,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1847,6 +1911,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1869,6 +1934,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1891,6 +1957,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1921,6 +1988,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -1950,6 +2018,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1972,6 +2041,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -1994,6 +2064,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -2016,6 +2087,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -2038,6 +2110,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -2060,6 +2133,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(false)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -2087,6 +2161,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -2109,6 +2184,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -2131,6 +2207,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -2153,6 +2230,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -2175,6 +2253,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     iterator = new ExpressionNumericIterator(node, RESULT, 
@@ -2205,6 +2284,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -2242,6 +2322,7 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericSummaryIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericSummaryIterator.java
@@ -95,6 +95,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -142,6 +143,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -179,6 +181,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .setNegate(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -214,6 +217,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .setNegate(true)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
@@ -277,6 +281,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -340,6 +345,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -418,6 +424,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -458,6 +465,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -490,6 +498,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -530,6 +539,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -562,6 +572,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight(literal)
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -598,6 +609,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -631,6 +643,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -667,6 +680,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -699,6 +713,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight(true)
         .setRightType(OperandType.LITERAL_BOOL)
         .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -735,6 +750,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -769,6 +785,7 @@ public class TestExpressionNumericSummaryIterator
         .setRight(null)
         .setRightType(OperandType.NULL)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(CONFIG)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionParseNode.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionParseNode.java
@@ -17,6 +17,7 @@ package net.opentsdb.query.processor.expressions;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 
@@ -95,6 +96,7 @@ public class TestExpressionParseNode {
         .setRight("42")
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(mock(ExpressionConfig.class))
         .build();
     assertEquals("a", node.left());
     assertEquals(OperandType.VARIABLE, node.leftType());

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionResult.java
@@ -86,6 +86,7 @@ public class TestExpressionResult {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     
     when(node.config()).thenReturn(config);
@@ -124,6 +125,7 @@ public class TestExpressionResult {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -143,6 +145,7 @@ public class TestExpressionResult {
         .setRight("sub1")
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -162,6 +165,7 @@ public class TestExpressionResult {
         .setRight("sub2")
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -181,6 +185,7 @@ public class TestExpressionResult {
         .setRight("42")
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -200,6 +205,7 @@ public class TestExpressionResult {
         .setRight("42")
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -219,6 +225,7 @@ public class TestExpressionResult {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -238,6 +245,7 @@ public class TestExpressionResult {
         .setRight("sub2")
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -279,6 +287,7 @@ public class TestExpressionResult {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -298,6 +307,7 @@ public class TestExpressionResult {
         .setRight("sub1")
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -317,6 +327,7 @@ public class TestExpressionResult {
         .setRight("sub2")
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -336,6 +347,7 @@ public class TestExpressionResult {
         .setRight("42")
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -355,6 +367,7 @@ public class TestExpressionResult {
         .setRight("42")
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -374,6 +387,7 @@ public class TestExpressionResult {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     
@@ -393,6 +407,7 @@ public class TestExpressionResult {
         .setRight("sub2")
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(config)
         .build();
     when(node.expressionConfig()).thenReturn(expression_config);
     

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionTimeSeries.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionTimeSeries.java
@@ -61,7 +61,7 @@ public class TestExpressionTimeSeries {
   private TimeSeriesId left_id;
   private TimeSeriesId right_id;
   private TimeSeriesId joined_id;
-  private ExpressionFactory factory;
+  private BinaryExpressionNodeFactory factory;
   
   @Before
   public void before() throws Exception {
@@ -70,7 +70,7 @@ public class TestExpressionTimeSeries {
     joiner = mock(Joiner.class);
     left = mock(TimeSeries.class);
     right = mock(TimeSeries.class);
-    factory = mock(ExpressionFactory.class);
+    factory = mock(BinaryExpressionNodeFactory.class);
     
     when(node.id()).thenReturn("e1");
     when(node.joiner()).thenReturn(joiner);


### PR DESCRIPTION
- Disable time spec equivalence testing for now in the
  AbstractQueryPipelineContext.
- Fix the DefaultQueryPlanner to try looking up factories one more time.
- Add the BinaryExpressionNodeFactory that now generates the actual nodes.
- Tweak ExpressionFactory so that it now simply mutates the graph when
  setupGraph is called. It will now populate the graph with the
  ExecutionParseNode configs. Then the BinaryExpressionNodeFactory will
  populate the node graph.
- Add raw parsing for JSON to the ExpressionConfig make the parse node
  config take a reference to the original config.