### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/core/PluginsConfig.java
+++ b/core/src/main/java/net/opentsdb/core/PluginsConfig.java
@@ -110,6 +110,7 @@ public class PluginsConfig extends Validatable {
     DEFAULT_TYPES.add("net.opentsdb.query.filter.QueryFilterFactory");
     DEFAULT_TYPES.add("net.opentsdb.stats.StatsCollector");
     DEFAULT_TYPES.add("net.opentsdb.query.interpolation.QueryInterpolatorFactory");
+    DEFAULT_TYPES.add("net.opentsdb.data.types.numeric.aggregators.NumericArrayAggregatorFactory");
     DEFAULT_TYPES.add("net.opentsdb.storage.DatumIdValidator");
     DEFAULT_TYPES.add("net.opentsdb.uid.UniqueIdFactory");
     DEFAULT_TYPES.add("net.opentsdb.query.serdes.SerdesFactory");

--- a/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByResult.java
@@ -109,7 +109,7 @@ public class GroupByResult implements QueryResult {
         final long hash = LongHashFunction.xx_r39().hashChars(buf.toString());
         GroupByTimeSeries group = (GroupByTimeSeries) groups.get(hash);
         if (group == null) {
-          group = new GroupByTimeSeries(node, next);
+          group = new GroupByTimeSeries(node, this);
           groups.put(hash, group);
         }
         group.addSource(series);
@@ -151,7 +151,7 @@ public class GroupByResult implements QueryResult {
           final long hash = LongHashFunction.xx_r39().hashBytes(buf.toByteArray());
           GroupByTimeSeries group = (GroupByTimeSeries) groups.get(hash);
           if (group == null) {
-            group = new GroupByTimeSeries(node, next);
+            group = new GroupByTimeSeries(node, this);
             groups.put(hash, group);
           }
           group.addSource(series);


### PR DESCRIPTION
- Load the array aggregators by default.
- Pass a reference to the GroupByResult to it's series instead of the source
  array.