### PR TITLE
ISSUE-1344 Fix NPE on null datapoint in set

### DIFF
--- a/src/tsd/PutDataPointRpc.java
+++ b/src/tsd/PutDataPointRpc.java
@@ -170,6 +170,14 @@ final class PutDataPointRpc implements TelnetRpc, HttpRpc {
       }
       
       try {
+        if (dp == null) {
+          if (show_details) {
+            details.add(this.getHttpDetails("Unexpected null datapoint encountered in set.", dp));
+          }
+          LOG.warn("Datapoint null was encountered in set.");
+          illegal_arguments.incrementAndGet();
+          continue;
+        }
         if (dp.getMetric() == null || dp.getMetric().isEmpty()) {
           if (show_details) {
             details.add(this.getHttpDetails("Metric name was empty", dp));


### PR DESCRIPTION
When receiving a set of datapoints, if one of them is null OpenTSDB gives null pointer exception and instead of returning code 400 (bad data) it returns 500 which would make a client resend the bad data.