### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV2ExpQuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV2ExpQuerySerdes.java
@@ -110,9 +110,10 @@ public class JsonV2ExpQuerySerdes implements TimeSeriesSerdes {
     }
   }
   
+  // TODO - better way to avoid sync I hope.
   @Override
-  public Deferred<Object> serialize(final QueryResult result, 
-                                    final Span span) {
+  public synchronized Deferred<Object> serialize(final QueryResult result, 
+                                                 final Span span) {
     if (result == null) {
       throw new IllegalArgumentException("Data may not be null.");
     }
@@ -378,8 +379,7 @@ public class JsonV2ExpQuerySerdes implements TimeSeriesSerdes {
       throw new QueryExecutionException("Failed to resolve IDs", 500, e);
     }
   }
-
-
+  
   @Override
   public void serializeComplete(final Span span) {
     try {

--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV2QuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV2QuerySerdes.java
@@ -108,7 +108,6 @@ public class JsonV2QuerySerdes implements TimeSeriesSerdes {
   @Override
   public Deferred<Object> serialize(final QueryResult result,
                                     final Span span) {
-    System.out.println("WOWOWOWOWOTOTOTOTOTOTO");
     synchronized(this) {
       if (result == null) {
         throw new IllegalArgumentException("Data may not be null.");

--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
@@ -92,9 +92,10 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes {
     }
   }
   
+  // TODO - find a better way to not sync
   @Override
-  public Deferred<Object> serialize(final QueryResult result, 
-                                    final Span span) {
+  public synchronized Deferred<Object> serialize(final QueryResult result, 
+                                                 final Span span) {
     if (result == null) {
       throw new IllegalArgumentException("Data may not be null.");
     }

--- a/core/src/main/java/net/opentsdb/storage/MockDataStore.java
+++ b/core/src/main/java/net/opentsdb/storage/MockDataStore.java
@@ -100,7 +100,7 @@ public class MockDataStore implements ReadableTimeSeriesDataStore, WritableTimeS
   private Map<TimeSeriesDatumStringId, MockSpan> database;
   
   /** Thread pool used by the executions. */
-  private ExecutorService thread_pool;
+  private final ExecutorService thread_pool;
   
   public MockDataStore(final TSDB tsdb, final String id) {
     this.tsdb = tsdb;
@@ -108,9 +108,15 @@ public class MockDataStore implements ReadableTimeSeriesDataStore, WritableTimeS
     
     database = Maps.newHashMap();
     generateMockData();
-    if (tsdb.getConfig().hasProperty("MockDataStore.threadpool.enable") && 
-        tsdb.getConfig().getBoolean("MockDataStore.threadpool.enable")) {
+    if (!tsdb.getConfig().hasProperty("MockDataStore.threadpool.enable")) {
+      tsdb.getConfig().register("MockDataStore.threadpool.enable", false, 
+          false, "Whether or not to execute results in an asynchronous "
+              + "thread pool or not.");
+    }
+    if (tsdb.getConfig().getBoolean("MockDataStore.threadpool.enable")) {
       thread_pool = Executors.newCachedThreadPool();
+    } else {
+      thread_pool = null;
     }
   }
   

--- a/core/src/main/resources/META-INF/services/net.opentsdb.storage.TimeSeriesDataStoreFactory
+++ b/core/src/main/resources/META-INF/services/net.opentsdb.storage.TimeSeriesDataStoreFactory
@@ -1,1 +1,2 @@
 net.opentsdb.storage.MockDataStoreFactory
+net.opentsdb.storage.schemas.tsdb1x.SchemaFactory

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
@@ -117,13 +117,13 @@ final public class QueryRpc {
   @POST
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  public Response post(final @Context ServletConfig servlet_config, 
+  public void post(final @Context ServletConfig servlet_config, 
                        final @Context HttpServletRequest request,
                        final @Context HttpServletResponse response) throws Exception {
     if (request.getAttribute(OpenTSDBApplication.QUERY_EXCEPTION_ATTRIBUTE) != null) {
-      return handleException(request);
+      handleException(request);
     } else {
-      return handleQuery(servlet_config, request, response, false);
+      handleQuery(servlet_config, request, response, false);
     }
   }
   
@@ -137,13 +137,13 @@ final public class QueryRpc {
    */
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  public Response get(final @Context ServletConfig servlet_config, 
+  public void get(final @Context ServletConfig servlet_config, 
                       final @Context HttpServletRequest request,
                       final @Context HttpServletResponse response) throws Exception {
     if (request.getAttribute(OpenTSDBApplication.QUERY_EXCEPTION_ATTRIBUTE) != null) {
-      return handleException(request);
+      handleException(request);
     } else {
-      return handleQuery(servlet_config, request, response, true);
+      handleQuery(servlet_config, request, response, true);
     }
   }
   
@@ -157,11 +157,10 @@ final public class QueryRpc {
    * @throws Exception if something went pear shaped.
    */
   @VisibleForTesting
-  Response handleQuery(final ServletConfig servlet_config, 
+  void handleQuery(final ServletConfig servlet_config, 
                        final HttpServletRequest request,
                        final HttpServletResponse response,
                        final boolean is_get) throws Exception {
-    response.setHeader("Content-Type", "application/json");
     Object obj = servlet_config.getServletContext()
         .getAttribute(OpenTSDBApplication.TSD_ATTRIBUTE);
     if (obj == null) {
@@ -385,7 +384,6 @@ final public class QueryRpc {
                   .setTag("finalThread", Thread.currentThread().getName())
                   .finish();
     }
-    return null;
   }
   
   /**


### PR DESCRIPTION
- Synchronize on the JSON serializer methods for now to avoid race issues.
- Fix the thread pool config in MockDataStore.

SERVLET:
- Temporarily fix query result serialization. It was racing and returning a 204
  instead of actually writing the proper data to the channel. This still needs
  a lot of work.