### PR TITLE
SERVLET:

### DIFF
--- a/implementation/tracer-brave/src/main/java/net/opentsdb/stats/BraveSpan.java
+++ b/implementation/tracer-brave/src/main/java/net/opentsdb/stats/BraveSpan.java
@@ -117,6 +117,7 @@ public class BraveSpan implements net.opentsdb.stats.Span {
   public BraveSpanBuilder newChild(final String id) {
     return new BraveSpanBuilder(trace)
         .buildSpan(id)
+        .withTag("startThread", Thread.currentThread().getName())
         .asChildOf(this);
   }
   


### PR DESCRIPTION
- More tracing for 2x query.

BRAVE:
- Log the start thread in each child span.