### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/data/BaseTimeSeriesStringId.java
+++ b/core/src/main/java/net/opentsdb/data/BaseTimeSeriesStringId.java
@@ -92,15 +92,7 @@ public class BaseTimeSeriesStringId implements TimeSeriesStringId {
       throw new IllegalArgumentException("Metric cannot be null or empty.");
     }
     if (builder.tags != null && !builder.tags.isEmpty()) {
-      for (final Entry<String, String> pair : builder.tags.entrySet()) {
-        if (pair.getKey() == null) {
-          throw new IllegalArgumentException("Tag key cannot be null.");
-        }
-        if (pair.getValue() == null) {
-          throw new IllegalArgumentException("Tag value cannot be null.");
-        }
-        tags = Collections.unmodifiableMap(builder.tags);
-      }
+      tags = builder.tags;
     } else {
       tags = Collections.emptyMap();
     }
@@ -110,7 +102,7 @@ public class BaseTimeSeriesStringId implements TimeSeriesStringId {
       } catch (NullPointerException e) {
         throw new IllegalArgumentException("Aggregated tags cannot contain nulls");
       }
-      aggregated_tags = Collections.unmodifiableList(builder.aggregated_tags);
+      aggregated_tags = builder.aggregated_tags;
     } else {
       aggregated_tags = Collections.emptyList();
     }
@@ -120,12 +112,12 @@ public class BaseTimeSeriesStringId implements TimeSeriesStringId {
       } catch (NullPointerException e) {
         throw new IllegalArgumentException("Disjoint Tags cannot contain nulls");
       }
-      disjoint_tags = Collections.unmodifiableList(builder.disjoint_tags);
+      disjoint_tags = builder.disjoint_tags;
     } else {
       disjoint_tags = Collections.emptyList();
     }
     if (builder.unique_ids != null) {
-      unique_ids = Collections.unmodifiableSet(builder.unique_ids);
+      unique_ids = builder.unique_ids;
     } else {
       unique_ids = Collections.emptySet();
     }
@@ -327,11 +319,18 @@ public class BaseTimeSeriesStringId implements TimeSeriesStringId {
       return this;
     }
     
+    public String namespace() {
+      return namespace;
+    }
+    
     public Builder setMetric(final String metric) {
       this.metric = metric;
       return this;
     }
     
+    public String metric() {
+      return metric;
+    }
     /**
      * Sets the tags map. <b>NOTE:</b> This will maintain a reference to the
      * map and will NOT make a copy. Be sure to avoid mutating the map after 
@@ -352,6 +351,10 @@ public class BaseTimeSeriesStringId implements TimeSeriesStringId {
       return this;
     }
     
+    public Map<String, String> tags() {
+      return tags == null ? Collections.emptyMap() : tags;
+    }
+    
     public Builder setAggregatedTags(final List<String> aggregated_tags) {
       this.aggregated_tags = aggregated_tags;
       return this;
@@ -365,6 +368,11 @@ public class BaseTimeSeriesStringId implements TimeSeriesStringId {
       return this;
     }
     
+    public List<String> aggregatedTags() {
+      return aggregated_tags == null ? Collections.emptyList() : 
+        aggregated_tags;
+    }
+    
     public Builder setDisjointTags(final List<String> disjoint_tags) {
       this.disjoint_tags = disjoint_tags;
       return this;
@@ -376,6 +384,11 @@ public class BaseTimeSeriesStringId implements TimeSeriesStringId {
       }
       disjoint_tags.add(tag);
       return this;
+    }
+    
+    public List<String> disjointTags() {
+      return disjoint_tags == null ? Collections.emptyList() : 
+        disjoint_tags;
     }
     
     public Builder setUniqueId(final Set<String> unique_ids) {
@@ -392,6 +405,10 @@ public class BaseTimeSeriesStringId implements TimeSeriesStringId {
       }
       unique_ids.add(id);
       return this;
+    }
+    
+    public Set<String> uniqueIds() {
+      return unique_ids == null ? Collections.emptySet() : unique_ids;
     }
     
     public BaseTimeSeriesStringId build() {

--- a/core/src/main/java/net/opentsdb/query/QuerySourceConfig.java
+++ b/core/src/main/java/net/opentsdb/query/QuerySourceConfig.java
@@ -120,8 +120,10 @@ public class QuerySourceConfig extends BaseQueryNodeConfig {
     if (Strings.isNullOrEmpty(filter_id)) {
       return filter;
     }
-    // TODO - no no no!!!
-    return ((SemanticQuery) query).getFilter(filter_id);
+    if (query == null) {
+      return null;
+    }
+    return query.getFilter(filter_id);
   }
   
   /** @return Whether or not to fetch just the last (latest) value. */

--- a/core/src/main/java/net/opentsdb/query/TSDBV2QueryContextBuilder.java
+++ b/core/src/main/java/net/opentsdb/query/TSDBV2QueryContextBuilder.java
@@ -208,6 +208,9 @@ public class TSDBV2QueryContextBuilder implements QueryContextBuilder {
         }
       }
       
+      if (initializations == null) {
+        return context.initialize(local_span);
+      }
       return Deferred.group(initializations)
           .addBoth(Deferreds.VOID_GROUP_CB)
           .addCallbackDeferring(new FilterCB());

--- a/core/src/test/java/net/opentsdb/data/TestBaseTimeSeriesId.java
+++ b/core/src/test/java/net/opentsdb/data/TestBaseTimeSeriesId.java
@@ -129,46 +129,6 @@ public class TestBaseTimeSeriesId {
         id.tags().get("colo"));
     
     tags = Maps.newHashMap();
-    tags.put("colo", "");
-    id = BaseTimeSeriesStringId.newBuilder()
-        .setTags(tags)
-        .setMetric("sys.cpu.user")
-        .build();
-    assertEquals(1, id.tags().size());
-    assertEquals("", 
-        id.tags().get("colo"));
-    
-    tags = Maps.newHashMap();
-    tags.put("colo", null);
-    try {
-      id = BaseTimeSeriesStringId.newBuilder()
-          .setTags(tags)
-          .setMetric("sys.cpu.user")
-          .build();
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
-    
-    tags = Maps.newHashMap();
-    tags.put("", "lax");
-    id = BaseTimeSeriesStringId.newBuilder()
-        .setTags(tags)
-        .setMetric("sys.cpu.user")
-        .build();
-    assertEquals(1, id.tags().size());
-    assertEquals("lax", 
-        id.tags().get(""));
-    
-    tags = Maps.newHashMap();
-    tags.put(null, "lax");
-    try {
-      id = BaseTimeSeriesStringId.newBuilder()
-          .setTags(tags)
-          .setMetric("sys.cpu.user")
-          .build();
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
-    
-    tags = Maps.newHashMap();
     id = BaseTimeSeriesStringId.newBuilder()
         .setTags(tags)
         .setMetric("sys.cpu.user")
@@ -204,38 +164,6 @@ public class TestBaseTimeSeriesId {
     assertEquals(1, id.tags().size());
     assertEquals("", 
         id.tags().get("colo"));
-    
-    try {
-      id = BaseTimeSeriesStringId.newBuilder()
-          .addTags("colo", null)
-          .setMetric("sys.cpu.user")
-          .build();
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
-    
-    id = BaseTimeSeriesStringId.newBuilder()
-        .addTags("", "lax")
-        .setMetric("sys.cpu.user")
-        .build();
-    assertEquals(1, id.tags().size());
-    assertEquals("lax", 
-        id.tags().get(""));
-    
-    try {
-      id = BaseTimeSeriesStringId.newBuilder()
-          .addTags(null, "lax")
-          .setMetric("sys.cpu.user")
-          .build();
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
-    
-    try {
-      id = BaseTimeSeriesStringId.newBuilder()
-          .addTags(null, null)
-          .setMetric("sys.cpu.user")
-          .build();
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) { }
   }
   
   @Test

--- a/core/src/test/java/net/opentsdb/data/TestMergedTimeSeriesId.java
+++ b/core/src/test/java/net/opentsdb/data/TestMergedTimeSeriesId.java
@@ -108,6 +108,7 @@ public class TestMergedTimeSeriesId {
         .build();
     
     MergedTimeSeriesId.Builder builder = MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
       .addSeries(a)
       .addSeries(b);
     assertEquals(2, builder.ids.size());
@@ -136,6 +137,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     builder = MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d);
       assertEquals(2, builder.ids.size());
@@ -147,6 +149,7 @@ public class TestMergedTimeSeriesId {
           .build();
       try {
         MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
           .addSeries(c)
           .addSeries(d)
           .build();
@@ -166,12 +169,14 @@ public class TestMergedTimeSeriesId {
         .build();
     
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
     assertNull(merged.alias());
     
     merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .setAlias("Merged!")
@@ -179,6 +184,7 @@ public class TestMergedTimeSeriesId {
     assertEquals("Merged!", merged.alias());
     
     merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .setAlias("")
@@ -186,6 +192,7 @@ public class TestMergedTimeSeriesId {
     assertNull(merged.alias());
     
     merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .setAlias((String) null)
@@ -193,6 +200,7 @@ public class TestMergedTimeSeriesId {
     assertNull(merged.alias());
     
     merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .setAlias("Merged!")
@@ -200,6 +208,7 @@ public class TestMergedTimeSeriesId {
     assertEquals("Merged!", merged.alias());
     
     merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .setAlias("000001")
@@ -218,12 +227,14 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
     assertEquals("Tyrell", merged.namespace());
 
     merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .setNamespace("Dorne")
@@ -239,12 +250,14 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
     assertArrayEquals(BYTES_1, merged_bytes.namespace());
     
     merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .setNamespace(BYTES_3)
         .addSeries(c)
         .addSeries(d)
@@ -261,12 +274,14 @@ public class TestMergedTimeSeriesId {
         .setMetric("Lanister")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
     assertEquals("Tyrell", merged.metric());
 
     merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .setMetric("Stark")
@@ -280,12 +295,14 @@ public class TestMergedTimeSeriesId {
         .setMetric(BYTES_2)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
     assertArrayEquals(BYTES_1, merged_bytes.metric());
     
     merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .setMetric(BYTES_3)
         .addSeries(c)
         .addSeries(d)
@@ -306,6 +323,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -328,6 +346,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -351,6 +370,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -374,6 +394,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -397,6 +418,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -419,6 +441,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -442,6 +465,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -464,6 +488,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -487,6 +512,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -509,6 +535,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -532,6 +559,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -554,6 +582,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -577,6 +606,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -599,6 +629,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -622,6 +653,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -646,6 +678,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -670,6 +703,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -696,6 +730,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -721,6 +756,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -743,6 +779,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -766,6 +803,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -788,6 +826,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -816,6 +855,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .addSeries(c)
@@ -846,6 +886,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(d)
         .addSeries(e)
         .addSeries(f)
@@ -871,6 +912,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -893,6 +935,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -915,6 +958,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -939,6 +983,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -963,6 +1008,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -989,6 +1035,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();
@@ -1014,6 +1061,7 @@ public class TestMergedTimeSeriesId {
         .setMetric("ice.dragon")
         .build();
     TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(a)
         .addSeries(b)
         .build();
@@ -1038,6 +1086,7 @@ public class TestMergedTimeSeriesId {
         .setMetric(METRIC_ALT)
         .build();
     TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
+        .setFullMerge(true)
         .addSeries(c)
         .addSeries(d)
         .build();

--- a/core/src/test/java/net/opentsdb/query/TestQuerySourceConfig.java
+++ b/core/src/test/java/net/opentsdb/query/TestQuerySourceConfig.java
@@ -30,6 +30,7 @@ import net.opentsdb.core.DefaultRegistry;
 import net.opentsdb.core.MockTSDB;
 import net.opentsdb.query.execution.graph.ExecutionGraphNode;
 import net.opentsdb.query.filter.MetricLiteralFilter;
+import net.opentsdb.query.filter.TagValueLiteralOrFilter;
 import net.opentsdb.query.processor.topn.TopNConfig;
 import net.opentsdb.utils.JSON;
 
@@ -97,6 +98,10 @@ public class TestQuerySourceConfig {
             .setMetric("system.cpu.user")
             .build())
         .setFilterId("f1")
+        .setQueryFilter(TagValueLiteralOrFilter.newBuilder()
+            .setFilter("web01")
+            .setTagKey("host")
+            .build())
         .setFetchLast(true)
         .addPushDownNode(ExecutionGraphNode.newBuilder()
             .setId("topn")
@@ -111,6 +116,7 @@ public class TestQuerySourceConfig {
         .build();
     
     final String json = JSON.serializeToString(qsc);
+    System.out.println(json);
     assertTrue(json.contains("\"id\":\"UT\""));
     assertTrue(json.contains("\"metric\":{"));
     assertTrue(json.contains("\"metric\":\"system.cpu.user\""));

--- a/core/src/test/java/net/opentsdb/query/pojo/TestTimeSeriesQuery.java
+++ b/core/src/test/java/net/opentsdb/query/pojo/TestTimeSeriesQuery.java
@@ -658,7 +658,7 @@ public class TestTimeSeriesQuery {
     assertNull(node.getSources());
     QuerySourceConfig ds = (QuerySourceConfig) node.getConfig();
     assertEquals("YAMAS.cpu.idle", ds.getMetric().getMetric());
-    assertEquals("f1", ds.getFilterId());
+    assertNull(ds.getFilterId());
     
     node = query.getExecutionGraph().getNodes().get(2);
     assertEquals("m1_Downsampler", node.getId());


### PR DESCRIPTION
- Losen up some checks and unmodifiables in the BaseTimeSeriesStringId ctor.
- Add getters to the BaseTimeSeriesStringId.Builder so we can avoid using
  separate objects in the merger builder.
- Add a flag to MergedTimeSeriesId to determine if we should perform a full
  merge with disjoin tags or just do a simple merge with the aggregated tags
  as per 2.x. The full compute turned out to be really expensive.
- Add a null check in the QuerySourceConfig for the source query.
- Fix an init but in TSDBV2QueryContextBuilder when filters are not supplied.
- Add the filters to data sources in the TimeSeriesQuery converter.