### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
+++ b/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
@@ -542,7 +542,12 @@ public abstract class AbstractQueryPipelineContext implements QueryPipelineConte
         countdowns.get(result.source().config().getId() + ":" 
             + result.dataSource()).decrementAndGet();
       }
-      result.close();
+      checkComplete();
+      try {
+        result.close();
+      } catch (Throwable t) {
+        LOG.error("Failed to close result: " + result, t);
+      }
     }
     
   }

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/exceptions/GenericExceptionMapper.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/exceptions/GenericExceptionMapper.java
@@ -29,8 +29,8 @@ import javax.ws.rs.ext.ExceptionMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ch.qos.logback.classic.spi.ThrowableProxy;
-import ch.qos.logback.classic.spi.ThrowableProxyUtil;
+import com.google.common.base.Throwables;
+
 import net.opentsdb.exceptions.QueryExecutionException;
 import net.opentsdb.utils.JSON;
 
@@ -52,14 +52,11 @@ public class GenericExceptionMapper implements ExceptionMapper<Throwable> {
     }
     
     LOG.error("Unexpected exception", t);
-    final ThrowableProxy tp = new ThrowableProxy(t);
-    tp.calculatePackagingData();
-    final String formattedTrace = ThrowableProxyUtil.asString(tp);
     
     final Map<String, Object> response = new HashMap<String, Object>(3);
     response.put("code", Response.Status.INTERNAL_SERVER_ERROR);
     response.put("message", t.getMessage());
-    response.put("trace", formattedTrace);
+    response.put("trace", Throwables.getStackTraceAsString(t));
     
     final Map<String, Object> outerMap = new HashMap<String, Object>(1);
     outerMap.put("error", response);
@@ -81,10 +78,6 @@ public class GenericExceptionMapper implements ExceptionMapper<Throwable> {
     
     LOG.error("Unexpected exception", t);
     
-    final ThrowableProxy tp = new ThrowableProxy(t);
-    tp.calculatePackagingData();
-    final String formattedTrace = ThrowableProxyUtil.asString(tp);
-    
     int status = Status.INTERNAL_SERVER_ERROR.getStatusCode();
     if (t instanceof QueryExecutionException) {
       status = ((QueryExecutionException) t).getStatusCode();
@@ -93,7 +86,8 @@ public class GenericExceptionMapper implements ExceptionMapper<Throwable> {
     final Map<String, Object> map = new HashMap<String, Object>(3);
     map.put("code", status);
     map.put("message", t.getMessage());
-    map.put("trace", formattedTrace);
+    map.put("trace", 
+        Throwables.getStackTraceAsString(t));
     
     final Map<String, Object> outerMap = new HashMap<String, Object>(1);
     outerMap.put("error", map);

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/exceptions/QueryExecutionExceptionMapper.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/exceptions/QueryExecutionExceptionMapper.java
@@ -27,10 +27,9 @@ import javax.ws.rs.ext.ExceptionMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 
-import ch.qos.logback.classic.spi.ThrowableProxy;
-import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import jersey.repackaged.com.google.common.collect.Lists;
 import net.opentsdb.exceptions.QueryExecutionException;
 import net.opentsdb.utils.JSON;
@@ -89,10 +88,8 @@ public class QueryExecutionExceptionMapper implements
     response.put("code", e.getStatusCode());
     response.put("message", e.getMessage());
     if (show_trace) {
-      final ThrowableProxy tp = new ThrowableProxy(e);
-      tp.calculatePackagingData();
-      final String formatted_trace = ThrowableProxyUtil.asString(tp);
-      response.put("trace", formatted_trace);  
+      response.put("trace", 
+          Throwables.getStackTraceAsString(e.getCause()));  
     }
     if (!e.getThrowables().isEmpty()) {
       final List<Map<String, Object>> sub_exceptions = 
@@ -111,10 +108,8 @@ public class QueryExecutionExceptionMapper implements
               ((QueryExecutionException) t).getStatusCode() : 0);
           sub_exception.put("message", t.getMessage());
           if (show_trace) {
-            final ThrowableProxy tp = new ThrowableProxy(t);
-            tp.calculatePackagingData();
-            final String formatted_trace = ThrowableProxyUtil.asString(tp);
-            sub_exception.put("trace", formatted_trace);  
+            sub_exception.put("trace", 
+                Throwables.getStackTraceAsString(e.getCause()));  
           }
           sub_exceptions.add(sub_exception);
         }
@@ -133,10 +128,8 @@ public class QueryExecutionExceptionMapper implements
             ((QueryExecutionException) e.getCause()).getStatusCode() : 0);
         cause.put("message", e.getCause().getMessage());
         if (show_trace) {
-          final ThrowableProxy tp = new ThrowableProxy(e.getCause());
-          tp.calculatePackagingData();
-          final String formatted_trace = ThrowableProxyUtil.asString(tp);
-          cause.put("trace", formatted_trace);  
+          cause.put("trace", 
+              Throwables.getStackTraceAsString(e.getCause()));  
         }
         response.put("cause", cause);
       }


### PR DESCRIPTION
- Fix the removed on accident checkComplete() in the AQPC.

SERVLET:
- Remove the logback dependency and use Guava's throwables to print the
  exception for now.