### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
+++ b/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
@@ -97,8 +97,12 @@ public class QueryDataSourceFactory implements SingleQueryNodeFactory, TSDBPlugi
                                      final JsonNode node) {
     QuerySourceConfig.Builder builder = QuerySourceConfig.newBuilder();
     // TODO - types
+    JsonNode n = node.get("sourceId");
+    if (n != null && !n.isNull()) {
+      builder.setSourceId(n.asText());
+    }
     
-    JsonNode n = node.get("metric");
+    n = node.get("metric");
     if (n == null) {
       throw new IllegalArgumentException("Missing the metric field.");
     }

--- a/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
+++ b/core/src/main/java/net/opentsdb/query/QueryDataSourceFactory.java
@@ -141,7 +141,7 @@ public class QueryDataSourceFactory implements SingleQueryNodeFactory, TSDBPlugi
       builder.setFilterId(n.asText());
     } else {
       n = node.get("filter");
-      if (n != null) {
+      if (n != null && !n.isNull()) {
         type_node = n.get("type");
         if (type_node == null) {
           throw new IllegalArgumentException("Missing the filter type field.");

--- a/core/src/main/java/net/opentsdb/query/QuerySourceConfig.java
+++ b/core/src/main/java/net/opentsdb/query/QuerySourceConfig.java
@@ -41,6 +41,9 @@ import net.opentsdb.query.filter.QueryFilter;
 @JsonInclude(Include.NON_NULL)
 @JsonDeserialize(builder = QuerySourceConfig.Builder.class)
 public class QuerySourceConfig extends BaseQueryNodeConfig {
+  /** The source provider ID. */
+  private final String source_id;
+  
   /** The original and complete time series query. */
   private TimeSeriesQuery query;
   
@@ -73,6 +76,7 @@ public class QuerySourceConfig extends BaseQueryNodeConfig {
     if (builder.metric == null) {
       throw new IllegalArgumentException("Metric filter cannot be null.");
     }
+    source_id = builder.sourceId;
     query = builder.query;
     types = builder.types;
     metric = builder.metric;
@@ -80,6 +84,11 @@ public class QuerySourceConfig extends BaseQueryNodeConfig {
     filter = builder.filter;
     fetch_last = builder.fetchLast;
     push_down_nodes = builder.push_down_nodes;
+  }
+  
+  /** @return The source ID. May be null in which case we use the default. */
+  public String getSourceId() {
+    return source_id;
   }
   
   /** @return The non-null query object. */
@@ -187,6 +196,7 @@ public class QuerySourceConfig extends BaseQueryNodeConfig {
   /** @return A new builder. */
   public static Builder newBuilder(final QuerySourceConfig config) {
     return (Builder) new Builder()
+        .setSourceId(config.source_id)
         .setQuery(config.query)
         .setTypes(config.types != null ? Lists.newArrayList(config.types) : null)
         .setMetric(config.metric)
@@ -201,6 +211,8 @@ public class QuerySourceConfig extends BaseQueryNodeConfig {
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Builder extends BaseQueryNodeConfig.Builder {
     @JsonProperty
+    private String sourceId;
+    @JsonProperty
     private TimeSeriesQuery query;
     @JsonProperty
     private List<String> types;
@@ -213,6 +225,11 @@ public class QuerySourceConfig extends BaseQueryNodeConfig {
     @JsonProperty
     private boolean fetchLast;
     private List<ExecutionGraphNode> push_down_nodes;
+    
+    public Builder setSourceId(final String source_id) {
+      sourceId = source_id;
+      return this;
+    }
     
     /** 
      * @param query The non-null query to execute.

--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
@@ -420,51 +420,67 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes {
       final Iterator<TimeSeriesValue<?>> iterator, 
       final JsonGenerator json,
       final QueryResult result) throws IOException {
-    // TODO!
-//    if (result.timeSpecification() != null) {
-//      json.writeObjectFieldStart("NumericSummaryType");
-//      // just the values
-//      while (value != null) {
-//        if (value.timestamp().compare(Op.GT, options.end())) {
-//          break;
-//        }
-//        long ts = (options != null && options.msResolution()) 
-//            ? value.timestamp().msEpoch() 
-//            : value.timestamp().msEpoch() / 1000;
-//        json.writeObjectFieldStart(Long.toString(ts));
-//        if (value.value() == null) {
-//          json.writeNull();
-//        } else {
-//          final NumericSummaryType v = ((TimeSeriesValue<NumericSummaryType>) value).value();
-//          json.writeStartArray();
-//          for (final int summary : v.summariesAvailable()) {
-//            final NumericType summary_value = v.value(summary);
-//            if (summary_value == null) {
-//              json.writeNumberField(Integer.toString(summary), null);
-//            } else if (summary_value.isInteger()) {
-//              json.writeNumberField(Integer.toString(summary),
-//                  summary_value.longValue());
-//            } else {
-//              json.writeNumberField(Integer.toString(summary),
-//                  summary_value.doubleValue());
-//            }
-//            
-//          }
-//          json.writeEndArray();
-//        }
-//        json.writeEndObject();
-//        
-//        if (iterator.hasNext()) {
-//          value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
-//        } else {
-//          value = null;
-//        }
-//      }
-//      json.writeEndObject();
-//      return;
-//    }
+    if (result.timeSpecification() != null) {
+      json.writeObjectFieldStart("NumericSummaryType");
+      // just the values
+   // NOTE: This is assuming all values have the same summaries available.
+      final List<Integer> summaries = Lists.newArrayList(
+          ((TimeSeriesValue<NumericSummaryType>) value).value().summariesAvailable());
+      json.writeArrayFieldStart("aggregations");
+      for (final int summary : summaries) {
+        json.writeString(result.rollupConfig().getAggregatorForId(summary));
+      }
+      json.writeEndArray();
+      
+      json.writeArrayFieldStart("data");
+      while (value != null) {
+        if (value.timestamp().compare(Op.GT, end)) {
+          break;
+        }
+        long ts = (options != null && options.getMsResolution()) 
+            ? value.timestamp().msEpoch() 
+            : value.timestamp().msEpoch() / 1000;
+        final String ts_string = Long.toString(ts);
+        if (value.value() == null) {
+          json.writeNullField(ts_string);
+        } else {
+          final NumericSummaryType v = ((TimeSeriesValue<NumericSummaryType>) value).value();
+          json.writeStartArray();
+          for (final int summary : summaries) {
+            final NumericType summary_value = v.value(summary);
+            if (summary_value == null) {
+              json.writeNull();
+            } else if (summary_value.isInteger()) {
+              json.writeNumber(summary_value.longValue());
+            } else {
+              json.writeNumber(summary_value.doubleValue());
+            }
+          }
+          json.writeEndArray();
+        }
+        
+        if (iterator.hasNext()) {
+          value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+        } else {
+          value = null;
+        }
+      }
+      json.writeEndArray();
+      json.writeEndObject();
+      return;
+    }
     
     json.writeObjectFieldStart("NumericSummaryType");
+    // NOTE: This is assuming all values have the same summaries available.
+    final List<Integer> summaries = Lists.newArrayList(
+        ((TimeSeriesValue<NumericSummaryType>) value).value().summariesAvailable());
+    json.writeArrayFieldStart("aggregations");
+    for (final int summary : summaries) {
+      json.writeString(result.rollupConfig().getAggregatorForId(summary));
+    }
+    json.writeEndArray();
+    
+    json.writeArrayFieldStart("data");
     while (value != null) {
       if (value.timestamp().compare(Op.GT, end)) {
         break;
@@ -476,23 +492,21 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes {
       if (value.value() == null) {
         json.writeNullField(ts_string);
       } else {
+        json.writeStartObject();
         final NumericSummaryType v = ((TimeSeriesValue<NumericSummaryType>) value).value();
         json.writeArrayFieldStart(ts_string);
-        for (final int summary : v.summariesAvailable()) {
-          json.writeStartObject();
+        for (final int summary : summaries) {
           final NumericType summary_value = v.value(summary);
           if (summary_value == null) {
-            json.writeNumberField(Integer.toString(summary), null);
+            json.writeNull();
           } else if (summary_value.isInteger()) {
-            json.writeNumberField(result.rollupConfig().getAggregatorForId(summary),
-                summary_value.longValue());
+            json.writeNumber(summary_value.longValue());
           } else {
-            json.writeNumberField(result.rollupConfig().getAggregatorForId(summary),
-                summary_value.doubleValue());
+            json.writeNumber(summary_value.doubleValue());
           }
-          json.writeEndObject();
         }
         json.writeEndArray();
+        json.writeEndObject();
       }
       
       if (iterator.hasNext()) {
@@ -501,6 +515,7 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes {
         value = null;
       }
     }
+    json.writeEndArray();
     
     json.writeEndObject();
   }

--- a/core/src/test/java/net/opentsdb/query/TestQuerySourceConfig.java
+++ b/core/src/test/java/net/opentsdb/query/TestQuerySourceConfig.java
@@ -41,6 +41,7 @@ public class TestQuerySourceConfig {
     final TimeSeriesQuery query = mock(TimeSeriesQuery.class);
     
     QuerySourceConfig qsc = (QuerySourceConfig) QuerySourceConfig.newBuilder()
+        .setSourceId("HBase")
         .setQuery(query)
         .setMetric(MetricLiteralFilter.newBuilder()
             .setMetric("system.cpu.user")
@@ -48,6 +49,7 @@ public class TestQuerySourceConfig {
         .addPushDownNode(mock(ExecutionGraphNode.class))
         .setId("UT")
         .build();
+    assertEquals("HBase", qsc.getSourceId());
     assertSame(query, qsc.query());
     assertEquals("system.cpu.user", qsc.getMetric().getMetric());
     assertEquals("UT", qsc.getId());
@@ -68,6 +70,7 @@ public class TestQuerySourceConfig {
   public void builderClone() throws Exception {
     final TimeSeriesQuery query = mock(TimeSeriesQuery.class);
     QuerySourceConfig qsc = (QuerySourceConfig) QuerySourceConfig.newBuilder()
+        .setSourceId("HBase")
         .setQuery(query)
         .setTypes(Lists.newArrayList("Numeric", "Annotation"))
         .setMetric(MetricLiteralFilter.newBuilder()
@@ -79,6 +82,7 @@ public class TestQuerySourceConfig {
     
     QuerySourceConfig clone = QuerySourceConfig.newBuilder(qsc).build();
     assertNotSame(qsc, clone);
+    assertEquals("HBase", clone.getSourceId());
     assertSame(query, clone.query());
     assertNotSame(qsc.getTypes(), clone.getTypes());
     assertEquals(2, clone.getTypes().size());
@@ -93,6 +97,7 @@ public class TestQuerySourceConfig {
   public void serialize() throws Exception {
     final TimeSeriesQuery query = mock(TimeSeriesQuery.class);
     QuerySourceConfig qsc = (QuerySourceConfig) QuerySourceConfig.newBuilder()
+        .setSourceId("HBase")
         .setQuery(query)
         .setMetric(MetricLiteralFilter.newBuilder()
             .setMetric("system.cpu.user")
@@ -116,7 +121,7 @@ public class TestQuerySourceConfig {
         .build();
     
     final String json = JSON.serializeToString(qsc);
-    System.out.println(json);
+    assertTrue(json.contains("\"sourceId\":\"HBase\""));
     assertTrue(json.contains("\"id\":\"UT\""));
     assertTrue(json.contains("\"metric\":{"));
     assertTrue(json.contains("\"metric\":\"system.cpu.user\""));
@@ -129,7 +134,7 @@ public class TestQuerySourceConfig {
   
   @Test
   public void parseConfig() throws Exception {
-    final String json = "{\"id\":\"UT\",\"metric\":{\"metric\":"
+    final String json = "{\"sourceId\":\"HBase\",\"id\":\"UT\",\"metric\":{\"metric\":"
         + "\"system.cpu.user\",\"type\":\"MetricLiteral\"},\"filterId\":"
         + "\"f1\",\"fetchLast\":true,\"pushDownNodes\":[{\"id\":\"topn\","
         + "\"type\":\"topn\",\"config\":{\"id\":\"Toppy\",\"count\":10,"
@@ -143,6 +148,7 @@ public class TestQuerySourceConfig {
     QuerySourceConfig config = (QuerySourceConfig) 
         new QueryDataSourceFactory().parseConfig(JSON.getMapper(), 
             tsdb, root);
+    assertEquals("HBase", config.getSourceId());
     assertEquals("UT", config.getId());
     assertEquals("system.cpu.user", config.getMetric().getMetric());
     assertTrue(config.getMetric() instanceof MetricLiteralFilter);

--- a/core/src/test/java/net/opentsdb/query/TestQuerySourceConfig.java
+++ b/core/src/test/java/net/opentsdb/query/TestQuerySourceConfig.java
@@ -136,7 +136,7 @@ public class TestQuerySourceConfig {
   public void parseConfig() throws Exception {
     final String json = "{\"sourceId\":\"HBase\",\"id\":\"UT\",\"metric\":{\"metric\":"
         + "\"system.cpu.user\",\"type\":\"MetricLiteral\"},\"filterId\":"
-        + "\"f1\",\"fetchLast\":true,\"pushDownNodes\":[{\"id\":\"topn\","
+        + "\"f1\",\"filter\":null,\"fetchLast\":true,\"pushDownNodes\":[{\"id\":\"topn\","
         + "\"type\":\"topn\",\"config\":{\"id\":\"Toppy\",\"count\":10,"
         + "\"top\":true,\"infectiousNan\":true}}]}";
     

--- a/core/src/test/java/net/opentsdb/query/TestTSDBV2QueryContextBuilder.java
+++ b/core/src/test/java/net/opentsdb/query/TestTSDBV2QueryContextBuilder.java
@@ -151,7 +151,7 @@ public class TestTSDBV2QueryContextBuilder {
                 .setFilter("web01")
                 .setType("literal_or")
                 .setTagk("host")))
-        .build().convert()
+        .build().convert(TSDB)
         .build();
     
     when(SINK_FACTORY.newSink(any(QueryContext.class), 

--- a/core/src/test/java/net/opentsdb/query/execution/TestCachingQueryExecutor.java
+++ b/core/src/test/java/net/opentsdb/query/execution/TestCachingQueryExecutor.java
@@ -48,6 +48,7 @@ import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.common.Const;
 import net.opentsdb.configuration.Configuration;
+import net.opentsdb.core.TSDB;
 import net.opentsdb.data.iterators.IteratorGroups;
 import net.opentsdb.query.ConvertedQueryResult;
 import net.opentsdb.query.QueryContext;
@@ -127,7 +128,7 @@ public class TestCachingQueryExecutor extends BaseExecutorTest {
             .setId("m1")
             .setMetric("system.cpu.user"))
         .build()
-        .convert().build();
+        .convert(mock(TSDB.class)).build();
     when(pcontext.query()).thenReturn(query);
    // cache_execution = new MockDownstream<IteratorGroups>(query);
     when(plugin.fetch(any(QueryContext.class), any(byte[].class), any(Span.class)))

--- a/core/src/test/java/net/opentsdb/query/execution/serdes/TestJsonV2QuerySerdes.java
+++ b/core/src/test/java/net/opentsdb/query/execution/serdes/TestJsonV2QuerySerdes.java
@@ -38,6 +38,7 @@ import com.google.common.reflect.TypeToken;
 import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.common.Const;
+import net.opentsdb.core.TSDB;
 import net.opentsdb.data.MillisecondTimeStamp;
 import net.opentsdb.data.MockTimeSeries;
 import net.opentsdb.data.SecondTimeStamp;
@@ -87,7 +88,7 @@ public class TestJsonV2QuerySerdes {
             .setId("m1")
             .setMetric("sys.cpu.user"))
         .build()
-        .convert().build();
+        .convert(mock(TSDB.class)).build();
     when(context.query()).thenReturn(query);
     
     id1 = BaseTimeSeriesStringId.newBuilder()
@@ -190,7 +191,7 @@ public class TestJsonV2QuerySerdes {
             .setId("m1")
             .setMetric("sys.cpu.user"))
         .build()
-        .convert().build();
+        .convert(mock(TSDB.class)).build();
     when(context.query()).thenReturn(query);
     
     final ByteArrayOutputStream output = new ByteArrayOutputStream();
@@ -224,7 +225,7 @@ public class TestJsonV2QuerySerdes {
             .setId("m1")
             .setMetric("sys.cpu.user"))
         .build()
-        .convert().build();
+        .convert(mock(TSDB.class)).build();
     when(context.query()).thenReturn(query);
     
     final ByteArrayOutputStream output = new ByteArrayOutputStream();
@@ -257,7 +258,7 @@ public class TestJsonV2QuerySerdes {
             .setId("m1")
             .setMetric("sys.cpu.user"))
         .build()
-        .convert().build();
+        .convert(mock(TSDB.class)).build();
     when(context.query()).thenReturn(query);
     
     final ByteArrayOutputStream output = new ByteArrayOutputStream();
@@ -280,7 +281,7 @@ public class TestJsonV2QuerySerdes {
             .setId("m1")
             .setMetric("sys.cpu.user"))
         .build()
-        .convert().build();
+        .convert(mock(TSDB.class)).build();
     when(context.query()).thenReturn(query);
     
     final ByteArrayOutputStream output = new ByteArrayOutputStream();

--- a/core/src/test/java/net/opentsdb/query/execution/serdes/TestJsonV2QuerySerdesFactory.java
+++ b/core/src/test/java/net/opentsdb/query/execution/serdes/TestJsonV2QuerySerdesFactory.java
@@ -57,7 +57,7 @@ public class TestJsonV2QuerySerdesFactory {
             .setId("m1")
             .setMetric("sys.cpu.user"))
         .build()
-        .convert().build();
+        .convert(mock(TSDB.class)).build();
     when(context.query()).thenReturn(query);
     
     JsonV2QuerySerdesFactory factory = new JsonV2QuerySerdesFactory();

--- a/core/src/test/java/net/opentsdb/query/pojo/TestTimeSeriesQuery.java
+++ b/core/src/test/java/net/opentsdb/query/pojo/TestTimeSeriesQuery.java
@@ -16,6 +16,7 @@ package net.opentsdb.query.pojo;
 
 import net.opentsdb.configuration.Configuration;
 import net.opentsdb.configuration.UnitTestConfiguration;
+import net.opentsdb.core.TSDB;
 import net.opentsdb.query.QuerySourceConfig;
 import net.opentsdb.query.SemanticQuery;
 import net.opentsdb.query.execution.graph.ExecutionGraphNode;
@@ -43,6 +44,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 public class TestTimeSeriesQuery {
   
@@ -640,7 +642,7 @@ public class TestTimeSeriesQuery {
   @Test
   public void convert() throws Exception {
     SemanticQuery.Builder builder = 
-        JSON.parseToObject(json, TimeSeriesQuery.class).convert();
+        JSON.parseToObject(json, TimeSeriesQuery.class).convert(mock(TSDB.class));
     SemanticQuery query = builder.build();
     assertEquals(4, query.getExecutionGraph().getNodes().size());
     

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestTsdb1xQueryResult.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestTsdb1xQueryResult.java
@@ -90,7 +90,7 @@ public class TestTsdb1xQueryResult extends SchemaBase {
               .setId("m1")
               .setMetric(METRIC_STRING))
           .build()
-          .convert().build())
+          .convert(tsdb).build())
         .setId("m1")
         .build();
     when(node.config()).thenReturn(source_config);
@@ -137,7 +137,7 @@ public class TestTsdb1xQueryResult extends SchemaBase {
               .setId("m1")
               .setMetric(METRIC_STRING))
           .build()
-          .convert().build())
+          .convert(tsdb).build())
         .addOverride(Schema.QUERY_BYTE_LIMIT_KEY, "42")
         .addOverride(Schema.QUERY_DP_LIMIT_KEY, "24")
         .setId("m1")
@@ -396,7 +396,7 @@ public class TestTsdb1xQueryResult extends SchemaBase {
               .setId("m1")
               .setMetric(METRIC_STRING))
           .build()
-          .convert().build())
+          .convert(tsdb).build())
         .addOverride(Schema.QUERY_BYTE_LIMIT_KEY, "42")
         .addOverride(Schema.QUERY_DP_LIMIT_KEY, "24")
         .setId("m1")

--- a/implementation/protobuf/src/test/java/net/opentsdb/query/serdes/TestPBufSerdes.java
+++ b/implementation/protobuf/src/test/java/net/opentsdb/query/serdes/TestPBufSerdes.java
@@ -103,7 +103,7 @@ public class TestPBufSerdes {
         .addMetric(Metric.newBuilder()
             .setId("m1")
             .setMetric("sys.cpu.user"))
-        .build().convert().build();
+        .build().convert(TSDB).build();
     
     when(context.query()).thenReturn(query);
     
@@ -224,7 +224,7 @@ public class TestPBufSerdes {
         .addMetric(Metric.newBuilder()
             .setId("m1")
             .setMetric("sys.cpu.user"))
-        .build().convert().build();
+        .build().convert(TSDB).build();
     when(context.query()).thenReturn(query);
     
     QueryResult result = mock(QueryResult.class);

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/ExpressionRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/ExpressionRpc.java
@@ -177,7 +177,7 @@ public class ExpressionRpc {
       }
     }
     
-    final SemanticQuery.Builder query = ts_query.convert();
+    final SemanticQuery.Builder query = ts_query.convert(tsdb);
     
     LOG.info("Executing new query=" + JSON.serializeToString(
         ImmutableMap.<String, Object>builder()

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
@@ -278,7 +278,7 @@ final public class QueryRpc {
         .getAttribute(OpenTSDBApplication.ASYNC_TIMEOUT_ATTRIBUTE));
     
     // TODO - oh this is so ugly it isn't even funny.
-    final SemanticQuery q = query.convert().build();
+    final SemanticQuery q = query.convert(tsdb).build();
     SerdesOptions serdes = q.getSerdesConfigs().isEmpty() ? null :
       q.getSerdesConfigs().get(0);
     if (serdes == null) {


### PR DESCRIPTION
- Add a setting tsd.query.convert.2x.rate1to0 that will help fix backwards compatible
  queries for the fixed rate behavior.