### PR TITLE
OpenTSDB repair wrapper

### DIFF
--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -18,14 +18,19 @@ log.addHandler(ch)
 
 class TSDRepair(object):
     def __init__(self, args):
-        self.timeout = args.get("timeout", 360)
+        self.timeout = args.get("timeout", 900)
         self.retries = args.get("retries", 1)
-        self.time_range = args.get("time_range", 26280)
+        self.time_range = args.get("time_range", 48)
         self.tsd_path = args.get("tsd_path", "/usr/share/opentsdb/bin/tsdb")
         self.cfg_path = args.get("cfg_path", "/etc/opentsdb/opentsdb.conf")
         self.use_sudo = args.get("use_sudo", False)
         self.sudo_user = args.get("sudo_user", "opentsdb")
-        self.log = logging.getLogger("repair-tsd.class")
+        self.log = logging.getLogger("repair-tsd")
+        self.base = "{} fsck --config={}".format(self.tsd_path, self.cfg_path)
+        self.check_cmd = "{} uid --config={} metrics".format(self.tsd_path, self.cfg_path)
+        if self.use_sudo:
+            self.base = "sudo -u {} {}".format(self.sudo_user, self.base)
+            self.check_cmd = "sudo -u {} {}".format(self.sudo_user, self.check_cmd)
         warn = "You have set a timeout of {} seconds.".format(self.timeout)
         warn += " All individual metric repairs are allowed to run"
         warn += " that long. Please don't cancel a repair while it"
@@ -49,21 +54,57 @@ class TSDRepair(object):
         self.log.info("There are {} metrics to process".format(len(metrics)))
         return metrics
 
+    def _repair_metric(self, metric, timestr, chunk):
+        self.log.debug("Running chunk {} for {}".format(chunk, metric))
+        cmd = "{} {} sum".format(self.base, timestr)
+        for x in range(0, self.retries + 1):
+            self.log.debug("Repair try {} for {}".format(x + 1, timestr))
+            fullcmd = "{} {} --fix-all --compact".format(cmd, metric)
+            self.log.debug("Full command: {}".format(fullcmd))
+            metricproc = Popen(fullcmd, shell=True, stdout=PIPE, stderr=PIPE)
+            try:
+                results, err = metricproc.communicate(timeout=self.timeout)
+            except TimeoutExpired:
+                self.log.debug("{} failed to complete in window (run {})".format(metric, x + 1))
+                continue
+            except Exception as e:
+                self.log.error("General exception processing {} :: {}".format(metric,
+                                                                              e))
+            else:
+                results = [r for r in results.decode().split("\n") if r][-26:]
+                final_results = []
+                # We'll only collect results that are non-0, since we're not super interested in stuff that didn't change
+                for r in results:
+                    # Strip the timestamp from the log line
+                    line = r.split(" ")[6:]
+                    try:
+                        if int(line[-1]) != 0:
+                            final_results.append(" ".join(line))
+                    except Exception:
+                        final_results.append(" ".join(line))
+                # We'll always show the run time, so separate that from the other lines
+                try:
+                    runtime = int(final_results.pop(-1).split()[3].strip('[]'))
+                except Exception:
+                    self.log.error("Bad runtime results for {} :: {}".format(metric, final_results))
+                result_str = "\n".join(final_results)
+                self.log.debug("{} results:\n{}".format(metric, result_str))
+                self.log.info("{} (chunk {}): completed in {} seconds".format(metric, chunk, runtime))
+                return [], runtime
+        else:
+            self.log.error("Failed to completely repair {}".format(metric))
+            return metric, 0
+
     def process_metrics(self):
         """
         Run fsck on a list of metrics over a time range
         """
         failed_metrics = []
-        base = "{} fsck --config={}".format(self.tsd_path, self.cfg_path)
-        check_cmd = "{} uid --config={} metrics".format(self.tsd_path, self.cfg_path)
-        if self.use_sudo:
-            base = "sudo -u {} {}".format(self.sudo_user, base)
-            check_cmd = "sudo -u {} {}".format(self.sudo_user, check_cmd)
-        cmd = "{} {}h-ago sum".format(base, self.time_range)
+        timer = 0
         metrics = self._get_metrics()
         for index, metric in enumerate(metrics):
             try:
-                check_output("{} {}".format(check_cmd, metric), shell=True)
+                check_output("{} {}".format(self.check_cmd, metric), shell=True)
             except Exception:
                 log.warning("{} doesn't actually exist! Skipping...".format(metric))
                 continue
@@ -71,35 +112,15 @@ class TSDRepair(object):
                                                                        index + 1,
                                                                        len(metrics),
                                                                        len(failed_metrics)))
-            for x in range(0, self.retries + 1):
-                fullcmd = "{} {} --fix-all --compact".format(cmd, metric)
-                metricproc = Popen(fullcmd, shell=True, stdout=PIPE, stderr=PIPE)
-                try:
-                    results, err = metricproc.communicate(timeout=self.timeout)
-                except TimeoutExpired:
-                    self.log.debug("{} failed to complete in window (run {})".format(metric, x + 1))
-                    continue
-                except Exception as e:
-                    self.log.error("General exception processing {} :: {}".format(metric,
-                                                                              e))
-                else:
-                    results = [r for r in results.decode().split("\n") if r][-26:]
-                    final_results = []
-                    for r in results:
-                        line = r.split(" ")[6:]
-                        try:
-                            if int(line[-1]) != 0:
-                                final_results.append(" ".join(line))
-                        except Exception:
-                            final_results.append(" ".join(line))
-                    runtime = final_results.pop(-1)
-                    result_str = "\n".join(final_results)
-                    self.log.debug("{} results:\n{}".format(metric, result_str))
-                    self.log.info("{}: {}".format(metric, runtime))
-                    break
-            else:
-                self.log.error("Failed to completely repair {}".format(metric))
-                failed_metrics.append(metric)
+            failed, count = self._repair_metric(metric, "1h-ago", 1)
+            failed_metrics.append(failed)
+            timer += count
+            for x in range(2, self.time_range):
+                failed, count = self._repair_metric(metric, "{}h-ago {}h-ago".format(x, x - 1), x)
+                failed_metrics.append(failed)
+                timer += count
+            self.log.info("{} took {} seconds to complete".format(metric, timer))
+            exit(1)
         self.log.info("Failed metrics: {}".format(failed_metrics))
         return failed_metrics
 
@@ -109,9 +130,9 @@ def cli_opts():
                             formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument("--debug", action="store_true", default=False,
                         help="Show debug information")
-    parser.add_argument("--time-range", default="730",
+    parser.add_argument("--time-range", default="48",
                         help="How many hours of time we collect to repair")
-    parser.add_argument("--timeout", default="420",
+    parser.add_argument("--timeout", default="900",
                         help="How many seconds we allow each fsck to run")
     parser.add_argument("--retries", default="1",
                         help="How many times we should try failed metrics")

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+from subprocess import Popen, PIPE, TimeoutExpired
+from random import shuffle
+import time
+import argparse
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+import logging
+import pprint
+
+log = logging.getLogger("tsd-repair")
+log.setLevel(logging.INFO)
+ch = logging.StreamHandler()
+logformat = '%(asctime)s %(name)s %(levelname)s %(message)s'
+formatter = logging.Formatter(logformat)
+ch.setFormatter(formatter)
+log.addHandler(ch)
+
+
+def get_metrics():
+    """
+    Collect all metrics from OpenTSDB
+
+    :returns: all metrics
+    :rtype: list
+    """
+    proc = Popen('/usr/share/opentsdb/bin/tsdb uid grep metrics ".*"',
+                 shell=True, stdout=PIPE, stderr=PIPE)
+    results = proc.communicate()
+    metrics = [m.split(" ")[1].strip(":")
+               for m in results[0].decode().split("\n") if m]
+    metrics = [m for m in metrics if m and m != "\x00"]
+    shuffle(metrics)
+    log.info("There are {} metrics to process".format(len(metrics)))
+    return metrics
+
+
+def process_metrics(metrics, time_range, timeout):
+    """
+    Run fsck on a list of metrics over a time range
+    """
+    failed_metrics = []
+    base = "sudo -u opentsdb /usr/share/opentsdb/bin/tsdb fsck"
+    cmd = "{} {}h-ago sum".format(base, time_range)
+    for index, metric in enumerate(metrics):
+        log.info("Repairing {} ({} of {})".format(metric,
+                                                  index + 1,
+                                                  len(metrics)))
+        fullcmd = "{} {} --fix-all --compact".format(cmd, metric)
+        metricproc = Popen(fullcmd, shell=True, stdout=PIPE, stderr=PIPE)
+        try:
+            results, err = metricproc.communicate(timeout=timeout)
+        except TimeoutExpired:
+            log.warning("{} failed to complete in window".format(metric))
+            failed_metrics.append(metric)
+        except Exception as e:
+            log.error("General exception processing {} :: {}".format(metric,
+                                                                     e))
+        else:
+            results = [r for r in results.decode().split("\n") if r][-26:]
+            final_results = []
+            for r in results:
+                line = r.split(" ")[6:]
+                try:
+                    if int(line[-1]) != 0:
+                        final_results.append(" ".join(line))
+                except Exception:
+                    final_results.append(" ".join(line))
+            result_str = "\n".join(final_results)
+            log.info("{} results:\n{}".format(metric,
+                                              result_str))
+        log.debug("Waiting 10 seconds to give HBase a break...")
+        time.sleep(10)
+    return failed_metrics
+
+
+def cli_opts():
+    parser = ArgumentParser(description="Repair all OpenTSDB metrics",
+                            formatter_class=ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--debug", action="store_true", default=False,
+                        help="Show debug information")
+    parser.add_argument("--time-range", default="730",
+                        help="How many hours of time we collect to repair")
+    parser.add_argument("--timeout", default="360",
+                        help="How many seconds we allow each fsck to run")
+    parser.add_argument("--retries", default="1",
+                        help="How many times we should try failed metrics")
+    return parser.parse_args()
+
+
+def main():
+    args = cli_opts()
+    if args.debug:
+        log.setLevel(logging.DEBUG)
+    try:
+        time_range = int(args.time_range)
+    except Exception as e:
+        log.error("Invalid time range {} :: {}".format(args.time_range, e))
+    try:
+        retries = int(args.retries)
+    except Exception as e:
+        log.error("Invalid retry number {} :: {}".format(args.retries, e))
+    try:
+        timeout = int(args.timeout)
+    except Exception as e:
+        log.error("Invalid timeout {} :: {}".format(args.timeout, e))
+
+    warn = "You have set a timeout of {} seconds.".format(timeout)
+    warn += " All individual metric repairs are allowed to run"
+    warn += " that long. Please don't cancel a repair while it"
+    warn += " is running!"
+    log.warning(warn)
+    metrics = get_metrics()
+    failed = process_metrics(metrics, time_range, timeout)
+
+    for x in range(0, retries):
+        if not failed:
+            continue
+        log.info("{} metrics failed".format(len(failed)))
+        failed_str = "\n".join(failed)
+        log.debug("failed metrics:\n{}".format(pprint.pformat(failed_str)))
+        log.info("Re-trying with failed metrics only...")
+        failed = process_metrics(failed, time_range, timeout)
+    log.info("After {} repair runs:".format(retries+1))
+    log.info("{} un-repaired metrics".format(len(failed)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -18,7 +18,12 @@ log.addHandler(ch)
 
 class TSDRepair(object):
     def __init__(self, args):
-        self.timeout = args.get("timeout", 900)
+        """
+        We'll magic number the timeout because we know each individual chunk should take
+        less than one hour to complete. So 58 minutes * 60 seconds per minute is our
+        time limit per metric chunk...
+        """
+        self.timeout = 58 * 60
         self.retries = args.get("retries", 1)
         self.time_range = args.get("time_range", 48)
         self.tsd_path = args.get("tsd_path", "/usr/share/opentsdb/bin/tsdb")
@@ -89,18 +94,17 @@ class TSDRepair(object):
                     self.log.error("Bad runtime results for {} :: {}".format(metric, final_results))
                 result_str = "\n".join(final_results)
                 self.log.debug("{} results:\n{}".format(metric, result_str))
-                self.log.info("{} (chunk {}): completed in {} seconds".format(metric, chunk, runtime))
-                return [], runtime
+                self.log.debug("{} (chunk {}): completed in {} seconds".format(metric, chunk, runtime))
+                return []
         else:
             self.log.error("Failed to completely repair {}".format(metric))
-            return metric, 0
+            return metric
 
     def process_metrics(self):
         """
         Run fsck on a list of metrics over a time range
         """
         failed_metrics = []
-        timer = 0
         metrics = self._get_metrics()
         for index, metric in enumerate(metrics):
             try:
@@ -112,15 +116,12 @@ class TSDRepair(object):
                                                                        index + 1,
                                                                        len(metrics),
                                                                        len(failed_metrics)))
-            failed, count = self._repair_metric(metric, "1h-ago", 1)
-            failed_metrics.append(failed)
-            timer += count
-            for x in range(2, self.time_range):
-                failed, count = self._repair_metric(metric, "{}h-ago {}h-ago".format(x, x - 1), x)
-                failed_metrics.append(failed)
-                timer += count
-            self.log.info("{} took {} seconds to complete".format(metric, timer))
-            exit(1)
+            start_time = time.time()
+            failed_metrics.append(self._repair_metric(metric, "1h-ago", 1))
+            for x in range(2, self.time_range + 1):
+                failed_metrics.append(self._repair_metric(metric, "{}h-ago {}h-ago".format(x, x - 1), x))
+            runtime = time.time() - start_time
+            self.log.info("{} took {} seconds to complete".format(metric, runtime))
         self.log.info("Failed metrics: {}".format(failed_metrics))
         return failed_metrics
 
@@ -132,8 +133,6 @@ def cli_opts():
                         help="Show debug information")
     parser.add_argument("--time-range", default="48",
                         help="How many hours of time we collect to repair")
-    parser.add_argument("--timeout", default="900",
-                        help="How many seconds we allow each fsck to run")
     parser.add_argument("--retries", default="1",
                         help="How many times we should try failed metrics")
     parser.add_argument("--tsd-path", default="/usr/share/opentsdb/bin/tsdb",
@@ -159,13 +158,9 @@ def main():
         retries = int(args.retries)
     except Exception as e:
         log.error("Invalid retry number {} :: {}".format(args.retries, e))
-    try:
-        timeout = int(args.timeout)
-    except Exception as e:
-        log.error("Invalid timeout {} :: {}".format(args.timeout, e))
 
-    repair_tool = TSDRepair({"timeout": timeout, "time_range": time_range,
-                             "use_sudo": args.use_sudo, "sudo_user": args.sudo_user,
+    repair_tool = TSDRepair({"time_range": time_range, "use_sudo": args.use_sudo,
+                             "sudo_user": args.sudo_user,
                              "tsd_path": args.tsd_path, "cfg_path": args.cfg_path,
                              "retries": retries})
     repair_tool.process_metrics()

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -18,15 +18,12 @@ log.addHandler(ch)
 
 class TSDRepair(object):
     def __init__(self, args):
-        """
-        We'll magic number the timeout because we know each individual chunk should take
-        less than one hour to complete. So 58 minutes * 60 seconds per minute is our
-        time limit per metric chunk...
-        """
-        self.timeout = 58 * 60
-        self.time_chunk = 30
+        self.time_chunk = args.get("time_chunk", 15)
+        self.timeout = int(self.time_chunk * 60)
         self.retries = args.get("retries", 1)
+        self.multiplier = int(60 / self.time_chunk)
         self.time_range = args.get("time_range", 48)
+        self.chunk_count = self.time_range * self.multiplier
         self.tsd_path = args.get("tsd_path", "/usr/share/opentsdb/bin/tsdb")
         self.cfg_path = args.get("cfg_path", "/etc/opentsdb/opentsdb.conf")
         self.use_sudo = args.get("use_sudo", False)
@@ -50,8 +47,9 @@ class TSDRepair(object):
         :returns: all metrics
         :rtype: list
         """
-        proc = Popen('{} uid --config={} grep metrics ".*"'.format(self.tsd_path, self.cfg_path),
-                     shell=True, stdout=PIPE, stderr=PIPE)
+        cmd = '{} uid --config={} grep metrics ".*"'.format(self.tsd_path,
+                                                            self.cfg_path)
+        proc = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)
         results = proc.communicate()
         metrics = [m.split(" ")[1].strip(":")
                    for m in results[0].decode().split("\n") if m]
@@ -68,19 +66,19 @@ class TSDRepair(object):
             timestr = "{}m-ago {}m-ago".format((chunk + 1) * self.time_chunk,
                                                chunk * self.time_chunk)
         cmd = "{} {} sum".format(self.base, timestr)
-        for x in range(0, self.retries + 1):
-            self.log.debug("Repair try {} for {}".format(x + 1, timestr))
+        for x in range(1, self.retries + 2):
+            self.log.debug("Repair try {} for {}".format(x, timestr))
             fullcmd = "{} {} --fix-all --compact".format(cmd, metric)
             self.log.debug("Full command: {}".format(fullcmd))
             metricproc = Popen(fullcmd, shell=True, stdout=PIPE, stderr=PIPE)
             try:
                 results, err = metricproc.communicate(timeout=self.timeout)
             except TimeoutExpired:
-                self.log.debug("{} failed to complete in window (run {})".format(metric, x + 1))
+                self.log.debug("{} failed to complete in window (run {})".format(metric, x))
                 continue
             except Exception as e:
-                self.log.error("General exception processing {} :: {}".format(metric,
-                                                                              e))
+                self.log.error("General exception {} :: {}".format(metric,
+                                                                   e))
             else:
                 results = [r for r in results.decode().split("\n") if r][-26:]
                 final_results = []
@@ -93,17 +91,10 @@ class TSDRepair(object):
                             final_results.append(" ".join(line))
                     except Exception:
                         final_results.append(" ".join(line))
-                # We'll always show the run time, so separate that from the other lines
-                try:
-                    runtime = int(final_results.pop(-1).split()[3].strip('[]'))
-                except Exception:
-                    self.log.error("Bad runtime results for {} :: {}".format(metric, final_results))
                 result_str = "\n".join(final_results)
+                if self.chunk_count % chunk == 0:
+                    self.log.info("Completed {} chunks (of {}) for {}".format(chunk, self.chunk_count, metric))
                 self.log.debug("{} results:\n{}".format(metric, result_str))
-                if runtime > 30:
-                    self.log.info("{} (chunk {}): completed in {} seconds".format(metric, chunk, runtime))
-                else:
-                    self.log.debug("{} (chunk {}): completed in {} seconds".format(metric, chunk, runtime))
                 return []
         else:
             self.log.error("Failed to completely repair {}".format(metric))
@@ -115,23 +106,23 @@ class TSDRepair(object):
         """
         failed_metrics = []
         metrics = self._get_metrics()
-        multiplier = int(60 / self.time_chunk)
-        chunk_count = self.time_range * multiplier
         for index, metric in enumerate(metrics):
             try:
-                check_output("{} {}".format(self.check_cmd, metric), shell=True)
+                check_output("{} {}".format(self.check_cmd, metric),
+                             shell=True)
             except Exception:
-                log.warning("{} doesn't actually exist! Skipping...".format(metric))
+                log.warning("{} doesn't exist! Skipping...".format(metric))
                 continue
             logline = "{} ({} of {})".format(metric, index + 1, len(metrics))
             logline += " ({} failed) in {} chunks".format(len(failed_metrics),
-                                                              chunk_count)
+                                                              self.chunk_count)
             self.log.info(logline)
             start_time = time.time()
-            for x in range(1, (self.time_range * multiplier) + 1):
-                failed_metrics.extend(self._repair_metric(metric, x))
+            failed_metrics = [self._repair_metric(metric, x)
+                              for x in range(1, self.chunk_count + 1)]
             runtime = time.time() - start_time
-            self.log.info("{} took {} seconds to complete".format(metric, int(runtime)))
+            self.log.info("{} repair took {} seconds".format(metric,
+                                                             int(runtime)))
         self.log.info("Failed metrics: {}".format(failed_metrics))
         return failed_metrics
 
@@ -143,6 +134,8 @@ def cli_opts():
                         help="Show debug information")
     parser.add_argument("--time-range", default="48",
                         help="How many hours of time we collect to repair")
+    parser.add_argument("--time-chunk", default="15",
+                        help="How many minutes of data we should scan at a time")
     parser.add_argument("--retries", default="1",
                         help="How many times we should try failed metrics")
     parser.add_argument("--tsd-path", default="/usr/share/opentsdb/bin/tsdb",
@@ -168,13 +161,21 @@ def main():
         retries = int(args.retries)
     except Exception as e:
         log.error("Invalid retry number {} :: {}".format(args.retries, e))
+    try:
+        time_chunk = int(args.time_chunk)
+        if 60 % time_chunk != 0:
+            raise ArithmeticError
+    except Exception as e:
+        log.error("Invalid time chunk {} :: {}".format(args.retries, e))
 
-    repair_tool = TSDRepair({"time_range": time_range, "use_sudo": args.use_sudo,
+    repair_tool = TSDRepair({"time_range": time_range,
+                             "use_sudo": args.use_sudo,
                              "sudo_user": args.sudo_user,
-                             "tsd_path": args.tsd_path, "cfg_path": args.cfg_path,
+                             "time_chunk": time_chunk,
+                             "tsd_path": args.tsd_path,
+                             "cfg_path": args.cfg_path,
                              "retries": retries})
     repair_tool.process_metrics()
-
     repair_tool.process_metrics()
 
 

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -53,7 +53,7 @@ class TSDRepair(object):
         """
         Run fsck on a list of metrics over a time range
         """
-        failed_metrics = 0
+        failed_metrics = []
         base = "{} fsck --config={}".format(self.tsd_path, self.cfg_path)
         check_cmd = "{} uid --config={} metrics".format(self.tsd_path, self.cfg_path)
         if self.use_sudo:
@@ -70,14 +70,14 @@ class TSDRepair(object):
             self.log.info("Repairing {} ({} of {}) ({} failed)".format(metric,
                                                                        index + 1,
                                                                        len(metrics),
-                                                                       failed_metrics))
+                                                                       len(failed_metrics)))
             for x in range(0, self.retries + 1):
                 fullcmd = "{} {} --fix-all --compact".format(cmd, metric)
                 metricproc = Popen(fullcmd, shell=True, stdout=PIPE, stderr=PIPE)
                 try:
                     results, err = metricproc.communicate(timeout=self.timeout)
                 except TimeoutExpired:
-                    self.log.warning("{} failed to complete in window".format(metric))
+                    self.log.debug("{} failed to complete in window (run {})".format(metric, x + 1))
                     continue
                 except Exception as e:
                     self.log.error("General exception processing {} :: {}".format(metric,
@@ -98,10 +98,10 @@ class TSDRepair(object):
                     self.log.info("{}: {}".format(metric, runtime))
                     break
             else:
-                failed_metrics += 1
-            # self.log.debug("Waiting 5 seconds to give HBase a break...")
-            # time.sleep(5)
-        self.log.info("{} metrics failed".format(failed_metrics))
+                self.log.error("Failed to completely repair {}".format(metric))
+                failed_metrics.append(metric)
+        self.log.info("Failed metrics: {}".format(failed_metrics))
+        return failed_metrics
 
 
 def cli_opts():

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -19,6 +19,7 @@ log.addHandler(ch)
 class TSDRepair(object):
     def __init__(self, args):
         self.timeout = args.get("timeout", 360)
+        self.retries = args.get("retries", 1)
         self.time_range = args.get("time_range", 26280)
         self.tsd_path = args.get("tsd_path", "/usr/share/opentsdb/bin/tsdb")
         self.cfg_path = args.get("cfg_path", "/etc/opentsdb/opentsdb.conf")
@@ -30,7 +31,6 @@ class TSDRepair(object):
         warn += " that long. Please don't cancel a repair while it"
         warn += " is running!"
         self.log.warning(warn)
-        self.metrics = self._get_metrics()
 
     def _get_metrics(self):
         """
@@ -39,7 +39,7 @@ class TSDRepair(object):
         :returns: all metrics
         :rtype: list
         """
-        proc = Popen('{} uid grep metrics ".*"'.format(self.tsd_path),
+        proc = Popen('{} uid --config={} grep metrics ".*"'.format(self.tsd_path, self.cfg_path),
                      shell=True, stdout=PIPE, stderr=PIPE)
         results = proc.communicate()
         metrics = [m.split(" ")[1].strip(":")
@@ -53,14 +53,15 @@ class TSDRepair(object):
         """
         Run fsck on a list of metrics over a time range
         """
-        failed_metrics = []
-        base = "{} fsck".format(self.tsd_path)
-        check_cmd = "{} uid metrics".format(self.tsd_path)
+        failed_metrics = 0
+        base = "{} fsck --config={}".format(self.tsd_path, self.cfg_path)
+        check_cmd = "{} uid --config={} metrics".format(self.tsd_path, self.cfg_path)
         if self.use_sudo:
             base = "sudo -u {} {}".format(self.sudo_user, base)
             check_cmd = "sudo -u {} {}".format(self.sudo_user, check_cmd)
         cmd = "{} {}h-ago sum".format(base, self.time_range)
-        for index, metric in enumerate(self.metrics):
+        metrics = self._get_metrics()
+        for index, metric in enumerate(metrics):
             try:
                 check_output("{} {}".format(check_cmd, metric), shell=True)
             except Exception:
@@ -68,36 +69,39 @@ class TSDRepair(object):
                 continue
             self.log.info("Repairing {} ({} of {}) ({} failed)".format(metric,
                                                                        index + 1,
-                                                                       len(self.metrics),
-                                                                       len(failed_metrics)))
-            fullcmd = "{} {} --fix-all --compact".format(cmd, metric)
-            metricproc = Popen(fullcmd, shell=True, stdout=PIPE, stderr=PIPE)
-            try:
-                results, err = metricproc.communicate(timeout=self.timeout)
-            except TimeoutExpired:
-                self.log.warning("{} failed to complete in window".format(metric))
-                failed_metrics.append(metric)
-            except Exception as e:
-                self.log.error("General exception processing {} :: {}".format(metric,
+                                                                       len(metrics),
+                                                                       failed_metrics))
+            for x in range(0, self.retries + 1):
+                fullcmd = "{} {} --fix-all --compact".format(cmd, metric)
+                metricproc = Popen(fullcmd, shell=True, stdout=PIPE, stderr=PIPE)
+                try:
+                    results, err = metricproc.communicate(timeout=self.timeout)
+                except TimeoutExpired:
+                    self.log.warning("{} failed to complete in window".format(metric))
+                    continue
+                except Exception as e:
+                    self.log.error("General exception processing {} :: {}".format(metric,
                                                                               e))
-            else:
-                results = [r for r in results.decode().split("\n") if r][-26:]
-                final_results = []
-                for r in results:
-                    line = r.split(" ")[6:]
-                    try:
-                        if int(line[-1]) != 0:
+                else:
+                    results = [r for r in results.decode().split("\n") if r][-26:]
+                    final_results = []
+                    for r in results:
+                        line = r.split(" ")[6:]
+                        try:
+                            if int(line[-1]) != 0:
+                                final_results.append(" ".join(line))
+                        except Exception:
                             final_results.append(" ".join(line))
-                    except Exception:
-                        final_results.append(" ".join(line))
-                runtime = final_results.pop(-1)
-                result_str = "\n".join(final_results)
-                self.log.debug("{} results:\n{}".format(metric, result_str))
-                self.log.info("{}: {}".format(metric, runtime))
+                    runtime = final_results.pop(-1)
+                    result_str = "\n".join(final_results)
+                    self.log.debug("{} results:\n{}".format(metric, result_str))
+                    self.log.info("{}: {}".format(metric, runtime))
+                    break
+            else:
+                failed_metrics += 1
             # self.log.debug("Waiting 5 seconds to give HBase a break...")
             # time.sleep(5)
-        self.log.info("{} metrics failed".format(len(failed_metrics)))
-        self.metrics = failed_metrics
+        self.log.info("{} metrics failed".format(failed_metrics))
 
 
 def cli_opts():
@@ -141,18 +145,11 @@ def main():
 
     repair_tool = TSDRepair({"timeout": timeout, "time_range": time_range,
                              "use_sudo": args.use_sudo, "sudo_user": args.sudo_user,
-                             "tsd_path": args.tsd_path, "cfg_path": args.cfg_path})
+                             "tsd_path": args.tsd_path, "cfg_path": args.cfg_path,
+                             "retries": retries})
     repair_tool.process_metrics()
 
-    for x in range(0, retries):
-        if not repair_tool.metrics:
-            continue
-        failed_str = "\n".join(repair_tool.metrics)
-        log.debug("failed metrics:\n{}".format(pprint.pformat(failed_str)))
-        log.info("Re-trying with failed metrics only...")
-        repair_tool.process_metrics()
-    log.info("After {} repair runs:".format(retries+1))
-    log.info("{} un-repaired metrics".format(len(repair_tool.metrics)))
+    repair_tool.process_metrics()
 
 
 if __name__ == "__main__":

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -24,6 +24,7 @@ class TSDRepair(object):
         time limit per metric chunk...
         """
         self.timeout = 58 * 60
+        self.time_chunk = 30
         self.retries = args.get("retries", 1)
         self.time_range = args.get("time_range", 48)
         self.tsd_path = args.get("tsd_path", "/usr/share/opentsdb/bin/tsdb")
@@ -59,8 +60,13 @@ class TSDRepair(object):
         self.log.info("There are {} metrics to process".format(len(metrics)))
         return metrics
 
-    def _repair_metric(self, metric, timestr, chunk):
+    def _repair_metric(self, metric, chunk):
         self.log.debug("Running chunk {} for {}".format(chunk, metric))
+        if chunk < 2:
+            timestr = "{}m-ago".format(self.time_chunk)
+        else:
+            timestr = "{}m-ago {}m-ago".format((chunk + 1) * self.time_chunk,
+                                               chunk * self.time_chunk)
         cmd = "{} {} sum".format(self.base, timestr)
         for x in range(0, self.retries + 1):
             self.log.debug("Repair try {} for {}".format(x + 1, timestr))
@@ -120,9 +126,9 @@ class TSDRepair(object):
                                                                        len(metrics),
                                                                        len(failed_metrics)))
             start_time = time.time()
-            failed_metrics.extend(self._repair_metric(metric, "1h-ago", 1))
-            for x in range(2, self.time_range + 1):
-                failed_metrics.extend(self._repair_metric(metric, "{}h-ago {}h-ago".format(x, x - 1), x))
+            multiplier = int(60 / self.time_chunk)
+            for x in range(1, (self.time_range * multiplier) + 1):
+                failed_metrics.extend(self._repair_metric(metric, x))
             runtime = time.time() - start_time
             self.log.info("{} took {} seconds to complete".format(metric, int(runtime)))
         self.log.info("Failed metrics: {}".format(failed_metrics))

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -115,18 +115,19 @@ class TSDRepair(object):
         """
         failed_metrics = []
         metrics = self._get_metrics()
+        multiplier = int(60 / self.time_chunk)
+        chunk_count = self.time_range * multiplier
         for index, metric in enumerate(metrics):
             try:
                 check_output("{} {}".format(self.check_cmd, metric), shell=True)
             except Exception:
                 log.warning("{} doesn't actually exist! Skipping...".format(metric))
                 continue
-            self.log.info("Repairing {} ({} of {}) ({} failed)".format(metric,
-                                                                       index + 1,
-                                                                       len(metrics),
-                                                                       len(failed_metrics)))
+            logline = "{} ({} of {})".format(metric, index + 1, len(metrics))
+            logline += " ({} failed) in {} chunks".format(len(failed_metrics),
+                                                              chunk_count)
+            self.log.info(logline)
             start_time = time.time()
-            multiplier = int(60 / self.time_chunk)
             for x in range(1, (self.time_range * multiplier) + 1):
                 failed_metrics.extend(self._repair_metric(metric, x))
             runtime = time.time() - start_time

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from subprocess import Popen, PIPE, TimeoutExpired
+from subprocess import Popen, PIPE, TimeoutExpired, check_output
 from random import shuffle
 import time
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
@@ -21,6 +21,7 @@ class TSDRepair(object):
         self.timeout = args.get("timeout", 360)
         self.time_range = args.get("time_range", 26280)
         self.tsd_path = args.get("tsd_path", "/usr/share/opentsdb/bin/tsdb")
+        self.cfg_path = args.get("cfg_path", "/etc/opentsdb/opentsdb.conf")
         self.use_sudo = args.get("use_sudo", False)
         self.sudo_user = args.get("sudo_user", "opentsdb")
         self.log = logging.getLogger("repair-tsd.class")
@@ -54,11 +55,21 @@ class TSDRepair(object):
         """
         failed_metrics = []
         base = "{} fsck".format(self.tsd_path)
+        check_cmd = "{} uid metrics".format(self.tsd_path)
         if self.use_sudo:
             base = "sudo -u {} {}".format(self.sudo_user, base)
+            check_cmd = "sudo -u {} {}".format(self.sudo_user, check_cmd)
         cmd = "{} {}h-ago sum".format(base, self.time_range)
         for index, metric in enumerate(self.metrics):
-            self.log.info("Repairing {} ({} of {})".format(metric, index + 1, len(self.metrics)))
+            try:
+                check_output("{} {}".format(check_cmd, metric), shell=True)
+            except Exception:
+                log.warning("{} doesn't actually exist! Skipping...".format(metric))
+                continue
+            self.log.info("Repairing {} ({} of {}) ({} failed)".format(metric,
+                                                                       index + 1,
+                                                                       len(self.metrics),
+                                                                       len(failed_metrics)))
             fullcmd = "{} {} --fix-all --compact".format(cmd, metric)
             metricproc = Popen(fullcmd, shell=True, stdout=PIPE, stderr=PIPE)
             try:
@@ -79,13 +90,13 @@ class TSDRepair(object):
                             final_results.append(" ".join(line))
                     except Exception:
                         final_results.append(" ".join(line))
+                runtime = final_results.pop(-1)
                 result_str = "\n".join(final_results)
-                self.log.info("{} results:\n{}".format(metric, result_str))
-            self.log.debug("Waiting 10 seconds to give HBase a break...")
-            time.sleep(10)
+                self.log.debug("{} results:\n{}".format(metric, result_str))
+                self.log.info("{}: {}".format(metric, runtime))
+            # self.log.debug("Waiting 5 seconds to give HBase a break...")
+            # time.sleep(5)
         self.log.info("{} metrics failed".format(len(failed_metrics)))
-        failed_str = "\n".join(failed_metrics)
-        log.debug("failed metrics:\n{}".format(pprint.pformat(failed_str)))
         self.metrics = failed_metrics
 
 
@@ -96,12 +107,14 @@ def cli_opts():
                         help="Show debug information")
     parser.add_argument("--time-range", default="730",
                         help="How many hours of time we collect to repair")
-    parser.add_argument("--timeout", default="360",
+    parser.add_argument("--timeout", default="420",
                         help="How many seconds we allow each fsck to run")
     parser.add_argument("--retries", default="1",
                         help="How many times we should try failed metrics")
     parser.add_argument("--tsd-path", default="/usr/share/opentsdb/bin/tsdb",
                         help="Path to the OpenTSDB CLI binary")
+    parser.add_argument("--cfg-path", default="/etc/opentsdb/opentsdb.conf",
+                        help="Path to OpenTSDB config")
     parser.add_argument("--use-sudo", action="store_true",
                         default=False, help="Whether to switch user when running repairs")
     parser.add_argument("--sudo-user", default="opentsdb",
@@ -128,12 +141,14 @@ def main():
 
     repair_tool = TSDRepair({"timeout": timeout, "time_range": time_range,
                              "use_sudo": args.use_sudo, "sudo_user": args.sudo_user,
-                             "tsd_path": args.tsd_path})
+                             "tsd_path": args.tsd_path, "cfg_path": args.cfg_path})
     repair_tool.process_metrics()
 
     for x in range(0, retries):
         if not repair_tool.metrics:
             continue
+        failed_str = "\n".join(repair_tool.metrics)
+        log.debug("failed metrics:\n{}".format(pprint.pformat(failed_str)))
         log.info("Re-trying with failed metrics only...")
         repair_tool.process_metrics()
     log.info("After {} repair runs:".format(retries+1))

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -94,7 +94,10 @@ class TSDRepair(object):
                     self.log.error("Bad runtime results for {} :: {}".format(metric, final_results))
                 result_str = "\n".join(final_results)
                 self.log.debug("{} results:\n{}".format(metric, result_str))
-                self.log.debug("{} (chunk {}): completed in {} seconds".format(metric, chunk, runtime))
+                if runtime > 30:
+                    self.log.info("{} (chunk {}): completed in {} seconds".format(metric, chunk, runtime))
+                else:
+                    self.log.debug("{} (chunk {}): completed in {} seconds".format(metric, chunk, runtime))
                 return []
         else:
             self.log.error("Failed to completely repair {}".format(metric))

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -83,6 +83,7 @@ class TSDRepair(object):
                 self.log.info("{} results:\n{}".format(metric, result_str))
             self.log.debug("Waiting 10 seconds to give HBase a break...")
             time.sleep(10)
+        self.log.info("{} metrics failed".format(len(failed_metrics)))
         self.metrics = failed_metrics
 
 
@@ -131,7 +132,6 @@ def main():
     for x in range(0, retries):
         if not repair_tool.metrics:
             continue
-        log.info("{} metrics failed".format(len(repair_tool.metrics)))
         failed_str = "\n".join(repair_tool.metrics)
         log.debug("failed metrics:\n{}".format(pprint.pformat(failed_str)))
         log.info("Re-trying with failed metrics only...")

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -98,7 +98,7 @@ class TSDRepair(object):
                 return []
         else:
             self.log.error("Failed to completely repair {}".format(metric))
-            return metric
+            return [metric]
 
     def process_metrics(self):
         """
@@ -117,11 +117,11 @@ class TSDRepair(object):
                                                                        len(metrics),
                                                                        len(failed_metrics)))
             start_time = time.time()
-            failed_metrics.append(self._repair_metric(metric, "1h-ago", 1))
+            failed_metrics.extend(self._repair_metric(metric, "1h-ago", 1))
             for x in range(2, self.time_range + 1):
-                failed_metrics.append(self._repair_metric(metric, "{}h-ago {}h-ago".format(x, x - 1), x))
+                failed_metrics.extend(self._repair_metric(metric, "{}h-ago {}h-ago".format(x, x - 1), x))
             runtime = time.time() - start_time
-            self.log.info("{} took {} seconds to complete".format(metric, runtime))
+            self.log.info("{} took {} seconds to complete".format(metric, int(runtime)))
         self.log.info("Failed metrics: {}".format(failed_metrics))
         return failed_metrics
 

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -34,11 +34,6 @@ class TSDRepair(object):
         if self.use_sudo:
             self.base = "sudo -u {} {}".format(self.sudo_user, self.base)
             self.check_cmd = "sudo -u {} {}".format(self.sudo_user, self.check_cmd)
-        warn = "You have set a timeout of {} seconds.".format(self.timeout)
-        warn += " All individual metric repairs are allowed to run"
-        warn += " that long. Please don't cancel a repair while it"
-        warn += " is running!"
-        self.log.warning(warn)
 
     def _get_metrics(self):
         """
@@ -47,18 +42,28 @@ class TSDRepair(object):
         :returns: all metrics
         :rtype: list
         """
+        try:
+            self.store_path = args.get('store_path', '/tmp/opentsdb.list')
+            with open(self.store_path, 'r') as f_in:
+                finished_metrics = [m for m in f_in.read().split('\n') if m]
+        except Exception:
+            finished_metrics = []
         cmd = '{} uid --config={} grep metrics ".*"'.format(self.tsd_path,
                                                             self.cfg_path)
         proc = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)
         results = proc.communicate()
         metrics = [m.split(" ")[1].strip(":")
                    for m in results[0].decode().split("\n") if m]
-        metrics = [m for m in metrics if m and m != "\x00"]
+        metrics = [m for m in metrics if m and m != "\x00" and
+                   m not in finished_metrics]
         shuffle(metrics)
         self.log.info("There are {} metrics to process".format(len(metrics)))
         return metrics
 
-    def _repair_metric(self, metric, chunk):
+    def _repair_metric_chunk(self, metric, chunk):
+        """
+        Repair one 'chunk' of data for a metric
+        """
         self.log.debug("Running chunk {} for {}".format(chunk, metric))
         if chunk < 2:
             timestr = "{}m-ago".format(self.time_chunk)
@@ -66,6 +71,9 @@ class TSDRepair(object):
             timestr = "{}m-ago {}m-ago".format((chunk + 1) * self.time_chunk,
                                                chunk * self.time_chunk)
         cmd = "{} {} sum".format(self.base, timestr)
+        """
+        Even though we're chunking, it's worth trying things more than once
+        """
         for x in range(1, self.retries + 2):
             self.log.debug("Repair try {} for {}".format(x, timestr))
             fullcmd = "{} {} --fix-all --compact".format(cmd, metric)
@@ -77,12 +85,15 @@ class TSDRepair(object):
                 self.log.debug("{} failed to complete in window (run {})".format(metric, x))
                 continue
             except Exception as e:
-                self.log.error("General exception {} :: {}".format(metric,
+                self.log.error("{} general exception :: {}".format(metric,
                                                                    e))
             else:
                 results = [r for r in results.decode().split("\n") if r][-26:]
                 final_results = []
-                # We'll only collect results that are non-0, since we're not super interested in stuff that didn't change
+                """
+                We'll only collect results that are non-0
+                since we're not super interested in stuff that didn't change.
+                """
                 for r in results:
                     # Strip the timestamp from the log line
                     line = r.split(" ")[6:]
@@ -92,13 +103,20 @@ class TSDRepair(object):
                     except Exception:
                         final_results.append(" ".join(line))
                 result_str = "\n".join(final_results)
-                if self.chunk_count % chunk == 0:
-                    self.log.info("Completed {} chunks (of {}) for {}".format(chunk, self.chunk_count, metric))
                 self.log.debug("{} results:\n{}".format(metric, result_str))
-                return []
+                if chunk % 20 == 0:
+                    self.log.info("Chunk {} of {} finished".format(chunk, self.chunk_count))
+                else:
+                    self.log.debug("Chunk {} of {} finished".format(chunk, self.chunk_count))
+                try:
+                    with open(self.store_path, 'a') as f_out:
+                        f_out.write("{}\n".format(metric))
+                except Exception:
+                    pass
+                return None
         else:
             self.log.error("Failed to completely repair {}".format(metric))
-            return [metric]
+            return metric
 
     def process_metrics(self):
         """
@@ -118,8 +136,10 @@ class TSDRepair(object):
                                                               self.chunk_count)
             self.log.info(logline)
             start_time = time.time()
-            failed_metrics = [self._repair_metric(metric, x)
+            start_time_min = int(start_time//60 * 60)
+            failed_metrics = [self._repair_metric_chunk(metric, x)
                               for x in range(1, self.chunk_count + 1)]
+            failed_metrics = [m for m in failed_metrics if m]
             runtime = time.time() - start_time
             self.log.info("{} repair took {} seconds".format(metric,
                                                              int(runtime)))
@@ -135,15 +155,18 @@ def cli_opts():
     parser.add_argument("--time-range", default="48",
                         help="How many hours of time we collect to repair")
     parser.add_argument("--time-chunk", default="15",
-                        help="How many minutes of data we should scan at a time")
+                        help="How many minutes of data to scan per chunk")
     parser.add_argument("--retries", default="1",
                         help="How many times we should try failed metrics")
     parser.add_argument("--tsd-path", default="/usr/share/opentsdb/bin/tsdb",
                         help="Path to the OpenTSDB CLI binary")
     parser.add_argument("--cfg-path", default="/etc/opentsdb/opentsdb.conf",
                         help="Path to OpenTSDB config")
+    parser.add_argument("--store-path", default="/opentsdb-fsck.list",
+                        help="Path to OpenTSDB config")
     parser.add_argument("--use-sudo", action="store_true",
-                        default=False, help="Whether to switch user when running repairs")
+                        default=False,
+                        help="switch user when running repairs?")
     parser.add_argument("--sudo-user", default="opentsdb",
                         help="User to switch to...")
     return parser.parse_args()
@@ -174,8 +197,8 @@ def main():
                              "time_chunk": time_chunk,
                              "tsd_path": args.tsd_path,
                              "cfg_path": args.cfg_path,
+                             "store_path": args.store_path,
                              "retries": retries})
-    repair_tool.process_metrics()
     repair_tool.process_metrics()
 
 

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -3,12 +3,11 @@
 from subprocess import Popen, PIPE, TimeoutExpired
 from random import shuffle
 import time
-import argparse
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import logging
 import pprint
 
-log = logging.getLogger("tsd-repair")
+log = logging.getLogger("repair-tsd")
 log.setLevel(logging.INFO)
 ch = logging.StreamHandler()
 logformat = '%(asctime)s %(name)s %(levelname)s %(message)s'
@@ -17,61 +16,74 @@ ch.setFormatter(formatter)
 log.addHandler(ch)
 
 
-def get_metrics():
-    """
-    Collect all metrics from OpenTSDB
+class TSDRepair(object):
+    def __init__(self, args):
+        self.timeout = args.get("timeout", 360)
+        self.time_range = args.get("time_range", 26280)
+        self.tsd_path = args.get("tsd_path", "/usr/share/opentsdb/bin/tsdb")
+        self.use_sudo = args.get("use_sudo", False)
+        self.sudo_user = args.get("sudo_user", "opentsdb")
+        self.log = logging.getLogger("repair-tsd.class")
+        warn = "You have set a timeout of {} seconds.".format(self.timeout)
+        warn += " All individual metric repairs are allowed to run"
+        warn += " that long. Please don't cancel a repair while it"
+        warn += " is running!"
+        self.log.warning(warn)
+        self.metrics = self._get_metrics()
 
-    :returns: all metrics
-    :rtype: list
-    """
-    proc = Popen('/usr/share/opentsdb/bin/tsdb uid grep metrics ".*"',
-                 shell=True, stdout=PIPE, stderr=PIPE)
-    results = proc.communicate()
-    metrics = [m.split(" ")[1].strip(":")
-               for m in results[0].decode().split("\n") if m]
-    metrics = [m for m in metrics if m and m != "\x00"]
-    shuffle(metrics)
-    log.info("There are {} metrics to process".format(len(metrics)))
-    return metrics
+    def _get_metrics(self):
+        """
+        Collect all metrics from OpenTSDB
 
+        :returns: all metrics
+        :rtype: list
+        """
+        proc = Popen('{} uid grep metrics ".*"'.format(self.tsd_path),
+                     shell=True, stdout=PIPE, stderr=PIPE)
+        results = proc.communicate()
+        metrics = [m.split(" ")[1].strip(":")
+                   for m in results[0].decode().split("\n") if m]
+        metrics = [m for m in metrics if m and m != "\x00"]
+        shuffle(metrics)
+        self.log.info("There are {} metrics to process".format(len(metrics)))
+        return metrics
 
-def process_metrics(metrics, time_range, timeout):
-    """
-    Run fsck on a list of metrics over a time range
-    """
-    failed_metrics = []
-    base = "sudo -u opentsdb /usr/share/opentsdb/bin/tsdb fsck"
-    cmd = "{} {}h-ago sum".format(base, time_range)
-    for index, metric in enumerate(metrics):
-        log.info("Repairing {} ({} of {})".format(metric,
-                                                  index + 1,
-                                                  len(metrics)))
-        fullcmd = "{} {} --fix-all --compact".format(cmd, metric)
-        metricproc = Popen(fullcmd, shell=True, stdout=PIPE, stderr=PIPE)
-        try:
-            results, err = metricproc.communicate(timeout=timeout)
-        except TimeoutExpired:
-            log.warning("{} failed to complete in window".format(metric))
-            failed_metrics.append(metric)
-        except Exception as e:
-            log.error("General exception processing {} :: {}".format(metric,
-                                                                     e))
-        else:
-            results = [r for r in results.decode().split("\n") if r][-26:]
-            final_results = []
-            for r in results:
-                line = r.split(" ")[6:]
-                try:
-                    if int(line[-1]) != 0:
+    def process_metrics(self):
+        """
+        Run fsck on a list of metrics over a time range
+        """
+        failed_metrics = []
+        base = "{} fsck".format(self.tsd_path)
+        if self.use_sudo:
+            base = "sudo -u {} {}".format(self.sudo_user, base)
+        cmd = "{} {}h-ago sum".format(base, self.time_range)
+        for index, metric in enumerate(self.metrics):
+            self.log.info("Repairing {} ({} of {})".format(metric, index + 1, len(self.metrics)))
+            fullcmd = "{} {} --fix-all --compact".format(cmd, metric)
+            metricproc = Popen(fullcmd, shell=True, stdout=PIPE, stderr=PIPE)
+            try:
+                results, err = metricproc.communicate(timeout=self.timeout)
+            except TimeoutExpired:
+                self.log.warning("{} failed to complete in window".format(metric))
+                failed_metrics.append(metric)
+            except Exception as e:
+                self.log.error("General exception processing {} :: {}".format(metric,
+                                                                              e))
+            else:
+                results = [r for r in results.decode().split("\n") if r][-26:]
+                final_results = []
+                for r in results:
+                    line = r.split(" ")[6:]
+                    try:
+                        if int(line[-1]) != 0:
+                            final_results.append(" ".join(line))
+                    except Exception:
                         final_results.append(" ".join(line))
-                except Exception:
-                    final_results.append(" ".join(line))
-            result_str = "\n".join(final_results)
-            log.info("{} results:\n{}".format(metric,
-                                              result_str))
-        log.debug("Waiting 10 seconds to give HBase a break...")
-        time.sleep(10)
-    return failed_metrics
+                result_str = "\n".join(final_results)
+                self.log.info("{} results:\n{}".format(metric, result_str))
+            self.log.debug("Waiting 10 seconds to give HBase a break...")
+            time.sleep(10)
+        self.metrics = failed_metrics
 
 
 def cli_opts():
@@ -85,6 +97,12 @@ def cli_opts():
                         help="How many seconds we allow each fsck to run")
     parser.add_argument("--retries", default="1",
                         help="How many times we should try failed metrics")
+    parser.add_argument("--tsd-path", default="/usr/share/opentsdb/bin/tsdb",
+                        help="Path to the OpenTSDB CLI binary")
+    parser.add_argument("--use-sudo", action="store_true",
+                        default=False, help="Whether to switch user when running repairs")
+    parser.add_argument("--sudo-user", default="opentsdb",
+                        help="User to switch to...")
     return parser.parse_args()
 
 
@@ -105,24 +123,21 @@ def main():
     except Exception as e:
         log.error("Invalid timeout {} :: {}".format(args.timeout, e))
 
-    warn = "You have set a timeout of {} seconds.".format(timeout)
-    warn += " All individual metric repairs are allowed to run"
-    warn += " that long. Please don't cancel a repair while it"
-    warn += " is running!"
-    log.warning(warn)
-    metrics = get_metrics()
-    failed = process_metrics(metrics, time_range, timeout)
+    repair_tool = TSDRepair({"timeout": timeout, "time_range": time_range,
+                             "use_sudo": args.use_sudo, "sudo_user": args.sudo_user,
+                             "tsd_path": args.tsd_path})
+    repair_tool.process_metrics()
 
     for x in range(0, retries):
-        if not failed:
+        if not repair_tool.metrics:
             continue
-        log.info("{} metrics failed".format(len(failed)))
-        failed_str = "\n".join(failed)
+        log.info("{} metrics failed".format(len(repair_tool.metrics)))
+        failed_str = "\n".join(repair_tool.metrics)
         log.debug("failed metrics:\n{}".format(pprint.pformat(failed_str)))
         log.info("Re-trying with failed metrics only...")
-        failed = process_metrics(failed, time_range, timeout)
+        repair_tool.process_metrics()
     log.info("After {} repair runs:".format(retries+1))
-    log.info("{} un-repaired metrics".format(len(failed)))
+    log.info("{} un-repaired metrics".format(len(repair_tool.metrics)))
 
 
 if __name__ == "__main__":

--- a/tools/repair-tsd
+++ b/tools/repair-tsd
@@ -84,6 +84,8 @@ class TSDRepair(object):
             self.log.debug("Waiting 10 seconds to give HBase a break...")
             time.sleep(10)
         self.log.info("{} metrics failed".format(len(failed_metrics)))
+        failed_str = "\n".join(failed_metrics)
+        log.debug("failed metrics:\n{}".format(pprint.pformat(failed_str)))
         self.metrics = failed_metrics
 
 
@@ -132,8 +134,6 @@ def main():
     for x in range(0, retries):
         if not repair_tool.metrics:
             continue
-        failed_str = "\n".join(repair_tool.metrics)
-        log.debug("failed metrics:\n{}".format(pprint.pformat(failed_str)))
         log.info("Re-trying with failed metrics only...")
         repair_tool.process_metrics()
     log.info("After {} repair runs:".format(retries+1))


### PR DESCRIPTION
This tool runs an OpenTSDB `fsck` one metric at a time, attempting to repair any problems with each metric, and keeping track of metrics that can't complete repair in a pre-defined timeframe.

We needed this tool because we had corruption/problems with our `tsdb` table in our OpenTSDB install, but we didn't know exactly where it was, and a `--full-scan` would hang. Repairing one metric at a time has allowed us to get past our corruption problems in an efficient way.

This tool does require python 3 for the timeout function in subprocess.