### PR TITLE
CORE:

### DIFF
--- a/common/src/main/java/net/opentsdb/core/TSDB.java
+++ b/common/src/main/java/net/opentsdb/core/TSDB.java
@@ -14,6 +14,8 @@
 // limitations under the License.
 package net.opentsdb.core;
 
+import java.util.concurrent.ExecutorService;
+
 import io.netty.util.Timer;
 import net.opentsdb.configuration.Configuration;
 import net.opentsdb.stats.StatsCollector;
@@ -37,5 +39,21 @@ public interface TSDB {
   /** @return A timer used for scheduling non-critical maintenance tasks
    * like metrics collection, expirations, etc. */
   public Timer getMaintenanceTimer();
+  
+  /**
+   * A thread pool for use by query nodes when operations need to be 
+   * handled in a separate thread.
+   * @return A non-null executor service.
+   */
+  public ExecutorService getQueryThreadPool();
+  
+  /**
+   * A timer for use by queries.
+   * <b>WARNING:</b> Make sure to use {@link #getQueryThreadPool()} as 
+   * soon as the timer task is executed. Do not perform heavy work in
+   * the timer thread itself.
+   * @return A non-null timer.
+   */
+  public Timer getQueryTimer();
   
 }

--- a/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverter.java
+++ b/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverter.java
@@ -1,0 +1,179 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.idconverter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.common.Const;
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesByteId;
+import net.opentsdb.data.TimeSeriesDataType;
+import net.opentsdb.data.TimeSeriesId;
+import net.opentsdb.data.TimeSeriesStringId;
+import net.opentsdb.data.TypedTimeSeriesIterator;
+import net.opentsdb.query.AbstractQueryNode;
+import net.opentsdb.query.BaseWrappedQueryResult;
+import net.opentsdb.query.QueryNodeConfig;
+import net.opentsdb.query.QueryNodeFactory;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.QueryResult;
+
+/**
+ * Simply converts byte encoded IDs to their strings using the 
+ * data store associated with each. For string ID results, they're just
+ * passed upstream.
+ * 
+ * @since 3.0
+ */
+public class ByteToStringIdConverter extends AbstractQueryNode {
+
+  /** The config. */
+  private final ByteToStringIdConverterConfig config;
+  
+  /**
+   * Default ctor.
+   * @param factory The parent factory.
+   * @param context The non-null query context.
+   * @param config The non-null config.
+   */
+  public ByteToStringIdConverter(final QueryNodeFactory factory,
+                                 final QueryPipelineContext context,
+                                 final ByteToStringIdConverterConfig config) {
+    super(factory, context);
+    this.config = config;
+  }
+
+  @Override
+  public QueryNodeConfig config() {
+    return config;
+  }
+
+  @Override
+  public void close() {
+    // TODO Auto-generated method stub
+  }
+
+  @Override
+  public void onNext(final QueryResult next) {
+    if (next.idType() == Const.TS_STRING_ID ||
+        next.timeSeries().isEmpty()) {
+      sendUpstream(next);
+      return;
+    }
+    
+    // conversion time!
+    final List<Deferred<TimeSeriesStringId>> deferreds = 
+        Lists.newArrayListWithExpectedSize(next.timeSeries().size());
+    for (final TimeSeries series : next.timeSeries()) {
+      deferreds.add(((TimeSeriesByteId) 
+          series.id()).dataStore().resolveByteId(
+              (TimeSeriesByteId) series.id(), null /* TODO */));
+    }
+    
+    class ResolveCB implements Callback<Void, ArrayList<TimeSeriesStringId>> {
+
+      @Override
+      public Void call(final ArrayList<TimeSeriesStringId> ids) throws Exception {
+        sendUpstream(new ConvertedResult(next, ids));
+        return null;
+      }
+      
+    }
+    
+    class ErrorCB implements Callback<Void, Exception> {
+
+      @Override
+      public Void call(final Exception e) throws Exception {
+        sendUpstream(e);
+        return null;
+      }
+      
+    }
+    
+    Deferred.groupInOrder(deferreds)
+      .addCallbacks(new ResolveCB(), new ErrorCB());
+  }
+
+  /** Simple wrapped result. */
+  class ConvertedResult extends BaseWrappedQueryResult {
+
+    private final List<TimeSeries> wrapped_series;
+    
+    public ConvertedResult(final QueryResult result, 
+                           final List<TimeSeriesStringId> ids) {
+      super(result);
+      wrapped_series = Lists.newArrayListWithExpectedSize(result.timeSeries().size());
+      int index = 0;
+      // Invariate: the number of ids must match the time series AND the
+      // order of iteration must be the same every time it's called.
+      for (final TimeSeries series : result.timeSeries()) {
+        wrapped_series.add(new ConvertedTimeSeries(ids.get(index++), series));
+      }
+    }
+    
+    @Override
+    public Collection<TimeSeries> timeSeries() {
+      return wrapped_series;
+    }
+    
+  }
+  
+  /** Overloads the ID. */
+  class ConvertedTimeSeries implements TimeSeries {
+
+    private final TimeSeriesId id;
+    private final TimeSeries source;
+    
+    ConvertedTimeSeries(final TimeSeriesId id, final TimeSeries source) {
+      this.id = id;
+      this.source = source;
+    }
+    
+    @Override
+    public TimeSeriesId id() {
+      return id;
+    }
+
+    @Override
+    public Optional<TypedTimeSeriesIterator> iterator(
+        final TypeToken<? extends TimeSeriesDataType> type) {
+      return source.iterator(type);
+    }
+
+    @Override
+    public Collection<TypedTimeSeriesIterator> iterators() {
+      return source.iterators();
+    }
+
+    @Override
+    public Collection<TypeToken<? extends TimeSeriesDataType>> types() {
+      return source.types();
+    }
+
+    @Override
+    public void close() {
+      source.close();
+    }
+    
+  }
+}

--- a/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverter.java
+++ b/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverter.java
@@ -136,6 +136,11 @@ public class ByteToStringIdConverter extends AbstractQueryNode {
       return wrapped_series;
     }
     
+    @Override
+    public TypeToken<? extends TimeSeriesId> idType() {
+      return Const.TS_STRING_ID;
+    }
+    
   }
   
   /** Overloads the ID. */

--- a/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverterConfig.java
+++ b/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverterConfig.java
@@ -1,0 +1,106 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.idconverter;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.HashCode;
+
+import net.opentsdb.core.Const;
+import net.opentsdb.query.BaseQueryNodeConfig;
+import net.opentsdb.query.QueryNodeConfig;
+
+/**
+ * Simple config wherein all we need is the ID. Nothing else is configurable.
+ * 
+ * @since 3.0
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonDeserialize(builder = ByteToStringIdConverterConfig.Builder.class)
+public class ByteToStringIdConverterConfig extends BaseQueryNodeConfig {
+  
+  protected ByteToStringIdConverterConfig(final Builder builder) {
+    super(builder);
+  }
+
+  @Override
+  public HashCode buildHashCode() {
+    // TODO Auto-generated method stub
+    return Const.HASH_FUNCTION().newHasher()
+        .putString(id, Const.UTF8_CHARSET)
+        .hash();
+  }
+
+  @Override
+  public boolean pushDown() {
+    return true;
+  }
+
+  @Override
+  public boolean joins() {
+    return false;
+  }
+
+  @Override
+  public Builder toBuilder() {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public int compareTo(final QueryNodeConfig o) {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    // TODO Auto-generated method stub
+    if (o == null) {
+      return false;
+    }
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof ByteToStringIdConverterConfig)) {
+      return false;
+    }
+    
+    return id.equals(((ByteToStringIdConverterConfig) o).id);
+  }
+
+  @Override
+  public int hashCode() {
+    return buildHashCode().asInt();
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+  
+  public static class Builder extends BaseQueryNodeConfig.Builder {
+
+    Builder() {
+      setType(ByteToStringIdConverterFactory.TYPE);
+    }
+    
+    @Override
+    public QueryNodeConfig build() {
+      return new ByteToStringIdConverterConfig(this);
+    }
+    
+  }
+}

--- a/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverterFactory.java
+++ b/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverterFactory.java
@@ -1,0 +1,84 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.idconverter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryNodeConfig;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.TimeSeriesQuery;
+import net.opentsdb.query.plan.QueryPlanner;
+import net.opentsdb.query.processor.BaseQueryNodeFactory;
+
+/**
+ * Super simple factory to return ID converters.
+ * 
+ * @since 3.0
+ */
+public class ByteToStringIdConverterFactory extends BaseQueryNodeFactory {
+
+  public static final String TYPE = "ByteToStringIdConverter";
+
+  @Override
+  public QueryNodeConfig parseConfig(final ObjectMapper mapper, 
+                                     final TSDB tsdb,
+                                     final JsonNode node) {
+    try {
+      return mapper.treeToValue(node, ByteToStringIdConverterConfig.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Failed to parse Json",e);
+    }
+  }
+
+  @Override
+  public void setupGraph(final TimeSeriesQuery query, 
+                         final QueryNodeConfig config,
+                         final QueryPlanner planner) {
+    // no-op
+  }
+
+  @Override
+  public QueryNode newNode(final QueryPipelineContext context) {
+    return new ByteToStringIdConverter(this, context, 
+        (ByteToStringIdConverterConfig) ByteToStringIdConverterConfig.newBuilder()
+          .setId(TYPE)
+          .build());
+  }
+
+  @Override
+  public QueryNode newNode(final QueryPipelineContext context,
+                           final QueryNodeConfig config) {
+    return new ByteToStringIdConverter(this, context, 
+        (ByteToStringIdConverterConfig) config);
+  }
+
+  @Override
+  public Deferred<Object> initialize(final TSDB tsdb, final String id) {
+    this.id = Strings.isNullOrEmpty(id) ? TYPE : id;
+    return Deferred.fromResult(null);
+  }
+
+  @Override
+  public String type() {
+    return TYPE;
+  }
+  
+}

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
@@ -138,7 +138,7 @@ public class Schema implements WritableTimeSeriesDataStore {
     final String store_name = tsdb.getConfig().getString(key);
     
     final Tsdb1xDataStoreFactory store_factory = tsdb.getRegistry()
-          .getDefaultPlugin(Tsdb1xDataStoreFactory.class);
+          .getPlugin(Tsdb1xDataStoreFactory.class, store_name);
     if (store_factory == null) {
       throw new ConfigurationException("No factory found for: " + store_name);
     }

--- a/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverter.java
+++ b/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverter.java
@@ -1,0 +1,232 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.idconverter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Iterator;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.common.Const;
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesByteId;
+import net.opentsdb.data.TimeSeriesDataSourceFactory;
+import net.opentsdb.data.TimeSeriesId;
+import net.opentsdb.data.TimeSeriesStringId;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryNodeFactory;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.QueryResult;
+import net.opentsdb.utils.UnitTestException;
+
+public class TestByteToStringIdConverter {
+
+  private QueryPipelineContext context;
+  private QueryNode upstream;
+  private ByteToStringIdConverterConfig config;
+  
+  @Before
+  public void before() throws Exception {
+    context = mock(QueryPipelineContext.class);
+    upstream = mock(QueryNode.class);
+    config = (ByteToStringIdConverterConfig)
+        ByteToStringIdConverterConfig.newBuilder()
+          .setId("cvtr")
+          .build();
+    
+    when(context.upstream(any(QueryNode.class)))
+      .thenReturn(Lists.newArrayList(upstream));
+  }
+  
+  @Test
+  public void ctor() throws Exception {
+    ByteToStringIdConverter node = new ByteToStringIdConverter(
+        mock(QueryNodeFactory.class), 
+        context, 
+        config);
+    assertSame(config, node.config());
+    assertSame(context, node.pipelineContext());
+  }
+  
+  @Test
+  public void onNextStringResult() throws Exception {
+    QueryResult result = mock(QueryResult.class);
+    when(result.idType()).thenAnswer(new Answer<TypeToken<? extends TimeSeriesId>>() {
+      @Override
+      public TypeToken<? extends TimeSeriesId> answer(
+          InvocationOnMock invocation) throws Throwable {
+        return Const.TS_STRING_ID;
+      }
+    });
+    
+    ByteToStringIdConverter node = new ByteToStringIdConverter(
+        mock(QueryNodeFactory.class), 
+        context, 
+        config);
+    node.initialize(null).join(250);
+    node.onNext(result);
+    verify(upstream, times(1)).onNext(result);
+  }
+  
+  @Test
+  public void onNextByteEmptyResult() throws Exception {
+    QueryResult result = mock(QueryResult.class);
+    when(result.idType()).thenAnswer(new Answer<TypeToken<? extends TimeSeriesId>>() {
+      @Override
+      public TypeToken<? extends TimeSeriesId> answer(
+          InvocationOnMock invocation) throws Throwable {
+        return Const.TS_BYTE_ID;
+      }
+    });
+    
+    ByteToStringIdConverter node = new ByteToStringIdConverter(
+        mock(QueryNodeFactory.class), 
+        context, 
+        config);
+    node.initialize(null).join(250);
+    node.onNext(result);
+    verify(upstream, times(1)).onNext(result);
+  }
+  
+  @Test
+  public void onNextByteResult() throws Exception {
+    QueryResult result = mock(QueryResult.class);
+    when(result.idType()).thenAnswer(new Answer<TypeToken<? extends TimeSeriesId>>() {
+      @Override
+      public TypeToken<? extends TimeSeriesId> answer(
+          InvocationOnMock invocation) throws Throwable {
+        return Const.TS_BYTE_ID;
+      }
+    });
+    
+    TimeSeries ts1 = mock(TimeSeries.class);
+    TimeSeries ts2 = mock(TimeSeries.class);
+    when(result.timeSeries()).thenReturn(Lists.newArrayList(ts1, ts2));
+    
+    TimeSeriesByteId bid1 = mock(TimeSeriesByteId.class);
+    TimeSeriesByteId bid2 = mock(TimeSeriesByteId.class);
+    
+    when(ts1.id()).thenReturn(bid1);
+    when(ts2.id()).thenReturn(bid2);
+    
+    TimeSeriesDataSourceFactory factory = mock(TimeSeriesDataSourceFactory.class);
+    when(bid1.dataStore()).thenReturn(factory);
+    when(bid2.dataStore()).thenReturn(factory);
+    
+    TimeSeriesStringId sid1 = mock(TimeSeriesStringId.class);
+    TimeSeriesStringId sid2 = mock(TimeSeriesStringId.class);
+    
+    when(factory.resolveByteId(bid1, null)).thenReturn(
+        Deferred.fromResult(sid1));
+    when(factory.resolveByteId(bid2, null)).thenReturn(
+        Deferred.fromResult(sid2));
+    
+    QueryResult[] from_upstream = new QueryResult[1];
+    doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        from_upstream[0] = (QueryResult) invocation.getArguments()[0];
+        return null;
+      }
+    }).when(upstream).onNext(any(QueryResult.class));
+    
+    ByteToStringIdConverter node = new ByteToStringIdConverter(
+        mock(QueryNodeFactory.class), 
+        context, 
+        config);
+    node.initialize(null).join(250);
+    node.onNext(result);
+    verify(upstream, never()).onNext(result);
+    verify(upstream, never()).onError(any(Throwable.class));
+    
+    assertEquals(2, from_upstream[0].timeSeries().size());
+    Iterator<TimeSeries> iterator = from_upstream[0].timeSeries().iterator();
+    TimeSeries series = iterator.next();
+    assertSame(sid1, series.id());
+    series = iterator.next();
+    assertSame(sid2, series.id());
+  }
+  
+  @Test
+  public void onNextByteResultException() throws Exception {
+    QueryResult result = mock(QueryResult.class);
+    when(result.idType()).thenAnswer(new Answer<TypeToken<? extends TimeSeriesId>>() {
+      @Override
+      public TypeToken<? extends TimeSeriesId> answer(
+          InvocationOnMock invocation) throws Throwable {
+        return Const.TS_BYTE_ID;
+      }
+    });
+    
+    TimeSeries ts1 = mock(TimeSeries.class);
+    TimeSeries ts2 = mock(TimeSeries.class);
+    when(result.timeSeries()).thenReturn(Lists.newArrayList(ts1, ts2));
+    
+    TimeSeriesByteId bid1 = mock(TimeSeriesByteId.class);
+    TimeSeriesByteId bid2 = mock(TimeSeriesByteId.class);
+    
+    when(ts1.id()).thenReturn(bid1);
+    when(ts2.id()).thenReturn(bid2);
+    
+    TimeSeriesDataSourceFactory factory = mock(TimeSeriesDataSourceFactory.class);
+    when(bid1.dataStore()).thenReturn(factory);
+    when(bid2.dataStore()).thenReturn(factory);
+    
+    TimeSeriesStringId sid1 = mock(TimeSeriesStringId.class);
+    
+    when(factory.resolveByteId(bid1, null)).thenReturn(
+        Deferred.fromResult(sid1));
+    when(factory.resolveByteId(bid2, null)).thenReturn(
+        Deferred.fromError(new UnitTestException()));
+    
+    QueryResult[] from_upstream = new QueryResult[1];
+    doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        from_upstream[0] = (QueryResult) invocation.getArguments()[0];
+        return null;
+      }
+    }).when(upstream).onNext(any(QueryResult.class));
+    
+    ByteToStringIdConverter node = new ByteToStringIdConverter(
+        mock(QueryNodeFactory.class), 
+        context, 
+        config);
+    node.initialize(null).join(250);
+    node.onNext(result);
+    verify(upstream, never()).onNext(result);
+    verify(upstream, times(1)).onError(any(UnitTestException.class));
+    
+    assertNull(from_upstream[0]);
+  }
+  
+}

--- a/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverter.java
+++ b/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverter.java
@@ -169,6 +169,7 @@ public class TestByteToStringIdConverter {
     verify(upstream, never()).onError(any(Throwable.class));
     
     assertEquals(2, from_upstream[0].timeSeries().size());
+    assertEquals(Const.TS_STRING_ID, from_upstream[0].idType());
     Iterator<TimeSeries> iterator = from_upstream[0].timeSeries().iterator();
     TimeSeries series = iterator.next();
     assertSame(sid1, series.id());

--- a/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverterConfig.java
+++ b/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverterConfig.java
@@ -1,0 +1,62 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.idconverter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import net.opentsdb.core.MockTSDB;
+import net.opentsdb.core.MockTSDBDefault;
+import net.opentsdb.utils.JSON;
+
+public class TestByteToStringIdConverterConfig {
+
+  @Test
+  public void builder() throws Exception {
+    ByteToStringIdConverterConfig config = 
+        (ByteToStringIdConverterConfig) ByteToStringIdConverterConfig.newBuilder()
+        .setId("cvtr")
+        .build();
+    
+    assertEquals("cvtr", config.getId());
+    assertEquals(ByteToStringIdConverterFactory.TYPE, config.getType());
+  }
+  
+  @Test
+  public void serdes() throws Exception {
+    ByteToStringIdConverterConfig config = 
+        (ByteToStringIdConverterConfig) ByteToStringIdConverterConfig.newBuilder()
+        .setId("cvtr")
+        .build();
+    
+    String json = JSON.serializeToString(config);
+    assertTrue(json.contains("\"id\":\"cvtr\""));
+    assertTrue(json.contains("\"type\":\"ByteToStringIdConverter\""));
+    
+    MockTSDB tsdb = MockTSDBDefault.getMockTSDB();
+    JsonNode node = JSON.getMapper().readTree(json);
+    config = (ByteToStringIdConverterConfig) new ByteToStringIdConverterFactory()
+        .parseConfig(JSON.getMapper(), tsdb, node);
+    
+    assertEquals("cvtr", config.getId());
+    assertEquals(ByteToStringIdConverterFactory.TYPE, config.getType());
+    
+  }
+  
+}

--- a/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverterFactory.java
+++ b/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverterFactory.java
@@ -1,0 +1,60 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.idconverter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.query.QueryPipelineContext;
+
+public class TestByteToStringIdConverterFactory {
+
+  @Test
+  public void ctor() throws Exception {
+    ByteToStringIdConverterFactory factory = new ByteToStringIdConverterFactory();
+    assertEquals(0, factory.types().size());
+    assertEquals(ByteToStringIdConverterFactory.TYPE, factory.type());
+  }
+  
+  @Test
+  public void newNode() throws Exception {
+    ByteToStringIdConverterFactory factory = new ByteToStringIdConverterFactory();
+    ByteToStringIdConverter node = (ByteToStringIdConverter) 
+        factory.newNode(mock(QueryPipelineContext.class));
+    assertEquals(ByteToStringIdConverterFactory.TYPE, node.config().getId());
+    
+    node = (ByteToStringIdConverter) factory.newNode(
+        mock(QueryPipelineContext.class),
+        ByteToStringIdConverterConfig.newBuilder()
+          .setId("cvtr")
+          .build());
+    assertEquals("cvtr", node.config().getId());
+  }
+  
+  @Test
+  public void initialize() throws Exception {
+    ByteToStringIdConverterFactory factory = new ByteToStringIdConverterFactory();
+    assertNull(factory.initialize(mock(TSDB.class), null).join(250));
+    assertEquals(ByteToStringIdConverterFactory.TYPE, factory.id());
+    
+    factory = new ByteToStringIdConverterFactory();
+    assertNull(factory.initialize(mock(TSDB.class), "cvtr").join(250));
+    assertEquals("cvtr", factory.id());
+  }
+}

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/SchemaBase.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/SchemaBase.java
@@ -124,7 +124,7 @@ public class SchemaBase {
     id_validator = mock(DatumIdValidator.class);
     
     // return the default
-    when(tsdb.registry.getDefaultPlugin(Tsdb1xDataStoreFactory.class))
+    when(tsdb.registry.getPlugin(eq(Tsdb1xDataStoreFactory.class), anyString()))
       .thenReturn(store_factory);
     when(store_factory.newInstance(any(TSDB.class), anyString(), any(Schema.class)))
       .thenReturn(store);    

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchema.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchema.java
@@ -94,7 +94,7 @@ public class TestSchema extends SchemaBase {
   @Test
   public void ctorOverrides() throws Exception {
     MockTSDB tsdb = new MockTSDB();
-    when(tsdb.registry.getDefaultPlugin(Tsdb1xDataStoreFactory.class))
+    when(tsdb.registry.getPlugin(eq(Tsdb1xDataStoreFactory.class), anyString()))
       .thenReturn(store_factory);
     when(store_factory.newInstance(any(TSDB.class), anyString(), any(Schema.class)))
       .thenReturn(store);    
@@ -126,7 +126,7 @@ public class TestSchema extends SchemaBase {
     UniqueId uc = mock(UniqueId.class);
     Tsdb1xDataStoreFactory sf = mock(Tsdb1xDataStoreFactory.class);
     Tsdb1xDataStore s = mock(Tsdb1xDataStore.class);
-    when(tsdb.registry.getDefaultPlugin(Tsdb1xDataStoreFactory.class))
+    when(tsdb.registry.getPlugin(eq(Tsdb1xDataStoreFactory.class), anyString()))
       .thenReturn(sf);
     when(sf.newInstance(eq(tsdb), eq(TESTID), any(Schema.class))).thenReturn(s);
     when(tsdb.registry.getSharedObject(TESTID + "_uidstore"))
@@ -170,7 +170,7 @@ public class TestSchema extends SchemaBase {
   public void ctorNullStoreFromFactory() throws Exception {
     MockTSDB tsdb = new MockTSDB();
     Tsdb1xDataStoreFactory store_factory = mock(Tsdb1xDataStoreFactory.class);
-    when(tsdb.registry.getDefaultPlugin(Tsdb1xDataStoreFactory.class))
+    when(tsdb.registry.getPlugin(eq(Tsdb1xDataStoreFactory.class), anyString()))
       .thenReturn(store_factory);
     when(store_factory.newInstance(eq(tsdb), eq(null), any(Schema.class)))
       .thenReturn(null);
@@ -184,7 +184,7 @@ public class TestSchema extends SchemaBase {
   public void ctorStoreInstantiationFailure() throws Exception {
     MockTSDB tsdb = new MockTSDB();
     Tsdb1xDataStoreFactory store_factory = mock(Tsdb1xDataStoreFactory.class);
-    when(tsdb.registry.getDefaultPlugin(Tsdb1xDataStoreFactory.class))
+    when(tsdb.registry.getPlugin(eq(Tsdb1xDataStoreFactory.class), anyString()))
       .thenReturn(store_factory);
     when(store_factory.newInstance(eq(tsdb), eq(null), any(Schema.class)))
       .thenThrow(new UnitTestException());
@@ -533,7 +533,7 @@ public class TestSchema extends SchemaBase {
     
     // salt and diff metric width
     MockTSDB tsdb = new MockTSDB();
-    when(tsdb.registry.getDefaultPlugin(Tsdb1xDataStoreFactory.class))
+    when(tsdb.registry.getPlugin(eq(Tsdb1xDataStoreFactory.class), anyString()))
       .thenReturn(store_factory);
     when(store_factory.newInstance(any(TSDB.class), anyString(), any(Schema.class)))
       .thenReturn(store);    
@@ -565,7 +565,7 @@ public class TestSchema extends SchemaBase {
   @Test
   public void prefixKeyWithSalt() throws Exception {
     MockTSDB tsdb = new MockTSDB();
-    when(tsdb.registry.getDefaultPlugin(Tsdb1xDataStoreFactory.class))
+    when(tsdb.registry.getPlugin(eq(Tsdb1xDataStoreFactory.class), anyString()))
       .thenReturn(store_factory);
     when(store_factory.newInstance(any(TSDB.class), anyString(), any(Schema.class)))
       .thenReturn(store);    
@@ -663,7 +663,7 @@ public class TestSchema extends SchemaBase {
   @Test
   public void prefixKeyWithSaltMultiByte() throws Exception {
     MockTSDB tsdb = new MockTSDB();
-    when(tsdb.registry.getDefaultPlugin(Tsdb1xDataStoreFactory.class))
+    when(tsdb.registry.getPlugin(eq(Tsdb1xDataStoreFactory.class), anyString()))
       .thenReturn(store_factory);
     when(store_factory.newInstance(any(TSDB.class), anyString(), any(Schema.class)))
       .thenReturn(store);    
@@ -1003,7 +1003,7 @@ public class TestSchema extends SchemaBase {
   public void createRowKeySuccessSalted() throws Exception {
     resetConfig();
     MockTSDB tsdb = new MockTSDB();
-    when(tsdb.registry.getDefaultPlugin(Tsdb1xDataStoreFactory.class))
+    when(tsdb.registry.getPlugin(eq(Tsdb1xDataStoreFactory.class), anyString()))
       .thenReturn(store_factory);
     when(store_factory.newInstance(any(TSDB.class), anyString(), any(Schema.class)))
       .thenReturn(store);    

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xUniqueIdStore.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xUniqueIdStore.java
@@ -2761,7 +2761,7 @@ public class TestTsdb1xUniqueIdStore extends UTBase {
       .thenReturn(Deferred.fromResult(null));
     
     timer = new FakeTaskTimer();
-    tsdb.timer = timer;
+    tsdb.maint_timer = timer;
     
     when(tsdb.registry.getDefaultPlugin(
         UniqueIdAssignmentAuthorizer.class)).thenReturn(filter);

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/UTBase.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/UTBase.java
@@ -145,7 +145,7 @@ public class UTBase {
     uid_factory = mock(UniqueIdFactory.class);
     data_store = mock(Tsdb1xHBaseDataStore.class);
     
-    when(tsdb.registry.getDefaultPlugin(Tsdb1xDataStoreFactory.class))
+    when(tsdb.registry.getPlugin(eq(Tsdb1xDataStoreFactory.class), anyString()))
       .thenReturn(store_factory);
     when(store_factory.newInstance(any(TSDB.class), any(), any(Schema.class)))
       .thenReturn(data_store);    

--- a/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableUniqueIdStore.java
+++ b/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableUniqueIdStore.java
@@ -2778,7 +2778,7 @@ public class TestTsdb1xBigtableUniqueIdStore extends UTBase {
       .thenReturn(Deferred.fromResult(null));
     
     timer = new FakeTaskTimer();
-    tsdb.timer = timer;
+    tsdb.maint_timer = timer;
     
     when(tsdb.registry.getDefaultPlugin(
         UniqueIdAssignmentAuthorizer.class)).thenReturn(filter);

--- a/storage/bigtable/src/test/java/net/opentsdb/storage/UTBase.java
+++ b/storage/bigtable/src/test/java/net/opentsdb/storage/UTBase.java
@@ -197,7 +197,7 @@ public class UTBase {
       }
     });
     
-    when(tsdb.registry.getDefaultPlugin(Tsdb1xDataStoreFactory.class))
+    when(tsdb.registry.getPlugin(eq(Tsdb1xDataStoreFactory.class), anyString()))
       .thenReturn(store_factory);
     when(store_factory.newInstance(any(TSDB.class), any(), any(Schema.class)))
       .thenReturn(data_store);


### PR DESCRIPTION
- Add the ByteToStringIdConverter that we can now use to convert
  result sets cleanly. Will let us yank a lot of code when we put it
  in the query planner.