### PR TITLE
SERVLET:

### DIFF
--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/sinks/ServletSink.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/sinks/ServletSink.java
@@ -90,20 +90,22 @@ public class ServletSink implements QuerySink {
   public void onComplete() {
     try {
       serdes.serializeComplete(null);
-      try {
-        // TODO - oh this is sooooo ugly.... *sniff*
-        config.response().setContentType("application/json");
-        final byte[] data = stream.toByteArray();
-        stream.close();
-        config.response().setContentLength(data.length);
-        config.response().setStatus(200);
-        config.response().getOutputStream().write(data);
-        config.response().getOutputStream().close();
-      } catch (IOException e1) {
-        onError(e1);
-        return;
-      }
-      config.async().complete();
+      config.request().setAttribute("DATA", stream);
+//      try {
+//        // TODO - oh this is sooooo ugly.... *sniff*
+//        config.response().setContentType("application/json");
+//        final byte[] data = stream.toByteArray();
+//        stream.close();
+//        config.response().setContentLength(data.length);
+//        config.response().setStatus(200);
+//        config.response().getOutputStream().write(data);
+//        config.response().getOutputStream().close();
+//      } catch (IOException e1) {
+//        onError(e1);
+//        return;
+//      }
+      //config.async().complete();
+      config.async().dispatch();
       logComplete();
     } catch (Exception e) {
       LOG.error("Unexpected exception dispatching async request for "

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/sinks/ServletSinkConfig.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/sinks/ServletSinkConfig.java
@@ -17,6 +17,7 @@ package net.opentsdb.servlet.sinks;
 import java.util.List;
 
 import javax.servlet.AsyncContext;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -43,12 +44,14 @@ public class ServletSinkConfig implements QuerySinkConfig {
   private final SerdesOptions options;
   private final AsyncContext async;
   private final HttpServletResponse response;
+  private final HttpServletRequest request;
   
   ServletSinkConfig(final Builder builder) {
     id = builder.id;
     options = builder.serdesOptions;
     async = builder.async;
     response = builder.response;
+    request = builder.request;
   }
   
   @Override
@@ -75,6 +78,10 @@ public class ServletSinkConfig implements QuerySinkConfig {
     return response;
   }
   
+  public HttpServletRequest request() {
+    return request;
+  }
+  
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -94,6 +101,7 @@ public class ServletSinkConfig implements QuerySinkConfig {
     
     private AsyncContext async;
     private HttpServletResponse response;
+    private HttpServletRequest request;
     
     public Builder setId(final String id) {
       this.id = id;
@@ -112,6 +120,11 @@ public class ServletSinkConfig implements QuerySinkConfig {
     
     public Builder setResponse(final HttpServletResponse response) {
       this.response = response;
+      return this;
+    }
+    
+    public Builder setRequest(final HttpServletRequest request) {
+      this.request = request;
       return this;
     }
     


### PR DESCRIPTION
- Temporary fix that allows us to serialize exceptions properly again for
  the RPCs. The old way would send a 204 if something went pear shaped
  which is essentially useless.