### PR TITLE
Update asynchbase version to a release or snapshot 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ src-main
 src-test
 plugin_test.jar
 bin/
+*/*/dependency-reduced-pom.xml
+
 
 #Docker
 tools/docker/libs

--- a/storage/asynchbase/pom.xml
+++ b/storage/asynchbase/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
           <groupId>org.hbase</groupId>
           <artifactId>asynchbase</artifactId>
-          <version>1.8.2-20180403.213215-1</version>
+          <version>1.8.2</version>
         </dependency>
         
         <!-- used for fast primitive maps. May try others. -->


### PR DESCRIPTION
COMMON:
- Update asynchbase version to a release or snapshot instead of a specific snapshot, It might fail to compile.