### PR TITLE
A few minor improvements and a bugfix of fd leak.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -17,7 +17,7 @@
     <packaging>jar</packaging>
     
     <properties>
-
+      <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
     </properties>
     
     <dependencies>
@@ -99,7 +99,9 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
+          <version>${maven.source.plugin.version}</version>
           <executions>
             <execution>
               <id>attach-sources</id>

--- a/core/README.md
+++ b/core/README.md
@@ -61,7 +61,7 @@ This contains the abstract interface to a concrete data store (responsible for s
 
 Until the main documentation is up we'll note some important configs here.
 
-So far, the 3.x configuration is similar to the 2.x branch with the ``opentsdb.conf`` file. Here are some important, common configs for 3.x.
+So far, the 3.x configuration is similar to the 2.x branch with the ``opentsdb.yaml`` file. Here are some important, common configs for 3.x.
 
 * ``tsd.query.default_execution_graphs`` - A JSON config that defines the default execution graphs available on startup for the TSD. If the config value ends with ``.json`` (in lower case) then it's assumed the value is the path to a file that will be opened and parsed. Otherwise users can paste quote-escaped (``\"``) JSON in the config file. (But since it's ugly, try using the file method).
 * ``tsd.plugin.config`` - A JSON config that defines the plugins loaded by the TSD and the order in which they are initialized.

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -84,7 +84,7 @@
               <groupId>com.spotify</groupId>
               <artifactId>docker-maven-plugin</artifactId>
               <version>0.4.14</version>
-              
+
               <configuration>
                 <serverId>docker-hub</serverId>
                 <dockerDirectory>${basedir}/src/resources/docker</dockerDirectory>

--- a/implementation/elasticsearch/pom.xml
+++ b/implementation/elasticsearch/pom.xml
@@ -108,10 +108,6 @@
          <version>${project.version}</version>
          <scope>compile</scope>
       </dependency>
-       <dependency>
-           <groupId>net.opentsdb</groupId>
-           <artifactId>opentsdb-core</artifactId>
-       </dependency>
    </dependencies>
    
    <build>

--- a/implementation/server-undertow/README.md
+++ b/implementation/server-undertow/README.md
@@ -15,7 +15,7 @@ us know what you think.
 
 Undertow is a stripped down J2EE server comparable to Jetty. We use it at Yahoo for a number of projects so we'll offer this as a TSDB host for providing the HTTP API.
 
-The following parameters can be used in the ``opentsdb.conf`` file to control the server's behavior.
+The following parameters can be used in the ``opentsdb.yaml`` file to control the server's behavior.
 
 * ``tsd.network.port`` - Copied from 2.x, controls the HTTP port the server will listen on. Required.
 * ``tsd.network.ssl_port`` - If SSL is required, the port for HTTPS connections. Optional

--- a/implementation/server-undertow/src/main/java/net/opentsdb/tsd/TSDMain.java
+++ b/implementation/server-undertow/src/main/java/net/opentsdb/tsd/TSDMain.java
@@ -93,7 +93,7 @@ public class TSDMain {
   /** The TSD reference. Static so we can shutdown gracefully. */
   private static DefaultTSDB tsdb = null;
   
-  /** The Undertwo server reference. Static so we can shutdown gracefully. */
+  /** The Undertow server reference. Static so we can shutdown gracefully. */
   private static Undertow server = null;
   
   /**
@@ -292,7 +292,7 @@ public class TSDMain {
       }
       return sslContext;
     } catch (CertificateException e) {
-      LOG.error("Failed to insantiate factory", e);
+      LOG.error("Failed to instantiate factory", e);
     } catch (Exception e) {
       LOG.error("Unexpected exception initializing SSL Context", e);
     }
@@ -302,7 +302,7 @@ public class TSDMain {
   
   /**
    * Attempts to load a keystore from disk and initialize an SSL Context 
-   * with the data therin. The keystore should contain all of the certs,
+   * with it. The keystore should contain all of the certs,
    * intermediates, CAs and the private key.
    * @param config A non-null config.
    * @return An instantiated context or null if something went wrong. The
@@ -531,7 +531,7 @@ public class TSDMain {
             server.stop();
           }
           if (tsdb != null) {
-            LOG.info("Shuttingdown TSD");
+            LOG.info("Shutting down TSD");
             tsdb.shutdown().join();
           }
           
@@ -591,7 +591,7 @@ public class TSDMain {
    * @return A private key if parsing was successful.
    * @throws IOException If the input was corrupted.
    * @throws GeneralSecurityException If parsing failed because the key
-   * appared to be in the wrong format.
+   * appeared to be in the wrong format.
    */
   static RSAPrivateKey parsePKCS1Key(final String key) throws 
       IOException, GeneralSecurityException {

--- a/implementation/server-undertow/src/main/java/net/opentsdb/tsd/TSDMain.java
+++ b/implementation/server-undertow/src/main/java/net/opentsdb/tsd/TSDMain.java
@@ -14,49 +14,10 @@
 // limitations under the License.
 package net.opentsdb.tsd;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.StringReader;
-import java.math.BigInteger;
-import java.security.GeneralSecurityException;
-import java.security.KeyFactory;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.RSAPrivateKeySpec;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.servlet.DispatcherType;
-import javax.servlet.ServletException;
-import javax.xml.bind.DatatypeConverter;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
-
 import io.undertow.Handlers;
 import io.undertow.Undertow;
 import io.undertow.Undertow.Builder;
@@ -73,8 +34,32 @@ import net.opentsdb.core.DefaultTSDB;
 import net.opentsdb.servlet.applications.OpenTSDBApplication;
 import net.opentsdb.servlet.filter.AuthFilter;
 import net.opentsdb.utils.ArgP;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import sun.security.util.DerInputStream;
 import sun.security.util.DerValue;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.servlet.DispatcherType;
+import javax.servlet.ServletException;
+import javax.xml.bind.DatatypeConverter;
+import java.io.*;
+import java.math.BigInteger;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPrivateKeySpec;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * A simple main method that instantiates a TSD and the TSD servlet package
@@ -330,9 +315,8 @@ public class TSDMain {
       throw new IllegalArgumentException("Cannot enable SSL without a "
           + "keystore password. Set '" + KEYSTORE_PASS_KEY +"'");
     }
-    try {
-      // load an initialize the keystore.
-      final FileInputStream file = new FileInputStream(keystore_location);
+    // load an initialize the keystore.
+    try(final FileInputStream file = new FileInputStream(keystore_location)) {
       final KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
       keystore.load(file, keystore_key.toCharArray());
       

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,9 @@
         <artifactId>cobertura-maven-plugin</artifactId>
         <version>2.7</version>
         <configuration>
+          <check>
+            <!--TODO by qudongfang-->
+          </check>
           <format>xml</format>
           <maxmem>256m</maxmem>
           <!-- aggregated reports for multi-module projects -->


### PR DESCRIPTION
COMMON:
- Fix a few typo.
- Replace 'opentsdb.conf' with 'opentsdb.yaml'(the new
  config file name) in READMEs.
- Remove a few WARNINGs in maven pom.xml files.

IMPLEMENTATION:
- Close keystore 'FileInputStream' in server-undertow to fix a FD leak.

Signed-off-by: qudongfang <qudongfang@gmail.com>