### PR TITLE
Add systemd unit template to the RPM build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,8 @@ nodist_bin_SCRIPTS = tsdb
 dist_noinst_SCRIPTS = src/create_table.sh src/upgrade_1to2.sh src/mygnuplot.sh \
   src/mygnuplot.bat src/opentsdb.conf tools/opentsdb_restart.py src/logback.xml
 dist_noinst_DATA = pom.xml.in build-aux/rpm/opentsdb.conf \
-  build-aux/rpm/logback.xml build-aux/rpm/init.d/opentsdb
+  build-aux/rpm/logback.xml build-aux/rpm/init.d/opentsdb \
+  build-aux/rpm/systemd/opentsdb@.service
 tsdb_SRC := \
 	src/core/AggregationIterator.java	\
 	src/core/Aggregator.java	\
@@ -709,17 +710,23 @@ install-data-etc:
 	destdataetcdir="$(DESTDIR)$(pkgdatadir)/etc" ; \
 	destdataconfdir="$$destdataetcdir/opentsdb" ; \
 	destdatainitdir="$$destdataetcdir/init.d" ; \
+	destdatasystemddir="$$destdataetcdir/systemd/system" ; \
 	echo " $(mkdir_p) $$destdataconfdir"; \
 	$(mkdir_p) "$$destdataconfdir" || exit 1; \
 	echo " $(mkdir_p) $$destdatainitdir"; \
 	$(mkdir_p) "$$destdatainitdir" || exit 1; \
+	echo " $(mkdir_p) $$destdatasystemddir"; \
+	$(mkdir_p) "$$destdatasystemddir" || exit 1; \
 	conf_files="$$conf_files $(top_srcdir)/build-aux/rpm/opentsdb.conf" ; \
 	conf_files="$$conf_files $(top_srcdir)/build-aux/rpm/logback.xml" ; \
 	echo " $(INSTALL_SCRIPT)" $$conf_files "$$destdataconfdir" ; \
 	$(INSTALL_DATA) $$conf_files "$$destdataconfdir" || exit 1; \
 	init_file="$(top_srcdir)/build-aux/rpm/init.d/opentsdb" ; \
 	echo " $(INSTALL_SCRIPT)" $$init_file "$$destdatainitdir" ; \
-	$(INSTALL_SCRIPT) $$init_file "$$destdatainitdir" || exit 1;
+	$(INSTALL_SCRIPT) $$init_file "$$destdatainitdir" || exit 1; \
+	systemd_file="$(top_srcdir)/build-aux/rpm/systemd/opentsdb@.service" ; \
+	echo " $(INSTALL_SCRIPT)" $$systemd_file "$$destdatasystemddir" ; \
+	$(INSTALL_SCRIPT) $$systemd_file "$$destdatasystemddir" || exit 1;
 
 uninstall-data-etc:
 	@$(NORMAL_UNINSTALL)

--- a/build-aux/rpm/init.d/opentsdb
+++ b/build-aux/rpm/init.d/opentsdb
@@ -75,7 +75,7 @@ start() {
 
   # Set a default value for JVMARGS
   : ${JVMXMX:=-Xmx6000m}
-  : ${JVMARGS:=-DLOG_FILE_PREFIX=${LOG_FILE} -enableassertions -enablesystemassertions $JVMXMX -XX:OnOutOfMemoryError=/usr/share/opentsdb/tools/opentsdb_restart.py}
+  : ${JVMARGS:=-DLOG_FILE=${LOG_FILE}opentsdb.log -DQUERY_LOG=${LOG_FILE}queries.log -enableassertions -enablesystemassertions $JVMXMX -XX:OnOutOfMemoryError=/usr/share/opentsdb/tools/opentsdb_restart.py}
   export JVMARGS
 
   if [ "`id -u -n`" == root ] ; then
@@ -83,6 +83,7 @@ start() {
     # daemons to create and rename log files.
     chown $USER: $LOG_DIR > /dev/null 2>&1
     chown $USER: ${LOG_FILE}*opentsdb.log > /dev/null 2>&1
+    chown $USER: ${LOG_FILE}*queries.log > /dev/null 2>&1
     chown $USER: ${LOG_FILE}opentsdb.out > /dev/null 2>&1
     chown $USER: ${LOG_FILE}opentsdb.err > /dev/null 2>&1
 

--- a/build-aux/rpm/logback.xml
+++ b/build-aux/rpm/logback.xml
@@ -19,11 +19,11 @@
   
   <!-- Appender to write OpenTSDB data to a set of rotating log files -->
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>/var/log/opentsdb/opentsdb.log</file>
+    <file>${LOG_FILE}</file>
     <append>true</append>
     
     <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-      <fileNamePattern>/var/log/opentsdb/opentsdb.log.%i</fileNamePattern>
+      <fileNamePattern>${LOG_FILE}.%i</fileNamePattern>
       <minIndex>1</minIndex>
       <maxIndex>3</maxIndex>
     </rollingPolicy>
@@ -40,11 +40,11 @@
   <!-- Appender for writing full and completed queries to a log file. To use it, make
        sure to set the "level" to "INFO" in QueryLog below. -->
   <appender name="QUERY_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>/var/log/opentsdb/queries.log</file>
+    <file>${QUERY_LOG}</file>
     <append>true</append>
 
     <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-        <fileNamePattern>/var/log/opentsdb/queries.log.%i</fileNamePattern>
+        <fileNamePattern>${QUERY_LOG}.%i</fileNamePattern>
         <minIndex>1</minIndex>
         <maxIndex>4</maxIndex>
     </rollingPolicy>

--- a/build-aux/rpm/systemd/opentsdb@.service
+++ b/build-aux/rpm/systemd/opentsdb@.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=OpenTSDB on port %i
+After=network-online.target
+Before=shutdown.target
+
+[Service]
+Type=simple
+User=opentsdb
+Group=opentsdb
+LimitNOFILE=65535
+Environment=JAVA_HOME=/usr/lib/jvm/jre-openjdk
+Environment='JVMARGS=-Xmx6000m -DLOG_FILE=/var/log/opentsdb/%p_%i.log -DQUERY_LOG=/var/log/opentsdb/%p_%i_queries.log -XX:+ExitOnOutOfMemoryError -enableassertions -enablesystemassertions'
+ExecStart=/usr/bin/tsdb tsd --config /etc/opentsdb/opentsdb.conf --port %i
+Restart=always
+StandardOutput=journal

--- a/opentsdb.spec.in
+++ b/opentsdb.spec.in
@@ -55,7 +55,8 @@ make
 %install
 rm -rf %{buildroot}
 make install DESTDIR=%{buildroot}
-mkdir -p %{buildroot}/var/cache/opentsdb
+mkdir -p %{buildroot}%{_localstatedir}/cache/opentsdb
+mkdir -p %{buildroot}%{_localstatedir}/log/opentsdb
 mkdir -p %{buildroot}%{_datarootdir}/opentsdb/plugins
 # TODO: Use alternatives to manage the init script and configuration.
 
@@ -70,29 +71,38 @@ rm -rf %{buildroot}
 %attr(0755,root,root) %{_datarootdir}/opentsdb/plugins
 %attr(0755,root,root) %{_datarootdir}/opentsdb/tools/*
 %attr(0755,root,root) %{_datarootdir}/opentsdb/etc/init.d/opentsdb
+%attr(0644,root,root) %{_datarootdir}/opentsdb/etc/systemd/system/opentsdb@.service
 %config %{_datarootdir}/opentsdb/etc/opentsdb/opentsdb.conf
 %config %{_datarootdir}/opentsdb/etc/opentsdb/logback.xml
 %doc
 %{_datarootdir}/opentsdb
 %{_bindir}/tsdb
-%dir %{_localstatedir}/cache/opentsdb
+%dir %attr(0755,opentsdb,opentsdb) %{_localstatedir}/cache/opentsdb
+%dir %attr(0755,opentsdb,opentsdb) %{_localstatedir}/log/opentsdb
 
 %changelog
 
-%post
+%pre
+getent group opentsdb 2>/dev/null >/dev/null || /usr/sbin/groupadd -r opentsdb
+getent passwd opentsbd 2>&1 > /dev/null || /usr/sbin/useradd -c "OpenTSDB" -s /sbin/nologin -g opentsdb -r -d %{_datarootdir}/opentsdb opentsdb 2> /dev/null || :
 
+%post
 if [ $1 -eq 1 ]; then
   # we're installing the first version of this package
   ln -s %{_datarootdir}/opentsdb/etc/opentsdb /etc/opentsdb
-  ln -s %{_datarootdir}/opentsdb/etc/init.d/opentsdb /etc/init.d/opentsdb
+  if [ -d /run/systemd/system ]; then
+    ln -s %{_datarootdir}/opentsdb/etc/systemd/system/opentsdb@.service /lib/systemd/system
+  else
+    ln -s %{_datarootdir}/opentsdb/etc/init.d/opentsdb /etc/init.d/opentsdb
+  fi
 fi
 exit 0
 
 %postun
-
 if [ $1 -eq 0 ]; then
   # we're removing last version of this package
-  rm -rf /etc/opentsdb
-  rm -rf /etc/init.d/opentsdb
+  [ -L /etc/opentsdb ] && rm -f /etc/opentsdb
+  [ -L /etc/init.d/opentsdb ] && rm -f /etc/init.d/opentsdb
+  [ -L /lib/systemd/system/opentsdb@.service ] && rm -f /lib/systemd/system/opentsdb@.service
 fi
 exit 0

--- a/opentsdb.spec.in
+++ b/opentsdb.spec.in
@@ -92,6 +92,7 @@ if [ $1 -eq 1 ]; then
   ln -s %{_datarootdir}/opentsdb/etc/opentsdb /etc/opentsdb
   if [ -d /run/systemd/system ]; then
     ln -s %{_datarootdir}/opentsdb/etc/systemd/system/opentsdb@.service /lib/systemd/system
+    systemctl daemon-reload
   else
     ln -s %{_datarootdir}/opentsdb/etc/init.d/opentsdb /etc/init.d/opentsdb
   fi
@@ -104,5 +105,6 @@ if [ $1 -eq 0 ]; then
   [ -L /etc/opentsdb ] && rm -f /etc/opentsdb
   [ -L /etc/init.d/opentsdb ] && rm -f /etc/init.d/opentsdb
   [ -L /lib/systemd/system/opentsdb@.service ] && rm -f /lib/systemd/system/opentsdb@.service
+  [ -d /run/systemd/system ] && systemctl daemon-reload
 fi
 exit 0


### PR DESCRIPTION
Add a systemd unit to be included in the RPM package. As the unit file is a template to launch multiple instances, I also modified logback.xml and the linked init.d script. I could also add a static opentsdb systemd unit file if desired, but the same can be accomplished by enabling the template as "opentsdb@4242.service". To replace PR #1429 against master