### PR TITLE
CORE:

### DIFF
--- a/implementation/elasticsearch/src/main/java/net/opentsdb/meta/NamespacedAggregatedDocumentSchema.java
+++ b/implementation/elasticsearch/src/main/java/net/opentsdb/meta/NamespacedAggregatedDocumentSchema.java
@@ -46,6 +46,8 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 
+import javax.naming.Context;
+
 /**
  * Run the Meta Query on Meta Store with schema and form the results.
  *
@@ -345,9 +347,15 @@ public class NamespacedAggregatedDocumentSchema extends BaseTSDBPlugin implement
             }
             
             // if we have too many results, bail out with a no-data error.
-            if (response.getHits().getTotalHits() > tsdb.getConfig().getInt(MAX_CARD_KEY)) {
+            if (max_hits > tsdb.getConfig().getInt(MAX_CARD_KEY)) {
               if (LOG.isTraceEnabled()) {
                 LOG.trace("Too many hits from ES: " + response.getHits().getTotalHits());
+              }
+              if (queryPipelineContext.query().isDebugEnabled()) {
+                queryPipelineContext.queryContext().logDebug(
+                    "Total hits from ES: " + max_hits 
+                      + " exceeded the configured limit: " 
+                      + tsdb.getConfig().getInt(MAX_CARD_KEY));
               }
               result = new NamespacedAggregatedDocumentResult(
                   tsdb.getConfig().getBoolean(ESClusterClient.FALLBACK_ON_NO_DATA_KEY) 

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/RawQueryRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/RawQueryRpc.java
@@ -205,6 +205,10 @@ public class RawQueryRpc {
             .build())
         .build();
     
+    if (trace != null && query.isDebugEnabled()) {
+      context.logDebug("Trace ID: " + trace.traceId());
+    }
+    
     class AsyncTimeout implements AsyncListener {
 
       @Override

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
@@ -134,6 +134,9 @@ public class Tsdb1xQueryNode implements TimeSeriesDataSource, SourceNode {
   /** An optional downsample config from upstream. */
   protected DownsampleConfig ds_config;
   
+  /** When we start fetching data. */
+  protected long fetch_start;
+  
   /**
    * Default ctor.
    * @param factory The Tsdb1xHBaseDataStore that instantiated this node.

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xMultiGet.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xMultiGet.java
@@ -60,11 +60,13 @@ import net.opentsdb.data.MillisecondTimeStamp;
 import net.opentsdb.data.TimeStamp;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
+import net.opentsdb.query.QueryContext;
 import net.opentsdb.query.QueryMode;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.SemanticQuery;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
+import net.opentsdb.query.TimeSeriesQuery;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.filter.MetricLiteralFilter;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
@@ -110,6 +112,8 @@ public class TestTsdb1xMultiGet extends UTBase {
     when(schema.rollupConfig()).thenReturn(rollup_config);
     when(context.upstreamOfType(any(QueryNode.class), any()))
       .thenReturn(Collections.emptyList());
+    when(context.queryContext()).thenReturn(mock(QueryContext.class));
+    when(context.query()).thenReturn(mock(TimeSeriesQuery.class));
     
     PowerMockito.whenNew(Tsdb1xScanner.class).withAnyArguments()
       .thenAnswer(new Answer<Tsdb1xScanner>() {


### PR DESCRIPTION
- If a source has multiple upstream nodes, pass them up via the thread pool.
  TODO - This is just a quick hack to increase query parallelism. We need
  something smarter.

ELASTICSEARCH:
- Log some more information and handle max cardinality for multigets.

SERVLET:
- More query logging.

ASYNCHBASE:
- More query logging.