### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/data/TimeSeriesDataSourceFactory.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesDataSourceFactory.java
@@ -24,6 +24,7 @@ import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
 import net.opentsdb.query.TimeSeriesQuery;
+import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.Span;
 
 /**
@@ -103,5 +104,11 @@ public interface TimeSeriesDataSourceFactory extends TSDBPlugin,
   public Deferred<List<byte[]>> encodeJoinMetrics(
       final List<String> join_metrics, 
       final Span span);
+  
+  /**
+   * An optional rollup config if the source supports lower resolutions of data.
+   * @return Null if the source doesn't support rollups, a rollup config if it does.
+   */
+  public RollupConfig rollupConfig();
   
 }

--- a/common/src/main/java/net/opentsdb/query/TimeSeriesDataSourceConfig.java
+++ b/common/src/main/java/net/opentsdb/query/TimeSeriesDataSourceConfig.java
@@ -36,6 +36,9 @@ public interface TimeSeriesDataSourceConfig extends QueryNodeConfig {
    * all. */
   public List<String> getTypes();
   
+  /** @return An optional namespace for such systems as support it. */
+  public String getNamespace();
+  
   /** @return The non-null metric filter. */
   public MetricFilter getMetric();
   
@@ -51,6 +54,18 @@ public interface TimeSeriesDataSourceConfig extends QueryNodeConfig {
   /** @return An optional list of push down nodes. May be null. */
   public List<QueryNodeConfig> getPushDownNodes();
   
+  /** @return An optional list of rollup intervals as durations. */
+  public List<String> getRollupIntervals();
+  
+  /** @return An optional list of aggregations for rollups. */
+  public List<String> getRollupAggregations();
+  
+  /** @return An optional pre-query start time padding string as a duration. */
+  public String getPrePadding();
+  
+  /** @return An optional post-query end time padding string as a duration. */
+  public String getPostPadding();
+  
   /**
    * A base builder interface for data source configs.
    */
@@ -60,6 +75,8 @@ public interface TimeSeriesDataSourceConfig extends QueryNodeConfig {
     public Builder setTypes(final List<String> types);
     
     public Builder addType(final String type);
+    
+    public Builder setNamespace(final String namespace);
     
     public Builder setMetric(final MetricFilter metric);
     
@@ -73,6 +90,18 @@ public interface TimeSeriesDataSourceConfig extends QueryNodeConfig {
         final List<QueryNodeConfig> push_down_nodes);
     
     public Builder addPushDownNode(final QueryNodeConfig node);
+
+    public Builder setRollupIntervals(final List<String> rollup_intervals);
+    
+    public Builder addRollupInterval(final String rollup_interval);
+    
+    public Builder setRollupAggregations(final List<String> rollup_aggregations);
+    
+    public Builder addRollupAggregation(final String rollup_aggregation);
+    
+    public Builder setPrePadding(final String pre_padding);
+    
+    public Builder setPostPadding(final String post_padding);
     
     public String id();
     

--- a/common/src/main/java/net/opentsdb/query/plan/QueryPlanner.java
+++ b/common/src/main/java/net/opentsdb/query/plan/QueryPlanner.java
@@ -14,11 +14,14 @@
 // limitations under the License.
 package net.opentsdb.query.plan;
 
+import java.util.Collection;
+
 import com.google.common.graph.MutableGraph;
 import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeConfig;
+import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.stats.Span;
 
@@ -96,5 +99,20 @@ public interface QueryPlanner {
    * @return The node if found, null if not.
    */
   public QueryNode nodeForId(final String id);
+  
+  /**
+   * Attempts to load a factory for the given node ID.
+   * <b>WARNING:</b> The node ID MUST be in the graph already.
+   * @param node A non-null query node config object.
+   * @return A factory if found, null if no factory could be found.
+   */
+  public QueryNodeFactory getFactory(final QueryNodeConfig node);
+  
+  /** 
+   * Finds the terminal source nodes that feed into the given config.
+   * @param config A non-null query node config.
+   * @return A list of source nodes for the node. Null until the query has
+   * started planning. */
+  public Collection<QueryNodeConfig> terminalSourceNodes(final QueryNodeConfig config);
   
 }

--- a/common/src/main/java/net/opentsdb/rollup/RollupConfig.java
+++ b/common/src/main/java/net/opentsdb/rollup/RollupConfig.java
@@ -14,6 +14,7 @@
 // limitations under the License.
 package net.opentsdb.rollup;
 
+import java.util.List;
 import java.util.Map;
 
 public interface RollupConfig {
@@ -34,5 +35,21 @@ public interface RollupConfig {
    * aggregator was null or empty.
    */
   public int getIdForAggregator(final String aggregator);
+  
+  /**
+   * An ordered set of resolutions supported by this source starting with the 
+   * lowest resolution working towards the highest.
+   * @return A non-null list of intervals in TSDB Duration formation, e.g. "1h"
+   */
+  public List<String> getIntervals();
+  
+  /**
+   * Returns a list of applicable intervals given a downsample interval. If no
+   * intervals apply then it will return an empty list.
+   * @param interval A non-null and non-empty string.
+   * @return A non-null, possibly empty list of intervals from lowest resolution
+   * to highest.
+   */
+  public List<String> getPossibleIntervals(final String interval);
   
 }

--- a/core/src/main/java/net/opentsdb/query/hacluster/HAClusterFactory.java
+++ b/core/src/main/java/net/opentsdb/query/hacluster/HAClusterFactory.java
@@ -47,6 +47,7 @@ import net.opentsdb.query.plan.QueryPlanner;
 import net.opentsdb.query.pojo.FillPolicy;
 import net.opentsdb.query.processor.BaseQueryNodeFactory;
 import net.opentsdb.query.processor.merge.MergerConfig;
+import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.Span;
 import net.opentsdb.utils.DateTime;
 
@@ -628,6 +629,12 @@ public class HAClusterFactory extends BaseQueryNodeFactory implements
       
       canPushDown(predecessors.iterator().next(), factory, push_downs, planner);
     }
+  }
+
+  @Override
+  public RollupConfig rollupConfig() {
+    // TODO Auto-generated method stub
+    return null;
   }
   
 }

--- a/core/src/main/java/net/opentsdb/query/router/TimeRouterFactory.java
+++ b/core/src/main/java/net/opentsdb/query/router/TimeRouterFactory.java
@@ -49,6 +49,7 @@ import net.opentsdb.query.pojo.FillPolicy;
 import net.opentsdb.query.processor.BaseQueryNodeFactory;
 import net.opentsdb.query.processor.merge.MergerConfig;
 import net.opentsdb.query.router.TimeRouterConfigEntry.MatchType;
+import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.Span;
 
 /**
@@ -264,6 +265,12 @@ public class TimeRouterFactory extends BaseQueryNodeFactory
     } else {
       return KEY_PREFIX + id + "." + suffix;
     }
+  }
+
+  @Override
+  public RollupConfig rollupConfig() {
+    // TODO Auto-generated method stub
+    return null;
   }
 
 }

--- a/core/src/main/java/net/opentsdb/storage/MockDataStoreFactory.java
+++ b/core/src/main/java/net/opentsdb/storage/MockDataStoreFactory.java
@@ -37,6 +37,7 @@ import net.opentsdb.query.BaseTimeSeriesDataSourceConfig;
 import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
 import net.opentsdb.query.TimeSeriesQuery;
 import net.opentsdb.query.plan.QueryPlanner;
+import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.Span;
 
 /**
@@ -133,5 +134,11 @@ public class MockDataStoreFactory extends BaseTSDBPlugin
       final List<String> join_metrics, 
       final Span span) {
     return Deferred.fromError(new UnsupportedOperationException());
+  }
+
+  @Override
+  public RollupConfig rollupConfig() {
+    // TODO Auto-generated method stub
+    return null;
   }
 }

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
@@ -14,8 +14,6 @@
 // limitations under the License.
 package net.opentsdb.storage.schemas.tsdb1x;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -27,7 +25,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.io.Files;
 import com.google.common.reflect.TypeToken;
 import com.stumbleupon.async.Callback;
 import com.stumbleupon.async.Deferred;
@@ -67,7 +64,6 @@ import net.opentsdb.uid.UniqueIdType;
 import net.opentsdb.utils.Bytes;
 import net.opentsdb.utils.Bytes.ByteMap;
 import net.opentsdb.utils.Exceptions;
-import net.opentsdb.utils.JSON;
 import net.opentsdb.utils.Pair;
 
 /**
@@ -118,7 +114,6 @@ public class Schema implements WritableTimeSeriesDataStore {
   
   protected final boolean timeless_salting;
   protected final boolean old_salting;
-  protected final DefaultRollupConfig rollup_config;
   
   protected Map<TypeToken<?>, Codec> codecs;
   
@@ -207,29 +202,7 @@ public class Schema implements WritableTimeSeriesDataStore {
       throw new IllegalStateException("Factory " + uid_factory 
           + " returned a null UniqueId instance.");
     }
-    
-    key = configKey("rollups.enable");
-    final boolean rollups_enabled = tsdb.getConfig().getBoolean(key);
-    if (rollups_enabled) {
-      key = configKey("rollups.config");
-      value = tsdb.getConfig().getString(key);
-      if (Strings.isNullOrEmpty(value)) { 
-        throw new ConfigurationException("Null value for config key: " + key);
-      }
-      
-      if (value.endsWith(".json")) {
-        try {
-          value = Files.toString(new File(value), Const.UTF8_CHARSET);
-        } catch (IOException e) {
-          throw new IllegalArgumentException("Failed to open conf file: " 
-              + value, e);
-        }
-      }
-      rollup_config = JSON.parseToObject(value, DefaultRollupConfig.class);
-    } else {
-      rollup_config = null;
-    }
-    
+        
     if (!tsdb.getConfig().hasProperty(QUERY_BYTE_LIMIT_KEY)) {
       tsdb.getConfig().register(QUERY_BYTE_LIMIT_KEY, 
           QUERY_BYTE_LIMIT_DEFAULT, true, 
@@ -657,7 +630,7 @@ public class Schema implements WritableTimeSeriesDataStore {
   }
   
   public DefaultRollupConfig rollupConfig() {
-    return rollup_config;
+    return factory.rollup_config;
   }
   
   /**

--- a/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterFactory.java
+++ b/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterFactory.java
@@ -68,6 +68,7 @@ import net.opentsdb.query.processor.downsample.DownsampleConfig;
 import net.opentsdb.query.processor.groupby.GroupBy;
 import net.opentsdb.query.processor.groupby.GroupByConfig;
 import net.opentsdb.query.processor.merge.Merger;
+import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.QueryStats;
 import net.opentsdb.stats.Span;
 
@@ -1224,6 +1225,12 @@ public class TestHAClusterFactory {
     @Override
     public String version() {
       return "3.0.0";
+    }
+
+    @Override
+    public RollupConfig rollupConfig() {
+      // TODO Auto-generated method stub
+      return null;
     }
     
   }

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericSummaryIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericSummaryIterator.java
@@ -82,7 +82,7 @@ public class TestDownsampleNumericSummaryIterator {
   
   @Before
   public void before() throws Exception {
-    rollup_config = DefaultRollupConfig.builder()
+    rollup_config = DefaultRollupConfig.newBuilder()
         .addAggregationId("sum", 0)
         .addAggregationId("count", 2)
         .addAggregationId("avg", 5)

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByFactory.java
@@ -131,7 +131,7 @@ public class TestGroupByFactory {
     when(source_result.timeSpecification()).thenReturn(time_spec);
     when(time_spec.start()).thenReturn(new MillisecondTimeStamp(1000));
     
-    final DefaultRollupConfig rollup_config = DefaultRollupConfig.builder()
+    final DefaultRollupConfig rollup_config = DefaultRollupConfig.newBuilder()
         .addAggregationId("sum", 0)
         .addAggregationId("count", 2)
         .addAggregationId("avg", 5)

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByNumericSummaryIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByNumericSummaryIterator.java
@@ -75,7 +75,7 @@ public class TestGroupByNumericSummaryIterator {
   
   @Before
   public void before() throws Exception {
-    rollup_config = DefaultRollupConfig.builder()
+    rollup_config = DefaultRollupConfig.newBuilder()
         .addAggregationId("sum", 0)
         .addAggregationId("count", 2)
         .addAggregationId("avg", 5)

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerFactory.java
@@ -129,7 +129,7 @@ public class TestMergerFactory {
     when(source_result.timeSpecification()).thenReturn(time_spec);
     when(time_spec.start()).thenReturn(new MillisecondTimeStamp(1000));
     
-    final DefaultRollupConfig rollup_config = DefaultRollupConfig.builder()
+    final DefaultRollupConfig rollup_config = DefaultRollupConfig.newBuilder()
         .addAggregationId("sum", 0)
         .addAggregationId("count", 2)
         .addAggregationId("avg", 5)

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerNumericSummaryIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerNumericSummaryIterator.java
@@ -73,7 +73,7 @@ public class TestMergerNumericSummaryIterator {
   
   @Before
   public void before() throws Exception {
-    rollup_config = DefaultRollupConfig.builder()
+    rollup_config = DefaultRollupConfig.newBuilder()
         .addAggregationId("sum", 0)
         .addAggregationId("count", 2)
         .addAggregationId("avg", 5)

--- a/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerNumericIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerNumericIterator.java
@@ -67,7 +67,7 @@ public class TestSummarizerNumericIterator {
         .setId("summarizer")
         .build();
     
-    rollup_config = DefaultRollupConfig.builder()
+    rollup_config = DefaultRollupConfig.newBuilder()
         .addAggregationId("sum", 0)
         .addAggregationId("count", 1)
         .addAggregationId("max", 2)

--- a/core/src/test/java/net/opentsdb/query/processor/topn/TestTopNNumericSummaryAggregator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/topn/TestTopNNumericSummaryAggregator.java
@@ -76,7 +76,7 @@ public class TestTopNNumericSummaryAggregator {
         .build();
     when(node.config()).thenReturn(config);
     
-    RollupConfig rollup_config = DefaultRollupConfig.builder()
+    RollupConfig rollup_config = DefaultRollupConfig.newBuilder()
         .addAggregationId("sum", 0)
         .addAggregationId("count", 2)
         .addAggregationId("avg", 5)

--- a/core/src/test/java/net/opentsdb/query/router/TestTimeRouterFactory.java
+++ b/core/src/test/java/net/opentsdb/query/router/TestTimeRouterFactory.java
@@ -63,6 +63,7 @@ import net.opentsdb.query.processor.downsample.DownsampleConfig;
 import net.opentsdb.query.processor.groupby.GroupByConfig;
 import net.opentsdb.query.processor.merge.Merger;
 import net.opentsdb.query.router.TimeRouterConfigEntry.MatchType;
+import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.QueryStats;
 import net.opentsdb.stats.Span;
 
@@ -419,6 +420,12 @@ public class TestTimeRouterFactory {
     @Override
     public String version() {
       return "3.0.0";
+    }
+
+    @Override
+    public RollupConfig rollupConfig() {
+      // TODO Auto-generated method stub
+      return null;
     }
     
   }

--- a/core/src/test/java/net/opentsdb/rollup/TestRollupConfig.java
+++ b/core/src/test/java/net/opentsdb/rollup/TestRollupConfig.java
@@ -60,7 +60,7 @@ public class TestRollupConfig {
         .setRowSpan("1d")
         .build();
     
-    builder = DefaultRollupConfig.builder()
+    builder = DefaultRollupConfig.newBuilder()
         .addAggregationId("Sum", 0)
         .addAggregationId("Max", 1)
         .addAggregationId("count", 2)
@@ -97,7 +97,7 @@ public class TestRollupConfig {
     assertEquals("min", config.ids_to_aggregations.get(3));
     
     // missing aggregations
-    builder = DefaultRollupConfig.builder()
+    builder = DefaultRollupConfig.newBuilder()
         .addInterval(raw)
         .addInterval(tenmin);
     try {
@@ -106,7 +106,7 @@ public class TestRollupConfig {
     } catch (IllegalArgumentException e) { }
     
     // duplicate aggregation id
-    builder = DefaultRollupConfig.builder()
+    builder = DefaultRollupConfig.newBuilder()
         .addAggregationId("Sum", 1)
         .addAggregationId("Max", 1)
         .addInterval(raw)
@@ -117,7 +117,7 @@ public class TestRollupConfig {
     } catch (IllegalArgumentException e) { }
     
     // invalid ID
-    builder = DefaultRollupConfig.builder()
+    builder = DefaultRollupConfig.newBuilder()
         .addAggregationId("Sum", 0)
         .addAggregationId("Max", 128)
         .addInterval(raw)
@@ -128,7 +128,7 @@ public class TestRollupConfig {
     } catch (IllegalArgumentException e) { }
     
     // empty intervals
-    builder = DefaultRollupConfig.builder()
+    builder = DefaultRollupConfig.newBuilder()
         .addAggregationId("Sum", 0)
         .addAggregationId("Max", 1);
     try {
@@ -137,7 +137,7 @@ public class TestRollupConfig {
     } catch (IllegalArgumentException e) { }
     
     // dupe intervals
-    builder = DefaultRollupConfig.builder()
+    builder = DefaultRollupConfig.newBuilder()
         .addAggregationId("Sum", 0)
         .addAggregationId("Max", 1)
         .addInterval(raw)
@@ -155,7 +155,7 @@ public class TestRollupConfig {
         .setRowSpan("1d")
         .setDefaultInterval(true)
         .build();
-    builder = DefaultRollupConfig.builder()
+    builder = DefaultRollupConfig.newBuilder()
         .addAggregationId("Sum", 0)
         .addAggregationId("Max", 1)
         .addInterval(raw)
@@ -268,6 +268,30 @@ public class TestRollupConfig {
       config.getRollupIntervals(0, "1m");
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
+  }
+  
+  @Test
+  public void getPossibleIntervals() throws Exception {
+    DefaultRollupConfig config = builder.build();
+    
+    List<String> intervals = config.getPossibleIntervals("1m");
+    assertEquals(0, intervals.size());
+    
+    intervals = config.getPossibleIntervals("10m");
+    assertEquals(1, intervals.size());
+    assertSame(tenmin.getInterval(), intervals.get(0));
+    
+    intervals = config.getPossibleIntervals("20m");
+    assertEquals(1, intervals.size());
+    assertSame(tenmin.getInterval(), intervals.get(0));
+    
+    intervals = config.getPossibleIntervals("12m");
+    assertEquals(0, intervals.size());
+    
+    try {
+      config.getPossibleIntervals("1s");
+      fail("Expected NoSuchRollupForIntervalException");
+    } catch (NoSuchRollupForIntervalException e) { }
   }
   
   @Test

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestNumericSummaryRowSeq.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestNumericSummaryRowSeq.java
@@ -63,7 +63,7 @@ public class TestNumericSummaryRowSeq {
         .setRowSpan("1d")
         .build();
     
-    CONFIG = DefaultRollupConfig.builder()
+    CONFIG = DefaultRollupConfig.newBuilder()
         .addAggregationId("Sum", 0)
         .addAggregationId("Max", 1)
         .addAggregationId("Count", 2)

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestNumericSummarySpan.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestNumericSummarySpan.java
@@ -59,7 +59,7 @@ public class TestNumericSummarySpan {
         .setRowSpan("1d")
         .build();
     
-    CONFIG = DefaultRollupConfig.builder()
+    CONFIG = DefaultRollupConfig.newBuilder()
         .addAggregationId("Sum", 0)
         .addAggregationId("Max", 1)
         .addAggregationId("Count", 2)

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchemaFactory.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchemaFactory.java
@@ -39,6 +39,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.google.common.collect.Lists;
 
+import net.opentsdb.core.MockTSDB;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.data.TimeSeriesByteId;
 import net.opentsdb.query.QueryNode;
@@ -57,7 +58,7 @@ public class TestSchemaFactory extends SchemaBase {
   
   @Before
   public void before() throws Exception {
-    tsdb = mock(TSDB.class);
+    tsdb = new MockTSDB();
     store = mock(Tsdb1xDataStore.class);
     node = mock(QueryNode.class);
     

--- a/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Factory.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Factory.java
@@ -34,6 +34,7 @@ import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
 import net.opentsdb.query.TimeSeriesQuery;
 import net.opentsdb.query.plan.QueryPlanner;
+import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.Span;
 
 public class HttpQueryV3Factory extends BaseHttpExecutorFactory {
@@ -132,5 +133,11 @@ public class HttpQueryV3Factory extends BaseHttpExecutorFactory {
       tsdb.getConfig().register(getConfigKey(ENDPOINT_KEY), "/api/query/graph", true,
           "The endpoint to send queries to.");
     }
+  }
+
+  @Override
+  public RollupConfig rollupConfig() {
+    // TODO Auto-generated method stub
+    return null;
   }
 }

--- a/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Result.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Result.java
@@ -602,6 +602,18 @@ public class HttpQueryV3Result implements QueryResult {
     public int getIdForAggregator(final String aggregator) {
       return name_to_id.get(aggregator);
     }
+
+    @Override
+    public List<String> getIntervals() {
+      // TODO Auto-generated method stub
+      return null;
+    }
+
+    @Override
+    public List<String> getPossibleIntervals(String interval) {
+      // TODO Auto-generated method stub
+      return null;
+    }
     
   }
   

--- a/implementation/protobuf/src/main/java/net/opentsdb/grpc/QueryGRPCClientFactory.java
+++ b/implementation/protobuf/src/main/java/net/opentsdb/grpc/QueryGRPCClientFactory.java
@@ -47,6 +47,7 @@ import net.opentsdb.query.BaseTimeSeriesDataSourceConfig;
 import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
 import net.opentsdb.query.processor.downsample.DownsampleConfig;
 import net.opentsdb.query.serdes.PBufSerdesFactory;
+import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.Span;
 
 /**
@@ -198,5 +199,11 @@ public class QueryGRPCClientFactory extends BaseTSDBPlugin
       TimeSeriesDataSourceConfig config) {
     // TODO Auto-generated method stub
     return true;
+  }
+
+  @Override
+  public RollupConfig rollupConfig() {
+    // TODO Auto-generated method stub
+    return null;
   }
 }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xQueryNode.java
@@ -49,8 +49,6 @@ import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
-import net.opentsdb.query.processor.downsample.Downsample;
-import net.opentsdb.query.processor.downsample.DownsampleConfig;
 import net.opentsdb.rollup.RollupInterval;
 import net.opentsdb.rollup.RollupUtils.RollupUsage;
 import net.opentsdb.stats.Span;
@@ -60,7 +58,6 @@ import net.opentsdb.uid.NoSuchUniqueName;
 import net.opentsdb.uid.UniqueIdType;
 import net.opentsdb.utils.Bytes;
 import net.opentsdb.utils.Bytes.ByteMap;
-import net.opentsdb.utils.DateTime;
 import net.opentsdb.utils.Exceptions;
 
 /**
@@ -125,14 +122,8 @@ public class Tsdb1xQueryNode implements TimeSeriesDataSource, SourceNode {
   /** Rollup fallback mode. */
   protected final RollupUsage rollup_usage;
   
-  /** The rollup downsampling aggregation by name. */
-  protected String rollup_aggregation;
-  
   /** Rollup intervals matching the query downsampler if applicable. */
   protected List<RollupInterval> rollup_intervals;
-  
-  /** An optional downsample config from upstream. */
-  protected DownsampleConfig ds_config;
   
   /** When we start fetching data. */
   protected long fetch_start;
@@ -280,24 +271,20 @@ public class Tsdb1xQueryNode implements TimeSeriesDataSource, SourceNode {
     }
 
     if (parent.schema().rollupConfig() != null && 
-        rollup_usage != RollupUsage.ROLLUP_RAW) {
-      Collection<QueryNode> downsamplers = context.upstreamOfType(this, Downsample.class);
-      if (!downsamplers.isEmpty()) {
-        // TODO - find the lowest-common resolution if possible.
-        ds_config = (DownsampleConfig) downsamplers.iterator().next().config();
-        rollup_intervals = parent.schema()
-            .rollupConfig().getRollupIntervals(
-                DateTime.parseDuration(ds_config.getInterval()) / 1000, 
-                ds_config.getInterval(), 
-                true);
-        rollup_aggregation = ds_config.getAggregator();
-      } else {
-        rollup_intervals = null;
-        rollup_aggregation = null;
+        rollup_usage != RollupUsage.ROLLUP_RAW &&
+        config.getRollupIntervals() != null && 
+        !config.getRollupIntervals().isEmpty()) {
+      rollup_intervals = Lists.newArrayListWithExpectedSize(
+          config.getRollupIntervals().size());
+      for (final String interval : config.getRollupIntervals()) {
+        final RollupInterval ri = parent.schema().rollupConfig()
+            .getRollupInterval(interval);
+        if (ri != null) {
+          rollup_intervals.add(ri);
+        }
       }
     } else {
       rollup_intervals = null;
-      rollup_aggregation = null;
     }
     
     upstream = context.upstream(this);
@@ -424,16 +411,6 @@ public class Tsdb1xQueryNode implements TimeSeriesDataSource, SourceNode {
   /** @return The rollup usage mode. */
   RollupUsage rollupUsage() {
     return rollup_usage;
-  }
-
-  /** @return The optional rollup aggregation. May be null. */
-  String rollupAggregation() {
-    return rollup_aggregation;
-  }
-  
-  /** @return The optional downsample config. May be null. */
-  DownsampleConfig downsampleConfig() {
-    return ds_config;
   }
   
   /**

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xMultiGet.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xMultiGet.java
@@ -58,7 +58,6 @@ import com.google.common.primitives.Bytes;
 
 import net.opentsdb.data.MillisecondTimeStamp;
 import net.opentsdb.data.TimeStamp;
-import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
 import net.opentsdb.query.QueryContext;
 import net.opentsdb.query.QueryMode;
@@ -67,11 +66,7 @@ import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.SemanticQuery;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
 import net.opentsdb.query.TimeSeriesQuery;
-import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.filter.MetricLiteralFilter;
-import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
-import net.opentsdb.query.pojo.FillPolicy;
-import net.opentsdb.query.processor.downsample.DownsampleConfig;
 import net.opentsdb.rollup.DefaultRollupConfig;
 import net.opentsdb.rollup.RollupInterval;
 import net.opentsdb.rollup.RollupUtils.RollupUsage;
@@ -131,7 +126,8 @@ public class TestTsdb1xMultiGet extends UTBase {
         .setExecutionGraph(Collections.emptyList())
         .build();
     
-    source_config = (TimeSeriesDataSourceConfig) DefaultTimeSeriesDataSourceConfig.newBuilder()
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
         .setMetric(MetricLiteralFilter.newBuilder()
             .setMetric(METRIC_STRING)
             .build())
@@ -251,19 +247,16 @@ public class TestTsdb1xMultiGet extends UTBase {
 
   @Test
   public void ctorRollups() throws Exception {
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("1h")
-        .setAggregator("avg")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+        .setMetric(MetricLiteralFilter.newBuilder()
+            .setMetric(METRIC_STRING)
             .build())
-        .build());
-    when(node.rollupAggregation()).thenReturn("avg");
+        .addRollupAggregation("sum")
+        .addRollupAggregation("count")
+        .addRollupInterval("1h")
+        .setId("m1")
+        .build();
     when(node.rollupIntervals())
       .thenReturn(Lists.<RollupInterval>newArrayList(RollupInterval.builder()
           .setInterval("1h")
@@ -293,8 +286,8 @@ public class TestTsdb1xMultiGet extends UTBase {
     FilterList filter = (FilterList) mget.filter;
     assertEquals(4, filter.filters().size());
     assertArrayEquals("sum".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(0)).comparator()).value());
-    assertArrayEquals("count".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(1)).comparator()).value());
-    assertArrayEquals(new byte[] { 1 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(2)).comparator()).value());
+    assertArrayEquals(new byte[] { 1 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(1)).comparator()).value());
+    assertArrayEquals("count".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(2)).comparator()).value());
     assertArrayEquals(new byte[] { 2 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(3)).comparator()).value());
     
     // pre-agg
@@ -308,6 +301,9 @@ public class TestTsdb1xMultiGet extends UTBase {
         .setMetric(MetricLiteralFilter.newBuilder()
             .setMetric(METRIC_STRING)
             .build())
+        .addRollupAggregation("sum")
+        .addRollupAggregation("count")
+        .addRollupInterval("1h")
         .addOverride(Tsdb1xHBaseDataStore.PRE_AGG_KEY, "true")
         .setId("m1")
         .build();
@@ -328,24 +324,11 @@ public class TestTsdb1xMultiGet extends UTBase {
     filter = (FilterList) mget.filter;
     assertEquals(4, filter.filters().size());
     assertArrayEquals("sum".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(0)).comparator()).value());
-    assertArrayEquals("count".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(1)).comparator()).value());
-    assertArrayEquals(new byte[] { 1 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(2)).comparator()).value());
+    assertArrayEquals(new byte[] { 1 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(1)).comparator()).value());
+    assertArrayEquals("count".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(2)).comparator()).value());
     assertArrayEquals(new byte[] { 2 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(3)).comparator()).value());
     
     // sum
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("1h")
-        .setAggregator("sum")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
-            .build())
-        .build());
-    when(node.rollupAggregation()).thenReturn("sum");
     query = SemanticQuery.newBuilder()
         .setMode(QueryMode.SINGLE)
         .setStart(Integer.toString(START_TS))
@@ -356,6 +339,8 @@ public class TestTsdb1xMultiGet extends UTBase {
         .setMetric(MetricLiteralFilter.newBuilder()
             .setMetric(METRIC_STRING)
             .build())
+        .addRollupAggregation("sum")
+        .addRollupInterval("1h")
         .setId("m1")
         .build();
     when(context.query()).thenReturn(query);
@@ -412,27 +397,15 @@ public class TestTsdb1xMultiGet extends UTBase {
         .setMetric(MetricLiteralFilter.newBuilder()
             .setMetric(METRIC_STRING)
             .build())
+        .addRollupAggregation("max")
+        .setPrePadding("2h")
+        .setPostPadding("2h")
         .setId("m1")
         .build();
     when(context.query()).thenReturn(query);
     
     Tsdb1xMultiGet mget = new Tsdb1xMultiGet(node, source_config, tsuids);
-    assertEquals(END_TS - 900, mget.timestamp.epoch());
-    
-    // downsample 2 hours
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("2h")
-        .setAggregator("max")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
-            .build())
-        .build());
-    when(node.rollupAggregation()).thenReturn("max");
+    assertEquals(END_TS - 900 - 3600, mget.timestamp.epoch());
     
     mget = new Tsdb1xMultiGet(node, source_config, tsuids);
     assertEquals(START_TS - 900, mget.timestamp.epoch());
@@ -1315,30 +1288,20 @@ public class TestTsdb1xMultiGet extends UTBase {
           .setRowSpan("6h")
           .build()));
     
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("1h")
-        .setAggregator("avg")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
-            .build())
-        .build());
-    when(node.rollupAggregation()).thenReturn("avg");
-    
     query = SemanticQuery.newBuilder()
         .setMode(QueryMode.SINGLE)
         .setStart(Integer.toString(START_TS))
         .setEnd(Integer.toString(END_TS))
         .setExecutionGraph(Collections.emptyList())
         .build();
+    
     source_config = (TimeSeriesDataSourceConfig) DefaultTimeSeriesDataSourceConfig.newBuilder()
         .setMetric(MetricLiteralFilter.newBuilder()
             .setMetric(METRIC_STRING)
             .build())
+        .addRollupAggregation("sum")
+        .addRollupAggregation("count")
+        .addRollupInterval("1h")
         .addOverride(Schema.QUERY_REVERSE_KEY, reversed ? "true" : "false")
         .setId("m1")
         .build();

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xQueryResult.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xQueryResult.java
@@ -345,7 +345,7 @@ public class TestTsdb1xQueryResult extends UTBase {
         .setPreAggregationTable("tsdb-rollup-1h")
         .build();
     interval.setConfig(rollup_config);
-    rollup_config = DefaultRollupConfig.builder()
+    rollup_config = DefaultRollupConfig.newBuilder()
         .addInterval(interval)
         .addAggregationId("sum", 0)
         .build();
@@ -381,7 +381,7 @@ public class TestTsdb1xQueryResult extends UTBase {
         .setPreAggregationTable("tsdb-rollup-1h")
         .build();
     interval.setConfig(rollup_config);
-    rollup_config = DefaultRollupConfig.builder()
+    rollup_config = DefaultRollupConfig.newBuilder()
         .addInterval(interval)
         .addAggregationId("sum", 0)
         .build();

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xScanners.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xScanners.java
@@ -132,7 +132,8 @@ public class TestTsdb1xScanners extends UTBase {
         .setExecutionGraph(Collections.emptyList())
         .build();
     
-    source_config = (TimeSeriesDataSourceConfig) DefaultTimeSeriesDataSourceConfig.newBuilder()
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
         .setMetric(MetricLiteralFilter.newBuilder()
             .setMetric(METRIC_STRING)
             .build())
@@ -251,19 +252,17 @@ public class TestTsdb1xScanners extends UTBase {
           .setRowSpan("1d")
           .build()));
     
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("1h")
-        .setAggregator("avg")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+        .setMetric(MetricLiteralFilter.newBuilder()
+            .setMetric(METRIC_STRING)
             .build())
-        .build());
-    when(node.rollupAggregation()).thenReturn("avg");
+        .addRollupAggregation("sum")
+        .addRollupAggregation("count")
+        .setPrePadding("1h")
+        .setPostPadding("1h")
+        .setId("m1")
+        .build();
     
     Tsdb1xScanners scanners = new Tsdb1xScanners(node, source_config);
     assertEquals(State.CONTINUE, scanners.state());
@@ -339,42 +338,31 @@ public class TestTsdb1xScanners extends UTBase {
         .setExecutionGraph(Collections.emptyList())
         .build();
     when(context.query()).thenReturn(query);
-    source_config = (TimeSeriesDataSourceConfig) DefaultTimeSeriesDataSourceConfig.newBuilder()
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
         .setMetric(MetricLiteralFilter.newBuilder()
             .setMetric(METRIC_STRING)
             .build())
+        .addRollupAggregation("max")
+        .setPrePadding("1h")
+        .setPostPadding("1h")
         .setId("m1")
         .build();
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("1h")
-        .setAggregator("max")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
-            .build())
-        .build());
-    when(node.rollupAggregation()).thenReturn("max");
     scanners = new Tsdb1xScanners(node, source_config);
     start = scanners.setStartKey(METRIC_BYTES, null, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, END_TS - 900, null), start);
     
     // downsample 2 hours
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("2h")
-        .setAggregator("max")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+        .setMetric(MetricLiteralFilter.newBuilder()
+            .setMetric(METRIC_STRING)
             .build())
-        .build());
+        .addRollupAggregation("max")
+        .setPrePadding("2h")
+        .setPostPadding("2h")
+        .setId("m1")
+        .build();
     scanners = new Tsdb1xScanners(node, source_config);
     start = scanners.setStartKey(METRIC_BYTES, null, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, START_TS - 900, null), start);
@@ -417,37 +405,33 @@ public class TestTsdb1xScanners extends UTBase {
     assertArrayEquals(makeRowKey(METRIC_BYTES, 1514851200, null), stop);
     
     // downsample
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("1h")
-        .setAggregator("avg")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+        .setMetric(MetricLiteralFilter.newBuilder()
+            .setMetric(METRIC_STRING)
             .build())
-        .build());
-    when(node.rollupAggregation()).thenReturn("avg");
+        .addRollupAggregation("sum")
+        .addRollupAggregation("count")
+        .setPrePadding("1h")
+        .setPostPadding("1h")
+        .setId("m1")
+        .build();
     scanners = new Tsdb1xScanners(node, source_config);
     stop = scanners.setStopKey(METRIC_BYTES, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, (END_TS - 900 + 7200), null), stop);
     
     // downsample 2 hours
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("2h")
-        .setAggregator("avg")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+        .setMetric(MetricLiteralFilter.newBuilder()
+            .setMetric(METRIC_STRING)
             .build())
-        .build());
-    when(node.rollupAggregation()).thenReturn("avg");
+        .addRollupAggregation("sum")
+        .addRollupAggregation("count")
+        .setPrePadding("2h")
+        .setPostPadding("2h")
+        .setId("m1")
+        .build();
     scanners = new Tsdb1xScanners(node, source_config);
     stop = scanners.setStopKey(METRIC_BYTES, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, (END_TS - 900 + 10800), null), stop);
@@ -858,8 +842,8 @@ public class TestTsdb1xScanners extends UTBase {
     assertEquals(4, filter.filters().size());
     assertTrue(filter.filters().get(0) instanceof QualifierFilter);
     assertArrayEquals("sum".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(0)).comparator()).value());
-    assertArrayEquals("count".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(1)).comparator()).value());
-    assertArrayEquals(new byte[] { 1 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(2)).comparator()).value());
+    assertArrayEquals(new byte[] { 1 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(1)).comparator()).value());
+    assertArrayEquals("count".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(2)).comparator()).value());
     assertArrayEquals(new byte[] { 2 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(3)).comparator()).value());
     
     // raw
@@ -998,8 +982,8 @@ public class TestTsdb1xScanners extends UTBase {
       assertEquals(4, filter.filters().size());
       assertTrue(filter.filters().get(0) instanceof QualifierFilter);
       assertArrayEquals("sum".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(0)).comparator()).value());
-      assertArrayEquals("count".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(1)).comparator()).value());
-      assertArrayEquals(new byte[] { 1 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(2)).comparator()).value());
+      assertArrayEquals(new byte[] { 1 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(1)).comparator()).value());
+      assertArrayEquals("count".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(2)).comparator()).value());
       assertArrayEquals(new byte[] { 2 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(3)).comparator()).value());
     }
     
@@ -1187,10 +1171,13 @@ public class TestTsdb1xScanners extends UTBase {
             .build())
         .build();
     when(context.query()).thenReturn(query);
-    source_config = (TimeSeriesDataSourceConfig) DefaultTimeSeriesDataSourceConfig.newBuilder()
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
         .setMetric(MetricLiteralFilter.newBuilder()
             .setMetric(METRIC_STRING)
             .build())
+        .addRollupAggregation("sum")
+        .addRollupAggregation("count")
         .setFilterId("f1")
         .setId("m1")
         .build();
@@ -1239,6 +1226,8 @@ public class TestTsdb1xScanners extends UTBase {
     filter = (FilterList) ((FilterList) filter.filters().get(2));
     assertArrayEquals("sum".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(0)).comparator()).value());
     assertArrayEquals(new byte[] { 1 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(1)).comparator()).value());
+    assertArrayEquals("count".getBytes(), ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(2)).comparator()).value());
+    assertArrayEquals(new byte[] { 2 }, ((BinaryPrefixComparator) ((QualifierFilter) filter.filters().get(3)).comparator()).value());
     
     // raw
     verify(caught.get(1), times(1)).setFamily(Tsdb1xHBaseDataStore.DATA_FAMILY);
@@ -2460,6 +2449,16 @@ public class TestTsdb1xScanners extends UTBase {
     if (pre_agg) {
       builder.addOverride(Tsdb1xHBaseDataStore.PRE_AGG_KEY, "true");
     }
+    if (ds != null) {
+      if (ds.equals("avg")) {
+        builder.addRollupAggregation("sum")
+               .addRollupAggregation("count");
+      } else {
+        builder.addRollupAggregation(ds);
+      }
+      builder.setPrePadding("1h")
+             .setPostPadding("1h");
+    }
     
     source_config = builder.build();
     
@@ -2477,20 +2476,6 @@ public class TestTsdb1xScanners extends UTBase {
             .setPreAggregationTable("tsdb-agg-30m")
             .setRowSpan("1d")
             .build()));
-      
-      when(node.downsampleConfig()).thenReturn(
-          (DownsampleConfig) DownsampleConfig.newBuilder()
-          .setId("ds")
-          .setInterval("1h")
-          .setAggregator(ds)
-          .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-              .setFillPolicy(FillPolicy.NONE)
-              .setRealFillPolicy(FillWithRealPolicy.NONE)
-              .setType("interp")
-              .setDataType(NumericType.TYPE.toString())
-              .build())
-          .build());
-      when(node.rollupAggregation()).thenReturn(ds);
     }
     return filter;
   }

--- a/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableQueryNode.java
+++ b/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableQueryNode.java
@@ -207,27 +207,20 @@ public class TestTsdb1xBigtableQueryNode extends UTBase {
     Schema schema = mock(Schema.class);
     when(data_store.schema()).thenReturn(schema);
     
-    when(rollup_config.getRollupIntervals(3600, "1h", true))
-      .thenReturn(Lists.<RollupInterval>newArrayList(RollupInterval.builder()
+    when(rollup_config.getRollupInterval("1h")).thenReturn(
+        RollupInterval.builder()
           .setInterval("1h")
           .setTable("tsdb-1h")
           .setPreAggregationTable("tsdb-agg-1h")
           .setRowSpan("1d")
-          .build(),
+          .build());
+    when(rollup_config.getRollupInterval("30m")).thenReturn(
         RollupInterval.builder()
           .setInterval("30m")
           .setTable("tsdb-30m")
           .setPreAggregationTable("tsdb-agg-30m")
           .setRowSpan("1d")
-          .build()));
-    
-    when(rollup_config.getRollupIntervals(1800, "30m", true))
-      .thenReturn(Lists.<RollupInterval>newArrayList(RollupInterval.builder()
-          .setInterval("30m")
-          .setTable("tsdb-30m")
-          .setPreAggregationTable("tsdb-agg-30m")
-          .setRowSpan("1d")
-          .build()));
+          .build());
     
     when(schema.rollupConfig()).thenReturn(rollup_config);
     
@@ -246,6 +239,19 @@ public class TestTsdb1xBigtableQueryNode extends UTBase {
     when(context.upstreamOfType(any(QueryNode.class), eq(Downsample.class)))
       .thenReturn(Lists.newArrayList(ds));
     
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+        .setMetric(MetricLiteralFilter.newBuilder()
+            .setMetric(METRIC_STRING)
+            .build())
+        .addRollupAggregation("sum")
+        .addRollupAggregation("count")
+        .addRollupInterval("1h")
+        .addRollupInterval("30m")
+        .setPrePadding("1h")
+        .setPostPadding("1h")
+        .setId("m1")
+        .build();
     Tsdb1xBigtableQueryNode node = new Tsdb1xBigtableQueryNode(
         data_store, context, source_config);
     assertSame(source_config, node.config);

--- a/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableQueryResult.java
+++ b/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableQueryResult.java
@@ -350,7 +350,7 @@ public class TestTsdb1xBigtableQueryResult extends UTBase {
         .setPreAggregationTable("tsdb-rollup-1h")
         .build();
     interval.setConfig(rollup_config);
-    rollup_config = DefaultRollupConfig.builder()
+    rollup_config = DefaultRollupConfig.newBuilder()
         .addInterval(interval)
         .addAggregationId("sum", 0)
         .build();
@@ -384,7 +384,7 @@ public class TestTsdb1xBigtableQueryResult extends UTBase {
         .setPreAggregationTable("tsdb-rollup-1h")
         .build();
     interval.setConfig(rollup_config);
-    rollup_config = DefaultRollupConfig.builder()
+    rollup_config = DefaultRollupConfig.newBuilder()
         .addInterval(interval)
         .addAggregationId("sum", 0)
         .build();

--- a/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableScanners.java
+++ b/storage/bigtable/src/test/java/net/opentsdb/storage/TestTsdb1xBigtableScanners.java
@@ -260,19 +260,17 @@ public class TestTsdb1xBigtableScanners extends UTBase {
           .setRowSpan("1d")
           .build()));
     
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("1h")
-        .setAggregator("avg")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+        .setMetric(MetricLiteralFilter.newBuilder()
+            .setMetric(METRIC_STRING)
             .build())
-        .build());
-    when(node.rollupAggregation()).thenReturn("avg");
+        .addRollupAggregation("sum")
+        .addRollupAggregation("count")
+        .setPrePadding("1h")
+        .setPostPadding("1h")
+        .setId("m1")
+        .build();
     
     Tsdb1xBigtableScanners scanners = new Tsdb1xBigtableScanners(node, source_config);
     assertEquals(State.CONTINUE, scanners.state());
@@ -354,36 +352,31 @@ public class TestTsdb1xBigtableScanners extends UTBase {
             .build())
         .setId("m1")
         .build();
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("1h")
-        .setAggregator("max")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+        .setMetric(MetricLiteralFilter.newBuilder()
+            .setMetric(METRIC_STRING)
             .build())
-        .build());
-    when(node.rollupAggregation()).thenReturn("max");
+        .addRollupAggregation("max")
+        .setPrePadding("1h")
+        .setPostPadding("1h")
+        .setId("m1")
+        .build();
     scanners = new Tsdb1xBigtableScanners(node, source_config);
     start = scanners.setStartKey(METRIC_BYTES, null, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, END_TS - 900, null), start);
     
     // downsample 2 hours
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("2h")
-        .setAggregator("max")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+        .setMetric(MetricLiteralFilter.newBuilder()
+            .setMetric(METRIC_STRING)
             .build())
-        .build());
+        .addRollupAggregation("max")
+        .setPrePadding("2h")
+        .setPostPadding("2h")
+        .setId("m1")
+        .build();
     scanners = new Tsdb1xBigtableScanners(node, source_config);
     start = scanners.setStartKey(METRIC_BYTES, null, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, START_TS - 900, null), start);
@@ -426,37 +419,33 @@ public class TestTsdb1xBigtableScanners extends UTBase {
     assertArrayEquals(makeRowKey(METRIC_BYTES, 1514851200, null), stop);
     
     // downsample
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("1h")
-        .setAggregator("avg")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+        .setMetric(MetricLiteralFilter.newBuilder()
+            .setMetric(METRIC_STRING)
             .build())
-        .build());
-    when(node.rollupAggregation()).thenReturn("avg");
+        .addRollupAggregation("sum")
+        .addRollupAggregation("count")
+        .setPrePadding("1h")
+        .setPostPadding("1h")
+        .setId("m1")
+        .build();
     scanners = new Tsdb1xBigtableScanners(node, source_config);
     stop = scanners.setStopKey(METRIC_BYTES, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, (END_TS - 900 + 7200), null), stop);
     
     // downsample 2 hours
-    when(node.downsampleConfig()).thenReturn(
-        (DownsampleConfig) DownsampleConfig.newBuilder()
-        .setId("ds")
-        .setInterval("2h")
-        .setAggregator("avg")
-        .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-            .setFillPolicy(FillPolicy.NONE)
-            .setRealFillPolicy(FillWithRealPolicy.NONE)
-            .setType("interp")
-            .setDataType(NumericType.TYPE.toString())
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+        .setMetric(MetricLiteralFilter.newBuilder()
+            .setMetric(METRIC_STRING)
             .build())
-        .build());
-    when(node.rollupAggregation()).thenReturn("avg");
+        .addRollupAggregation("sum")
+        .addRollupAggregation("count")
+        .setPrePadding("2h")
+        .setPostPadding("2h")
+        .setId("m1")
+        .build();
     scanners = new Tsdb1xBigtableScanners(node, source_config);
     stop = scanners.setStopKey(METRIC_BYTES, null);
     assertArrayEquals(makeRowKey(METRIC_BYTES, (END_TS - 900 + 10800), null), stop);
@@ -877,9 +866,9 @@ public class TestTsdb1xBigtableScanners extends UTBase {
     assertEquals(4, interleave.getFiltersCount());
     assertArrayEquals("sum".getBytes(Const.ASCII_CHARSET), 
         interleave.getFilters(0).getColumnQualifierRegexFilter().toByteArray());
-    assertArrayEquals("count".getBytes(Const.ASCII_CHARSET), 
-        interleave.getFilters(1).getColumnQualifierRegexFilter().toByteArray());
     assertArrayEquals(new byte[] { 1 }, 
+        interleave.getFilters(1).getColumnQualifierRegexFilter().toByteArray());
+    assertArrayEquals("count".getBytes(Const.ASCII_CHARSET), 
         interleave.getFilters(2).getColumnQualifierRegexFilter().toByteArray());
     assertArrayEquals(new byte[] { 2 }, 
         interleave.getFilters(3).getColumnQualifierRegexFilter().toByteArray());
@@ -1004,9 +993,9 @@ public class TestTsdb1xBigtableScanners extends UTBase {
       assertEquals(4, interleave.getFiltersCount());
       assertArrayEquals("sum".getBytes(Const.ASCII_CHARSET), 
           interleave.getFilters(0).getColumnQualifierRegexFilter().toByteArray());
-      assertArrayEquals("count".getBytes(Const.ASCII_CHARSET), 
-          interleave.getFilters(1).getColumnQualifierRegexFilter().toByteArray());
       assertArrayEquals(new byte[] { 1 }, 
+          interleave.getFilters(1).getColumnQualifierRegexFilter().toByteArray());
+      assertArrayEquals("count".getBytes(Const.ASCII_CHARSET), 
           interleave.getFilters(2).getColumnQualifierRegexFilter().toByteArray());
       assertArrayEquals(new byte[] { 2 }, 
           interleave.getFilters(3).getColumnQualifierRegexFilter().toByteArray());
@@ -1203,10 +1192,13 @@ public class TestTsdb1xBigtableScanners extends UTBase {
             .build())
         .build();
     when(context.query()).thenReturn(query);
-    source_config = (TimeSeriesDataSourceConfig) DefaultTimeSeriesDataSourceConfig.newBuilder()
+    source_config = (TimeSeriesDataSourceConfig) 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
         .setMetric(MetricLiteralFilter.newBuilder()
             .setMetric(METRIC_STRING)
             .build())
+        .addRollupAggregation("sum")
+        .addRollupAggregation("count")
         .setFilterId("f1")
         .setId("m1")
         .build();
@@ -1250,11 +1242,15 @@ public class TestTsdb1xBigtableScanners extends UTBase {
     assertArrayEquals(Tsdb1xBigtableDataStore.DATA_FAMILY, 
         chain.getFilters(1).getFamilyNameRegexFilterBytes().toByteArray());
     Interleave interleave = chain.getFilters(2).getInterleave();
-    assertEquals(2, interleave.getFiltersCount());
+    assertEquals(4, interleave.getFiltersCount());
     assertArrayEquals("sum".getBytes(Const.ASCII_CHARSET), 
         interleave.getFilters(0).getColumnQualifierRegexFilter().toByteArray());
     assertArrayEquals(new byte[] { 1 }, 
         interleave.getFilters(1).getColumnQualifierRegexFilter().toByteArray());
+    assertArrayEquals("count".getBytes(Const.ASCII_CHARSET), 
+        interleave.getFilters(2).getColumnQualifierRegexFilter().toByteArray());
+    assertArrayEquals(new byte[] { 2 }, 
+        interleave.getFilters(3).getColumnQualifierRegexFilter().toByteArray());
     
     // raw
     request = storage.getScanners().get(1).request();
@@ -2397,6 +2393,7 @@ public class TestTsdb1xBigtableScanners extends UTBase {
     }
     query = query_builder.build();
     when(context.query()).thenReturn(query);
+    
     DefaultTimeSeriesDataSourceConfig.Builder builder = 
         (DefaultTimeSeriesDataSourceConfig.Builder) DefaultTimeSeriesDataSourceConfig.newBuilder()
         .setMetric(MetricLiteralFilter.newBuilder()
@@ -2406,6 +2403,16 @@ public class TestTsdb1xBigtableScanners extends UTBase {
         .setId("m1");
     if (pre_agg) {
       builder.addOverride(Tsdb1xBigtableDataStore.PRE_AGG_KEY, "true");
+    }
+    if (ds != null) {
+      if (ds.equals("avg")) {
+        builder.addRollupAggregation("sum")
+               .addRollupAggregation("count");
+      } else {
+        builder.addRollupAggregation(ds);
+      }
+      builder.setPrePadding("1h")
+             .setPostPadding("1h");
     }
     
     source_config = builder.build();
@@ -2424,20 +2431,6 @@ public class TestTsdb1xBigtableScanners extends UTBase {
             .setPreAggregationTable("tsdb-agg-30m")
             .setRowSpan("1d")
             .build()));
-      
-      when(node.downsampleConfig()).thenReturn(
-          (DownsampleConfig) DownsampleConfig.newBuilder()
-          .setId("ds")
-          .setInterval("1h")
-          .setAggregator(ds)
-          .addInterpolatorConfig(NumericInterpolatorConfig.newBuilder()
-              .setFillPolicy(FillPolicy.NONE)
-              .setRealFillPolicy(FillWithRealPolicy.NONE)
-              .setType("interp")
-              .setDataType(NumericType.TYPE.toString())
-              .build())
-          .build());
-      when(node.rollupAggregation()).thenReturn(ds);
     }
     return filter;
   }


### PR DESCRIPTION
- Add rollupConfig() to TimeSeriesDataSourceFactory so the planner can find
  out what rollups are supported.
- Add namespace() to the TimeSeriesDataSourceConfig as we'll be able to use
  that with systems that support it.
- Also add getRollupIntervals and getRollupAggregations so that the
  downsample config can plan out what rollups to get.
- And add pre and post padding to the data source config so we can tell the
  driver how much to get before and after the query.
- Have the QueryPlanner interface allow other callers to get the factory for
  a node and return a collection of source nodes for a node.
- Add the getIntervals() and getPossibleIntervals() interfaces to RollupConfig.

CORE:
- Implement the new bits in BaseTimeSeriesDataSourceConfig.
- Implement the new bits in DefaultQueryPlanner and clean it up a little,
  moving more calls into the getFactory() method.
- DownsampleFactory will now scan for sources and update them with padding and
  an optional rollup config.
- Fix some logging in the DefaultRollupConfig to trace and implement the new
  methods
- Load the rollup config in the SchemaFactory now and share it with the Schema.

ASYNCHBASE/BIGTABLE:
- Use the new rollup setup.