### PR TITLE
Do PutDataPointRpc.GroupCB asynchronously

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,7 @@ tsdb_SRC := \
 	src/core/RequestBuilder.java	\
 	src/core/RowKey.java	\
 	src/core/RowSeq.java	\
+	src/core/RpcResponder.java	\
 	src/core/iRowSeq.java	\
 	src/core/SaltScanner.java	\
 	src/core/SeekableView.java	\
@@ -316,6 +317,7 @@ test_SRC := \
 	test/core/TestRateSpan.java	\
 	test/core/TestRowKey.java	\
 	test/core/TestRowSeq.java	\
+	test/core/TestRpcResponsder.java	\
 	test/core/TestSaltScanner.java	\
 	test/core/TestSpan.java	\
 	test/core/TestSpanGroup.java	\

--- a/src/core/RpcResponder.java
+++ b/src/core/RpcResponder.java
@@ -1,0 +1,110 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2017  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import net.opentsdb.utils.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * This class is responsible for building result of requests and
+ * respond to clients asynchronously.
+ *
+ * It can reduce requests that stacking in AsyncHBase, especially put requests.
+ * When a HBase's RPC has completed, the "AsyncHBase I/O worker" just decodes
+ * the response, and then do callback by this class asynchronously. We should
+ * take up workers as short as possible time so that workers can remove RPCs
+ * from in-flight state more quickly.
+ *
+ */
+public class RpcResponder {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RpcResponder.class);
+
+  public static final String TSD_RESPONSE_ASYNC_KEY = "tsd.core.response.async";
+  public static final boolean TSD_RESPONSE_ASYNC_DEFAULT = true;
+
+  public static final String TSD_RESPONSE_WORKER_NUM_KEY =
+          "tsd.core.response.worker.num";
+  public static final int TSD_RESPONSE_WORKER_NUM_DEFAULT = 10;
+
+  private final boolean async;
+  private ExecutorService responders;
+  private volatile boolean running = true;
+
+  RpcResponder(final Config config) {
+    async = config.getBoolean(TSD_RESPONSE_ASYNC_KEY,
+            TSD_RESPONSE_ASYNC_DEFAULT);
+
+    if (async) {
+      int threads = config.getInt(TSD_RESPONSE_WORKER_NUM_KEY,
+              TSD_RESPONSE_WORKER_NUM_DEFAULT);
+      responders = Executors.newFixedThreadPool(threads,
+        new ThreadFactoryBuilder()
+          .setNameFormat("OpenTSDB Responder #%d")
+          .setDaemon(true)
+          .setUncaughtExceptionHandler(new ExceptionHandler())
+          .build());
+    }
+
+    LOG.info("RpcResponder mode: {}", async ? "async" : "sync");
+  }
+
+  public void response(Runnable run) {
+    if (async) {
+      if (running) {
+        responders.execute(run);
+      } else {
+        throw new IllegalStateException("RpcResponder is closing or closed.");
+      }
+    } else {
+      run.run();
+    }
+  }
+
+  public void close() {
+    if (running) {
+      running = false;
+      responders.shutdown();
+    }
+
+    boolean completed;
+    try {
+      completed = responders.awaitTermination(5, TimeUnit.MINUTES);
+    } catch (InterruptedException e) {
+      completed = false;
+    }
+
+    if (!completed) {
+      LOG.warn(
+          "There are still some results that are not returned to the clients.");
+    }
+  }
+
+  public boolean isAsync() {
+    return async;
+  }
+
+  private class ExceptionHandler implements Thread.UncaughtExceptionHandler {
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+      LOG.error("Run into an uncaught exception in thread: " + t.getName(), e);
+    }
+  }
+}

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import net.opentsdb.core.RpcResponder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -341,6 +342,23 @@ public class Config {
   }
 
   /**
+   * Returns the given property as an integer.
+   * If no such property is specified, or if the specified value is not a valid
+   * <code>Int</code>, then <code>default_val</code> is returned.
+   *
+   * @param property    The property to load
+   * @param default_val default value
+   * @return A parsed integer or default_val.
+   */
+  public final int getInt(final String property, final int default_val) {
+    try {
+      return getInt(property);
+    } catch (Exception e) {
+      return default_val;
+    }
+  }
+
+  /**
    * Returns the given string trimed or null if is null
    * @param string The string be trimmed of
    * @return The string trimed or null
@@ -418,6 +436,23 @@ public class Config {
     if (val.equals("YES"))
       return true;
     return false;
+  }
+
+  /**
+   * Returns the given property as an boolean.
+   * If no such property is specified, or if the specified value is not a valid
+   * <code>boolean</code>, then <code>default_val</code> is returned.
+   *
+   * @param property    The property to load
+   * @param default_val default value
+   * @return A parsed boolean or default_val.
+   */
+  public final boolean getBoolean(final String property, final boolean default_val) {
+    try {
+      return getBoolean(property);
+    } catch (Exception e) {
+      return default_val;
+    }
   }
 
   /**

--- a/test/core/TestRpcResponsder.java
+++ b/test/core/TestRpcResponsder.java
@@ -1,0 +1,65 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2017  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+
+import net.opentsdb.utils.Config;
+import org.jboss.netty.util.internal.ThreadLocalRandom;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestRpcResponsder {
+
+  private final AtomicInteger complete_counter = new AtomicInteger(0);
+
+  @Test(timeout = 60000)
+  public void testGracefulShutdown() throws InterruptedException {
+    RpcResponder rpcResponder = new RpcResponder(new Config());
+
+    final int n = 100;
+    for (int i = 0; i < n; i++) {
+      rpcResponder.response(new MockResponseProcess());
+    }
+
+    Thread.sleep(500);
+    rpcResponder.close();
+
+    try {
+      rpcResponder.response(new MockResponseProcess());
+      Assert.fail("Expect an IllegalStateException");
+    } catch (IllegalStateException ignore) {
+    }
+
+    Assert.assertEquals(n, complete_counter.get());
+  }
+
+  private class MockResponseProcess implements Runnable {
+
+    @Override
+    public void run() {
+      long duration = ThreadLocalRandom.current().nextInt(5000);
+      while (duration > 0) {
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException ignore) {
+        }
+        duration -= 100;
+      }
+      complete_counter.incrementAndGet();
+    }
+  }
+
+
+}


### PR DESCRIPTION
There is a bottleneck that the Netty worker threads are the bottleneck for responses. 

Recently, we are doing pressure test for tsdb. We put data into a single tsd (1 tsd, 1 regionserver, batch 50, threads 48, in sync mode), and we found it can not run stably.  See the following picture.
![tps-tsdb-1](https://user-images.githubusercontent.com/8175507/50438676-e7df7000-0929-11e9-8d41-689c8e26a225.png)
TSDB's memory grow up quickly, and then cause FGC. The root cause is too many `PutRequest` in AsyncHBase. These `PutRequests` can not be removed from `rpcs_inflight`, because there is only one Netty worker decodes responses from regionserver (each regionserver corresponds to a NioClientSocketChannel). 

When AsyncHBase finish a RPC, it will remove this RPC from rpcs_inflight.  After that, AsyncHBase will call GroupCB, and then GroupCB send HTTP response to the client.  All of this runs in just one Netty worker. We tried to do GroupCB asynchronously, and got some good results. TSDB can run stably with almost 650K TPS.

![performacne-tsdb-2](https://user-images.githubusercontent.com/8175507/50439727-047da700-092e-11e9-9391-e3dd155a49f0.png)
