### PR TITLE
HTTP:

### DIFF
--- a/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Result.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Result.java
@@ -446,13 +446,23 @@ public class HttpQueryV3Result implements QueryResult {
           }
           double_data[idx++] = node.asDouble();
         } else {
-          if (idx >= long_data.length) {
-            long[] temp = new long[idx < 1024 ? idx * 2 : idx + 8];
-            for (int i = 0; i < idx; i++) {
-              temp[i] = long_data[i];
+          if (long_data == null) {
+            if (idx >= double_data.length) {
+              double[] temp = new double[idx < 1024 ? idx * 2 : idx + 8];
+              for (int i = 0; i < idx; i++) {
+                temp[i] = double_data[i];
+              }
             }
+            double_data[idx++] = node.asDouble();
+          } else {
+            if (idx >= long_data.length) {
+              long[] temp = new long[idx < 1024 ? idx * 2 : idx + 8];
+              for (int i = 0; i < idx; i++) {
+                temp[i] = long_data[i];
+              }
+            }
+            long_data[idx++] = node.asLong();
           }
-          long_data[idx++] = node.asLong();
         }
       }
     }


### PR DESCRIPTION
- Fix a parsing bug in the v3 results wherein if the array switches from a
  double to a long when serializing, it wouldn't properly handle the long
  and store it in the double array.
- Cleanup the V3 source and set the type to override others like HAConfig.
- Also pass in the log level and parse out the logs from downstream.