### PR TITLE
Always write tool output (fsck, metasync, etc.) to STDOUT by default

### DIFF
--- a/build-aux/deb/logback.xml
+++ b/build-aux/deb/logback.xml
@@ -64,6 +64,9 @@
   <logger name="org.apache.zookeeper" level="INFO"/>
   <logger name="org.hbase.async" level="INFO"/>
   <logger name="com.stumbleupon.async" level="INFO"/>
+  <logger name="net.opentsdb.tools" level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </logger>
   
   <!-- Fallthrough root logger and router -->
   <root level="INFO">

--- a/build-aux/rpm/logback.xml
+++ b/build-aux/rpm/logback.xml
@@ -64,6 +64,9 @@
   <logger name="org.apache.zookeeper" level="INFO"/>
   <logger name="org.hbase.async" level="INFO"/>
   <logger name="com.stumbleupon.async" level="INFO"/>
+  <logger name="net.opentsdb.tools" level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </logger>
   
   <!-- Fallthrough root logger and router -->
   <root level="INFO">

--- a/src/logback.xml
+++ b/src/logback.xml
@@ -63,6 +63,9 @@
   <logger name="org.apache.zookeeper" level="INFO"/>
   <logger name="org.hbase.async" level="INFO"/>
   <logger name="com.stumbleupon.async" level="INFO"/>
+  <logger name="net.opentsdb.tools" level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </logger>
   
   <!-- Fallthrough root logger and router -->
   <root level="INFO">


### PR DESCRIPTION
This helps make problems like https://github.com/OpenTSDB/opentsdb/issues/1351 ..less...

Basically, all CLI tools should write to stdout by default so people can see them working.

(try #2)