### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/utils/RefreshingSSLContext.java
+++ b/common/src/main/java/net/opentsdb/utils/RefreshingSSLContext.java
@@ -1,0 +1,800 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2019  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.utils;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPrivateKeySpec;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.xml.bind.DatatypeConverter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import com.google.common.io.Files;
+
+import io.netty.util.Timeout;
+import io.netty.util.TimerTask;
+import net.opentsdb.common.Const;
+import net.opentsdb.core.TSDB;
+import sun.security.provider.certpath.X509CertPath;
+import sun.security.util.DerInputStream;
+import sun.security.util.DerValue;
+
+/**
+ * First stab at a refreshing SSL context that watches the given params for
+ * updates and reloads the context on changes. Note that if the interval is set
+ * to 0 then refreshing is disabled. Makes it useful for servers that load once.
+ * 
+ * @since 3.0
+ */
+public class RefreshingSSLContext implements TimerTask {
+  private static Logger LOG = LoggerFactory.getLogger(RefreshingSSLContext.class);
+  
+  private static CertificateFactory CA_FACTORY;
+  
+  public static enum SourceType {
+    FILES,
+    KEYSTORE,
+    SECRET
+  }
+  
+  private final Builder builder;
+  private long last_hash;
+  private volatile SSLContext context;
+  
+  private RefreshingSSLContext(final Builder builder) {
+    if (builder.type == null) {
+      throw new IllegalArgumentException("Type cannot be null.");
+    }
+    
+    try {
+      CA_FACTORY = CertificateFactory.getInstance("X.509");
+    } catch (CertificateException e) {
+      throw new IllegalStateException(e);
+    }
+    
+    switch (builder.type) {
+    case FILES:
+      if (Strings.isNullOrEmpty(builder.cert)) {
+        throw new IllegalArgumentException("The certificate path cannot be "
+            + "null or empty.");
+      }
+      break;
+    case KEYSTORE:
+      if (Strings.isNullOrEmpty(builder.keystore)) {
+        throw new IllegalArgumentException("The keystore path cannot be "
+            + "null or empty.");
+      }
+      if (Strings.isNullOrEmpty(builder.keystore_pass)) {
+        throw new IllegalArgumentException("The keystor password cannot be "
+            + "null or empty.");
+      }
+      break;
+    case SECRET:
+      if (Strings.isNullOrEmpty(builder.secret_cert)) {
+        throw new IllegalArgumentException("The secret certificate key cannot be "
+            + "null or empty.");
+      }
+      break;
+    }
+    this.builder = builder;
+    
+    try {
+      run(null);
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+  
+  public synchronized SSLContext context() {
+    return context;
+  }
+  
+  public synchronized long hash() {
+    return last_hash;
+  }
+
+  public long forceRefresh() {
+    try {
+      switch (builder.type) {
+      case FILES:
+        runKeyAndCert();
+        break;
+      case KEYSTORE:
+        runKeystore();
+        break;
+      case SECRET:
+        runSecrets();
+        break;
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException("Failed to refresh SSLContext", t);
+    }
+    return last_hash;
+  }
+  
+  @Override
+  public void run(final Timeout timeout) throws Exception {
+    try {
+      switch (builder.type) {
+      case FILES:
+        runKeyAndCert();
+        break;
+      case KEYSTORE:
+        runKeystore();
+        break;
+      case SECRET:
+        runSecrets();
+        break;
+      }
+    } catch (Throwable t) {
+      LOG.error("Failed to refresh SSLContext: " + this, t);
+    }
+    
+    if (builder.interval < 1) {
+      return; // not scheduling it.
+    }
+    
+    builder.tsdb.getMaintenanceTimer().newTimeout(this, 
+        builder.interval, 
+        TimeUnit.MILLISECONDS);
+  }
+  
+  void runKeystore() throws FileNotFoundException, IOException, 
+      KeyStoreException, NoSuchAlgorithmException, CertificateException, 
+      UnrecoverableKeyException, KeyManagementException {
+    final File file = new File(builder.keystore);
+    if (!file.exists()) {
+      throw new IllegalArgumentException("No keystore file found at " 
+          + builder.keystore);
+    }
+    final long hash;
+    try {
+      hash = Files.asByteSource(file).hash(Const.HASH_FUNCTION()).asLong();
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Failed to open keystore found at " 
+          + builder.keystore, e);
+    }
+    
+    // if the hash is the same, we're done.
+    if (context != null && hash == last_hash) {
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Keystore hash was the same as the last load: " + builder.keystore);
+      }
+      return;
+    }
+    
+    LOG.info("Attempting to load keystore: " + builder.keystore);
+    
+    // load an initialize the keystore.
+    try(final FileInputStream stream = new FileInputStream(file)) {
+      final KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+      keystore.load(stream, builder.keystore_pass.toCharArray());
+      
+      // initialize a key manager to pass to the SSL context using the keystore.
+      final KeyManagerFactory key_factory = KeyManagerFactory.getInstance(
+          KeyManagerFactory.getDefaultAlgorithm());
+      key_factory.init(keystore, builder.keystore_pass.toCharArray());
+  
+      // init a trust manager so we can use the public cert.
+      final TrustManagerFactory trust_factory = 
+          TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trust_factory.init(keystore);
+      final TrustManager[] trustManagers = trust_factory.getTrustManagers();
+      
+      final SSLContext sslContext = SSLContext.getInstance("TLS"); 
+      sslContext.init(key_factory.getKeyManagers(), trustManagers, null);
+      synchronized (this) {
+        context =  sslContext;
+        last_hash = hash;
+      }
+      if (builder.callback != null) {
+        builder.callback.refresh(context);
+      }
+      LOG.info("Successfully loaded keystore: " + builder.keystore);
+    }
+  }
+
+  void runKeyAndCert() throws IOException, GeneralSecurityException {
+    
+    List<HashCode> hashes = Lists.newArrayListWithExpectedSize(3);
+    if (!Strings.isNullOrEmpty(builder.key)) {
+      final File key = new File(builder.key);
+      hashes.add(Files.asByteSource(key).hash(Const.HASH_FUNCTION()));
+    }
+    final File pub_cert = new File(builder.cert);
+    hashes.add(Files.asByteSource(pub_cert).hash(Const.HASH_FUNCTION()));
+    if (!Strings.isNullOrEmpty(builder.ca)) {
+      final File ca = new File(builder.ca);
+      hashes.add(Files.asByteSource(ca).hash(Const.HASH_FUNCTION()));
+    }
+    final long hash = Hashing.combineOrdered(hashes).asLong();
+    // if the hash is the same, we're done.
+    if (context != null && hash == last_hash) {
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Keystore hash was the same as the last load: " + builder.keystore);
+      }
+      return;
+    }
+    
+    RSAPrivateKey key = null;
+    if (!Strings.isNullOrEmpty(builder.key)) {
+      String raw_key = Files.asCharSource(new File(builder.key), Charsets.UTF_8).read();
+      if (Strings.isNullOrEmpty(raw_key)) {
+        throw new IllegalStateException("The key at location " 
+            + builder.key + " was null or empty.");
+      }
+      if (raw_key.contains("BEGIN PRIVATE KEY")) {
+        key = parsePKCS8Key(trimPrivateKey(raw_key));
+      } else if (raw_key.contains("BEGIN RSA PRIVATE KEY")) {
+        key = parsePKCS1Key(trimPrivateKey(raw_key));
+      } else {
+        throw new IllegalStateException("Unrecognized key at location " 
+            + builder.key);
+      }
+      LOG.info("Successfully loaded private key from file: " + builder.key);
+    }
+    
+    List<String> parts;
+    final KeyStore keystore;
+    final List<Certificate> certificates;
+    final String keystore_pass = Long.toString(System.currentTimeMillis());
+    int cert_id = 0;
+    
+    final String raw_certs = Files.toString(
+        new File(builder.cert), Charsets.UTF_8);
+    parts = splitPem(raw_certs);
+    if (parts.size() < 1) {
+      throw new IllegalStateException("No certificates found in path: " 
+          + builder.cert);
+    }
+    
+    keystore = KeyStore.getInstance("JKS");
+    keystore.load(null);
+    certificates = Lists.newArrayList();
+    boolean have_server_cert = false;
+    for (final String part : parts) {
+      if (part.contains("BEGIN PRIVATE KEY")) {
+        if (key != null) {
+          throw new RuntimeException("Already loaded a key but " 
+              + builder.cert + " also had a key.");
+        }
+        key = parsePKCS8Key(trimPrivateKey(part));
+      } else if (part.contains("BEGIN RSA PRIVATE KEY")) {
+        if (key != null) {
+          throw new RuntimeException("Already loaded a key but " 
+              + builder.cert + " also had a key.");
+        }
+        key = parsePKCS1Key(trimPrivateKey(part));
+      } else {
+        X509Certificate cert = parseCert(trimCertificate(part));
+        certificates.add(cert);
+        String cn = getCN(cert);
+        boolean is_server_cert = isServerCert(cert);
+        if (have_server_cert && is_server_cert) {
+          throw new IllegalStateException("Multiple server certs in "
+              + "the PEM are not allowed.");
+        } else if (is_server_cert) {
+          have_server_cert = is_server_cert;
+          LOG.info("Successfully loaded server certificate with CN:: " + cn);
+        } else {
+          LOG.info("Successfully loaded intermediate or CA cert with CN: " + cn);
+        }
+        keystore.setCertificateEntry(Integer.toString(cert_id++), cert);
+      }
+    }
+    
+    if (certificates.isEmpty()) {
+      throw new IllegalStateException("No certificates loaded from: " 
+          + builder.cert);
+    }
+    Certificate[] cert_array = new Certificate[certificates.size()];
+    certificates.toArray(cert_array);
+    keystore.setKeyEntry("key-alias", 
+                         key, 
+                         keystore_pass.toCharArray(),
+                         cert_array);
+    
+    if (!Strings.isNullOrEmpty(builder.ca)) {
+      if (new File(builder.ca).isDirectory()) {
+        // TODO - load all the certs in the dir
+        throw new UnsupportedOperationException("We don't support "
+            + "loading directories yet.");
+      } else {
+        final String raw_cas = Files.toString(new File(builder.ca), 
+            Charsets.UTF_8);
+        parts = splitPem(raw_cas);
+        for (final String part : parts) {
+          X509Certificate cert = parseCert(trimCertificate(part));
+          certificates.add(cert);
+          String cn = getCN(cert);
+          keystore.setCertificateEntry(Integer.toString(cert_id++), cert);
+          LOG.info("Successfully loaded CA cert with CN: " + cn);
+        }
+      }
+    }
+    
+    // initialize a key manager to pass to the SSL context using the keystore.
+    final KeyManagerFactory key_factory = KeyManagerFactory.getInstance(
+        KeyManagerFactory.getDefaultAlgorithm());
+    key_factory.init(keystore, keystore_pass.toCharArray());
+
+    // init a trust manager so we can use the public cert.
+    final TrustManagerFactory trust_factory = 
+        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+    trust_factory.init(keystore);
+    final TrustManager[] trustManagers = trust_factory.getTrustManagers();
+    
+    final SSLContext ssl_context = SSLContext.getInstance("TLS"); 
+    ssl_context.init(key_factory.getKeyManagers(), trustManagers, null);
+    synchronized (this) {
+      context = ssl_context;
+      last_hash = hash;
+    }
+    if (builder.callback != null) {
+      builder.callback.refresh(context);
+    }
+    LOG.info("Successfully loaded certificate from: " + builder.cert);
+  }
+  
+  void runSecrets() throws IOException, GeneralSecurityException {
+    final Object cert_secret = builder.tsdb.getConfig().getSecretObject(
+        builder.secret_cert);
+    if (cert_secret == null) {
+      throw new IllegalStateException("The secret object cannot be null: " 
+          + builder.secret_cert);
+    }
+    
+    final Hasher hasher = Const.HASH_FUNCTION().newHasher();
+    
+    RSAPrivateKey key = null;
+    if (!Strings.isNullOrEmpty(builder.secret_key)) {
+      final Object key_secret = builder.tsdb.getConfig().getSecretObject(
+          builder.secret_key);
+      if (key_secret != null) {
+        if (key_secret instanceof RSAPrivateKey) {
+          key = (RSAPrivateKey) key_secret;
+          hasher.putBytes(key.getEncoded());
+        } else if (key_secret instanceof String || key_secret instanceof byte[]) {
+          final String raw_key;
+          if (key_secret instanceof String) {
+            raw_key = (String) key_secret;
+          } else {
+            raw_key = new String((byte[]) key_secret, Const.UTF8_CHARSET);
+          }
+          if (raw_key.contains("BEGIN PRIVATE KEY")) {
+            key = parsePKCS8Key(trimPrivateKey(raw_key));
+          } else if (raw_key.contains("BEGIN RSA PRIVATE KEY")) {
+            key = parsePKCS1Key(trimPrivateKey(raw_key));
+          } else {
+            throw new IllegalStateException("Unrecognized key: " 
+                + builder.secret_key);
+          }
+          hasher.putString(raw_key, Const.UTF8_CHARSET);
+        } else {
+          throw new IllegalArgumentException("Unknown private key object type: " 
+              + key_secret.getClass().getCanonicalName().toString());
+        }
+        LOG.info("Successfully loaded private key from secret: "+  
+            builder.secret_key);
+      } else {
+        throw new IllegalArgumentException("Private key from secret was null: " 
+            + builder.secret_key);
+      }
+    }
+    
+    List<String> parts;
+    KeyStore keystore = null;
+    List<Certificate> certificates = null;
+    final String keystore_pass = Long.toString(System.currentTimeMillis());
+    int cert_id = 0;
+    
+    final String raw_certs;
+    if (cert_secret instanceof String) {
+      raw_certs = (String) cert_secret;
+      hasher.putString(raw_certs, Const.UTF8_CHARSET);
+    } else if (cert_secret instanceof byte[]) {
+      raw_certs = new String((byte[]) cert_secret, Const.UTF8_CHARSET);
+      hasher.putString(raw_certs, Const.UTF8_CHARSET);
+    } else if (cert_secret instanceof X509CertPath) {
+      raw_certs = null;
+      certificates = Lists.newArrayList();
+      keystore = KeyStore.getInstance("JKS");
+      keystore.load(null);
+      X509CertPath p = (X509CertPath) cert_secret;
+      hasher.putBytes(p.getEncoded());
+      boolean have_server_cert = false;
+      for (final X509Certificate c : p.getCertificates()) {
+        certificates.add(c);
+        String cn = getCN(c);
+        boolean is_server_cert = isServerCert(c);
+        if (have_server_cert && is_server_cert) {
+          throw new IllegalStateException("Multiple server certs in "
+              + "the PEM are not allowed.");
+        } else if (is_server_cert) {
+          have_server_cert = is_server_cert;
+          LOG.info("Successfully loaded server certificate with CN:: " + cn);
+        } else {
+          LOG.info("Successfully loaded intermediate or CA cert with CN: " + cn);
+        }
+        keystore.setCertificateEntry(Integer.toString(cert_id++), c);
+      }
+      
+    } else {
+      throw new IllegalArgumentException("Unrecognized secret class: " 
+          + cert_secret.getClass());
+    }
+    
+    if (raw_certs != null) {
+      parts = splitPem(raw_certs);
+      if (parts.size() < 1) {
+        throw new IllegalStateException("No certificates found in secret: " 
+            + builder.secret_cert);
+      }
+
+      keystore = KeyStore.getInstance("JKS");
+      keystore.load(null);
+      certificates = Lists.newArrayList();
+      boolean have_server_cert = false;
+      for (final String part : parts) {
+        if (part.contains("BEGIN PRIVATE KEY")) {
+          if (key != null) {
+            throw new RuntimeException("Already loaded a key but " 
+                + builder.secret_cert + " also had a key.");
+          }
+          key = parsePKCS8Key(trimPrivateKey(part));
+        } else if (part.contains("BEGIN RSA PRIVATE KEY")) {
+          if (key != null) {
+            throw new RuntimeException("Already loaded a key but " 
+                + builder.secret_cert + " also had a key.");
+          }
+          key = parsePKCS1Key(trimPrivateKey(part));
+        } else {
+          X509Certificate cert = parseCert(trimCertificate(part));
+          certificates.add(cert);
+          String cn = getCN(cert);
+          boolean is_server_cert = isServerCert(cert);
+          if (have_server_cert && is_server_cert) {
+            throw new IllegalStateException("Multiple server certs in "
+                + "the PEM are not allowed.");
+          } else if (is_server_cert) {
+            have_server_cert = is_server_cert;
+            LOG.info("Successfully loaded server certificate with CN:: " + cn);
+          } else {
+            LOG.info("Successfully loaded intermediate or CA cert with CN: " + cn);
+          }
+          keystore.setCertificateEntry(Integer.toString(cert_id++), cert);
+        }
+      }
+    }
+    
+    if (certificates.isEmpty()) {
+      throw new IllegalStateException("No certificates loaded from: " 
+          + builder.secret_cert);
+    }
+    Certificate[] cert_array = new Certificate[certificates.size()];
+    certificates.toArray(cert_array);
+    keystore.setKeyEntry("key-alias", 
+                         key, 
+                         keystore_pass.toCharArray(),
+                         cert_array);
+    
+    if (!Strings.isNullOrEmpty(builder.ca)) {
+      if (new File(builder.ca).isDirectory()) {
+        // TODO - load all the certs in the dir
+        throw new UnsupportedOperationException("We don't support "
+            + "loading directories yet.");
+      } else {
+        final String raw_cas = Files.asCharSource(new File(builder.ca), 
+            Charsets.UTF_8).read();
+        hasher.putString(raw_cas, Const.UTF8_CHARSET);
+        parts = splitPem(raw_cas);
+        for (final String part : parts) {
+          X509Certificate cert = parseCert(trimCertificate(part));
+          certificates.add(cert);
+          String cn = getCN(cert);
+          keystore.setCertificateEntry(Integer.toString(cert_id++), cert);
+          LOG.info("Successfully loaded CA cert with CN: " + cn);
+        }
+      }
+    }
+    
+    final long hash = hasher.hash().asLong();
+    // if the hash is the same, we're done.
+    if (context != null && hash == last_hash) {
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Keystore hash was the same as the last load: " + builder.keystore);
+      }
+      return;
+    }
+    
+    // initialize a key manager to pass to the SSL context using the keystore.
+    final KeyManagerFactory key_factory = KeyManagerFactory.getInstance(
+        KeyManagerFactory.getDefaultAlgorithm());
+    key_factory.init(keystore, keystore_pass.toCharArray());
+
+    // init a trust manager so we can use the public cert.
+    final TrustManagerFactory trust_factory = 
+        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+    trust_factory.init(keystore);
+    final TrustManager[] trustManagers = trust_factory.getTrustManagers();
+    
+    final SSLContext ssl_context = SSLContext.getInstance("TLS");
+    ssl_context.init(key_factory.getKeyManagers(), trustManagers, null);
+   
+    synchronized (this) {
+      context = ssl_context;
+      last_hash = hash;
+    }
+    if (builder.callback != null) {
+      builder.callback.refresh(context);
+    }
+    LOG.info("Successfully loaded certificate from: " + builder.secret_cert);
+  }
+  
+  /**
+   * Strips the header and footer from the key.
+   * @param key A non-null key.
+   * @return The clean key.
+   */
+  private static String trimPrivateKey(final String key) {
+    return key.replace("-----BEGIN PRIVATE KEY-----", "")
+              .replace("-----END PRIVATE KEY-----", "")
+              .replace("-----BEGIN RSA PRIVATE KEY-----", "")
+              .replace("-----END RSA PRIVATE KEY-----", "")
+              .trim();
+  }
+  
+  /**
+   * Strips the header and footer from the certificate.
+   * @param cert A non-null certificate.
+   * @return The clean certificate.
+   */
+  private static String trimCertificate(final String cert) {
+    return cert.replace("-----BEGIN CERTIFICATE-----", "")
+               .replace("-----END CERTIFICATE-----", "")
+               .trim();
+  }
+  
+  /**
+   * Parses a PKCS8 formatted private key.
+   * @param key A non-null key as a B64 encoded string.
+   * @return A private key if parsing was successful.
+   * @throws NoSuchAlgorithmException If the JVM is hosed.
+   * @throws InvalidKeySpecException If the key wasn't PKCS8 formatted.
+   */
+  private static RSAPrivateKey parsePKCS8Key(final String key) throws 
+      NoSuchAlgorithmException, InvalidKeySpecException {
+    final PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(
+        DatatypeConverter.parseBase64Binary(key));
+    final KeyFactory factory = KeyFactory.getInstance("RSA");
+    return (RSAPrivateKey) factory.generatePrivate(spec);
+  }
+  
+  /**
+   * Parses a PKCS1 formatted private key using unsafe classes (to avoid
+   * pulling in another jar just for this).
+   * @param key A non-null key as a B64 encoded string.
+   * @return A private key if parsing was successful.
+   * @throws IOException If the input was corrupted.
+   * @throws GeneralSecurityException If parsing failed because the key
+   * appeared to be in the wrong format.
+   */
+  private static RSAPrivateKey parsePKCS1Key(final String key) throws 
+      IOException, GeneralSecurityException {
+    final DerInputStream stream = new DerInputStream(
+        DatatypeConverter.parseBase64Binary(key));
+    final DerValue[] seq = stream.getSequence(0);
+
+    if (seq.length < 9) {
+      throw new GeneralSecurityException("Failed parsing the PKCS1 "
+          + "formatted key as it didn't have the right number of sequences.");
+    }
+
+    final BigInteger modulus = seq[1].getBigInteger();
+    final BigInteger private_exponent = seq[3].getBigInteger();
+    final RSAPrivateKeySpec spec = 
+        new RSAPrivateKeySpec(modulus, private_exponent);
+    final KeyFactory factory = KeyFactory.getInstance("RSA");
+    return (RSAPrivateKey) factory.generatePrivate(spec);
+  }
+  
+  /**
+   * Splits a PEM formatted file into individual certificates and keys.
+   * Just looks for the '-----BEGIN' header and appends to a buffer until
+   * the next header or the end of file is reached. New-lines are removed.
+   * @param pem A non-null pem file.
+   * @return A list of individual objects in the file.
+   */
+  private static List<String> splitPem(final String pem) {
+    final List<String> parts = Lists.newArrayList();
+    final StringBuilder buf = new StringBuilder();
+    try (BufferedReader br = new BufferedReader(new StringReader(pem))) {
+      for (String line = br.readLine(); line != null; line = br.readLine()) {
+        if (line.isEmpty()) {
+          continue;
+        }
+        if (line.startsWith("-----BEGIN")) {
+          if (buf.length() > 0) {
+            parts.add(buf.toString());
+            buf.setLength(0);
+          }
+        }
+        buf.append(line);
+      }
+      if (buf.length() > 0) {
+        parts.add(buf.toString());
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to parse the pem!", e);
+    }
+    return parts;
+  }
+  
+  /**
+   * Parses a B64 encoded certificate into an X509 representation.
+   * @param cert The non-null and non-empty certificate.
+   * @return A parsed certificate.
+   * @throws CertificateException If something goes pear shaped.
+   */
+  private static X509Certificate parseCert(final String cert) throws 
+      CertificateException {
+    return (X509Certificate) CA_FACTORY.generateCertificate(
+        new ByteArrayInputStream(
+            DatatypeConverter.parseBase64Binary((cert))));
+  }
+  
+  /**
+   * A helper to extract the CN from a certificate.
+   * @param cert A non-null certificate.
+   * @return The CN.
+   */
+  private static String getCN(final X509Certificate cert) {
+    String cn = cert.getSubjectX500Principal().getName()
+                    .replace("CN=", "");
+    cn = cn.substring(0, cn.indexOf(","));
+    return cn;
+  }
+  
+  /**
+   * A helper to determine if the cert could be used for TLS termination.
+   * @param cert A non-null cert.
+   * @return True if it could be, false if it was an intermediate or CA 
+   * certificate.
+   */
+  private static boolean isServerCert(final X509Certificate cert) {
+    boolean[] uses = cert.getKeyUsage();
+    if (uses == null) {
+      throw new IllegalStateException("The given certificate didn't "
+          + "have any usage extensions. This shouldn't happen with certs "
+          + "used for TLS: " + getCN(cert));
+    }
+    return (uses[0] && uses[2]);
+  }
+
+  public static interface RefreshCallback {
+    public void refresh(final SSLContext context);
+  }
+  
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+  
+  public static class Builder {
+    private SourceType type;
+    private String keystore;
+    private String keystore_pass;
+    private String cert;
+    private String key;
+    private String ca;
+    private String secret_cert;
+    private String secret_key;
+    private int interval;
+    private TSDB tsdb;
+    private RefreshCallback callback;
+    
+    public Builder setType(final SourceType type) {
+      this.type = type;
+      return this;
+    }
+    
+    public Builder setKeystore(final String keystore) {
+      this.keystore = keystore;
+      return this;
+    }
+    
+    public Builder setKeystorePass(final String keystore_pass) {
+      this.keystore_pass = keystore_pass;
+      return this;
+    }
+    
+    public Builder setCert(final String cert) {
+      this.cert = cert;
+      return this;
+    }
+    
+    public Builder setKey(final String key) {
+      this.key = key;
+      return this;
+    }
+    
+    public Builder setCa(final String ca) {
+      this.ca = ca;
+      return this;
+    }
+    
+    public Builder setSecret_cert(final String secret_cert) {
+      this.secret_cert = secret_cert;
+      return this;
+    }
+    
+    public Builder setSecret_key(final String secret_key) {
+      this.secret_key = secret_key;
+      return this;
+    }
+    
+    public Builder setInterval(final int interval) {
+      this.interval = interval;
+      return this;
+    }
+    
+    public Builder setTsdb(final TSDB tsdb) {
+      this.tsdb = tsdb;
+      return this;
+    }
+    
+    public Builder setCallback(final RefreshCallback callback) {
+      this.callback = callback;
+      return this;
+    }
+    
+    public RefreshingSSLContext build() {
+      return new RefreshingSSLContext(this);
+    }
+  }
+}

--- a/executors/http/src/main/java/net/opentsdb/query/execution/BaseHttpExecutorFactory.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/BaseHttpExecutorFactory.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2019  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpResponse;
-import org.apache.http.ParseException;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
@@ -60,6 +59,7 @@ public abstract class BaseHttpExecutorFactory implements
   public static final String KEY_PREFIX = "opentsdb.http.executor.";
   public static final String RETRY_KEY = "retries";
   public static final String HOSTS_KEY = "hosts";
+  public static final String HEADER_USER_KEY = "headers.user";
   public static final String ENDPOINT_KEY = "endpoint";
   public static final String HEALTH_ENDPOINT_KEY = "health.endpoint";
   public static final String HEALTH_INTERVAL_KEY = "health.interval";
@@ -364,6 +364,13 @@ public abstract class BaseHttpExecutorFactory implements
       tsdb.getConfig().register(getConfigKey(CLIENT_KEY), 
           null, false,
           "The ID of the SharedHttpClient plugin to use. Defaults to `null`.");
+    }
+    if (!tsdb.getConfig().hasProperty(getConfigKey(HEADER_USER_KEY))) {
+      tsdb.getConfig().register(getConfigKey(HEADER_USER_KEY), 
+          "X-OpenTSDB-User", true,
+          "An optional custom header to store the user in when making a "
+          + "downstream request. If null or empty then the header will not "
+          + "be sent.");
     }
   }
 

--- a/executors/http/src/main/java/net/opentsdb/utils/DefaultSharedHttpClient.java
+++ b/executors/http/src/main/java/net/opentsdb/utils/DefaultSharedHttpClient.java
@@ -1,0 +1,286 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.utils;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.ParseException;
+import org.apache.http.client.entity.DeflateDecompressingEntity;
+import org.apache.http.client.entity.GzipDecompressingEntity;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Strings;
+import com.stumbleupon.async.Deferred;
+
+import io.netty.util.Timeout;
+import io.netty.util.TimerTask;
+import net.opentsdb.core.BaseTSDBPlugin;
+import net.opentsdb.core.TSDB;
+import net.opentsdb.exceptions.RemoteQueryExecutionException;
+import net.opentsdb.utils.RefreshingSSLContext.RefreshCallback;
+import net.opentsdb.utils.RefreshingSSLContext.SourceType;
+
+/**
+ * A shared asynchronous HTTP client for making remote calls to various
+ * services.
+ * 
+ * @since 3.0
+ * @author clarsen
+ *
+ */
+public class DefaultSharedHttpClient extends BaseTSDBPlugin implements RefreshCallback {
+  private static final Logger LOG = LoggerFactory.getLogger(
+      DefaultSharedHttpClient.class);
+  
+  public static final String KEY_PREFIX = "httpclient.";
+  public static final String TYPE_KEY = "tls.type";
+  public static final String KEYSTORE_KEY = "tls.keystore";
+  public static final String KEYSTORE_PASS_KEY = "tls.keystore.password";
+  public static final String CERT_KEY = "tls.cert";
+  public static final String KEY_KEY = "tls.key";
+  public static final String CA_KEY = "tls.ca";
+  public static final String SECRET_CERT_KEY = "tls.secret.cert";
+  public static final String SECRET_KEY_KEY = "tls.secret.key";
+  public static final String INTERVAL_KEY = "tls.interval";
+  
+  public static final String TYPE = "SharedHttpClient";
+  
+  /** The client. */
+  protected volatile CloseableHttpAsyncClient client;
+  
+  @Override
+  public Deferred<Object> initialize(final TSDB tsdb, final String id) {
+    this.tsdb = tsdb;
+    this.id = id;
+    registerConfigs(tsdb);
+    if (!Strings.isNullOrEmpty(tsdb.getConfig().getString(getConfigKey(TYPE_KEY)))) {
+      RefreshingSSLContext ctx = RefreshingSSLContext.newBuilder()
+          .setType(SourceType.valueOf(tsdb.getConfig().getString(getConfigKey(TYPE_KEY))))
+          .setKeystore(tsdb.getConfig().getString(getConfigKey(KEYSTORE_KEY)))
+          .setKeystorePass(tsdb.getConfig().getString(getConfigKey(KEYSTORE_PASS_KEY)))
+          .setCert(tsdb.getConfig().getString(getConfigKey(CERT_KEY)))
+          .setKey(tsdb.getConfig().getString(getConfigKey(KEY_KEY)))
+          .setCa(tsdb.getConfig().getString(getConfigKey(CA_KEY)))
+          .setSecret_cert(tsdb.getConfig().getString(getConfigKey(SECRET_CERT_KEY)))
+          .setSecret_key(tsdb.getConfig().getString(getConfigKey(SECRET_KEY_KEY)))
+          .setInterval(tsdb.getConfig().getInt(getConfigKey(INTERVAL_KEY)))
+          .setTsdb(tsdb)
+          .setCallback(this)
+          .build();
+      client = HttpAsyncClients.custom()
+          .setSSLContext(ctx.context())
+          .setDefaultIOReactorConfig(IOReactorConfig.custom()
+              .setIoThreadCount(8).build())
+          .setMaxConnTotal(200)
+          .setMaxConnPerRoute(25)
+          .build();
+    } else {
+      // TODO - configs!
+      client = HttpAsyncClients.custom()
+        .setDefaultIOReactorConfig(IOReactorConfig.custom()
+            .setIoThreadCount(8).build())
+        .setMaxConnTotal(200)
+        .setMaxConnPerRoute(25)
+        .build();
+    }
+    client.start();
+    LOG.info("Initialized shared HTTP client.");
+    return Deferred.fromResult(null);
+  }
+  
+  @Override
+  public Deferred<Object> shutdown() {
+    if (client != null) {
+      try {
+        client.close();
+      } catch (IOException e) {
+        LOG.error("Failed to close HTTPClient", e);
+      }
+    }
+    return Deferred.fromResult(null);
+  }
+  
+  @Override
+  public String type() {
+    return TYPE;
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
+  }
+
+  /**
+   * NOTE: Do not close it.
+   * @return The non-null client.
+   */
+  public synchronized CloseableHttpAsyncClient getClient() {
+    return client;
+  }
+  
+  /**
+   * Helper that handles decompressing the result and parses the entity
+   * to a string. If the entity is an exception then we through a 
+   * {@link RemoteQueryExecutionException}.
+   * @param response The non-null response to parse.
+   * @param order The order of the result.
+   * @param remote_host The remote host name.
+   * @return A string if successful.
+   */
+  public static String parseResponse(final HttpResponse response,  
+                                     final int order, 
+                                     final String remote_host) {
+    final String content;
+    if (response.getEntity() == null) {
+      throw new RemoteQueryExecutionException("Content for http response "
+          + "was null: " + response, remote_host, order, 500);
+    }
+    
+    try {
+      final String encoding = (response.getEntity().getContentEncoding() != null &&
+          response.getEntity().getContentEncoding().getValue() != null ?
+              response.getEntity().getContentEncoding().getValue().toLowerCase() :
+                "");
+      if (encoding.equals("gzip") || encoding.equals("x-gzip")) {
+        content = EntityUtils.toString(
+            new GzipDecompressingEntity(response.getEntity()));
+      } else if (encoding.equals("deflate")) {
+        content = EntityUtils.toString(
+            new DeflateDecompressingEntity(response.getEntity()));
+      } else if (encoding.equals("")) {
+        content = EntityUtils.toString(response.getEntity());
+      } else {
+        throw new RemoteQueryExecutionException("Unhandled content encoding [" 
+            + encoding + "] : " + response, remote_host, 500, order);
+      }
+    } catch (ParseException e) {
+      LOG.error("Failed to parse content from HTTP response: " + response, e);
+      throw new RemoteQueryExecutionException("Content parsing failure for: " 
+          + response, remote_host, 500, order, e);
+    } catch (IOException e) {
+      LOG.error("Failed to parse content from HTTP response: " + response, e);
+      throw new RemoteQueryExecutionException("Content parsing failure for: " 
+          + response, remote_host, 500, order, e);
+    }
+  
+    if (response.getStatusLine().getStatusCode() == 200) {
+      return content;
+    }
+    
+    // NOTE assuming TSDB style exceptions
+    if (content.startsWith("{")) {
+      try {
+        final JsonNode root = JSON.getMapper().readTree(content);
+        JsonNode node = root.get("error");
+        if (node != null && !node.isNull()) {
+          final JsonNode message = node.get("message");
+          if (message != null && !message.isNull()) {
+            throw new RemoteQueryExecutionException(message.asText(), remote_host, 
+                response.getStatusLine().getStatusCode(), order);
+          }
+        }
+      } catch (IOException e) {
+        LOG.warn("Failed to parse the JSON exception: " + content, e);
+        // fall through
+      }
+    }
+    // TODO - parse out the exception
+    throw new RemoteQueryExecutionException(content, remote_host, 
+        response.getStatusLine().getStatusCode(), order);
+  }
+
+  String getConfigKey(final String key) {
+    return KEY_PREFIX + (Strings.isNullOrEmpty(id) ? "" : id + ".") + key;
+  }
+  
+  void registerConfigs(final TSDB tsdb) {
+    if (!tsdb.getConfig().hasProperty(getConfigKey(TYPE_KEY))) {
+      tsdb.getConfig().register(getConfigKey(TYPE_KEY), null, false, 
+          "The source of the certificate we're refreshing.");
+    }
+    if (!tsdb.getConfig().hasProperty(getConfigKey(KEYSTORE_KEY))) {
+      tsdb.getConfig().register(getConfigKey(KEYSTORE_KEY), null, false, 
+          "The full path to a keystore file.");
+    }
+    if (!tsdb.getConfig().hasProperty(getConfigKey(KEYSTORE_PASS_KEY))) {
+      tsdb.getConfig().register(getConfigKey(KEYSTORE_PASS_KEY), null, false, 
+          "The password for the keystore file.");
+    }
+    if (!tsdb.getConfig().hasProperty(getConfigKey(CERT_KEY))) {
+      tsdb.getConfig().register(getConfigKey(CERT_KEY), null, false, 
+          "The full path to a public certificate PEM file. May include "
+          + "the RSA key.");
+    }
+    if (!tsdb.getConfig().hasProperty(getConfigKey(KEY_KEY))) {
+      tsdb.getConfig().register(getConfigKey(KEY_KEY), null, false, 
+          "The full path to an RSA key in PEM format.");
+    }
+    if (!tsdb.getConfig().hasProperty(getConfigKey(CA_KEY))) {
+      tsdb.getConfig().register(getConfigKey(CA_KEY), null, false, 
+          "The path to an optioanl Certificate Authority PEM file with "
+          + "required CA certs.");
+    }
+    if (!tsdb.getConfig().hasProperty(getConfigKey(SECRET_CERT_KEY))) {
+      tsdb.getConfig().register(getConfigKey(SECRET_CERT_KEY), null, false, 
+          "The ID of a secret provider and key to use to fetch the public "
+          + "certificate PEM formatted data. It may include the RSA key.");
+    }
+    if (!tsdb.getConfig().hasProperty(getConfigKey(SECRET_KEY_KEY))) {
+      tsdb.getConfig().register(getConfigKey(SECRET_KEY_KEY), null, false, 
+          "The ID of a secret provider and the key to use to fetch the private "
+          + "key in PEM format.");
+    }
+    if (!tsdb.getConfig().hasProperty(getConfigKey(INTERVAL_KEY))) {
+      tsdb.getConfig().register(getConfigKey(INTERVAL_KEY), 300000, false, 
+          "The number of milliseconds to wait between refreshes.");
+    }
+  }
+
+  @Override
+  public void refresh(final SSLContext context) {
+    final CloseableHttpAsyncClient existing = client;
+    final CloseableHttpAsyncClient new_client = HttpAsyncClients.custom()
+        .setSSLContext(context)
+        .setDefaultIOReactorConfig(IOReactorConfig.custom()
+            .setIoThreadCount(8).build())
+        .setMaxConnTotal(200)
+        .setMaxConnPerRoute(25)
+        .build();
+    new_client.start();
+    synchronized (this) {
+      client = new_client;
+    }
+    
+    // we delay the closing to give existing calls time to finish.
+    class Release implements TimerTask {
+      @Override
+      public void run(final Timeout ignored) throws Exception {
+        existing.close();
+      }
+    }
+    
+    tsdb.getMaintenanceTimer().newTimeout(new Release(), 2, TimeUnit.MINUTES);
+  }
+}

--- a/executors/http/src/main/java/net/opentsdb/utils/SharedHttpClient.java
+++ b/executors/http/src/main/java/net/opentsdb/utils/SharedHttpClient.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2019  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,158 +14,20 @@
 // limitations under the License.
 package net.opentsdb.utils;
 
-import java.io.IOException;
-
-import org.apache.http.HttpResponse;
-import org.apache.http.ParseException;
-import org.apache.http.client.entity.DeflateDecompressingEntity;
-import org.apache.http.client.entity.GzipDecompressingEntity;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
-import org.apache.http.impl.nio.client.HttpAsyncClients;
-import org.apache.http.impl.nio.reactor.IOReactorConfig;
-import org.apache.http.util.EntityUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.stumbleupon.async.Deferred;
-
-import net.opentsdb.core.BaseTSDBPlugin;
-import net.opentsdb.core.TSDB;
-import net.opentsdb.exceptions.RemoteQueryExecutionException;
+import net.opentsdb.core.TSDBPlugin;
 
 /**
- * A shared asynchronous HTTP client for making remote calls to various
- * services.
- * 
- * @since 3.0
- * @author clarsen
- *
+ * An interface for a CloseableHttpAsyncClient with implementations that may
+ * tune or set client certs.
  */
-public class SharedHttpClient extends BaseTSDBPlugin {
-  private static final Logger LOG = LoggerFactory.getLogger(
-      SharedHttpClient.class);
-  
-  public static final String TYPE = "SharedHttpClient";
-  
-  /** The client. */
-  protected CloseableHttpAsyncClient client;
-  
-  @Override
-  public Deferred<Object> initialize(final TSDB tsdb, final String id) {
-    this.tsdb = tsdb;
-    this.id = id;
-    
-    // TODO - configs!
-    client = HttpAsyncClients.custom()
-      .setDefaultIOReactorConfig(IOReactorConfig.custom()
-          .setIoThreadCount(8).build())
-      .setMaxConnTotal(200)
-      .setMaxConnPerRoute(25)
-      .build();
-    client.start();
-    LOG.info("Initialized shared HTTP client.");
-    return Deferred.fromResult(null);
-  }
-  
-  @Override
-  public Deferred<Object> shutdown() {
-    if (client != null) {
-      try {
-        client.close();
-      } catch (IOException e) {
-        LOG.error("Failed to close HTTPClient", e);
-      }
-    }
-    return Deferred.fromResult(null);
-  }
-  
-  @Override
-  public String type() {
-    return TYPE;
-  }
-
-  @Override
-  public String version() {
-    return "3.0.0";
-  }
+public interface SharedHttpClient extends TSDBPlugin {
 
   /**
-   * NOTE: Do not close it.
-   * @return The non-null client.
+   * The shared client to use for making a request.
+   * @return A non-null client.
    */
-  public CloseableHttpAsyncClient getClient() {
-    return client;
-  }
+  public CloseableHttpAsyncClient getClient();
   
-  /**
-   * Helper that handles decompressing the result and parses the entity
-   * to a string. If the entity is an exception then we through a 
-   * {@link RemoteQueryExecutionException}.
-   * @param response The non-null response to parse.
-   * @param order The order of the result.
-   * @param remote_host The remote host name.
-   * @return A string if successful.
-   */
-  public static String parseResponse(final HttpResponse response,  
-                                     final int order, 
-                                     final String remote_host) {
-    final String content;
-    if (response.getEntity() == null) {
-      throw new RemoteQueryExecutionException("Content for http response "
-          + "was null: " + response, remote_host, order, 500);
-    }
-    
-    try {
-      final String encoding = (response.getEntity().getContentEncoding() != null &&
-          response.getEntity().getContentEncoding().getValue() != null ?
-              response.getEntity().getContentEncoding().getValue().toLowerCase() :
-                "");
-      if (encoding.equals("gzip") || encoding.equals("x-gzip")) {
-        content = EntityUtils.toString(
-            new GzipDecompressingEntity(response.getEntity()));
-      } else if (encoding.equals("deflate")) {
-        content = EntityUtils.toString(
-            new DeflateDecompressingEntity(response.getEntity()));
-      } else if (encoding.equals("")) {
-        content = EntityUtils.toString(response.getEntity());
-      } else {
-        throw new RemoteQueryExecutionException("Unhandled content encoding [" 
-            + encoding + "] : " + response, remote_host, 500, order);
-      }
-    } catch (ParseException e) {
-      LOG.error("Failed to parse content from HTTP response: " + response, e);
-      throw new RemoteQueryExecutionException("Content parsing failure for: " 
-          + response, remote_host, 500, order, e);
-    } catch (IOException e) {
-      LOG.error("Failed to parse content from HTTP response: " + response, e);
-      throw new RemoteQueryExecutionException("Content parsing failure for: " 
-          + response, remote_host, 500, order, e);
-    }
-  
-    if (response.getStatusLine().getStatusCode() == 200) {
-      return content;
-    }
-    
-    // NOTE assuming TSDB style exceptions
-    if (content.startsWith("{")) {
-      try {
-        final JsonNode root = JSON.getMapper().readTree(content);
-        JsonNode node = root.get("error");
-        if (node != null && !node.isNull()) {
-          final JsonNode message = node.get("message");
-          if (message != null && !message.isNull()) {
-            throw new RemoteQueryExecutionException(message.asText(), remote_host, 
-                response.getStatusLine().getStatusCode(), order);
-          }
-        }
-      } catch (IOException e) {
-        LOG.warn("Failed to parse the JSON exception: " + content, e);
-        // fall through
-      }
-    }
-    // TODO - parse out the exception
-    throw new RemoteQueryExecutionException(content, remote_host, 
-        response.getStatusLine().getStatusCode(), order);
-  }
 }

--- a/implementation/server-undertow/src/main/java/net/opentsdb/tsd/TSDMain.java
+++ b/implementation/server-undertow/src/main/java/net/opentsdb/tsd/TSDMain.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018  The OpenTSDB Authors.
+// Copyright (C) 2017-2019  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,10 +14,7 @@
 // limitations under the License.
 package net.opentsdb.tsd;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
-import com.google.common.io.Files;
 import io.undertow.Handlers;
 import io.undertow.Undertow;
 import io.undertow.Undertow.Builder;
@@ -31,58 +28,29 @@ import io.undertow.servlet.api.FilterInfo;
 import io.undertow.servlet.api.InstanceFactory;
 import io.undertow.servlet.api.InstanceHandle;
 import net.opentsdb.auth.Authentication;
-import net.opentsdb.common.Const;
 import net.opentsdb.configuration.Configuration;
 import net.opentsdb.configuration.ConfigurationEntrySchema;
 import net.opentsdb.core.DefaultTSDB;
 import net.opentsdb.servlet.applications.OpenTSDBApplication;
 import net.opentsdb.servlet.filter.AuthFilter;
 import net.opentsdb.utils.ArgP;
+import net.opentsdb.utils.RefreshingSSLContext;
+import net.opentsdb.utils.RefreshingSSLContext.SourceType;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnio.Options;
 import org.xnio.Sequence;
 import org.xnio.SslClientAuthMode;
 
-import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.ServletException;
-import javax.xml.bind.DatatypeConverter;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.StringReader;
-import java.math.BigInteger;
-import java.security.GeneralSecurityException;
-import java.security.KeyFactory;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.RSAPrivateKeySpec;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
-import sun.security.provider.certpath.*;
-import sun.security.util.DerInputStream;
-import sun.security.util.DerValue;
 
 /**
  * A simple main method that instantiates a TSD and the TSD servlet package
@@ -112,8 +80,6 @@ public class TSDMain {
   public static final String CORS_PATTERN_KEY = "tsd.http.request.cors.pattern";
   public static final String CORS_HEADERS_KEY = "tsd.http.request.cors.headers";
   public static final String DIRECTORY_KEY = "tsd.http.staticroot";
-  
-  private static CertificateFactory factory;
   
   /** Defaults */
   public static final String DEFAULT_PATH = "/";
@@ -301,8 +267,6 @@ public class TSDMain {
       }
     }
     
-    
-    
     final DeploymentManager manager = Servlets.defaultContainer()
         .addDeployment(servletBuilder);
     manager.deploy();
@@ -350,7 +314,8 @@ public class TSDMain {
       
       server = builder.build();
       server.start();
-      LOG.info("Undertow server successfully started.");
+      LOG.info("Undertow server successfully started, listening on " + bind + ":" + 
+          (port > 0 ? port : ssl_port));
       return;
     } catch (ServletException e) {
       LOG.error("Unable to start due to servlet exception", e);
@@ -368,430 +333,30 @@ public class TSDMain {
    * @return An SSL context. If a method threw an exception then we exit.
    */
   private static SSLContext buildSSLContext(final Configuration config) {
-    try {
-      factory = CertificateFactory.getInstance("X.509");
-      final String keystore_location = config.getString(KEYSTORE_KEY);
-      final SSLContext sslContext;
-      if (!Strings.isNullOrEmpty(keystore_location)) {
-        sslContext = contextFromKeystore(config);
-      } else if (config.hasProperty(TLS_SECRET_CERT_KEY) && 
-          !Strings.isNullOrEmpty(config.getString(TLS_SECRET_CERT_KEY))) {
-        sslContext = contextFromSecrets(config);
-      } else {
-        sslContext = contextFromKeyAndCerts(config);
-      }
-      if (sslContext == null) {
-        // Already threw an exception.
-        System.exit(1);
-      }
-      return sslContext;
-    } catch (CertificateException e) {
-      LOG.error("Failed to instantiate factory", e);
-    } catch (Exception e) {
-      LOG.error("Unexpected exception initializing SSL Context", e);
-    }
-    System.exit(1);
-    return null;
-  }
-  
-  /**
-   * Attempts to load a keystore from disk and initialize an SSL Context 
-   * with it. The keystore should contain all of the certs,
-   * intermediates, CAs and the private key.
-   * @param config A non-null config.
-   * @return An instantiated context or null if something went wrong. The
-   * exceptions will be logged.
-   */
-  private static SSLContext contextFromKeystore(final Configuration config) {
+    final RefreshingSSLContext.Builder builder = RefreshingSSLContext.newBuilder()
+        .setInterval(0);
     final String keystore_location = config.getString(KEYSTORE_KEY);
-    final String keystore_key = config.getString(KEYSTORE_PASS_KEY);
-    if (Strings.isNullOrEmpty(keystore_key)) {
-      throw new IllegalArgumentException("Cannot enable SSL without a "
-          + "keystore password. Set '" + KEYSTORE_PASS_KEY +"'");
+    if (!Strings.isNullOrEmpty(keystore_location)) {
+      builder.setType(SourceType.KEYSTORE)
+             .setKeystore(keystore_location)
+             .setKeystorePass(config.getString(KEYSTORE_PASS_KEY));
+    } else if (!Strings.isNullOrEmpty(config.getString(TLS_SECRET_CERT_KEY))) {
+      builder.setType(SourceType.SECRET)
+             .setSecret_cert(config.getString(TLS_SECRET_CERT_KEY))
+             .setSecret_key(config.getString(TLS_SECRET_KEY_KEY))
+             .setCa(config.getString(TLS_CA_KEY));
+    } else {
+      builder.setType(SourceType.FILES)
+             .setCert(config.getString(TLS_CERT_KEY))
+             .setKey(config.getString(TLS_KEY_KEY))
+             .setCa(config.getString(TLS_CA_KEY));
     }
-    // load an initialize the keystore.
-    try(final FileInputStream file = new FileInputStream(keystore_location)) {
-      final KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
-      keystore.load(file, keystore_key.toCharArray());
-      
-      // initialize a key manager to pass to the SSL context using the keystore.
-      final KeyManagerFactory key_factory = KeyManagerFactory.getInstance(
-          KeyManagerFactory.getDefaultAlgorithm());
-      key_factory.init(keystore, keystore_key.toCharArray());
-  
-      // init a trust manager so we can use the public cert.
-      final TrustManagerFactory trust_factory = 
-          TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-        trust_factory.init(keystore);
-      final TrustManager[] trustManagers = trust_factory.getTrustManagers();
-      
-      final SSLContext sslContext = SSLContext.getInstance("TLS"); 
-      sslContext.init(key_factory.getKeyManagers(), trustManagers, null);
-      return sslContext;
-    } catch (FileNotFoundException e) {
-      LOG.error("Unable to open keystore file: " + keystore_location, e);
-    } catch (NoSuchAlgorithmException e) {
-      LOG.error("Missing a required algorithm for TLS?", e);
-    } catch (CertificateException e) {
-      LOG.error("Invalid certificate in keystore: " + keystore_location, e);
-    } catch (IOException e) {
-      LOG.error("WTF? Something went pear shaped unexpectedly", e);
-    } catch (KeyManagementException e) {
-      LOG.error("Something was wrong with the key in the keystore: " 
-          + keystore_location, e);
-    } catch (UnrecoverableKeyException e) {
-      LOG.error("Possibly corrupted key in file: " + keystore_location, e);
-    } catch (KeyStoreException e) {
-      LOG.error("WTF! Unexpected exception in keystore: " + keystore_location, e);
-    }
-    return null;
-  }
-  
-  /**
-   * Attempts to load the key from a combination of private key file, 
-   * certificate file(s) and Certificate Authority pem.
-   * @param config A non-null config.
-   * @return An instantiated context or null if something went wrong. The
-   * exceptions will be logged.
-   */
-  private static SSLContext contextFromKeyAndCerts(final Configuration config) {
-    RSAPrivateKey key = null;
-    final String key_location = config.getString(TLS_KEY_KEY);
     try {
-      if (!Strings.isNullOrEmpty(key_location)) {
-        String raw_key = Files.toString(new File(key_location), Charsets.UTF_8);
-        if (Strings.isNullOrEmpty(raw_key)) {
-          throw new IllegalStateException("The key at location " 
-              + key_location + " was null or empty.");
-        }
-        if (raw_key.contains("BEGIN PRIVATE KEY")) {
-          key = parsePKCS8Key(trimPrivateKey(raw_key));
-        } else if (raw_key.contains("BEGIN RSA PRIVATE KEY")) {
-          key = parsePKCS1Key(trimPrivateKey(raw_key));
-        } else {
-          throw new IllegalStateException("Unrecognized key at location " 
-              + key_location);
-        }
-        LOG.info("Successfully loaded private key from file: "+  key_location);
-      }
-    } catch (IOException e) {
-      LOG.error("Failed to parse private key at: " + key_location);
-      return null;
-    } catch (GeneralSecurityException e) {
-      LOG.error("Failed to parse private key at: " + key_location);
-      return null;
-    }
-    
-    final String cert_file_location = config.getString(TLS_CERT_KEY);
-    if (Strings.isNullOrEmpty(cert_file_location)) {
-      throw new IllegalStateException("A certificate file, in PEM format, "
-          + "must be present at a location defined in: " + TLS_CERT_KEY);
-    }
-    
-    List<String> parts;
-    final KeyStore keystore;
-    final List<Certificate> certificates;
-    final String keystore_pass = Long.toString(System.currentTimeMillis());
-    int cert_id = 0;
-    
-    try {
-      final String raw_certs = Files.toString(
-          new File(cert_file_location), Charsets.UTF_8);
-      parts = splitPem(raw_certs);
-      if (parts.size() < 1) {
-        throw new IllegalStateException("No certificates found in path: " 
-      + cert_file_location);
-      }
-      
-      keystore = KeyStore.getInstance("JKS");
-      keystore.load(null);
-      certificates = Lists.newArrayList();
-      boolean have_server_cert = false;
-      for (final String part : parts) {
-        if (part.contains("BEGIN PRIVATE KEY")) {
-          if (key != null) {
-            throw new RuntimeException("Already loaded a key but " 
-                + cert_file_location + " also had a key.");
-          }
-          key = parsePKCS8Key(trimPrivateKey(part));
-        } else if (part.contains("BEGIN RSA PRIVATE KEY")) {
-          if (key != null) {
-            throw new RuntimeException("Already loaded a key but " 
-                + cert_file_location + " also had a key.");
-          }
-          key = parsePKCS1Key(trimPrivateKey(part));
-        } else {
-          X509Certificate cert = parseCert(trimCertificate(part));
-          certificates.add(cert);
-          String cn = getCN(cert);
-          boolean is_server_cert = isServerCert(cert);
-          if (have_server_cert && is_server_cert) {
-            throw new IllegalStateException("Multiple server certs in "
-                + "the PEM are not allowed.");
-          } else if (is_server_cert) {
-            have_server_cert = is_server_cert;
-            LOG.info("Successfully loaded server certificate with CN:: " + cn);
-          } else {
-            LOG.info("Successfully loaded intermediate or CA cert with CN: " + cn);
-          }
-          keystore.setCertificateEntry(Integer.toString(cert_id++), cert);
-        }
-      }
-      
-      if (certificates.isEmpty()) {
-        throw new IllegalStateException("No certificates loaded from: " 
-            + cert_file_location);
-      }
-      Certificate[] cert_array = new Certificate[certificates.size()];
-      certificates.toArray(cert_array);
-      keystore.setKeyEntry("key-alias", 
-                           key, 
-                           keystore_pass.toCharArray(),
-                           cert_array);
-    } catch (IOException | GeneralSecurityException e) {
-      LOG.error("Failed to load certificate(s) from " 
-          + cert_file_location, e);
-      return null;
-    }
-    
-    final String ca_certs_location = config.getString(TLS_CA_KEY);
-    if (!Strings.isNullOrEmpty(ca_certs_location)) {
-      try {
-        if (new File(ca_certs_location).isDirectory()) {
-          // TODO - load all the certs in the dir
-          throw new UnsupportedOperationException("We don't support "
-              + "loading directories yet.");
-        } else {
-          final String raw_cas = Files.toString(new File(ca_certs_location), 
-              Charsets.UTF_8);
-          parts = splitPem(raw_cas);
-          for (final String part : parts) {
-            X509Certificate cert = parseCert(trimCertificate(part));
-            certificates.add(cert);
-            String cn = getCN(cert);
-            keystore.setCertificateEntry(Integer.toString(cert_id++), cert);
-            LOG.info("Successfully loaded CA cert with CN: " + cn);
-          }
-        }
-      } catch (IOException | GeneralSecurityException e) {
-        LOG.error("Failed to load CA certificates from: " + ca_certs_location, e);
-        return null;
-      }
-    }
-    
-    try {
-      // initialize a key manager to pass to the SSL context using the keystore.
-      final KeyManagerFactory key_factory = KeyManagerFactory.getInstance(
-          KeyManagerFactory.getDefaultAlgorithm());
-      key_factory.init(keystore, keystore_pass.toCharArray());
-  
-      // init a trust manager so we can use the public cert.
-      final TrustManagerFactory trust_factory = 
-          TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-      trust_factory.init(keystore);
-      final TrustManager[] trustManagers = trust_factory.getTrustManagers();
-      
-      final SSLContext ssl_context = SSLContext.getInstance("TLS"); 
-      ssl_context.init(key_factory.getKeyManagers(), trustManagers, null);
-      return ssl_context;
-    } catch (GeneralSecurityException e) {
-      LOG.error("Failed to initialize SSLContext", e);
-      return null;
-    }
-  }
-  
-  /**
-   * Attempts to load the key from a combination of private key file, 
-   * certificate file(s) and Certificate Authority pem.
-   * @param config A non-null config.
-   * @return An instantiated context or null if something went wrong. The
-   * exceptions will be logged.
-   */
-  private static SSLContext contextFromSecrets(final Configuration config) {
-    final Object cert_secret = config.getSecretObject(
-        config.getString(TLS_SECRET_CERT_KEY));
-    if (cert_secret == null) {
-      throw new IllegalStateException("The secret object cannot be null: " 
-          + config.getString(TLS_SECRET_CERT_KEY));
-    }
-    
-    RSAPrivateKey key = null;
-    final Object key_secret = config.getSecretObject(
-        config.getString(TLS_SECRET_KEY_KEY));
-    try {
-      if (key_secret != null) {
-        if (key_secret instanceof RSAPrivateKey) {
-          key = (RSAPrivateKey) key_secret;
-        } else if (key_secret instanceof String || key_secret instanceof byte[]) {
-          final String raw_key;
-          if (key_secret instanceof String) {
-            raw_key = (String) key_secret;
-          } else {
-            raw_key = new String((byte[]) key_secret, Const.UTF8_CHARSET);
-          }
-          if (raw_key.contains("BEGIN PRIVATE KEY")) {
-            key = parsePKCS8Key(trimPrivateKey(raw_key));
-          } else if (raw_key.contains("BEGIN RSA PRIVATE KEY")) {
-            key = parsePKCS1Key(trimPrivateKey(raw_key));
-          } else {
-            throw new IllegalStateException("Unrecognized key: " 
-                + config.getString(TLS_SECRET_KEY_KEY));
-          }
-        } else {
-          throw new IllegalArgumentException("Unknown private key object type: " 
-              + key_secret.getClass().getCanonicalName().toString());
-        }
-        LOG.info("Successfully loaded private key from secret: "+  
-            config.getString(TLS_SECRET_KEY_KEY));
-      }
-    } catch (IOException | GeneralSecurityException e) {
-      LOG.error("Failed to parse private key at: " + 
-          config.getString(TLS_SECRET_KEY_KEY));
-      return null;
-    }
-    
-    List<String> parts;
-    KeyStore keystore = null;
-    List<Certificate> certificates = null;
-    final String keystore_pass = Long.toString(System.currentTimeMillis());
-    int cert_id = 0;
-    
-    try {
-      final String raw_certs;
-      if (cert_secret instanceof String) {
-        raw_certs = (String) cert_secret;
-      } else if (cert_secret instanceof byte[]) {
-        raw_certs = new String((byte[]) cert_secret, Const.UTF8_CHARSET);
-      } else if (cert_secret instanceof X509CertPath) {
-        raw_certs = null;
-        certificates = Lists.newArrayList();
-        keystore = KeyStore.getInstance("JKS");
-        keystore.load(null);
-        X509CertPath p = (X509CertPath) cert_secret;
-        boolean have_server_cert = false;
-        for (final X509Certificate c : p.getCertificates()) {
-          certificates.add(c);
-          String cn = getCN(c);
-          boolean is_server_cert = isServerCert(c);
-          if (have_server_cert && is_server_cert) {
-            throw new IllegalStateException("Multiple server certs in "
-                + "the PEM are not allowed.");
-          } else if (is_server_cert) {
-            have_server_cert = is_server_cert;
-            LOG.info("Successfully loaded server certificate with CN:: " + cn);
-          } else {
-            LOG.info("Successfully loaded intermediate or CA cert with CN: " + cn);
-          }
-          keystore.setCertificateEntry(Integer.toString(cert_id++), c);
-        }
-        
-      } else {
-        throw new IllegalArgumentException("Unrecognized secret class: " 
-            + cert_secret.getClass());
-      }
-      
-      if (raw_certs != null) {
-        parts = splitPem(raw_certs);
-        if (parts.size() < 1) {
-          throw new IllegalStateException("No certificates found in secret: " 
-              + config.getString(TLS_SECRET_CERT_KEY));
-        }
-
-        keystore = KeyStore.getInstance("JKS");
-        keystore.load(null);
-        certificates = Lists.newArrayList();
-        boolean have_server_cert = false;
-        for (final String part : parts) {
-          if (part.contains("BEGIN PRIVATE KEY")) {
-            if (key != null) {
-              throw new RuntimeException("Already loaded a key but " 
-                  + config.getString(TLS_SECRET_CERT_KEY) + " also had a key.");
-            }
-            key = parsePKCS8Key(trimPrivateKey(part));
-          } else if (part.contains("BEGIN RSA PRIVATE KEY")) {
-            if (key != null) {
-              throw new RuntimeException("Already loaded a key but " 
-                  + config.getString(TLS_SECRET_CERT_KEY) + " also had a key.");
-            }
-            key = parsePKCS1Key(trimPrivateKey(part));
-          } else {
-            X509Certificate cert = parseCert(trimCertificate(part));
-            certificates.add(cert);
-            String cn = getCN(cert);
-            boolean is_server_cert = isServerCert(cert);
-            if (have_server_cert && is_server_cert) {
-              throw new IllegalStateException("Multiple server certs in "
-                  + "the PEM are not allowed.");
-            } else if (is_server_cert) {
-              have_server_cert = is_server_cert;
-              LOG.info("Successfully loaded server certificate with CN:: " + cn);
-            } else {
-              LOG.info("Successfully loaded intermediate or CA cert with CN: " + cn);
-            }
-            keystore.setCertificateEntry(Integer.toString(cert_id++), cert);
-          }
-        }
-      }
-      
-      if (certificates.isEmpty()) {
-        throw new IllegalStateException("No certificates loaded from: " 
-            + config.getString(TLS_SECRET_CERT_KEY));
-      }
-      Certificate[] cert_array = new Certificate[certificates.size()];
-      certificates.toArray(cert_array);
-      keystore.setKeyEntry("key-alias", 
-                           key, 
-                           keystore_pass.toCharArray(),
-                           cert_array);
-    } catch (IOException | GeneralSecurityException e) {
-      LOG.error("Failed to load certificate(s) from " 
-          + config.getString(TLS_SECRET_CERT_KEY), e);
-      return null;
-    }
-    
-    final String ca_certs_location = config.getString(TLS_CA_KEY);
-    if (!Strings.isNullOrEmpty(ca_certs_location)) {
-      try {
-        if (new File(ca_certs_location).isDirectory()) {
-          // TODO - load all the certs in the dir
-          throw new UnsupportedOperationException("We don't support "
-              + "loading directories yet.");
-        } else {
-          final String raw_cas = Files.toString(new File(ca_certs_location), 
-              Charsets.UTF_8);
-          parts = splitPem(raw_cas);
-          for (final String part : parts) {
-            X509Certificate cert = parseCert(trimCertificate(part));
-            certificates.add(cert);
-            String cn = getCN(cert);
-            keystore.setCertificateEntry(Integer.toString(cert_id++), cert);
-            LOG.info("Successfully loaded CA cert with CN: " + cn);
-          }
-        }
-      } catch (IOException | GeneralSecurityException e) {
-        LOG.error("Failed to load CA certificates from: " + ca_certs_location, e);
-        return null;
-      }
-    }
-    
-    try {
-      // initialize a key manager to pass to the SSL context using the keystore.
-      final KeyManagerFactory key_factory = KeyManagerFactory.getInstance(
-          KeyManagerFactory.getDefaultAlgorithm());
-      key_factory.init(keystore, keystore_pass.toCharArray());
-  
-      // init a trust manager so we can use the public cert.
-      final TrustManagerFactory trust_factory = 
-          TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-      trust_factory.init(keystore);
-      final TrustManager[] trustManagers = trust_factory.getTrustManagers();
-      
-      final SSLContext ssl_context = SSLContext.getInstance("TLS");
-      ssl_context.init(key_factory.getKeyManagers(), trustManagers, null);
-     
-      return ssl_context;
-    } catch (GeneralSecurityException e) {
-      LOG.error("Failed to initialize SSLContext", e);
+    return builder.build().context();
+    } catch (Throwable t) {
+      LOG.error("Failed to initialize SSLContext", t);
+      t.printStackTrace();
+      System.exit(1);
       return null;
     }
   }
@@ -837,144 +402,5 @@ public class TSDMain {
     }
     Runtime.getRuntime().addShutdownHook(new TSDBShutdown());
   }
-  
-  /**
-   * Strips the header and footer from the key.
-   * @param key A non-null key.
-   * @return The clean key.
-   */
-  private static String trimPrivateKey(final String key) {
-    return key.replace("-----BEGIN PRIVATE KEY-----", "")
-              .replace("-----END PRIVATE KEY-----", "")
-              .replace("-----BEGIN RSA PRIVATE KEY-----", "")
-              .replace("-----END RSA PRIVATE KEY-----", "")
-              .trim();
-  }
-  
-  /**
-   * Strips the header and footer from the certificate.
-   * @param cert A non-null certificate.
-   * @return The clean certificate.
-   */
-  private static String trimCertificate(final String cert) {
-    return cert.replace("-----BEGIN CERTIFICATE-----", "")
-               .replace("-----END CERTIFICATE-----", "")
-               .trim();
-  }
-  
-  /**
-   * Parses a PKCS8 formatted private key.
-   * @param key A non-null key as a B64 encoded string.
-   * @return A private key if parsing was successful.
-   * @throws NoSuchAlgorithmException If the JVM is hosed.
-   * @throws InvalidKeySpecException If the key wasn't PKCS8 formatted.
-   */
-  private static RSAPrivateKey parsePKCS8Key(final String key) throws 
-      NoSuchAlgorithmException, InvalidKeySpecException {
-    final PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(
-        DatatypeConverter.parseBase64Binary(key));
-    final KeyFactory factory = KeyFactory.getInstance("RSA");
-    return (RSAPrivateKey) factory.generatePrivate(spec);
-  }
-  
-  /**
-   * Parses a PKCS1 formatted private key using unsafe classes (to avoid
-   * pulling in another jar just for this).
-   * @param key A non-null key as a B64 encoded string.
-   * @return A private key if parsing was successful.
-   * @throws IOException If the input was corrupted.
-   * @throws GeneralSecurityException If parsing failed because the key
-   * appeared to be in the wrong format.
-   */
-  static RSAPrivateKey parsePKCS1Key(final String key) throws 
-      IOException, GeneralSecurityException {
-    final DerInputStream stream = new DerInputStream(
-        DatatypeConverter.parseBase64Binary(key));
-    final DerValue[] seq = stream.getSequence(0);
 
-    if (seq.length < 9) {
-      throw new GeneralSecurityException("Failed parsing the PKCS1 "
-          + "formatted key as it didn't have the right number of sequences.");
-    }
-
-    final BigInteger modulus = seq[1].getBigInteger();
-    final BigInteger private_exponent = seq[3].getBigInteger();
-    final RSAPrivateKeySpec spec = 
-        new RSAPrivateKeySpec(modulus, private_exponent);
-    final KeyFactory factory = KeyFactory.getInstance("RSA");
-    return (RSAPrivateKey) factory.generatePrivate(spec);
-  }
-  
-  /**
-   * Splits a PEM formatted file into individual certificates and keys.
-   * Just looks for the '-----BEGIN' header and appends to a buffer until
-   * the next header or the end of file is reached. New-lines are removed.
-   * @param pem A non-null pem file.
-   * @return A list of individual objects in the file.
-   */
-  private static List<String> splitPem(final String pem) {
-    final List<String> parts = Lists.newArrayList();
-    final StringBuilder buf = new StringBuilder();
-    try (BufferedReader br = new BufferedReader(new StringReader(pem))) {
-      for (String line = br.readLine(); line != null; line = br.readLine()) {
-        if (line.isEmpty()) {
-          continue;
-        }
-        if (line.startsWith("-----BEGIN")) {
-          if (buf.length() > 0) {
-            parts.add(buf.toString());
-            buf.setLength(0);
-          }
-        }
-        buf.append(line);
-      }
-      if (buf.length() > 0) {
-        parts.add(buf.toString());
-      }
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to parse the pem!", e);
-    }
-    return parts;
-  }
-  
-  /**
-   * Parses a B64 encoded certificate into an X509 representation.
-   * @param cert The non-null and non-empty certificate.
-   * @return A parsed certificate.
-   * @throws CertificateException If something goes pear shaped.
-   */
-  private static X509Certificate parseCert(final String cert) throws 
-      CertificateException {
-    return (X509Certificate) factory.generateCertificate(
-        new ByteArrayInputStream(
-            DatatypeConverter.parseBase64Binary((cert))));
-  }
-  
-  /**
-   * A helper to extract the CN from a certificate.
-   * @param cert A non-null certificate.
-   * @return The CN.
-   */
-  private static String getCN(final X509Certificate cert) {
-    String cn = cert.getSubjectX500Principal().getName()
-                    .replace("CN=", "");
-    cn = cn.substring(0, cn.indexOf(","));
-    return cn;
-  }
-  
-  /**
-   * A helper to determine if the cert could be used for TLS termination.
-   * @param cert A non-null cert.
-   * @return True if it could be, false if it was an intermediate or CA 
-   * certificate.
-   */
-  private static boolean isServerCert(final X509Certificate cert) {
-    boolean[] uses = cert.getKeyUsage();
-    if (uses == null) {
-      throw new IllegalStateException("The given certificate didn't "
-          + "have any usage extensions. This shouldn't happen with certs "
-          + "used for TLS: " + getCN(cert));
-    }
-    return (uses[0] && uses[2]);
-  }
 }


### PR DESCRIPTION
- Add RefreshingSSLContext to build SSLContexts. TODO - needs tests and more
  validation.

HTTP-EXECUTOR:
- Add an opentsdb.http.executor.headers.user setting so that if a TSD is used
  as a proxy to other TSDs (e.g. HA Cluster) and we're using something like
  client certificates for authentication, we can send the real user downstream.
  TODO - more work around this.
- Rename SharedHttpClient to DefaultSharedHttpClient as the base implementation
  and create SharedHttpClient as an interface.
- In the v3 source, return the underlying error instead of the "unavailable
  hosts" error.

UNDERTOW:
- Use the new SSLContext refresher.