### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByConfig.java
@@ -122,8 +122,7 @@ public class GroupByConfig extends BaseQueryNodeConfigWithInterpolators {
   
   @Override
   public boolean pushDown() {
-    // TODO Auto-generated method stub
-    return false;
+    return true;
   }
   
   @Override


### PR DESCRIPTION
- Enable Group By for push down.
- Fix push down logic for more than one node when a non-pushed node is
  a predecessor in the graph.