### PR TITLE
Fix broken build

### DIFF
--- a/third_party/asyncbigtable/include.mk
+++ b/third_party/asyncbigtable/include.mk
@@ -15,7 +15,7 @@
 
 ASYNCBIGTABLE_VERSION := 0.3.1-20170903.031804-2
 ASYNCBIGTABLE := third_party/asyncbigtable/asyncbigtable-$(ASYNCBIGTABLE_VERSION)-jar-with-dependencies.jar
-ASYNCBIGTABLE_BASE_URL := https://oss.sonatype.org/content/repositories/snapshots/com/pythian/opentsdb/asyncbigtable/0.3.1-SNAPSHOT/
+ASYNCBIGTABLE_BASE_URL := https://oss.sonatype.org/content/repositories/snapshots/com/pythian/opentsdb/asyncbigtable/0.3.1-SNAPSHOT
 
 $(ASYNCBIGTABLE): $(ASYNCBIGTABLE).md5
 	set dummy "$(ASYNCBIGTABLE_BASE_URL)" "$(ASYNCBIGTABLE)"; shift; $(FETCH_DEPENDENCY)


### PR DESCRIPTION
My build is failing with this error messages:

set dummy "https://oss.sonatype.org/content/repositories/releases/com/pythian/opentsdb/asyncbigtable/0.3.0/" "third_party/asyncbigtable/asyncbigtable-0.3.0-jar-with-dependencies.jar"; shift; ./build-aux/fetchdep.sh "$@"
--2019-02-21 18:46:04--  https://oss.sonatype.org/content/repositories/releases/com/pythian/opentsdb/asyncbigtable/0.3.0//asyncbigtable-0.3.0-jar-with-dependencies.jar
Resolving oss.sonatype.org (oss.sonatype.org)... 18.235.158.122, 23.22.160.79, 54.226.35.221
Connecting to oss.sonatype.org (oss.sonatype.org)|18.235.158.122|:443... connected.
HTTP request sent, awaiting response... 302 Moved Temporarily
Location: https://repo1.maven.org:443/content/repositories/releases/com/pythian/opentsdb/asyncbigtable/0.3.0//asyncbigtable-0.3.0-jar-with-dependencies.jar [following]
--2019-02-21 18:46:04--  https://repo1.maven.org/content/repositories/releases/com/pythian/opentsdb/asyncbigtable/0.3.0//asyncbigtable-0.3.0-jar-with-dependencies.jar
Resolving repo1.maven.org (repo1.maven.org)... 151.101.184.209
Connecting to repo1.maven.org (repo1.maven.org)|151.101.184.209|:443... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://repo1.maven.org/maven2/com/pythian/opentsdb/asyncbigtable/0.3.0//asyncbigtable-0.3.0-jar-with-dependencies.jar [following]
--2019-02-21 18:46:05--  https://repo1.maven.org/maven2/com/pythian/opentsdb/asyncbigtable/0.3.0//asyncbigtable-0.3.0-jar-with-dependencies.jar
Reusing existing connection to repo1.maven.org:443.
HTTP request sent, awaiting response... 404 Not Found
2019-02-21 18:46:05 ERROR 404: Not Found.


Looking at fetchdep.sh, it is trying to wget this url https://repo1.maven.org/maven2/com/pythian/opentsdb/asyncbigtable/0.3.0//asyncbigtable-0.3.0-jar-with-dependencies.jar

But that "//" in the url makes a 404!