### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/processor/merge/MergerResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/merge/MergerResult.java
@@ -55,6 +55,12 @@ public class MergerResult implements QueryResult {
   /** The map of hash codes to groups. */
   protected final Map<Long, TimeSeries> groups;
   
+  /** The first non-null time specification. */
+  protected TimeSpecification time_spec;
+  
+  /** The first non-null rollup config. */
+  protected RollupConfig rollup_config;
+  
   /** Errors or exceptions from downstream. */
   protected String error;
   protected Throwable exception;
@@ -78,6 +84,8 @@ public class MergerResult implements QueryResult {
     this.next = Lists.newArrayList();
     this.next.add(next);
     groups = Maps.newHashMap();
+    time_spec = next.timeSpecification();
+    rollup_config = next.rollupConfig();
   }
   
   /**
@@ -86,6 +94,12 @@ public class MergerResult implements QueryResult {
    */
   void add(final QueryResult next) {
     this.next.add(next);
+    if (time_spec == null && next.timeSpecification() != null) {
+      time_spec = next.timeSpecification();
+    }
+    if (rollup_config == null && next.rollupConfig() != null) {
+      rollup_config = next.rollupConfig();
+    }
   }
   
   /**
@@ -119,7 +133,7 @@ public class MergerResult implements QueryResult {
   
   @Override
   public TimeSpecification timeSpecification() {
-    return next.get(0).timeSpecification();
+    return time_spec;
   }
 
   @Override
@@ -164,7 +178,7 @@ public class MergerResult implements QueryResult {
   
   @Override
   public RollupConfig rollupConfig() {
-    return next.get(0).rollupConfig();
+    return rollup_config;
   }
   
   @Override

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerResult.java
@@ -38,6 +38,7 @@ import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
 import net.opentsdb.query.pojo.FillPolicy;
+import net.opentsdb.rollup.RollupConfig;
 
 public class TestMergerResult {
   
@@ -46,6 +47,7 @@ public class TestMergerResult {
   private QueryResult result_a;
   private QueryResult result_b;
   private TimeSpecification time_spec;
+  private RollupConfig rollup_config;
   private NumericMillisecondShard ts1;
   private NumericMillisecondShard ts2;
   private NumericMillisecondShard ts3;
@@ -80,6 +82,7 @@ public class TestMergerResult {
     result_a = mock(QueryResult.class);
     result_b = mock(QueryResult.class);
     time_spec = mock(TimeSpecification.class);
+    rollup_config = mock(RollupConfig.class);
     
     when(node.config()).thenReturn(config);
     
@@ -121,8 +124,27 @@ public class TestMergerResult {
     
     when(result_a.timeSeries()).thenReturn(Lists.newArrayList(ts1, ts2));
     when(result_b.timeSeries()).thenReturn(Lists.newArrayList(ts3, ts4));
+    when(result_b.rollupConfig()).thenReturn(rollup_config);
     when(result_a.sequenceId()).thenReturn(42l);
     when(result_a.timeSpecification()).thenReturn(time_spec);
+  }
+  
+  @Test
+  public void addTimeSpec() throws Exception {
+    MergerResult merger = new MergerResult(node, result_b);
+    assertNull(merger.timeSpecification());
+    
+    merger.add(result_a);
+    assertSame(time_spec, merger.timeSpecification());
+  }
+  
+  @Test
+  public void addRollupConfig() throws Exception {
+    MergerResult merger = new MergerResult(node, result_a);
+    assertNull(merger.rollupConfig());
+    
+    merger.add(result_b);
+    assertSame(rollup_config, merger.rollupConfig());
   }
   
   @Test


### PR DESCRIPTION
- Fix the merger to return time spec and rollup configs when the first response
  was an error. Get the values from the second or later responses.