### PR TITLE
CORE:

### DIFF
--- a/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterFactory.java
+++ b/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterFactory.java
@@ -27,8 +27,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import net.opentsdb.query.processor.timeshift.TimeShift;
-import net.opentsdb.query.processor.timeshift.TimeShiftConfig;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -1485,7 +1483,7 @@ public class TestHAClusterFactory {
     DefaultQueryPlanner planner = new DefaultQueryPlanner(context, ctx_node);
     planner.plan(null).join(250);
     
-    assertEquals(7, planner.graph().nodes().size());
+    assertEquals(6, planner.graph().nodes().size());
     assertFalse(planner.configGraph().nodes().contains(query.getExecutionGraph().get(0)));
     QueryNode node = planner.nodeForId("ha_m1_s3");
     assertTrue(node instanceof TimeSeriesDataSource);
@@ -1503,7 +1501,7 @@ public class TestHAClusterFactory {
     
     assertTrue(planner.nodeForId("ha_m1") instanceof HACluster);
     assertTrue(planner.nodeForId("m1") instanceof Merger);
-    assertTrue(planner.nodeForId("IDConverter") instanceof ByteToStringIdConverter);
+    assertTrue(planner.nodeForId("m1_converter") instanceof ByteToStringIdConverter);
     
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"), 
         planner.nodeForId("ha_m1_s3")));
@@ -1516,8 +1514,6 @@ public class TestHAClusterFactory {
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("m1"), 
         planner.nodeForId("m1_converter")));
     assertTrue(planner.graph().hasEdgeConnecting(ctx_node, 
-        planner.nodeForId("IDConverter")));
-    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("IDConverter"), 
         planner.nodeForId("m1")));
   }
   

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchemaFactory.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchemaFactory.java
@@ -233,7 +233,7 @@ public class TestSchemaFactory extends SchemaBase {
     DefaultQueryPlanner plan = new DefaultQueryPlanner(context, sink);
     plan.plan(null).join();
     
-    assertEquals(3, plan.configGraph().nodes().size());
+    assertEquals(2, plan.configGraph().nodes().size());
     QueryNodeConfig node = plan.configNodeForId("m1");
     assertSame(config, node);
   }
@@ -270,7 +270,7 @@ public class TestSchemaFactory extends SchemaBase {
     DefaultQueryPlanner plan = new DefaultQueryPlanner(context, sink);
     plan.plan(null).join();
     
-    assertEquals(7, plan.configGraph().nodes().size());
+    assertEquals(6, plan.configGraph().nodes().size());
     QueryNodeConfig node = plan.configNodeForId("m1");
     assertSame(config, node);
     


### PR DESCRIPTION
- Fix UTs now that the QueryPlanner is only putting the ID converter when
  in push mode.