### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/configuration/provider/FileFactory.java
+++ b/common/src/main/java/net/opentsdb/configuration/provider/FileFactory.java
@@ -54,7 +54,8 @@ public class FileFactory implements ProtocolProviderFactory, ProviderFactory {
   @Override
   public Provider newInstance(final Configuration config, 
                               final HashedWheelTimer timer) {
-    throw new UnsupportedOperationException();
+    // try for the old default config.
+    return newInstance(config, timer, "file:///etc/opentsdb/opentsdb.conf");
   }
   
   @Override

--- a/common/src/main/java/net/opentsdb/stats/BlackholeStatsCollector.java
+++ b/common/src/main/java/net/opentsdb/stats/BlackholeStatsCollector.java
@@ -84,6 +84,11 @@ public class BlackholeStatsCollector extends BaseTSDBPlugin implements
     public void stop(final String... tags) {
       // Muahaha!
     }
+
+    @Override
+    public long startTimeNanos() {
+      return 0;
+    }
   }
   private static final BlackholeTimer TMR = new BlackholeTimer();
 }

--- a/common/src/main/java/net/opentsdb/stats/StatsCollector.java
+++ b/common/src/main/java/net/opentsdb/stats/StatsCollector.java
@@ -99,5 +99,9 @@ public interface StatsCollector extends TSDBPlugin {
      * @param tags An optional set of tag key, value, key, value pairs.
      */
     public void stop(final String... tags);
+    
+    /** @return The start time in nanos. */
+    public long startTimeNanos();
+    
   }
 }

--- a/common/src/main/java/net/opentsdb/utils/PluginLoader.java
+++ b/common/src/main/java/net/opentsdb/utils/PluginLoader.java
@@ -260,6 +260,9 @@ public final class PluginLoader {
       }
     } catch (IOException e) {
       LOG.warn("Unexpected exception searching class path for: " + type, e);
+    } catch (Error e) {
+      throw new Error("Failed to load plugins for type [" + type 
+          + "] and namespace [" + namespace + "]", e);
     }
     
     if (plugins.size() > 0) {


### PR DESCRIPTION
- Modify the FileFactory for configuration to try loading the old default
  /etc/opentsdb/opentsdb.conf if nothing was provided.
- Add a startTimeNanos() to the StatsTimer interface.
- Add an Error handler to the PluginLoader to help determine what class
  is throwing errors.