### PR TITLE
Collect stats from meta cache plugin if configured

### DIFF
--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -906,6 +906,14 @@ public final class TSDB {
         collector.clearExtraTag("plugin");
       }
     }
+    if (meta_cache != null) {
+      try {
+        collector.addExtraTag("plugin", "metaCache");
+        meta_cache.collectStats(collector);
+      } finally {
+        collector.clearExtraTag("plugin");
+      }
+    }
   }
 
   /** Returns a latency histogram for Put RPCs used to store data points. */


### PR DESCRIPTION
You can configure a meta cache plugin, but the call to ```collectStats()``` is not wired in, this PR adds it.

The only workaround available at the moment is to implement another plugin (such as the startup plugin) in the same jar file and take advantage of the fact all plugins are loaded from the same classpath and so share static state to pull stats across. This is clearly somewhat less than desirable.