### PR TITLE
Fix SaltScanner race condition on spans maps

### DIFF
--- a/src/core/MultiGetQuery.java
+++ b/src/core/MultiGetQuery.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -89,11 +90,11 @@ public class MultiGetQuery {
   private final Map<Integer, List<SimpleEntry<byte[], 
   List<HistogramDataPoint>>>> histMap = Maps.newConcurrentMap();
 
-  private final Deferred<TreeMap<byte[], Span>> results = 
-      new Deferred<TreeMap<byte[], Span>>();
+  private final Deferred<SortedMap<byte[], Span>> results =
+      new Deferred<>();
 
-  private final Deferred<TreeMap<byte[], HistogramSpan>> histogramResults = 
-      new Deferred<TreeMap<byte[], HistogramSpan>>();
+  private final Deferred<SortedMap<byte[], HistogramSpan>> histogramResults =
+      new Deferred<>();
 
   private final ArrayList<List<MultiGetTask>> multi_get_tasks;
   private final ArrayList<AtomicInteger> multi_get_indexs;
@@ -608,7 +609,7 @@ public class MultiGetQuery {
    * Initiate the get requests and return the tree map of results.
    * @return A non-null tree map of results (may be empty)
    */
-  public Deferred<TreeMap<byte[], Span>> fetch() {
+  public Deferred<SortedMap<byte[], Span>> fetch() {
     if(tags.isEmpty()) {
       return Deferred.fromResult(null);
     }
@@ -620,7 +621,7 @@ public class MultiGetQuery {
    * Initiate the get requests and return the tree map of results.
    * @return A non-null tree map of results (may be empty)
    */
-  public Deferred<TreeMap<byte[], HistogramSpan>> fetchHistogram() {
+  public Deferred<SortedMap<byte[], HistogramSpan>> fetchHistogram() {
     startFetch();
     return histogramResults;
   }

--- a/src/core/SaltScanner.java
+++ b/src/core/SaltScanner.java
@@ -12,14 +12,16 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
-import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -70,9 +72,9 @@ public class SaltScanner {
   
   /** This is a map that the caller must supply. We'll fill it with data.
    * WARNING: The salted row comparator should be applied to this map. */
-  private final TreeMap<byte[], Span> spans;
+  private final SortedMap<byte[], Span> spans;
   
-  private final TreeMap<byte[], HistogramSpan> histSpans;
+  private final SortedMap<byte[], HistogramSpan> histSpans;
   
   /** The list of pre-configured scanners. One scanner should be created per
    * salt bucket. */
@@ -93,11 +95,11 @@ public class SaltScanner {
     List<HistogramDataPoint>>>>();
   
   /** A deferred to call with the spans on completion */
-  private final Deferred<TreeMap<byte[], Span>> results = 
-          new Deferred<TreeMap<byte[], Span>>();
+  private final Deferred<SortedMap<byte[], Span>> results =
+          new Deferred<>();
   
-  private final Deferred<TreeMap<byte[], HistogramSpan>> histogramResults =
-      new Deferred<TreeMap<byte[], HistogramSpan>>();
+  private final Deferred<SortedMap<byte[], HistogramSpan>> histogramResults =
+      new Deferred<>();
   
   /** The metric this scanner set is dealing with. If a row comes in with a 
    * different metric we toss an exception. This shouldn't happen though. */
@@ -226,8 +228,8 @@ public class SaltScanner {
     }
     
     this.scanners = scanners;
-    this.spans = spans;
-    this.histSpans = histogramSpans;
+    this.spans = spans != null ? Collections.synchronizedSortedMap(spans) : null;
+    this.histSpans = histogramSpans != null ? Collections.synchronizedSortedMap(histogramSpans) : null;
     this.metric = metric;
     this.tsdb = tsdb;
     this.filters = filters;
@@ -264,7 +266,7 @@ public class SaltScanner {
    * first error will be returned, others will be logged. 
    * @return A deferred to wait on for results.
    */
-  public Deferred<TreeMap<byte[], Span>> scan() {
+  public Deferred<SortedMap<byte[], Span>> scan() {
     start_time = System.currentTimeMillis();
     int i = 0;
     for (final Scanner scanner: scanners) {
@@ -273,7 +275,7 @@ public class SaltScanner {
     return results; 
   }
 
-  public Deferred<TreeMap<byte[], HistogramSpan>> scanHistogram() {
+  public Deferred<SortedMap<byte[], HistogramSpan>> scanHistogram() {
     start_time = DateTime.currentTimeMillis();
 
     int index = 0;
@@ -528,7 +530,7 @@ public class SaltScanner {
     /**
     * Iterate through each row of the scanner results, parses out data
     * points (and optional meta data).
-    * @return null if no rows were found, otherwise the TreeMap with spans
+    * @return null if no rows were found, otherwise the SortedMap with spans
     */
     @Override
     public Object call(final ArrayList<ArrayList<KeyValue>> rows) 

--- a/src/core/TsdbQuery.java
+++ b/src/core/TsdbQuery.java
@@ -20,6 +20,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.slf4j.Logger;
@@ -791,7 +792,7 @@ final class TsdbQuery implements Query {
    * perform the search.
    * @throws IllegalArgumentException if bad data was retrieved from HBase.
    */
-  private Deferred<TreeMap<byte[], Span>> findSpans() throws HBaseException {
+  private Deferred<SortedMap<byte[], Span>> findSpans() throws HBaseException {
     final short metric_width = tsdb.metrics.width();
     final TreeMap<byte[], Span> spans = // The key is a row key from HBase.
       new TreeMap<byte[], Span>(new SpanCmp(
@@ -831,7 +832,7 @@ final class TsdbQuery implements Query {
     }
   }
   
-  private Deferred<TreeMap<byte[], Span>> findSpansWithMultiGetter() throws HBaseException {
+  private Deferred<SortedMap<byte[], Span>> findSpansWithMultiGetter() throws HBaseException {
     final short metric_width = tsdb.metrics.width();
     final TreeMap<byte[], Span> spans = // The key is a row key from HBase.
     new TreeMap<byte[], Span>(new SpanCmp(metric_width));
@@ -857,7 +858,7 @@ final class TsdbQuery implements Query {
    * perform the search.
    * @throws IllegalArgumentException if bad data was retreived from HBase.
    */
-  private Deferred<TreeMap<byte[], HistogramSpan>> findHistogramSpans() throws HBaseException {
+  private Deferred<SortedMap<byte[], HistogramSpan>> findHistogramSpans() throws HBaseException {
     final short metric_width = tsdb.metrics.width();
     final TreeMap<byte[], HistogramSpan> histSpans = new TreeMap<byte[], HistogramSpan>(new SpanCmp(metric_width));
     
@@ -896,7 +897,7 @@ final class TsdbQuery implements Query {
     }
   }
   
-  private Deferred<TreeMap<byte[], HistogramSpan>> findHistogramSpansWithMultiGetter() throws HBaseException {
+  private Deferred<SortedMap<byte[], HistogramSpan>> findHistogramSpansWithMultiGetter() throws HBaseException {
     final short metric_width = tsdb.metrics.width();
     // The key is a row key from HBase
     final TreeMap<byte[], HistogramSpan> histSpans = new TreeMap<byte[], HistogramSpan>(new SpanCmp(metric_width));
@@ -913,7 +914,7 @@ final class TsdbQuery implements Query {
    * {@link TsdbQuery#findSpans} to group and sort the results.
    */
   private class GroupByAndAggregateCB implements 
-    Callback<DataPoints[], TreeMap<byte[], Span>>{
+    Callback<DataPoints[], SortedMap<byte[], Span>>{
     
     /**
     * Creates the {@link SpanGroup}s to form the final results of this query.
@@ -923,7 +924,7 @@ final class TsdbQuery implements Query {
     * any 'GROUP BY' formulated in this query.
     */
     @Override
-    public DataPoints[] call(final TreeMap<byte[], Span> spans) throws Exception {
+    public DataPoints[] call(final SortedMap<byte[], Span> spans) throws Exception {
       if (query_stats != null) {
         query_stats.addStat(query_index, QueryStat.QUERY_SCAN_TIME, 
                 (System.nanoTime() - TsdbQuery.this.scan_start_time));
@@ -1048,7 +1049,7 @@ final class TsdbQuery implements Query {
    * {@link TsdbQuery#findHistogramSpans} to group and sort the results.
    */
    private class HistogramGroupByAndAggregateCB implements 
-     Callback<DataPoints[], TreeMap<byte[], HistogramSpan>>{
+     Callback<DataPoints[], SortedMap<byte[], HistogramSpan>>{
 
      /**
      * Creates the {@link HistogramSpanGroup}s to form the final results of this query.
@@ -1057,7 +1058,7 @@ final class TsdbQuery implements Query {
      * @return A possibly empty array of {@link HistogramSpanGroup}s built according to
      * any 'GROUP BY' formulated in this query.
      */
-     public DataPoints[] call(final TreeMap<byte[], HistogramSpan> spans) throws Exception {
+     public DataPoints[] call(final SortedMap<byte[], HistogramSpan> spans) throws Exception {
        if (query_stats != null) {
          query_stats.addStat(query_index, QueryStat.QUERY_SCAN_TIME, 
                  (System.nanoTime() - TsdbQuery.this.scan_start_time));

--- a/test/core/TestMultiGetQuery.java
+++ b/test/core/TestMultiGetQuery.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.SortedMap;
 
 import org.hbase.async.Bytes.ByteMap;
 import org.hbase.async.GetRequest;
@@ -690,7 +691,7 @@ public class TestMultiGetQuery extends BaseTsdbTest {
         start_ts, end_ts, tsdb.dataTable(), spans, null, 0, null, query_stats, 
         0, max_bytes, false, multiget_no_meta);
     
-    final TreeMap<byte[], Span> results = mgq.fetch().join();
+    final SortedMap<byte[], Span> results = mgq.fetch().join();
     assertSame(spans, results);
     verify(client, times(1)).get(anyList());
     System.out.println(spans);
@@ -705,7 +706,7 @@ public class TestMultiGetQuery extends BaseTsdbTest {
         start_ts, end_ts, tsdb.dataTable(), spans, null, 0, null, query_stats, 
         0, max_bytes, false, multiget_no_meta);
     
-    final TreeMap<byte[], Span> results = mgq.fetch().join();
+    final SortedMap<byte[], Span> results = mgq.fetch().join();
     assertSame(spans, results);
     verify(client, times(1)).get(anyList());
     System.out.println(spans);
@@ -719,7 +720,7 @@ public class TestMultiGetQuery extends BaseTsdbTest {
     MultiGetQuery mgq = new MultiGetQuery(tsdb, query, METRIC_BYTES, q_tags, 
         start_ts, end_ts, tsdb.dataTable(), spans, null, 0, null, query_stats, 
         0, max_bytes, false, multiget_no_meta);
-    final TreeMap<byte[], Span> results = mgq.fetch().join();
+    final SortedMap<byte[], Span> results = mgq.fetch().join();
   }
   
   @Test
@@ -730,7 +731,7 @@ public class TestMultiGetQuery extends BaseTsdbTest {
         start_ts, end_ts, tsdb.dataTable(), spans, null, 0, null, query_stats, 
         0, max_bytes, false, multiget_no_meta);
     
-    final TreeMap<byte[], Span> results = mgq.fetch().join();
+    final SortedMap<byte[], Span> results = mgq.fetch().join();
     assertSame(spans, results);
     assertTrue(spans.isEmpty());
     verify(client, times(1)).get(anyList());
@@ -745,7 +746,7 @@ public class TestMultiGetQuery extends BaseTsdbTest {
         start_ts, end_ts, tsdb.dataTable(), spans, null, 0, null, query_stats, 
         0, max_bytes, false, multiget_no_meta);
     
-    final TreeMap<byte[], Span> results = mgq.fetch().join();
+    final SortedMap<byte[], Span> results = mgq.fetch().join();
     assertSame(spans, results);
     verify(client, times(4)).get(anyList());
     validateSpans();
@@ -761,7 +762,7 @@ public class TestMultiGetQuery extends BaseTsdbTest {
         start_ts, end_ts, tsdb.dataTable(), spans, null, 0, null, query_stats, 
         0, max_bytes, false, multiget_no_meta);
     
-    final TreeMap<byte[], Span> results = mgq.fetch().join();
+    final SortedMap<byte[], Span> results = mgq.fetch().join();
     assertSame(spans, results);
     verify(client, times(4)).get(anyList());
     validateSpans();

--- a/test/core/TestSaltScanner.java
+++ b/test/core/TestSaltScanner.java
@@ -45,6 +45,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.stumbleupon.async.Deferred;
+import com.google.common.collect.Maps;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({"javax.management.*", "javax.xml.*",
@@ -136,7 +137,7 @@ public class TestSaltScanner extends BaseTsdbTest {
   public void scanNoData() throws Exception {
     final SaltScanner scanner = new SaltScanner(tsdb, METRIC_BYTES, scanners, 
         spans, filters);
-    assertTrue(spans == scanner.scan().joinUninterruptibly());
+    assertTrue(Maps.difference(spans, scanner.scan().joinUninterruptibly()).areEqual());
     assertTrue(spans.isEmpty());
   }
   
@@ -145,7 +146,7 @@ public class TestSaltScanner extends BaseTsdbTest {
     setupMockScanners(false);
     final SaltScanner scanner = new SaltScanner(tsdb, METRIC_BYTES, scanners, 
         spans, filters);
-    assertTrue(spans == scanner.scan().joinUninterruptibly());
+    assertTrue(Maps.difference(spans, scanner.scan().joinUninterruptibly()).areEqual());
     assertEquals(3, spans.size());
 
     Span span = spans.get(KEY_A);
@@ -181,7 +182,7 @@ public class TestSaltScanner extends BaseTsdbTest {
         .setTagk(TAGK_STRING).build());
     final SaltScanner scanner = new SaltScanner(tsdb, METRIC_BYTES, scanners, 
         spans, filters);
-    assertTrue(spans == scanner.scan().joinUninterruptibly());
+    assertTrue(Maps.difference(spans, scanner.scan().joinUninterruptibly()).areEqual());
     assertEquals(3, spans.size());
 
     Span span = spans.get(KEY_A);
@@ -219,7 +220,7 @@ public class TestSaltScanner extends BaseTsdbTest {
         .setTagk(TAGK_STRING).build());
     final SaltScanner scanner = new SaltScanner(tsdb, METRIC_BYTES, scanners, 
         spans, filters);
-    assertTrue(spans == scanner.scan().joinUninterruptibly());
+    assertTrue(Maps.difference(spans, scanner.scan().joinUninterruptibly()).areEqual());
     assertEquals(3, spans.size());
 
     Span span = spans.get(KEY_A);
@@ -256,7 +257,7 @@ public class TestSaltScanner extends BaseTsdbTest {
     
     final SaltScanner scanner = new SaltScanner(tsdb, METRIC_BYTES, scanners, 
         spans, filters);
-    assertTrue(spans == scanner.scan().joinUninterruptibly());
+    assertTrue(Maps.difference(spans, scanner.scan().joinUninterruptibly()).areEqual());
     assertEquals(0, spans.size());
 
     verify(tag_values, atLeast(1)).getNameAsync(TAGV_BYTES);
@@ -272,7 +273,7 @@ public class TestSaltScanner extends BaseTsdbTest {
         .setTagk(TAGK_STRING).build());
     final SaltScanner scanner = new SaltScanner(tsdb, METRIC_BYTES, scanners, 
         spans, filters);
-    assertTrue(spans == scanner.scan().joinUninterruptibly());
+    assertTrue(Maps.difference(spans, scanner.scan().joinUninterruptibly()).areEqual());
     assertEquals(0, spans.size());
 
     verify(tag_values, atLeast(1)).getNameAsync(TAGV_BYTES);

--- a/test/core/TestSaltScannerHistogram.java
+++ b/test/core/TestSaltScannerHistogram.java
@@ -39,6 +39,8 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
+import com.google.common.collect.Maps;
+
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -197,7 +199,7 @@ public class TestSaltScannerHistogram extends BaseTsdbTest {
 
     final SaltScanner scanner = new SaltScanner(tsdb, METRIC_BYTES, scanners, 
         null, null, false, null, query_stats, 0, spans, 0, 0);
-    assertTrue(spans == scanner.scanHistogram().joinUninterruptibly());
+    assertTrue(Maps.difference(spans, scanner.scan().joinUninterruptibly()).areEqual());
     assertEquals(3, spans.size());
 
     HistogramSpan span = spans.get(key_a);
@@ -230,7 +232,7 @@ public class TestSaltScannerHistogram extends BaseTsdbTest {
     final SaltScanner scanner = new SaltScanner(tsdb, METRIC_BYTES, scanners, 
         null, null, false, null, query_stats, 0, spans, 0, 0);
 
-    assertTrue(spans == scanner.scanHistogram().joinUninterruptibly());
+    assertTrue(Maps.difference(spans, scanner.scan().joinUninterruptibly()).areEqual());
     assertEquals(3, spans.size());
 
     HistogramSpan span = spans.get(key_a);
@@ -265,7 +267,7 @@ public class TestSaltScannerHistogram extends BaseTsdbTest {
     final SaltScanner scanner = new SaltScanner(tsdb, METRIC_BYTES, scanners, 
         null, null, false, null, query_stats, 0, spans, 0, 0);
 
-    assertTrue(spans == scanner.scanHistogram().joinUninterruptibly());
+    assertTrue(Maps.difference(spans, scanner.scan().joinUninterruptibly()).areEqual());
     assertEquals(3, spans.size());
 
     HistogramSpan span = spans.get(key_a);
@@ -299,7 +301,7 @@ public class TestSaltScannerHistogram extends BaseTsdbTest {
     final SaltScanner scanner = new SaltScanner(tsdb, METRIC_BYTES, scanners, 
         null, filters, false, null, query_stats, 0, spans, 0, 0);
 
-    assertTrue(spans == scanner.scanHistogram().joinUninterruptibly());
+    assertTrue(Maps.difference(spans, scanner.scan().joinUninterruptibly()).areEqual());
     assertEquals(0, spans.size());
   }
 


### PR DESCRIPTION
I believe this fixes one of the race condition issues described here https://github.com/OpenTSDB/opentsdb/issues/823

For context, we have 3 read only m5.2xlarge nodes, each serving query traffic at a rate of around 1,000  requests per minute.  Several times per day, we observed a TSD process becoming stuck, maxing out 1 core on the machine.  A closer look revealed one thread spending all of its time inside SaltScanner.mergeDataPoints() in a TreeMap.get().  I think there is a race condition which can trigger if validateAndTriggerCallback() and a handleException() occur concurrently.  

We have a health check process which restarts the TSD process if it starts to fail.  Since we have deployed this fix, we have noticed a significant decrease in restarts.  