### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/pools/ObjectPoolAllocator.java
+++ b/common/src/main/java/net/opentsdb/pools/ObjectPoolAllocator.java
@@ -27,6 +27,7 @@ import net.opentsdb.core.TSDBPlugin;
 public interface ObjectPoolAllocator extends TSDBPlugin {
   public static final String PREFIX = "objectpool.";
   public static final String POOL_ID_KEY = "pool.id";
+  public static final String GENERIC_POOL_ID_KEY = "generic.pool.id";
   public static final String COUNT_KEY = "count.initial";
   
   /** @return The initial size of an allocated object in bytes. */
@@ -43,5 +44,8 @@ public interface ObjectPoolAllocator extends TSDBPlugin {
   
   /** @return The type of data this allocator returns. */
   public TypeToken<?> dataType();
+  
+  /** @return The initial number of objects to allocate. */
+  public int initialCount();
   
 }

--- a/core/src/main/java/net/opentsdb/core/DefaultRegistry.java
+++ b/core/src/main/java/net/opentsdb/core/DefaultRegistry.java
@@ -113,9 +113,13 @@ public class DefaultRegistry implements Registry {
           .setValidator(new PluginConfigValidator())
           .build());
     }
-    tsdb.getConfig().register(DEFAULT_CLUSTERS_KEY, null, false, 
-        "TODO");
-    tsdb.getConfig().register(DEFAULT_GRAPHS_KEY, null, false, "TODO");
+    if (!tsdb.getConfig().hasProperty(DEFAULT_CLUSTERS_KEY)) {
+      tsdb.getConfig().register(DEFAULT_CLUSTERS_KEY, null, false, 
+          "TODO");
+    }
+    if (!tsdb.getConfig().hasProperty(DEFAULT_GRAPHS_KEY)) {
+      tsdb.getConfig().register(DEFAULT_GRAPHS_KEY, null, false, "TODO");
+    }
     
     this.tsdb = tsdb;
     type_map = Maps.newHashMap();

--- a/core/src/main/java/net/opentsdb/pools/BlockingQueueObjectPool.java
+++ b/core/src/main/java/net/opentsdb/pools/BlockingQueueObjectPool.java
@@ -1,0 +1,136 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2019  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.pools;
+
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.core.TSDB;
+
+/**
+ * This is a super simple {@link BlockingQueue} based pool if no other 
+ * plugin is found.
+ * 
+ * @since 3.0
+ */
+public class BlockingQueueObjectPool implements ObjectPool {
+  private static final Logger LOG = LoggerFactory.getLogger(
+      BlockingQueueObjectPool.class);
+  
+  /** Reference to the TSDB. */
+  private final TSDB tsdb;
+  
+  /** The config. */
+  private final ObjectPoolConfig config;
+  
+  /** The queue we'll circulate objects through. */
+  private final BlockingQueue<PooledObject> pool;
+  
+  /**
+   * The default ctor.
+   * @param tsdb The TSDB we'll use for stats.
+   * @param config The non-null config we'll pull the allocator from.
+   */
+  public BlockingQueueObjectPool(final TSDB tsdb, final ObjectPoolConfig config) {
+    this.tsdb = tsdb;
+    this.config = config;
+    int count = config.initialCount() > 0 ? config.initialCount() : 
+      config.allocator().initialCount();
+    if (count <= 0) {
+      count = 1024;
+    }
+    pool = new ArrayBlockingQueue<PooledObject>(count);
+    for (int i = 0; i < count; i++) {
+      final Object obj = config.allocator().allocate();
+      pool.offer(new LocalPooled(obj, true));
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Instantiated object pool with " + count + " entries for " 
+          + config.id());
+    }
+  }
+  
+  @Override
+  public PooledObject claim() {
+    PooledObject obj = pool.poll();
+    if (obj == null) {
+      tsdb.getStatsCollector().incrementCounter("objectpool.claim.miss", 
+          "pool", config.id());
+      return new LocalPooled(config.allocator().allocate(), false);
+    } else {
+      tsdb.getStatsCollector().incrementCounter("objectpool.claim.success", 
+          "pool", config.id());
+      return obj;
+    }
+  }
+
+  @Override
+  public PooledObject claim(long time, ChronoUnit unit) {
+    PooledObject obj = pool.poll();
+    if (obj == null) {
+      tsdb.getStatsCollector().incrementCounter("objectpool.claim.miss", 
+          "pool", config.id());
+      return new LocalPooled(config.allocator().allocate(), false);
+    } else {
+      tsdb.getStatsCollector().incrementCounter("objectpool.claim.success", 
+          "pool", config.id());
+      return obj;
+    }
+  }
+
+  @Override
+  public String id() {
+    return config.id();
+  }
+
+  @Override
+  public Deferred<Object> shutdown() {
+    return Deferred.fromResult(null);
+  }
+
+  /**
+   * Super simple wrapper.
+   */
+  private class LocalPooled implements PooledObject {
+    final Object obj;
+    final boolean was_pooled;
+    
+    protected LocalPooled(final Object obj, final boolean was_pooled) {
+      this.obj = obj;
+      this.was_pooled = was_pooled;
+    }
+    
+    @Override
+    public Object object() {
+      return obj;
+    }
+
+    @Override
+    public void release() {
+      if (was_pooled) {
+        if (!pool.offer(this)) {
+          LOG.warn("Failed to return a pooled object to the pool for " + config.id());
+        }
+      }
+    }
+    
+  };
+}

--- a/core/src/main/java/net/opentsdb/pools/BlockingQueueObjectPoolFactory.java
+++ b/core/src/main/java/net/opentsdb/pools/BlockingQueueObjectPoolFactory.java
@@ -1,0 +1,42 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2019  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.pools;
+
+import net.opentsdb.core.BaseTSDBPlugin;
+
+/**
+ * Generates blockign queue object pools.
+ * 
+ * @since 3.0
+ */
+public class BlockingQueueObjectPoolFactory extends BaseTSDBPlugin 
+  implements ObjectPoolFactory {
+
+  @Override
+  public ObjectPool newPool(final ObjectPoolConfig config) {
+    return new BlockingQueueObjectPool(tsdb, config);
+  }
+
+  @Override
+  public String type() {
+    return "BlockingQueueObjectPoolFactory";
+  }
+
+  @Override
+  public String version() {
+    return "3.0.0";
+  }
+
+}

--- a/core/src/main/java/net/opentsdb/pools/DummyObjectPool.java
+++ b/core/src/main/java/net/opentsdb/pools/DummyObjectPool.java
@@ -19,7 +19,6 @@ import java.time.temporal.ChronoUnit;
 import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.core.TSDB;
-import net.opentsdb.stats.StatsCollector;
 
 /**
  * This is a non-pooling pool that is used if no default implementation is found.
@@ -32,8 +31,8 @@ public class DummyObjectPool implements ObjectPool {
   /** The config. */
   private final ObjectPoolConfig config;
   
-  /** Stats. */
-  private final StatsCollector stats;
+  /** For stats. */
+  private final TSDB tsdb;
   
   /**
    * The default ctor.
@@ -41,13 +40,14 @@ public class DummyObjectPool implements ObjectPool {
    * @param config The non-null config we'll pull the allocator from.
    */
   public DummyObjectPool(final TSDB tsdb, final ObjectPoolConfig config) {
-    stats = tsdb.getStatsCollector();
+    this.tsdb = tsdb;
     this.config = config;
   }
   
   @Override
   public PooledObject claim() {
-    stats.incrementCounter("objectpool.claim.miss", "pool", config.id());
+    tsdb.getStatsCollector().incrementCounter("objectpool.claim.miss", 
+        "pool", config.id());
     final Object obj = config.allocator().allocate();;
     return new PooledObject() {
 
@@ -64,7 +64,8 @@ public class DummyObjectPool implements ObjectPool {
 
   @Override
   public PooledObject claim(long time, ChronoUnit unit) {
-    stats.incrementCounter("objectpool.claim.miss", "pool", config.id());
+    tsdb.getStatsCollector().incrementCounter("objectpool.claim.miss", 
+        "pool", config.id());
     final Object obj = config.allocator().allocate();;
     return new PooledObject() {
 

--- a/core/src/main/java/net/opentsdb/pools/LongArrayPool.java
+++ b/core/src/main/java/net/opentsdb/pools/LongArrayPool.java
@@ -78,7 +78,15 @@ public class LongArrayPool extends BaseObjectPoolAllocator {
   
   @Override
   protected void registerConfigs(final Configuration config, final String type) {
-    super.registerConfigs(config, type);
+    if (!config.hasProperty(configKey(POOL_ID_KEY, type))) {
+      config.register(configKey(POOL_ID_KEY, type), null, false, 
+          "The ID of an object pool factory plugin to use for this pool. "
+              + "Can be null to use the default.");
+    }
+    if (!config.hasProperty(configKey(COUNT_KEY, type))) {
+      config.register(configKey(COUNT_KEY, type), 4096, false, 
+          "The number of initial objects to allocate in this pool.");
+    }
     if (!config.hasProperty(configKey(LENGTH_KEY, TYPE))) {
       config.register(configKey(LENGTH_KEY, TYPE), 4096, false, 
           "The length of each array to allocate");

--- a/core/src/main/java/net/opentsdb/storage/MockDataStore.java
+++ b/core/src/main/java/net/opentsdb/storage/MockDataStore.java
@@ -1309,6 +1309,9 @@ public class MockDataStore implements WritableTimeSeriesDataStore {
       } else {
         this.id = id;
       }
+      
+      registerConfigs(tsdb.getConfig(), TYPE);
+      
       final ObjectPoolConfig config = DefaultObjectPoolConfig.newBuilder()
           .setAllocator(this)
           .setInitialCount(tsdb.getConfig().getInt(configKey(COUNT_KEY, TYPE)))

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Schema.java
@@ -1205,6 +1205,16 @@ public class Schema implements WritableTimeSeriesDataStore {
       final long id_hash, 
       final PartialTimeSeriesSet set,
       final RollupInterval interval) {
+    if (type == null) {
+      throw new IllegalArgumentException("Type cannot be null.");
+    }
+    if (base_timestamp == null) {
+      throw new IllegalArgumentException("Base timestamp cannot be null.");
+    }
+    if (set == null) {
+      throw new IllegalArgumentException("Set cannot be null.");
+    }
+    
     ObjectPool type_pool = pool_cache.get(type);
     ObjectPool array_pool = null;
     if (type_pool == null) {

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xNumericPartialTimeSeries.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xNumericPartialTimeSeries.java
@@ -59,19 +59,17 @@ public class Tsdb1xNumericPartialTimeSeries extends
   
   @Override
   public void release() {
-    if (reference_counter.decrementAndGet() <= 0) {
-      if (pooled_array != null) {
-        pooled_array.release();
-        pooled_array = null;
-      }
-      if (pooled_object != null) {
-        pooled_object.release();
-      }
-      set = null;
-      write_idx = 0;
-      needs_repair = false;
-      last_offset = -1;
+    if (pooled_array != null) {
+      pooled_array.release();
+      pooled_array = null;
     }
+    if (pooled_object != null) {
+      pooled_object.release();
+    }
+    set = null;
+    write_idx = 0;
+    needs_repair = false;
+    last_offset = -1;
   }
   
   @Override

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xNumericPartialTimeSeriesPool.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xNumericPartialTimeSeriesPool.java
@@ -56,7 +56,15 @@ public class Tsdb1xNumericPartialTimeSeriesPool extends BaseObjectPoolAllocator 
       this.id = id;
     }
     
-    registerConfigs(tsdb.getConfig(), TYPE);
+    if (!tsdb.getConfig().hasProperty(configKey(POOL_ID_KEY, TYPE))) {
+      tsdb.getConfig().register(configKey(POOL_ID_KEY, TYPE), null, false, 
+          "The ID of an object pool factory plugin to use for this pool. "
+              + "Can be null to use the default.");
+    }
+    if (!tsdb.getConfig().hasProperty(configKey(COUNT_KEY, TYPE))) {
+      tsdb.getConfig().register(configKey(COUNT_KEY, TYPE), 4096, false, 
+          "The number of initial objects to allocate in this pool.");
+    }
     
     final ObjectPoolConfig config = DefaultObjectPoolConfig.newBuilder()
         .setAllocator(this)

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xNumericSummaryPartialTimeSeries.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xNumericSummaryPartialTimeSeries.java
@@ -69,20 +69,18 @@ public class Tsdb1xNumericSummaryPartialTimeSeries extends
   
   @Override
   public void release() {
-    if (reference_counter.decrementAndGet() <= 0) {
-      if (pooled_array != null) {
-        pooled_array.release();
-        pooled_array = null;
-      }
-      if (pooled_object != null) {
-        pooled_object.release();
-      }
-      set = null;
-      write_idx = 0;
-      needs_repair = false;
-      last_ts = -1;
-      last_type = -1;
+    if (pooled_array != null) {
+      pooled_array.release();
+      pooled_array = null;
     }
+    if (pooled_object != null) {
+      pooled_object.release();
+    }
+    set = null;
+    write_idx = 0;
+    needs_repair = false;
+    last_ts = -1;
+    last_type = -1;
   }
   
   @Override

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xPartialTimeSeries.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xPartialTimeSeries.java
@@ -36,7 +36,6 @@ import net.opentsdb.rollup.RollupInterval;
  */
 public abstract class Tsdb1xPartialTimeSeries<T extends TimeSeriesDataType> 
     implements PartialTimeSeries<T>, CloseablePooledObject {
-  
   /** Reference to the Object pool for this instance. */
   protected PooledObject pooled_object;
   
@@ -145,7 +144,10 @@ public abstract class Tsdb1xPartialTimeSeries<T extends TimeSeriesDataType>
   
   @Override
   public void close() throws Exception {
-    release();
+    final int ref = reference_counter.decrementAndGet();
+    if (ref == 0) {
+      release();
+    }
   }
   
   @Override

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xPartialTimeSeriesSet.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xPartialTimeSeriesSet.java
@@ -14,7 +14,8 @@
 // limitations under the License.
 package net.opentsdb.storage.schemas.tsdb1x;
 
-import gnu.trove.map.TLongObjectMap;
+import java.util.Map;
+
 import net.opentsdb.core.TSDB;
 import net.opentsdb.data.NoDataPartialTimeSeries;
 import net.opentsdb.data.PartialTimeSeriesSet;
@@ -84,7 +85,7 @@ public class Tsdb1xPartialTimeSeriesSet implements PartialTimeSeriesSet,
   protected int total_sets;
   
   /** The reference to a map of time series IDs. */
-  protected TLongObjectMap<TimeSeriesId> ids;
+  protected Map<Long, TimeSeriesId> ids;
   
   /** A reference to the last partial time series discovered. */
   protected Tsdb1xPartialTimeSeries pts;
@@ -123,7 +124,7 @@ public class Tsdb1xPartialTimeSeriesSet implements PartialTimeSeriesSet,
                     final RollupUsage rollup_usage,
                     final int salts, 
                     final int total_sets, 
-                    final TLongObjectMap<TimeSeriesId> ids) {
+                    final Map<Long, TimeSeriesId> ids) {
     this.node = node;
     this.start.update(start);
     this.end.update(end);
@@ -175,9 +176,7 @@ public class Tsdb1xPartialTimeSeriesSet implements PartialTimeSeriesSet,
 
   @Override
   public TimeSeriesId id(final long hash) {
-    synchronized (ids) { // have to since it's a TLong map
-      return ids.get(hash);
-    }
+    return ids.get(hash);
   }
 
   @Override

--- a/core/src/main/resources/META-INF/services/net.opentsdb.pools.ObjectPoolFactory
+++ b/core/src/main/resources/META-INF/services/net.opentsdb.pools.ObjectPoolFactory
@@ -1,0 +1,1 @@
+net.opentsdb.pools.BlockingQueueObjectPoolFactory

--- a/core/src/test/java/net/opentsdb/pools/TestStringBuilderPool.java
+++ b/core/src/test/java/net/opentsdb/pools/TestStringBuilderPool.java
@@ -1,0 +1,76 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2019  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.pools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import net.opentsdb.core.MockTSDB;
+
+public class TestStringBuilderPool {
+  private static MockTSDB TSDB;
+  
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    TSDB = new MockTSDB();
+  }
+  
+  @Test
+  public void initialize() throws Exception {
+    ObjectPool pool = mock(ObjectPool.class);
+    ObjectPoolFactory factory = mock(ObjectPoolFactory.class);
+    when(factory.newPool(any(ObjectPoolConfig.class))).thenReturn(pool);
+    
+    StringBuilderPool allocator = new StringBuilderPool();
+    assertNull(allocator.initialize(TSDB, null).join());
+    assertEquals(StringBuilderPool.TYPE, allocator.id());
+    verify(TSDB.getRegistry(), atLeast(1)).registerObjectPool(
+        any(DummyObjectPool.class));
+    verify(TSDB.getRegistry(), never()).registerObjectPool(pool);
+    assertTrue(allocator.allocate() instanceof StringBuilder);
+    
+    when(TSDB.getRegistry().getPlugin(ObjectPoolFactory.class, null))
+      .thenReturn(factory);
+    assertNull(allocator.initialize(TSDB, null).join());
+    verify(TSDB.getRegistry(), times(1)).registerObjectPool(pool);
+    assertEquals(StringBuilderPool.TYPE, allocator.id());
+    assertTrue(allocator.allocate() instanceof StringBuilder);
+    
+    allocator.id = "foo";
+    allocator.registerConfigs(TSDB.config, StringBuilderPool.TYPE);
+    TSDB.config.override("objectpool.foo.pool.id", "myfactory");
+    TSDB.config.override("objectpool.foo.count.initial", "42");
+    ObjectPool pool2 = mock(ObjectPool.class);
+    ObjectPoolFactory factory2 = mock(ObjectPoolFactory.class);
+    when(factory2.newPool(any(ObjectPoolConfig.class))).thenReturn(pool2);
+    when(TSDB.getRegistry().getPlugin(ObjectPoolFactory.class, "myfactory"))
+      .thenReturn(factory);
+    
+    assertNull(allocator.initialize(TSDB, "foo").join());
+    verify(TSDB.getRegistry(), never()).registerObjectPool(pool2);
+  }
+  
+}

--- a/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterFactory.java
+++ b/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterFactory.java
@@ -25,12 +25,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import net.opentsdb.query.execution.serdes.BaseSerdesOptions;
-import net.opentsdb.query.execution.serdes.JsonV3QuerySerdes;
-import net.opentsdb.query.execution.serdes.JsonV3QuerySerdesFactory;
 import net.opentsdb.query.serdes.SerdesOptions;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringConverterForSource.java
+++ b/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringConverterForSource.java
@@ -103,7 +103,7 @@ public class TestByteToStringConverterForSource {
     assertTrue(source.sets.isEmpty());
     assertEquals(1, source.resolvers.size());
     
-    Resolver resolver = source.resolvers.get(42);
+    Resolver resolver = source.resolvers.get(42L);
     assertFalse(resolver.resolved.get());
     assertEquals(1, resolver.series.size());
     assertNotNull(resolver.deferred);
@@ -130,7 +130,7 @@ public class TestByteToStringConverterForSource {
     resolver.deferred.callback(decoded);
     
     assertEquals(1, source.decoded_ids.size());
-    assertSame(decoded, source.decoded_ids.get(42));
+    assertSame(decoded, source.decoded_ids.get(42L));
     assertEquals(2, source.sets.size());
     assertTrue(source.resolvers.isEmpty());
     assertEquals(2, sent_up.size());
@@ -143,7 +143,7 @@ public class TestByteToStringConverterForSource {
     source.resolve(pts_c);
     
     assertEquals(1, source.decoded_ids.size());
-    assertSame(decoded, source.decoded_ids.get(42));
+    assertSame(decoded, source.decoded_ids.get(42L));
     assertEquals(3, source.sets.size());
     assertTrue(source.resolvers.isEmpty());
     assertEquals(3, sent_up.size());
@@ -174,7 +174,7 @@ public class TestByteToStringConverterForSource {
     assertTrue(source.sets.isEmpty());
     assertEquals(1, source.resolvers.size());
     
-    Resolver resolver = source.resolvers.get(42);
+    Resolver resolver = source.resolvers.get(42L);
     assertFalse(resolver.resolved.get());
     assertEquals(1, resolver.series.size());
     assertNotNull(resolver.deferred);
@@ -189,22 +189,22 @@ public class TestByteToStringConverterForSource {
     assertTrue(source.sets.isEmpty());
     assertEquals(2, source.resolvers.size());
     
-    assertFalse(source.resolvers.get(42).resolved.get());
-    assertEquals(1, source.resolvers.get(42).series.size());
-    assertNotNull(source.resolvers.get(42).deferred);
-    assertFalse(source.resolvers.get(-1).resolved.get());
-    assertEquals(1, source.resolvers.get(-1).series.size());
-    assertNotNull(source.resolvers.get(-1).deferred);
+    assertFalse(source.resolvers.get(42L).resolved.get());
+    assertEquals(1, source.resolvers.get(42L).series.size());
+    assertNotNull(source.resolvers.get(42L).deferred);
+    assertFalse(source.resolvers.get(-1L).resolved.get());
+    assertEquals(1, source.resolvers.get(-1L).series.size());
+    assertNotNull(source.resolvers.get(-1L).deferred);
     assertTrue(sent_up.isEmpty());
     verify(factory, times(1)).resolveByteId(id_a, null);
     verify(factory, times(1)).resolveByteId(id_b, null);
     
     // resolve the first one
     TimeSeriesStringId decoded_a = mock(TimeSeriesStringId.class);
-    source.resolvers.get(42).deferred.callback(decoded_a);
+    source.resolvers.get(42L).deferred.callback(decoded_a);
     
     assertEquals(1, source.decoded_ids.size());
-    assertSame(decoded_a, source.decoded_ids.get(42));
+    assertSame(decoded_a, source.decoded_ids.get(42L));
     assertEquals(1, source.sets.size());
     assertEquals(1, source.resolvers.size());
     assertEquals(1, sent_up.size());
@@ -213,11 +213,11 @@ public class TestByteToStringConverterForSource {
     
     // resolve the first one
     TimeSeriesStringId decoded_b = mock(TimeSeriesStringId.class);
-    source.resolvers.get(-1).deferred.callback(decoded_b);
+    source.resolvers.get(-1L).deferred.callback(decoded_b);
     
     assertEquals(2, source.decoded_ids.size());
-    assertSame(decoded_a, source.decoded_ids.get(42));
-    assertSame(decoded_b, source.decoded_ids.get(-1));
+    assertSame(decoded_a, source.decoded_ids.get(42L));
+    assertSame(decoded_b, source.decoded_ids.get(-1L));
     assertEquals(1, source.sets.size());
     assertTrue(source.resolvers.isEmpty());
     assertEquals(2, sent_up.size());
@@ -260,7 +260,7 @@ public class TestByteToStringConverterForSource {
     assertTrue(source.sets.isEmpty());
     assertEquals(1, source.resolvers.size());
     
-    Resolver resolver = source.resolvers.get(42);
+    Resolver resolver = source.resolvers.get(42L);
     assertFalse(resolver.resolved.get());
     assertEquals(1, resolver.series.size());
     assertNotNull(resolver.deferred);

--- a/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverter.java
+++ b/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverter.java
@@ -321,7 +321,7 @@ public class TestByteToStringIdConverter {
     verify(upstream, never()).onError(any(Throwable.class));
     assertEquals(1, node.converters.size());
     ByteToStringConverterForSource src = node.converters.get("m1");
-    Resolver resolver = src.resolvers.get(42);
+    Resolver resolver = src.resolvers.get(42L);
     assertSame(pts_a, resolver.series.get(0));
     
     PartialTimeSeries pts_b = mock(PartialTimeSeries.class);
@@ -333,11 +333,11 @@ public class TestByteToStringIdConverter {
     verify(upstream, never()).onError(any(Throwable.class));
     assertEquals(2, node.converters.size());
     src = node.converters.get("m1");
-    resolver = src.resolvers.get(42);
+    resolver = src.resolvers.get(42L);
     assertSame(pts_a, resolver.series.get(0));
     
     src = node.converters.get("m2");
-    resolver = src.resolvers.get(-1);
+    resolver = src.resolvers.get(-1L);
     assertSame(pts_b, resolver.series.get(0));
   }
   

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchema.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestSchema.java
@@ -1195,5 +1195,20 @@ public class TestSchema extends SchemaBase {
           timestamp, 42, set, mock(RollupInterval.class));
       fail("Expected IllegalStateException");
     } catch (IllegalStateException e) { }
+    
+    try {
+      schema.newSeries(null, timestamp, 42, set, null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      schema.newSeries(NumericLongArrayType.TYPE, null, 42, set, null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      schema.newSeries(NumericLongArrayType.TYPE, timestamp, 42, null, null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
   }
 }

--- a/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestTsdb1xPartialTimeSeriesSet.java
+++ b/core/src/test/java/net/opentsdb/storage/schemas/tsdb1x/TestTsdb1xPartialTimeSeriesSet.java
@@ -27,13 +27,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import gnu.trove.map.TLongObjectMap;
 import net.opentsdb.core.MockTSDB;
 import net.opentsdb.data.NoDataPartialTimeSeries;
 import net.opentsdb.data.SecondTimeStamp;
@@ -50,7 +51,7 @@ public class TestTsdb1xPartialTimeSeriesSet {
   private static ObjectPool NO_DATA_POOL;
   
   private Tsdb1xQueryNode node;
-  private TLongObjectMap<TimeSeriesId> ids;
+  private Map<Long, TimeSeriesId> ids;
   
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -81,7 +82,7 @@ public class TestTsdb1xPartialTimeSeriesSet {
   @Before
   public void before() throws Exception {
     node = mock(Tsdb1xQueryNode.class);
-    ids = mock(TLongObjectMap.class);
+    ids = mock(Map.class);
     QueryNodeConfig config = mock(QueryNodeConfig.class);
     when(config.getId()).thenReturn("Mock");
     when(node.config()).thenReturn(config);

--- a/implementation/stormpot/src/test/java/net/opentsdb/pools/TestStormPotPool.java
+++ b/implementation/stormpot/src/test/java/net/opentsdb/pools/TestStormPotPool.java
@@ -219,6 +219,12 @@ public class TestStormPotPool {
     public TypeToken<?> dataType() {
       return TypeToken.of(byte[].class);
     }
+
+    
+    @Override
+    public int initialCount() {
+      return 8;
+    }
     
   }
 }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseQueryNode.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseQueryNode.java
@@ -56,6 +56,7 @@ import net.opentsdb.stats.Span;
 import net.opentsdb.storage.HBaseExecutor.State;
 import net.opentsdb.storage.schemas.tsdb1x.Schema;
 import net.opentsdb.storage.schemas.tsdb1x.Tsdb1xQueryNode;
+import net.opentsdb.storage.schemas.tsdb1x.Tsdb1xPartialTimeSeries;
 import net.opentsdb.uid.NoSuchUniqueName;
 import net.opentsdb.uid.UniqueIdType;
 import net.opentsdb.utils.Bytes;
@@ -493,11 +494,15 @@ public class Tsdb1xHBaseQueryNode implements Tsdb1xQueryNode {
             Tsdb1xScannersPool.TYPE).claim().object();
         ((Tsdb1xScanners) executor).reset(Tsdb1xHBaseQueryNode.this, config);
         if (initialized.compareAndSet(false, true)) {
-          executor.fetchNext(new Tsdb1xQueryResult(
-              sequence_id.incrementAndGet(), 
-              Tsdb1xHBaseQueryNode.this, 
-              parent.schema()), 
-          span);
+          if (push) {
+            executor.fetchNext(null, span);
+          } else {
+            executor.fetchNext(new Tsdb1xQueryResult(
+                sequence_id.incrementAndGet(), 
+                Tsdb1xHBaseQueryNode.this, 
+                parent.schema()), 
+            span);
+          }
         } else {
           LOG.error("WTF? We lost an initialization race??");
         }
@@ -594,11 +599,15 @@ public class Tsdb1xHBaseQueryNode implements Tsdb1xQueryNode {
             Tsdb1xScannersPool.TYPE).claim().object();
         ((Tsdb1xScanners) executor).reset(Tsdb1xHBaseQueryNode.this, config);
         if (initialized.compareAndSet(false, true)) {
-          executor.fetchNext(new Tsdb1xQueryResult(
-              sequence_id.incrementAndGet(), 
-              Tsdb1xHBaseQueryNode.this, 
-              parent.schema()), 
-          span);
+          if (push) {
+            executor.fetchNext(null, span);
+          } else {
+            executor.fetchNext(new Tsdb1xQueryResult(
+                sequence_id.incrementAndGet(), 
+                Tsdb1xHBaseQueryNode.this, 
+                parent.schema()), 
+            span);
+          }
         } else {
           LOG.error("WTF? We lost an initialization race??");
         }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xMultiGet.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xMultiGet.java
@@ -409,6 +409,7 @@ public class Tsdb1xMultiGet implements HBaseExecutor, CloseablePooledObject {
           } catch (Exception e) {
             LOG.error("Failed to close out set", e);
           }
+          sets.set(i, null);
         }
       }
     }
@@ -1011,13 +1012,6 @@ public class Tsdb1xMultiGet implements HBaseExecutor, CloseablePooledObject {
           node.parent().tsdb().getRegistry()
           .getObjectPool(Tsdb1xPartialTimeSeriesSetPool.TYPE)
           .claim().object();
-      set.reset(node, 
-          start, 
-          end, 
-          node.rollupUsage(),
-          1, 
-          sets.length(), 
-          ts_ids);
       if (!sets.compareAndSet(index, null, set)) {
         // lost the race
         try {
@@ -1025,8 +1019,15 @@ public class Tsdb1xMultiGet implements HBaseExecutor, CloseablePooledObject {
         } catch (Exception e) {
           LOG.error("Failed to close a set.", e);
         }
-        set = sets.get(index);
+        return sets.get(index);
       }
+      set.reset(node, 
+          start, 
+          end, 
+          node.rollupUsage(),
+          1, 
+          sets.length(), 
+          ts_ids);
     }
     return set;
   }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanners.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanners.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.hbase.async.Bytes.ByteMap;
 import org.hbase.async.FilterList.Operator;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.stumbleupon.async.Callback;
 
 import gnu.trove.map.TLongObjectMap;
@@ -185,7 +187,7 @@ public class Tsdb1xScanners implements HBaseExecutor, CloseablePooledObject {
   protected List<Duration> durations;
   
   /** A map of hashes to time series IDs for the sets. */
-  protected TLongObjectMap<TimeSeriesId> ts_ids;
+  protected Map<Long, TimeSeriesId> ts_ids;
     
   /**
    * Resets the cached scanners object.
@@ -277,7 +279,7 @@ public class Tsdb1xScanners implements HBaseExecutor, CloseablePooledObject {
         durations = Lists.newArrayList();
       }
       if (ts_ids == null) {
-        ts_ids = new TLongObjectHashMap<TimeSeriesId>();
+        ts_ids = Maps.newConcurrentMap();
       }
     }
   }
@@ -1422,18 +1424,14 @@ public class Tsdb1xScanners implements HBaseExecutor, CloseablePooledObject {
   }
 
   boolean idsContainsKey(final long hash) {
-    synchronized (ts_ids) {
-      return ts_ids.containsKey(hash);
-    }
+    return ts_ids.containsKey(hash);
   }
   
   void putId(final long hash, final TimeSeriesId id) {
-    synchronized (ts_ids) {
-      ts_ids.putIfAbsent(hash, id);
-    }
+    ts_ids.putIfAbsent(hash, id);
   }
   
-  TLongObjectMap<TimeSeriesId> tsIds() {
+   Map<Long, TimeSeriesId> tsIds() {
     return ts_ids;
   }
 }


### PR DESCRIPTION
- Add an initialCount() method to the ObjectPoolAllocator.

CORE:
- Support initialCount() in the BaseObjectPoolAllocator.
- Add a simple BlockingQueueObjectPool implementation. Looks like the Stormpot
  implementation has issues, maybe something to do with the thread local slot
  and we wind up stepping on checked-out objects.
- Bump default counts up for the LongArrayPool and numeric PTS.
  TODO - need to fix configs. They're all the same now.
- Add some validations to the Schema newSeries() call.
- Use the base Schema PTS to track references and remove it from the numeric
  and summary PTSs
- Fix the PTSSet in Schema wherein the order of object pool loading is
  indeterminate so we need to double check and cache the pool references.
- Add the StringBuilderObjectPool and use it in the Jsonv3 serdes class.

ASYNCHBASE:
- Don't instantiate QueryResults in Tsdb1xHBaseQueryNode when in push mode.
- In multiget, don't reset a node if we lost the race to claim one.
- In Scanners, restore closing sets.