### PR TITLE
HTTP:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/hacluster/HAClusterFactory.java
+++ b/core/src/main/java/net/opentsdb/query/hacluster/HAClusterFactory.java
@@ -348,6 +348,7 @@ public class HAClusterFactory extends BaseQueryNodeFactory implements
     }
     
     if (new_sources.size() == 1) {
+      // TODO - handle push-downs
       TimeSeriesDataSourceConfig rebuilt = (TimeSeriesDataSourceConfig) new_sources.get(0)
           .setId(config.getId())
           .build();

--- a/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Result.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Result.java
@@ -210,8 +210,16 @@ public class HttpQueryV3Result implements QueryResult {
     private final ZoneId time_zone;
     
     TimeSpec(final JsonNode node) {
-      start = new SecondTimeStamp(node.get("start").asLong());
-      end = new SecondTimeStamp(node.get("end").asLong());
+      long st = node.get("start").asLong();
+      long e = node.get("end").asLong();
+      if (st == HttpQueryV3Result.this.node.pipelineContext().query().startTime().epoch() &&
+          e == HttpQueryV3Result.this.node.pipelineContext().query().endTime().epoch()) {
+        start = HttpQueryV3Result.this.node.pipelineContext().query().startTime();
+        end = HttpQueryV3Result.this.node.pipelineContext().query().endTime();
+      } else {
+        start = new SecondTimeStamp(node.get("start").asLong());
+        end = new SecondTimeStamp(node.get("end").asLong());
+      }
       string_interval = node.get("interval").asText();
       if (string_interval.toLowerCase().equals("0all")) {
         interval = null;

--- a/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Source.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Source.java
@@ -131,8 +131,9 @@ public class HttpQueryV3Source extends AbstractQueryNode implements SourceNode {
   public void fetchNext(final Span span) {
     final long start = DateTime.nanoTime();
     SemanticQuery.Builder builder = SemanticQuery.newBuilder()
-        .setStart(context.query().getStart())
-        .setEnd(context.query().getEnd())
+        // always use the absolute time here so the queries match.
+        .setStart(Long.toString(context.query().startTime().msEpoch()))
+        .setEnd(Long.toString(context.query().endTime().msEpoch()))
         .setMode(context.query().getMode())
         .setTimeZone(context.query().getTimezone())
         .setLogLevel(context.query().getLogLevel());

--- a/executors/http/src/test/java/net/opentsdb/query/execution/TestHttpQueryV3Result.java
+++ b/executors/http/src/test/java/net/opentsdb/query/execution/TestHttpQueryV3Result.java
@@ -19,10 +19,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.time.ZoneId;
 import java.util.Iterator;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -35,7 +37,14 @@ import net.opentsdb.data.TypedTimeSeriesIterator;
 import net.opentsdb.data.types.numeric.NumericArrayType;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
+import net.opentsdb.query.QueryMode;
 import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.SemanticQuery;
+import net.opentsdb.query.TimeSeriesDataSourceConfig;
+import net.opentsdb.query.TimeSeriesQuery;
+import net.opentsdb.query.filter.MetricLiteralFilter;
 import net.opentsdb.rollup.DefaultRollupConfig;
 import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.rollup.RollupInterval;
@@ -43,6 +52,33 @@ import net.opentsdb.utils.JSON;
 
 public class TestHttpQueryV3Result {
 
+  private QueryNode query_node;
+  private QueryPipelineContext context;
+  private TimeSeriesQuery query;
+  
+  @Before
+  public void before() throws Exception {
+    query_node = mock(QueryNode.class);
+    context = mock(QueryPipelineContext.class);
+    TimeSeriesDataSourceConfig config = (TimeSeriesDataSourceConfig)
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("system.cpu.user")
+                .build())
+            .setFilterId(null)
+            .setId("m1")
+            .build();
+
+    query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1h-ago")
+        .addExecutionGraphNode(config)
+        .build();
+    
+    when(query_node.pipelineContext()).thenReturn(context);
+    when(context.query()).thenReturn(query);
+  }
+  
   @Test
   public void numericType() throws Exception {
     String json = "{\"results\":[{\"source\":\"m0:m0\",\"data\":["
@@ -57,7 +93,7 @@ public class TestHttpQueryV3Result {
     
     JsonNode node = JSON.getMapper().readTree(json);
     node = node.get("results").iterator().next();
-    HttpQueryV3Result result = new HttpQueryV3Result(mock(QueryNode.class), node, null);
+    HttpQueryV3Result result = new HttpQueryV3Result(query_node, node, null);
     assertNull(result.timeSpecification());
     assertEquals(2, result.timeSeries().size());
     assertNull(result.error());
@@ -134,7 +170,7 @@ public class TestHttpQueryV3Result {
     
     JsonNode node = JSON.getMapper().readTree(json);
     node = node.get("results").iterator().next();
-    HttpQueryV3Result result = new HttpQueryV3Result(mock(QueryNode.class), node, null);
+    HttpQueryV3Result result = new HttpQueryV3Result(query_node, node, null);
     assertEquals(1540567560, result.timeSpecification().start().epoch());
     assertEquals(1540567740, result.timeSpecification().end().epoch());
     assertEquals("1m", result.timeSpecification().stringInterval());
@@ -207,7 +243,7 @@ public class TestHttpQueryV3Result {
     
     JsonNode node = JSON.getMapper().readTree(json);
     node = node.get("results").iterator().next();
-    HttpQueryV3Result result = new HttpQueryV3Result(mock(QueryNode.class), node, null);
+    HttpQueryV3Result result = new HttpQueryV3Result(query_node, node, null);
     assertNull(result.timeSpecification());
     assertNull(result.error());
     assertNull(result.exception());
@@ -295,7 +331,7 @@ public class TestHttpQueryV3Result {
     
     JsonNode node = JSON.getMapper().readTree(json);
     node = node.get("results").iterator().next();
-    HttpQueryV3Result result = new HttpQueryV3Result(mock(QueryNode.class), node, rollup_config);
+    HttpQueryV3Result result = new HttpQueryV3Result(query_node, node, rollup_config);
     assertNull(result.timeSpecification());
     assertNull(result.error());
     assertNull(result.exception());
@@ -311,7 +347,7 @@ public class TestHttpQueryV3Result {
   @Test
   public void exception() throws Exception {
     RuntimeException ex = new RuntimeException("Boo!");
-    HttpQueryV3Result result = new HttpQueryV3Result(mock(QueryNode.class), null, null, ex);
+    HttpQueryV3Result result = new HttpQueryV3Result(query_node, null, null, ex);
     assertNull(result.timeSpecification());
     assertTrue(result.timeSeries().isEmpty());
     assertEquals("Boo!", result.error());
@@ -332,7 +368,7 @@ public class TestHttpQueryV3Result {
     
     JsonNode node = JSON.getMapper().readTree(json);
     node = node.get("results").iterator().next();
-    HttpQueryV3Result result = new HttpQueryV3Result(mock(QueryNode.class), node, null);
+    HttpQueryV3Result result = new HttpQueryV3Result(query_node, node, null);
     
     assertEquals(1540567560, result.timeSpecification().start().epoch());
     assertEquals(1540567740, result.timeSpecification().end().epoch());
@@ -377,6 +413,87 @@ public class TestHttpQueryV3Result {
     
     value = (TimeSeriesValue<NumericArrayType>) iterator.next();
     assertEquals(1540567560, value.timestamp().epoch());
+    assertEquals(0, value.value().offset());
+    assertEquals(1, value.value().end());
+    v = value.value().longArray();
+    
+    assertEquals(24, v[0]);
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void runAllMillis() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1559520000123")
+        .setEnd("1559523600123")
+        .addExecutionGraphNode((TimeSeriesDataSourceConfig)
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("system.cpu.user")
+                .build())
+            .setFilterId(null)
+            .setId("m1")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    String json = "{\"results\":[{\"source\":\"groupby:m1\","
+        + "\"timeSpecification\":{\"start\":1559520000,\"end\":1559523600,"
+        + "\"intervalISO\":null,\"interval\":\"0all\",\"timeZone\":"
+        + "\"UTC\",\"units\":null},\"data\":[{\"metric\":"
+        + "\"system.cpu.user\",\"tags\":{\"host\":\"web01\"},"
+        + "\"NumericType\":[42]},{\"metric\":"
+        + "\"system.cpu.user\",\"tags\":{\"host\":\"web02\"},"
+        + "\"NumericType\":[24]}]}]}";
+    
+    JsonNode node = JSON.getMapper().readTree(json);
+    node = node.get("results").iterator().next();
+    HttpQueryV3Result result = new HttpQueryV3Result(query_node, node, null);
+    
+    assertEquals(query.startTime().msEpoch(), result.timeSpecification().start().msEpoch());
+    assertEquals(query.endTime().msEpoch(), result.timeSpecification().end().msEpoch());
+    assertNull(result.timeSpecification().interval());
+    assertNull(result.timeSpecification().units());
+    assertEquals("0all", result.timeSpecification().stringInterval());
+    assertEquals(ZoneId.of("UTC"), result.timeSpecification().timezone());
+    assertEquals(2, result.timeSeries().size());
+    assertNull(result.error());
+    assertNull(result.exception());
+    assertEquals("m1", result.dataSource());
+    assertEquals(Const.TS_STRING_ID, result.idType());
+    
+    Iterator<TimeSeries> ts_iterator = result.timeSeries().iterator();
+    TimeSeries ts = ts_iterator.next();
+    TimeSeriesStringId id = (TimeSeriesStringId) ts.id();
+    assertEquals("system.cpu.user", id.metric());
+    assertEquals(1, id.tags().size());
+    assertEquals("web01", id.tags().get("host"));
+    assertEquals(1, ts.types().size());
+    assertTrue(ts.types().contains(NumericArrayType.TYPE));
+    
+    TypedTimeSeriesIterator iterator = ts.iterator(NumericArrayType.TYPE).get();
+    TimeSeriesValue<NumericArrayType> value = 
+        (TimeSeriesValue<NumericArrayType>) iterator.next();
+    assertEquals(query.startTime().msEpoch(), value.timestamp().msEpoch());
+    assertEquals(0, value.value().offset());
+    assertEquals(1, value.value().end());
+    long[] v = value.value().longArray();
+    
+    assertEquals(42, v[0]);
+    assertFalse(iterator.hasNext());
+    
+    ts = ts_iterator.next();
+    id = (TimeSeriesStringId) ts.id();
+    iterator = ts.iterator(NumericArrayType.TYPE).get();
+    assertEquals("system.cpu.user", id.metric());
+    assertEquals(1, id.tags().size());
+    assertEquals("web02", id.tags().get("host"));
+    assertEquals(1, ts.types().size());
+    assertTrue(ts.types().contains(NumericArrayType.TYPE));
+    
+    value = (TimeSeriesValue<NumericArrayType>) iterator.next();
+    assertEquals(query.startTime().msEpoch(), value.timestamp().msEpoch());
     assertEquals(0, value.value().offset());
     assertEquals(1, value.value().end());
     v = value.value().longArray();

--- a/executors/http/src/test/java/net/opentsdb/query/execution/TestHttpQueryV3Source.java
+++ b/executors/http/src/test/java/net/opentsdb/query/execution/TestHttpQueryV3Source.java
@@ -130,7 +130,8 @@ public class TestHttpQueryV3Source {
     assertEquals("application/json", request.getFirstHeader("Content-Type").getValue());
     assertNull(request.getFirstHeader("Cookie"));
     String json = EntityUtils.toString(((HttpPost) request).getEntity());
-    assertTrue(json.contains("\"start\":\"1h-ago\""));
+    assertTrue(json.matches(".*\"start\":\"\\d{13}\".*"));
+    assertTrue(json.matches(".*\"end\":\"\\d{13}\".*"));
     assertTrue(json.contains("\"mode\":\"SINGLE\""));
     assertTrue(json.contains("\"id\":\"m1\""));
     assertTrue(json.contains("\"metric\":\"system.cpu.user\""));
@@ -180,7 +181,8 @@ public class TestHttpQueryV3Source {
     assertEquals("application/json", request.getFirstHeader("Content-Type").getValue());
     assertNull(request.getFirstHeader("Cookie"));
     String json = EntityUtils.toString(((HttpPost) request).getEntity());
-    assertTrue(json.contains("\"start\":\"1h-ago\""));
+    assertTrue(json.matches(".*\"start\":\"\\d{13}\".*"));
+    assertTrue(json.matches(".*\"end\":\"\\d{13}\".*"));
     assertTrue(json.contains("\"mode\":\"SINGLE\""));
     assertTrue(json.contains("\"id\":\"m1\""));
     assertTrue(json.contains("\"metric\":\"system.cpu.user\""));
@@ -240,7 +242,8 @@ public class TestHttpQueryV3Source {
     assertEquals("application/json", request.getFirstHeader("Content-Type").getValue());
     assertNull(request.getFirstHeader("Cookie"));
     String json = EntityUtils.toString(((HttpPost) request).getEntity());
-    assertTrue(json.contains("\"start\":\"24h-ago\""));
+    assertTrue(json.matches(".*\"start\":\"\\d{13}\".*"));
+    assertTrue(json.matches(".*\"end\":\"\\d{13}\".*"));
     assertTrue(json.contains("\"mode\":\"SINGLE\""));
     assertTrue(json.contains("\"id\":\"m1\""));
     assertTrue(json.contains("\"interval\":\"15m\""));
@@ -304,7 +307,8 @@ public class TestHttpQueryV3Source {
     assertEquals("application/json", request.getFirstHeader("Content-Type").getValue());
     assertNull(request.getFirstHeader("Cookie"));
     String json = EntityUtils.toString(((HttpPost) request).getEntity());
-    assertTrue(json.contains("\"start\":\"1h-ago\""));
+    assertTrue(json.matches(".*\"start\":\"\\d{13}\".*"));
+    assertTrue(json.matches(".*\"end\":\"\\d{13}\".*"));
     assertTrue(json.contains("\"mode\":\"SINGLE\""));
     assertTrue(json.contains("\"id\":\"m1\""));
     assertTrue(json.contains("\"metric\":\"system.cpu.user\""));
@@ -351,7 +355,8 @@ public class TestHttpQueryV3Source {
     assertEquals("application/json", request.getFirstHeader("Content-Type").getValue());
     assertNull(request.getFirstHeader("Cookie"));
     String json = EntityUtils.toString(((HttpPost) request).getEntity());
-    assertTrue(json.contains("\"start\":\"1h-ago\""));
+    assertTrue(json.matches(".*\"start\":\"\\d{13}\".*"));
+    assertTrue(json.matches(".*\"end\":\"\\d{13}\".*"));
     assertTrue(json.contains("\"mode\":\"SINGLE\""));
     assertTrue(json.contains("\"id\":\"m1\""));
     assertTrue(json.contains("\"metric\":\"system.cpu.user\""));
@@ -418,7 +423,8 @@ public class TestHttpQueryV3Source {
     assertEquals("application/json", request.getFirstHeader("Content-Type").getValue());
     assertEquals("MyCookie", request.getFirstHeader("Cookie").getValue());
     String json = EntityUtils.toString(((HttpPost) request).getEntity());
-    assertTrue(json.contains("\"start\":\"1h-ago\""));
+    assertTrue(json.matches(".*\"start\":\"\\d{13}\".*"));
+    assertTrue(json.matches(".*\"end\":\"\\d{13}\".*"));
     assertTrue(json.contains("\"mode\":\"SINGLE\""));
     assertTrue(json.contains("\"id\":\"m1\""));
     assertTrue(json.contains("\"metric\":\"system.cpu.user\""));
@@ -448,7 +454,8 @@ public class TestHttpQueryV3Source {
     assertEquals("MyCookie", request.getFirstHeader("Cookie").getValue());
     assertEquals("UnitTest", request.getFirstHeader("X-OpenTSDB-User").getValue());
     String json = EntityUtils.toString(((HttpPost) request).getEntity());
-    assertTrue(json.contains("\"start\":\"1h-ago\""));
+    assertTrue(json.matches(".*\"start\":\"\\d{13}\".*"));
+    assertTrue(json.matches(".*\"end\":\"\\d{13}\".*"));
     assertTrue(json.contains("\"mode\":\"SINGLE\""));
     assertTrue(json.contains("\"id\":\"m1\""));
     assertTrue(json.contains("\"metric\":\"system.cpu.user\""));

--- a/implementation/server-undertow/src/main/java/net/opentsdb/tsd/TSDMain.java
+++ b/implementation/server-undertow/src/main/java/net/opentsdb/tsd/TSDMain.java
@@ -18,6 +18,7 @@ import com.google.common.base.Strings;
 import io.undertow.Handlers;
 import io.undertow.Undertow;
 import io.undertow.Undertow.Builder;
+import io.undertow.UndertowOptions;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.handlers.accesslog.AccessLogHandler;
 import io.undertow.server.handlers.accesslog.AccessLogReceiver;
@@ -87,6 +88,7 @@ public class TSDMain {
   
   public static final String READ_TO_KEY = "tsd.network.read_timeout";
   public static final String WRITE_TO_KEY = "tsd.network.write_timeout";
+  public static final String NO_REQUEST_KEY = "tsd.network.no_request_timeout";
   
   /** Defaults */
   public static final String DEFAULT_PATH = "/";
@@ -187,6 +189,9 @@ public class TSDMain {
     config.register(WRITE_TO_KEY, 5 * 60 * 1000, false, 
         "A timeout in milliseconds for writing data to a client after which "
         + "Undertow will close the connection.");
+    config.register(NO_REQUEST_KEY, 15 * 60 * 1000, false, 
+        "A timeout in milliseconds when we'll close a connection after not"
+        + "receiving a request.");
     
     int port = config.getInt(HTTP_PORT_KEY);
     int ssl_port = config.getInt(TLS_PORT_KEY);
@@ -336,6 +341,13 @@ public class TSDMain {
       // https://issues.jboss.org/browse/UNDERTOW-991
       builder.setSocketOption(Options.READ_TIMEOUT, config.getInt(READ_TO_KEY));
       builder.setSocketOption(Options.WRITE_TIMEOUT, config.getInt(WRITE_TO_KEY));
+      builder.setSocketOption(UndertowOptions.NO_REQUEST_TIMEOUT, 
+          config.getInt(NO_REQUEST_KEY));
+      
+      // https://issues.jboss.org/browse/UNDERTOW-991
+      builder.setWorkerOption(Options.KEEP_ALIVE, true);
+      builder.setSocketOption(Options.KEEP_ALIVE, true);
+      builder.setServerOption(Options.KEEP_ALIVE, true);
       
       server = builder.build();
       server.start();


### PR DESCRIPTION
- Implement a fudge for run-all queries downstream from the HA cluster
  where relative timestamps to different sources may differ a bit, particularly
  when set in milliseconds. Therefore we'll normalize them as best we can.