### PR TITLE
Allow rollup downsample and series aggregator to be different

### DIFF
--- a/src/rollup/RollupSeq.java
+++ b/src/rollup/RollupSeq.java
@@ -96,8 +96,8 @@ public final class RollupSeq implements iRowSeq {
     this.rollup_query = rollup_query;
     
     // TODO - others
-    need_count = rollup_query.getGroupBy() == Aggregators.AVG ||
-                 rollup_query.getGroupBy() == Aggregators.DEV;
+    need_count = rollup_query.getRollupAgg() == Aggregators.AVG ||
+                 rollup_query.getRollupAgg() == Aggregators.DEV;
     
     // WARNING overallocation
     qualifiers = new byte[rollup_query.getRollupInterval().getIntervals() * 2];


### PR DESCRIPTION
Hoping this fixes the issue described in https://github.com/OpenTSDB/opentsdb/issues/1501

Without the fix, I hit this exception, I think because of a mismatch between the downsample aggregator and series aggregator.
```
2019-06-20 15:18:21,789 ERROR [AsyncHBase I/O Worker #4] SaltScanner: Exception adding row to span
net.opentsdb.core.IllegalDataException: Attempt to add a different aggrregate cell =KeyValue(key=[0, 0, 0, 4, 0, 0, 5, 93, 8, 41, -128, 0, 0, 1, 0, 0, 1], family="t", qualifier=[0, 0, -64], value="d", timestamp=1561042795614), expected aggregator "sum:"
at net.opentsdb.rollup.RollupSeq.setRow(RollupSeq.java:159) ~[tsdb-2.4.1RC2skyscnr-290.jar:]
at net.opentsdb.rollup.RollupSpan.addRow(RollupSpan.java:70) ~[tsdb-2.4.1RC2skyscnr-290.jar:]
at net.opentsdb.core.SaltScanner.mergeDataPoints(SaltScanner.java:484) [tsdb-2.4.1RC2skyscnr-290.jar:]
at net.opentsdb.core.SaltScanner.mergeAndReturnResults(SaltScanner.java:362) [tsdb-2.4.1RC2skyscnr-290.jar:]
at net.opentsdb.core.SaltScanner.access$2800(SaltScanner.java:73) [tsdb-2.4.1RC2skyscnr-290.jar:]
at net.opentsdb.core.SaltScanner$ScannerCB.validateAndTriggerCallback(SaltScanner.java:1016) [tsdb-2.4.1RC2skyscnr-290.jar:]
at net.opentsdb.core.SaltScanner$ScannerCB.close(SaltScanner.java:980) [tsdb-2.4.1RC2skyscnr-290.jar:]
at net.opentsdb.core.SaltScanner$ScannerCB.call(SaltScanner.java:595) [tsdb-2.4.1RC2skyscnr-290.jar:]
at net.opentsdb.core.SaltScanner$ScannerCB.call(SaltScanner.java:516) [tsdb-2.4.1RC2skyscnr-290.jar:]
...
```

Here's a summary of some higher level testing performed to check the results and illustrate the problem.
**rollup_config.json**
```
{
    "aggregationIds": {
        "sum": 0,
        "count": 1,
        "min": 2,
        "max": 3,
        "avg": 4
    },
    "intervals": [
        {
            "table": "tsdb",
            "preAggregationTable": "tsdb",
            "interval": "1m",
            "rowSpan": "1h",
            "defaultInterval": true
        },
        {
            "table": "tsdb-rollup-1h",
            "preAggregationTable": "tsdb-rollup-1h",
            "interval": "1h",
            "rowSpan": "1d",
            "defaultInterval": false
        }
    ]
}
```

**Insert data**
```
curl -XPOST http://localhost:4242/api/rollup -d '[
  {"metric": "sys.cpu","timestamp": 1560859200,"value": 100,"tags": {"host": "1"},"interval": "1h","aggregator": "SUM"},
  {"metric": "sys.cpu","timestamp": 1560859200,"value": 5,"tags": {"host": "1"},"interval": "1h","aggregator": "COUNT"},
  {"metric": "sys.cpu","timestamp": 1560859200,"value": 50,"tags": {"host": "2"},"interval": "1h","aggregator": "SUM"},
  {"metric": "sys.cpu","timestamp": 1560859200,"value": 5,"tags": {"host": "2"},"interval": "1h","aggregator": "COUNT"},
  {"metric": "sys.cpu","timestamp": 1560862800,"value": 150,"tags": {"host": "1"},"interval": "1h","aggregator": "SUM"},
  {"metric": "sys.cpu","timestamp": 1560862800,"value": 10,"tags": {"host": "1"},"interval": "1h","aggregator": "COUNT"},
  {"metric": "sys.cpu","timestamp": 1560862800,"value": 50,"tags": {"host": "2"},"interval": "1h","aggregator": "SUM"},
  {"metric": "sys.cpu","timestamp": 1560862800,"value": 10,"tags": {"host": "2"},"interval": "1h","aggregator": "COUNT"}
]'
```

**Rollup query**
```
curl -X POST http://127.0.0.1:4242/api/query  -d '{
    "start": 1560859200,
    "end": 1560863000,
    "queries": [
        {
            "downsample": "1h-avg-zero",
            "aggregator": "sum",
            "metric": "sys.cpu",
            "rollupUsage": "ROLLUP_FALLBACK_RAW"
        }
    ]
}'
```

**Output**
```
[
    {
        "metric": "sys.cpu",
        "tags": {},
        "aggregateTags": [
            "host"
        ],
        "dps": {
            "1560859200": 30,   # (i.e. (100/5)+(50/5))
            "1560862800": 20    # (i.e. (150/10)+(50/10))
        }
    }
]
```