### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/processor/rate/RateConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/rate/RateConfig.java
@@ -82,6 +82,9 @@ public class RateConfig extends BaseQueryNodeConfig {
   
   /** Whether or not we just want a delta. */
   private boolean delta_only;
+  
+  /** Whether we want the rate to count. */
+  private boolean rate_to_count;
 
   /** Parsed values. */
   private Duration duration;
@@ -98,6 +101,7 @@ public class RateConfig extends BaseQueryNodeConfig {
     reset_value = builder.resetValue;
     interval = builder.interval;
     delta_only = builder.deltaOnly;
+    rate_to_count = builder.rateToCount;
     
     if (interval.toLowerCase().equals("auto")) {
       if (builder.start_time != null && builder.end_time != null) {
@@ -153,6 +157,11 @@ public class RateConfig extends BaseQueryNodeConfig {
   public boolean getDeltaOnly() {
     return delta_only;
   }
+
+  /** @return Whether or not we want to convert a rate to a count. */
+  public boolean getRateToCount() {
+    return rate_to_count;
+  }
   
   /** @return The duration of the rate to convert to. E.g. per second or per
    * 8 seconds, etc. */
@@ -174,6 +183,7 @@ public class RateConfig extends BaseQueryNodeConfig {
         .setCounterMax(counter_max)
         .setDeltaOnly(delta_only)
         .setResetValue(reset_value)
+        .setRateToCount(rate_to_count)
         .setOverrides(overrides)
         .setSources(sources)
         .setType(type)
@@ -288,7 +298,8 @@ public class RateConfig extends BaseQueryNodeConfig {
         .setCounterMax(options.counter_max)
         .setResetValue(options.reset_value)
         .setDropResets(options.drop_resets)
-        .setInterval(options.interval);
+        .setInterval(options.interval)
+        .setRateToCount(options.rate_to_count);
   }
   
   /**
@@ -308,6 +319,8 @@ public class RateConfig extends BaseQueryNodeConfig {
     private String interval = DEFAULT_INTERVAL;
     @JsonProperty
     private boolean deltaOnly;
+    @JsonProperty
+    private boolean rateToCount;
     private TimeStamp start_time;
     private TimeStamp end_time;
     private RateFactory factory;
@@ -343,6 +356,11 @@ public class RateConfig extends BaseQueryNodeConfig {
 
     public Builder setDeltaOnly(final boolean delta_only) {
       this.deltaOnly = delta_only;
+      return this;
+    }
+    
+    public Builder setRateToCount(final boolean rate_to_count) {
+      this.rateToCount = rate_to_count;
       return this;
     }
     

--- a/core/src/test/java/net/opentsdb/query/processor/rate/TestRateConfig.java
+++ b/core/src/test/java/net/opentsdb/query/processor/rate/TestRateConfig.java
@@ -18,9 +18,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 import java.util.List;
@@ -32,7 +31,6 @@ import org.junit.Test;
 import net.opentsdb.core.MockTSDB;
 import net.opentsdb.data.SecondTimeStamp;
 import net.opentsdb.utils.JSON;
-import org.mockito.Mockito;
 
 public class TestRateConfig {
 public static MockTSDB TSDB;
@@ -58,6 +56,7 @@ public static MockTSDB TSDB;
         .setCounterMax(Integer.MAX_VALUE)
         .setDropResets(true)
         .setDeltaOnly(true)
+        .setRateToCount(true)
         .setId("rate")
         .build();
     String json = JSON.serializeToString(options);
@@ -66,10 +65,11 @@ public static MockTSDB TSDB;
     assertTrue(json.contains("\"counterMax\":" + Integer.MAX_VALUE));
     assertTrue(json.contains("\"dropResets\":true"));
     assertTrue(json.contains("\"deltaOnly\":true"));
+    assertTrue(json.contains("\"rateToCount\":true"));
     
     json = "{\"id\":\"rate\",\"type\":\"Rate\",\"counter\":true,"
         + "\"interval\":\"60s\",\"dropResets\":true,\"counterMax\":2147483647,"
-        + "\"deltaOnly\":true}";
+        + "\"deltaOnly\":true,\"rateToCount\":true}";
     options = JSON.parseToObject(json, RateConfig.class);
     assertTrue(options.isCounter());
     assertTrue(options.getDropResets());
@@ -77,6 +77,7 @@ public static MockTSDB TSDB;
     assertEquals(Integer.MAX_VALUE, options.getCounterMax());
     assertTrue(options.getDropResets());
     assertTrue(options.getDeltaOnly());
+    assertTrue(options.getRateToCount());
   }
   
   @Test
@@ -84,6 +85,7 @@ public static MockTSDB TSDB;
     final RateConfig options = (RateConfig) RateConfig.newBuilder()
         .setCounter(true)
         .setInterval("60s")
+        .setRateToCount(true)
         .setCounterMax(Integer.MAX_VALUE)
         .setId("rate")
         .build();
@@ -91,6 +93,7 @@ public static MockTSDB TSDB;
         .setId("rate")
         .build();
     assertTrue(clone.isCounter());
+    assertTrue(clone.getRateToCount());
     assertFalse(clone.getDropResets());
     assertEquals("60s", clone.getInterval());
     assertEquals(0, clone.getResetValue());

--- a/core/src/test/java/net/opentsdb/query/processor/rate/TestRateNumericArrayIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/rate/TestRateNumericArrayIterator.java
@@ -150,6 +150,54 @@ public class TestRateNumericArrayIterator {
   }
   
   @Test
+  public void longsAsRate() {
+    setSource(new MutableNumericValue(new SecondTimeStamp(0L), 40),
+        new MutableNumericValue(new SecondTimeStamp(60L), 50),
+        new MutableNumericValue(new SecondTimeStamp(60L * 2), 40),
+        new MutableNumericValue(new SecondTimeStamp(60L * 3), 50),
+        new MutableNumericValue(new SecondTimeStamp(60L * 4), 40),
+        new MutableNumericValue(new SecondTimeStamp(60L * 5), 50));
+    
+    config = (RateConfig) RateConfig.newBuilder()
+        .setInterval("1s")
+        .setRateToCount(true)
+        .setId("foo")
+        .build();
+    
+    setupMock();
+    RateNumericArrayIterator it = new RateNumericArrayIterator(node, result,
+        Lists.newArrayList(source));
+    
+    assertTrue(it.hasNext());
+    TimeSeriesValue<NumericArrayType> value = 
+        (TimeSeriesValue<NumericArrayType>) it.next();
+    
+    assertArrayEquals(new double[] { Double.NaN, 3000, 2400, 
+        3000, 2400, 3000 }, 
+        value.value().doubleArray(), 0.001);
+    
+    assertFalse(it.hasNext());
+    
+    setSource(new MutableNumericValue(new SecondTimeStamp(0L), 0),
+        new MutableNumericValue(new SecondTimeStamp(60L), 60),
+        new MutableNumericValue(new SecondTimeStamp(60L * 2), 0),
+        new MutableNumericValue(new SecondTimeStamp(60L * 3), 60),
+        new MutableNumericValue(new SecondTimeStamp(60L * 4), 0),
+        new MutableNumericValue(new SecondTimeStamp(60L * 5), 60));
+    
+    it = new RateNumericArrayIterator(node, result,
+        Lists.newArrayList(source));
+    
+    assertTrue(it.hasNext());
+    value = (TimeSeriesValue<NumericArrayType>) it.next();
+    
+    assertArrayEquals(new double[] { Double.NaN, 3600, 0, 3600, 0, 3600 }, 
+        value.value().doubleArray(), 0.001);
+    
+    assertFalse(it.hasNext());
+  }
+  
+  @Test
   public void doubles() {
     setSource(new MutableNumericValue(new SecondTimeStamp(0L), 40.5),
         new MutableNumericValue(new SecondTimeStamp(60L), 50.5),

--- a/core/src/test/java/net/opentsdb/query/processor/rate/TestRateNumericIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/rate/TestRateNumericIterator.java
@@ -894,6 +894,110 @@ public class TestRateNumericIterator {
     assertFalse(it.hasNext());
   }
   
+  @Test
+  public void rateToCounterLongs() {
+    source = new NumericMillisecondShard(BaseTimeSeriesStringId.newBuilder()
+          .setMetric("a")
+          .build(), 
+        new MillisecondTimeStamp(BASE_TIME), 
+        new MillisecondTimeStamp(BASE_TIME + 10000000));
+    ((NumericMillisecondShard) source).add(BASE_TIME, 40);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 2000000L, 50);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 3600000L, 40);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 3605000L, 50);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 7200000L, 40);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 9200000L, 50);
+    
+    config = (RateConfig) RateConfig.newBuilder()
+        .setInterval("1s")
+        .setRateToCount(true)
+        .setId("foo")
+        .build();
+    
+    setupMock();
+    RateNumericIterator it = new RateNumericIterator(node, result,
+        Lists.newArrayList(source));
+    
+    assertTrue(it.hasNext());
+    TimeSeriesValue<NumericType> v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 2000000L, v.timestamp().msEpoch());
+    assertEquals(100000, v.value().doubleValue(), 0.001);
+    
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 3600000L, v.timestamp().msEpoch());
+    assertEquals(64000, v.value().doubleValue(), 0.001);
+    
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 3605000L, v.timestamp().msEpoch());
+    assertEquals(250, v.value().doubleValue(), 0.001);
+
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 7200000L, v.timestamp().msEpoch());
+    assertEquals(143800, v.value().doubleValue(), 0.001);
+    
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 9200000L, v.timestamp().msEpoch());
+    assertEquals(100000, v.value().doubleValue(), 0.001);
+    
+    assertFalse(it.hasNext());
+  }
+  
+  @Test
+  public void rateToCounterDoubles() {
+    source = new NumericMillisecondShard(BaseTimeSeriesStringId.newBuilder()
+          .setMetric("a")
+          .build(), 
+        new MillisecondTimeStamp(BASE_TIME), 
+        new MillisecondTimeStamp(BASE_TIME + 10000000));
+    ((NumericMillisecondShard) source).add(BASE_TIME, 40.5);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 2000000L, 50.5);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 3600000L, 40.5);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 3605000L, 50.5);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 7200000L, 40.5);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 9200000L, 50.5);
+    
+    config = (RateConfig) RateConfig.newBuilder()
+        .setInterval("1s")
+        .setRateToCount(true)
+        .setId("foo")
+        .build();
+    
+    setupMock();
+    RateNumericIterator it = new RateNumericIterator(node, result,
+         Lists.newArrayList(source));
+    
+    assertTrue(it.hasNext());
+    TimeSeriesValue<NumericType> v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 2000000L, v.timestamp().msEpoch());
+    assertEquals(101000, v.value().doubleValue(), 0.001);
+    
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 3600000L, v.timestamp().msEpoch());
+    assertEquals(64800, v.value().doubleValue(), 0.001);
+    
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 3605000L, v.timestamp().msEpoch());
+    assertEquals(252.5, v.value().doubleValue(), 0.001);
+
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 7200000L, v.timestamp().msEpoch());
+    assertEquals(145597.5, v.value().doubleValue(), 0.001);
+    
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 9200000L, v.timestamp().msEpoch());
+    assertEquals(101000, v.value().doubleValue(), 0.001);
+    
+    assertFalse(it.hasNext());
+  }
+  
   // TODO - test greater intervals once supported.
   
   @Test


### PR DESCRIPTION
- Add the rate to count flag for the Rate config. This is useful for systems like
  StatsD that report the rate per second allowing users to convert back number of
  measurements per interval.