### PR TITLE
ASYNCHBASE:

### DIFF
--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseQueryNode.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseQueryNode.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.hbase.async.HBaseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -308,7 +309,11 @@ public class Tsdb1xHBaseQueryNode implements Tsdb1xQueryNode {
     context.tsdb().getQueryThreadPool().submit(new Runnable() {
       @Override
       public void run() {
-        sendUpstream(t);        
+        if (t instanceof HBaseException) {
+          sendUpstream(new QueryExecutionException(t.getMessage(), 502, t));
+        } else {
+          sendUpstream(t);
+        }
       }
     }, context.queryContext());
   }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xMultiGet.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xMultiGet.java
@@ -592,7 +592,7 @@ public class Tsdb1xMultiGet implements HBaseExecutor, CloseablePooledObject {
           continue;
         }
         
-        if (node.push()) {
+        if (node != null && node.push()) {
           if (base_ts.epoch() == 0) {
             node.schema().baseTimestamp(result.getCells().get(0).key(), base_ts);
           }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanner.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanner.java
@@ -727,7 +727,9 @@ public class Tsdb1xScanner implements CloseablePooledObject {
         state = State.COMPLETE;
         owner.scannerDone();
       }
-      scanner.close(); // TODO - attach a callback for logging in case
+      if (scanner != null) {
+        scanner.close(); // TODO - attach a callback for logging in case
+      }
       // something goes pear shaped.
       clear();
     }
@@ -808,7 +810,9 @@ public class Tsdb1xScanner implements CloseablePooledObject {
   @Override
   public void close() {
     try {
-      scanner.close();
+      if (scanner != null) {
+        scanner.close();
+      }
     } catch (Exception e) {
       LOG.error("Failed to close scanner", e);
     }


### PR DESCRIPTION
- Bubble up HBase exceptions as 502s.
- Fix a couple of null checks when an exception happens while a scanner or
  multiget is inflight and responds after a failure.