### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/stats/QueryStats.java
+++ b/common/src/main/java/net/opentsdb/stats/QueryStats.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017  The OpenTSDB Authors.
+// Copyright (C) 2017-2019  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 package net.opentsdb.stats;
+
+import net.opentsdb.query.QueryContext;
 
 /**
  * A collector for statistics about a particular query including tracing and
@@ -36,4 +38,34 @@ public interface QueryStats {
    * a non-null tracer.
    */
   public Span querySpan();
+  
+  /**
+   * Called by the context to set the reference. Since we assign this to the 
+   * context during a build, we don't have a context to set. So the context
+   * <b>must</b> call this if we want any good stats.
+   * @param context The non-null context to set.
+   */
+  public void setQueryContext(final QueryContext context);
+  
+  /**
+   * Called to emit the stats collected by this object.
+   */
+  public void emitStats();
+  
+  public void incrementRawDataSize(final long size);
+  
+  public void incrementSerializedDataSize(final long size);
+  
+  public void incrementRawTimeSeriesCount(final long count);
+  
+  public void incrementSerializedTimeSeriesCount(final long count);
+  
+  public long rawDataSize();
+  
+  public long serializedDataSize();
+  
+  public long rawTimeSeriesCount();
+  
+  public long serializedTimeSeriesCount();
+  
 }

--- a/common/src/test/java/net/opentsdb/stats/MockStats.java
+++ b/common/src/test/java/net/opentsdb/stats/MockStats.java
@@ -14,6 +14,8 @@
 // limitations under the License.
 package net.opentsdb.stats;
 
+import net.opentsdb.query.QueryContext;
+
 /**
  * Class used for testing pipelines with a mock stats collector.
  */
@@ -39,6 +41,66 @@ public class MockStats implements QueryStats {
   @Override
   public Span querySpan() {
     return query_span;
+  }
+
+  @Override
+  public void setQueryContext(QueryContext context) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public void emitStats() {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public void incrementRawDataSize(long size) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public void incrementSerializedDataSize(long size) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public void incrementRawTimeSeriesCount(long count) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public void incrementSerializedTimeSeriesCount(long count) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public long rawDataSize() {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public long serializedDataSize() {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public long rawTimeSeriesCount() {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public long serializedTimeSeriesCount() {
+    // TODO Auto-generated method stub
+    return 0;
   }
 
 }

--- a/core/src/main/java/net/opentsdb/query/BaseQueryContext.java
+++ b/core/src/main/java/net/opentsdb/query/BaseQueryContext.java
@@ -78,6 +78,9 @@ public abstract class BaseQueryContext implements QueryContext {
           .start();
     }
     auth_state = builder.auth_state;
+    if (stats != null) {
+      stats.setQueryContext(this);
+    }
   }
   
   @Override

--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
@@ -63,6 +63,7 @@ import net.opentsdb.query.TimeSeriesQuery.LogLevel;
 import net.opentsdb.query.serdes.SerdesCallback;
 import net.opentsdb.query.serdes.SerdesOptions;
 import net.opentsdb.query.serdes.TimeSeriesSerdes;
+import net.opentsdb.stats.QueryStats;
 import net.opentsdb.stats.Span;
 import net.opentsdb.utils.Exceptions;
 import net.opentsdb.utils.JSON;
@@ -128,6 +129,11 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes {
       throw new IllegalArgumentException("Data may not be null.");
     }
     final JsonV2QuerySerdesOptions opts = (JsonV2QuerySerdesOptions) options;
+    
+    final QueryStats stats = context.stats();
+    if (stats != null) {
+      stats.incrementSerializedTimeSeriesCount(result.timeSeries().size());
+    }
     
     if (!initialized) {
       try {
@@ -275,13 +281,13 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes {
 
   @Override
   public void serializeComplete(final Span span) {
-    if (!initialized /* Onlyl on QueryResult */ && partials.size() > 0) {
+    if (!initialized /* Only on QueryResult */ && partials.size() > 0) {
       serializePush();
     }
     
     try {
       // TODO - other bits like the query and trace data
-      if (!initialized /* Onlyl on QueryResult */ && partials.isEmpty()) {
+      if (!initialized /* Only on QueryResult */ && partials.isEmpty()) {
         json.writeStartObject();
         json.writeArrayFieldStart("results");
       }

--- a/core/src/main/java/net/opentsdb/stats/DefaultQueryStats.java
+++ b/core/src/main/java/net/opentsdb/stats/DefaultQueryStats.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017  The OpenTSDB Authors.
+// Copyright (C) 2017-2019  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,14 @@
 // limitations under the License.
 package net.opentsdb.stats;
 
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.base.Strings;
+
+import net.opentsdb.query.QueryContext;
+import net.opentsdb.query.QueryNodeConfig;
+import net.opentsdb.query.TimeSeriesDataSourceConfig;
+
 /**
  * A simple default implementation of the Query Stats object. It simply takes a
  * trace for now. It will start a new span if the trace is not null.
@@ -23,8 +31,18 @@ package net.opentsdb.stats;
  * @since 3.0
  */
 public class DefaultQueryStats implements QueryStats {
+  private static final String RAW_DATA_METRIC = "storage.data.bytes";
+  private static final String RAW_TIMESERIES_METRIC = "storage.timeseries.count";
+  private static final String SERIALIZED_DATA_METRIC = "serialized.data.bytes";
+  private static final String SERIALIZED_TIMESERIES_METRIC = "serialized.timeseries.count";
+  
+  private QueryContext context;
   private final Trace trace;
   private final Span query_span;
+  private final AtomicLong raw_data_size;
+  private final AtomicLong raw_time_series_count;
+  private final AtomicLong serialized_data_size;
+  private final AtomicLong serialized_time_series_count;
   
   /**
    * Protected ctor.
@@ -33,6 +51,15 @@ public class DefaultQueryStats implements QueryStats {
   DefaultQueryStats(final Builder builder) {
     trace = builder.trace;
     query_span = builder.query_span;
+    raw_data_size = new AtomicLong();
+    raw_time_series_count = new AtomicLong();
+    serialized_data_size = new AtomicLong();
+    serialized_time_series_count = new AtomicLong();
+  }
+  
+  @Override
+  public void setQueryContext(final QueryContext context) {
+    this.context = context;
   }
   
   @Override
@@ -45,6 +72,83 @@ public class DefaultQueryStats implements QueryStats {
     return query_span;
   }
   
+  @Override
+  public void emitStats() {
+    if (context == null) {
+      throw new IllegalStateException("Context wasn't set!");
+    }
+    
+    final StatsCollector stats = context.tsdb().getStatsCollector();
+    if (stats == null) {
+      return;
+    }
+ 
+    // extract a namespace if possible.
+    String namespace = null;
+    for (final QueryNodeConfig config : context.query().getExecutionGraph()) {
+      if (config instanceof TimeSeriesDataSourceConfig) {
+        String local_namespace = ((TimeSeriesDataSourceConfig) config).getNamespace();
+        if (Strings.isNullOrEmpty(local_namespace)) {
+          // extract from metric filter.
+          local_namespace = ((TimeSeriesDataSourceConfig) config).getMetric().getMetric();
+          local_namespace = local_namespace.substring(0, local_namespace.indexOf('.'));
+        }
+        
+        if (namespace == null) {
+          namespace = local_namespace;
+        } else {
+          if (!namespace.equals(local_namespace)) {
+            // Different namespaces so we won't use one. 
+            namespace = "MultipleNameSpaces";
+            break;
+          }
+        }
+      }
+    }
+    
+    final String[] tags = new String[] { 
+        context.authState() != null ? 
+            context.authState().getUser() : "Unkown",
+        "namespace", namespace };
+    
+    stats.setGauge(RAW_DATA_METRIC, raw_data_size.get(), tags);
+    stats.setGauge(RAW_TIMESERIES_METRIC, raw_time_series_count.get(), tags);
+    stats.setGauge(SERIALIZED_DATA_METRIC, serialized_data_size.get(), tags);
+    stats.setGauge(SERIALIZED_TIMESERIES_METRIC, serialized_time_series_count.get(), tags);
+  }
+  
+  public void incrementRawDataSize(final long size) {
+    raw_data_size.addAndGet(size);
+  }
+  
+  public void incrementSerializedDataSize(final long size) {
+    serialized_data_size.addAndGet(size);
+  }
+  
+  public void incrementRawTimeSeriesCount(final long count) {
+    raw_time_series_count.addAndGet(count);
+  }
+  
+  public void incrementSerializedTimeSeriesCount(final long count) {
+    serialized_time_series_count.addAndGet(count);
+  }
+  
+  public long rawDataSize() {
+    return raw_data_size.get();
+  }
+  
+  public long serializedDataSize() {
+    return serialized_data_size.get();
+  }
+  
+  public long rawTimeSeriesCount() {
+    return raw_time_series_count.get();
+  }
+  
+  public long serializedTimeSeriesCount() {
+    return serialized_time_series_count.get();
+  }
+  
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -54,7 +158,6 @@ public class DefaultQueryStats implements QueryStats {
    */
   public static class Builder {
     private Trace trace;
-    
     private Span query_span;
     
     /**

--- a/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Source.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Source.java
@@ -421,9 +421,19 @@ public class HttpQueryV3Source extends AbstractQueryNode implements SourceNode {
               }
             }
             
+            if (context.queryContext().stats() != null) {
+              context.queryContext().stats().incrementRawDataSize(json.length());
+            }
+            
             for (final JsonNode result : results) {
-              sendUpstream(new HttpQueryV3Result(HttpQueryV3Source.this, result, 
-                  ((TimeSeriesDataSourceFactory) factory).rollupConfig()));
+              final HttpQueryV3Result series_result = new HttpQueryV3Result(
+                  HttpQueryV3Source.this, result, 
+                    ((TimeSeriesDataSourceFactory) factory).rollupConfig());
+              if (context.queryContext().stats() != null) {
+                context.queryContext().stats().incrementRawTimeSeriesCount(
+                    series_result.timeSeries().size());
+              }
+              sendUpstream(series_result);
             }
           }
         } catch (Throwable t) {

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseQueryNode.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseQueryNode.java
@@ -54,6 +54,7 @@ import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
 import net.opentsdb.rollup.RollupInterval;
 import net.opentsdb.rollup.RollupUtils.RollupUsage;
+import net.opentsdb.stats.QueryStats;
 import net.opentsdb.stats.Span;
 import net.opentsdb.storage.HBaseExecutor.State;
 import net.opentsdb.storage.schemas.tsdb1x.Schema;
@@ -271,6 +272,10 @@ public class Tsdb1xHBaseQueryNode implements Tsdb1xQueryNode {
 
   @Override
   public void onNext(final QueryResult next) {
+    final QueryStats stats = pipelineContext().queryContext().stats();
+    if (stats != null) {
+      stats.incrementRawTimeSeriesCount(next.timeSeries().size());
+    }
     context.tsdb().getQueryThreadPool().submit(new Runnable() {
       final State state = executor.state();
       


### PR DESCRIPTION
- Add some getters and setters to track some useful metrics in QueryStats.

CORE:
- Track these serialized time series and bytes stats.

HTTP:
- Track the raw stats in HttpQueryV3Source.

ASYNCHBASE:
- Track the raw stats.