### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/processor/rate/RateConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/rate/RateConfig.java
@@ -367,10 +367,12 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
       this.deltaOnly = delta_only;
       return this;
     }
+    
     public Builder setRateToCount(final boolean rate_to_count) {
       this.rateToCount = rate_to_count;
       return this;
     }
+    
     public Builder setStartTime(final TimeStamp start_time) {
       this.start_time = start_time;
       return this;

--- a/core/src/main/java/net/opentsdb/query/processor/rate/RateFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/rate/RateFactory.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018  The OpenTSDB Authors.
+// Copyright (C) 2017-2019  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,8 +36,6 @@ import net.opentsdb.data.TypedTimeSeriesIterator;
 import net.opentsdb.data.types.numeric.NumericArrayType;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryIteratorFactory;
-import net.opentsdb.query.QueryNode;
-import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.plan.QueryPlanner;
@@ -121,7 +119,7 @@ public class RateFactory extends BaseQueryNodeFactory<RateConfig, Rate> {
             getQueryNodeFactory(DownsampleFactory.TYPE.toLowerCase());
         intervals = downsample_factory.intervals();
       }
-      plan.replace(config, config.newBuilder()
+      plan.replace(config, config.toBuilder()
           .setFactory(this)
           .setStartTime(context.query().startTime())
           .setEndTime(context.query().endTime())

--- a/core/src/test/java/net/opentsdb/query/processor/rate/TestRateFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/rate/TestRateFactory.java
@@ -17,7 +17,9 @@ package net.opentsdb.query.processor.rate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -25,24 +27,77 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.stumbleupon.async.Deferred;
 
+import net.opentsdb.core.DefaultRegistry;
+import net.opentsdb.core.MockTSDB;
 import net.opentsdb.core.MockTSDBDefault;
 import net.opentsdb.data.BaseTimeSeriesStringId;
 import net.opentsdb.data.MillisecondTimeStamp;
 import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesDataSource;
+import net.opentsdb.data.TimeSeriesDataSourceFactory;
 import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.types.numeric.NumericMillisecondShard;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
+import net.opentsdb.query.QueryContext;
 import net.opentsdb.query.QueryIteratorFactory;
+import net.opentsdb.query.QueryMode;
 import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryNodeConfig;
+import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.SemanticQuery;
+import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
+import net.opentsdb.query.filter.MetricLiteralFilter;
+import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
+import net.opentsdb.query.plan.DefaultQueryPlanner;
+import net.opentsdb.query.pojo.FillPolicy;
+import net.opentsdb.stats.QueryStats;
+import net.opentsdb.stats.Span;
 
 public class TestRateFactory {
 
+
+  private static MockTSDB TSDB;
+  private static RateFactory FACTORY;
+  private static NumericInterpolatorConfig NUMERIC_CONFIG;
+  private static TimeSeriesDataSource SRC_MOCK;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    TSDB = new MockTSDB();
+    TSDB.registry = spy(new DefaultRegistry(TSDB));
+    SRC_MOCK = mock(TimeSeriesDataSource.class);
+    ((DefaultRegistry) TSDB.registry).initialize(true).join(60_000);
+    TimeSeriesDataSourceFactory s1 = mock(TimeSeriesDataSourceFactory.class);
+    when(s1.newNode(any(QueryPipelineContext.class), any(QueryNodeConfig.class)))
+      .thenReturn(SRC_MOCK);
+    TSDB.registry.registerPlugin(TimeSeriesDataSourceFactory.class, null, s1);
+    FACTORY = new RateFactory();
+    FACTORY.registerConfigs(TSDB);
+    FACTORY.initialize(TSDB, null).join(250);
+    
+    NUMERIC_CONFIG = (NumericInterpolatorConfig)
+        NumericInterpolatorConfig.newBuilder()
+            .setFillPolicy(FillPolicy.NOT_A_NUMBER)
+            .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
+            .setDataType(NumericType.TYPE.toString())
+            .build();
+    
+    QueryNodeConfig config = mock(QueryNodeConfig.class);
+    when(config.getId()).thenReturn("mock");
+    when(SRC_MOCK.config()).thenReturn(config);
+    when(SRC_MOCK.initialize(any(Span.class))).thenReturn(
+        Deferred.fromResult(null));
+  }
+  
   @Test
   public void ctor() throws Exception {
     final RateFactory factory = new RateFactory();
@@ -146,5 +201,79 @@ public class TestRateFactory {
       factory.newTypedIterator(NumericType.TYPE, node, result, Collections.emptyList());
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
+  }
+
+  @Test
+  public void setupGraph() throws Exception {
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setStart("1546304400")
+        .setEnd("1546308000")
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.if.in")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(RateConfig.newBuilder()
+            .setInterval("1s")
+            .addSource("m1")
+            .setId("rate")
+            .build())
+        .build();
+    
+    QueryContext ctx = mock(QueryContext.class);
+    when(ctx.stats()).thenReturn(mock(QueryStats.class));
+    QueryPipelineContext context = mock(QueryPipelineContext.class);
+    when(context.tsdb()).thenReturn(TSDB);
+    when(context.query()).thenReturn(query);
+    when(context.queryContext()).thenReturn(ctx);
+    when(context.downstreamSources(any(QueryNode.class)))
+        .thenReturn(Lists.newArrayList(SRC_MOCK));
+    
+    QueryNode ctx_node = mock(QueryNode.class);
+    DefaultQueryPlanner planner = new DefaultQueryPlanner(context, ctx_node);
+    planner.plan(null).join(250);
+    
+    assertEquals(3, planner.configGraph().nodes().size());
+    Rate node = (Rate) planner.nodeForId("rate");
+    assertEquals("1s", node.config().getInterval());
+  }
+  
+  @Test
+  public void setupGraphAuto() throws Exception {
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setStart("1546304400")
+        .setEnd("1546308000")
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.if.in")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(RateConfig.newBuilder()
+            .setInterval("auto")
+            .addSource("m1")
+            .setId("rate")
+            .build())
+        .build();
+    
+    QueryContext ctx = mock(QueryContext.class);
+    when(ctx.stats()).thenReturn(mock(QueryStats.class));
+    QueryPipelineContext context = mock(QueryPipelineContext.class);
+    when(context.tsdb()).thenReturn(TSDB);
+    when(context.query()).thenReturn(query);
+    when(context.queryContext()).thenReturn(ctx);
+    when(context.downstreamSources(any(QueryNode.class)))
+        .thenReturn(Lists.newArrayList(SRC_MOCK));
+    
+    QueryNode ctx_node = mock(QueryNode.class);
+    DefaultQueryPlanner planner = new DefaultQueryPlanner(context, ctx_node);
+    planner.plan(null).join(250);
+    
+    assertEquals(3, planner.configGraph().nodes().size());
+    Rate node = (Rate) planner.nodeForId("rate");
+    assertEquals("1m", node.config().getInterval());
   }
 }

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/RawQueryRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/RawQueryRpc.java
@@ -176,7 +176,7 @@ public class RawQueryRpc {
         //.put("queryHash", Bytes.byteArrayToString(query.buildTimelessHashCode().asBytes()))
         .put("traceId", trace != null ? trace.traceId() : "")
         .put("user", auth_state != null ? auth_state.getUser() : "Unkown")
-        .put("query", JSON.serializeToString(query))
+        .put("query", query)
         .build()));
     Span setup_span = null;
     if (query_span != null) {


### PR DESCRIPTION
- Fix a bug in the rate factory setupGraph method that was throwing an
  NPE.

SERVLET:
- Fix RawQueryRPC to seralize the raw semantic query in the logs.