### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/data/TimeSeriesDataSourceFactory.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesDataSourceFactory.java
@@ -24,7 +24,6 @@ import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
-import net.opentsdb.query.TimeSeriesQuery;
 import net.opentsdb.query.plan.QueryPlanner;
 import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.Span;
@@ -35,7 +34,8 @@ import net.opentsdb.stats.Span;
  * 
  * @since 3.0
  */
-public interface TimeSeriesDataSourceFactory<C extends TimeSeriesDataSourceConfig, N extends TimeSeriesDataSource> extends TSDBPlugin, QueryNodeFactory<C, N> {
+public interface TimeSeriesDataSourceFactory<C extends TimeSeriesDataSourceConfig, 
+    N extends TimeSeriesDataSource> extends TSDBPlugin, QueryNodeFactory<C, N> {
 
   /**
    * The type of {@link TimeSeriesId}s returned from this store by default.
@@ -56,7 +56,7 @@ public interface TimeSeriesDataSourceFactory<C extends TimeSeriesDataSourceConfi
    * may be empty) or false if the source does not support the query, e.g.
    * maybe the source doesn't handle the particular namespace or metric.
    */
-  public boolean supportsQuery(final TimeSeriesQuery query, 
+  public boolean supportsQuery(final QueryPipelineContext query, 
                                final C config);
   
   /**

--- a/common/src/main/java/net/opentsdb/data/TimeSeriesDataSourceFactory.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesDataSourceFactory.java
@@ -50,13 +50,13 @@ public interface TimeSeriesDataSourceFactory<C extends TimeSeriesDataSourceConfi
    * to determine if the data source handles the particular query. E.g. if
    * the source would handle the namespace or metric for the given query.
    * 
-   * @param query The non-null parent query.
+   * @param context The non-null query context.
    * @param config The non-null query that would be passed to this factory.
    * @return True if the data source supports the query (even if the results
    * may be empty) or false if the source does not support the query, e.g.
    * maybe the source doesn't handle the particular namespace or metric.
    */
-  public boolean supportsQuery(final QueryPipelineContext query, 
+  public boolean supportsQuery(final QueryPipelineContext context, 
                                final C config);
   
   /**

--- a/common/src/test/java/net/opentsdb/data/MockTimeSeries.java
+++ b/common/src/test/java/net/opentsdb/data/MockTimeSeries.java
@@ -107,7 +107,9 @@ public class MockTimeSeries implements TimeSeries {
     if (sort) {
       Collections.sort(types, new TimeSeriesValue.TimeSeriesValueComparator());
     }
-    return Optional.of(new MockTimeSeriesIterator(types.iterator(), type));
+    final TypedTimeSeriesIterator<? extends TimeSeriesDataType> iterator =
+        new MockTimeSeriesIterator(types.iterator(), type);
+    return Optional.of(iterator);
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/data/iterators/SlicedTimeSeries.java
+++ b/core/src/main/java/net/opentsdb/data/iterators/SlicedTimeSeries.java
@@ -16,7 +16,6 @@ package net.opentsdb.data.iterators;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -92,8 +91,9 @@ public class SlicedTimeSeries implements TimeSeries {
     if (!types.contains(type)) {
       return Optional.empty();
     }
-    
-    return Optional.of(new LocalIterator(type));
+    final TypedTimeSeriesIterator<? extends TimeSeriesDataType> iterator = 
+        new LocalIterator(type);
+    return Optional.of(iterator);
   }
   
   @Override

--- a/core/src/main/java/net/opentsdb/data/types/numeric/NumericArrayTimeSeries.java
+++ b/core/src/main/java/net/opentsdb/data/types/numeric/NumericArrayTimeSeries.java
@@ -14,7 +14,6 @@
 // limitations under the License.
 package net.opentsdb.data.types.numeric;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -129,7 +128,9 @@ public class NumericArrayTimeSeries implements TimeSeries {
   public Optional<TypedTimeSeriesIterator<? extends TimeSeriesDataType>> iterator(
       final TypeToken<? extends TimeSeriesDataType> type) {
     if (type == NumericArrayType.TYPE) {
-      return Optional.of(new LocalIterator());
+      final TypedTimeSeriesIterator<? extends TimeSeriesDataType> iterator = 
+          new LocalIterator();
+      return Optional.of(iterator);
     }
     return Optional.empty();
   }

--- a/core/src/main/java/net/opentsdb/query/hacluster/HAClusterFactory.java
+++ b/core/src/main/java/net/opentsdb/query/hacluster/HAClusterFactory.java
@@ -33,12 +33,9 @@ import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.TimeSeriesStringId;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
-import net.opentsdb.query.BaseTimeSeriesDataSourceConfig;
 import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
-import net.opentsdb.query.TimeSeriesQuery;
-import net.opentsdb.query.hacluster.HAClusterConfig.Builder;
 import net.opentsdb.query.idconverter.ByteToStringIdConverterConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.plan.DefaultQueryPlanner;
@@ -111,7 +108,7 @@ public class HAClusterFactory extends BaseQueryNodeFactory<
   }
 
   @Override
-  public boolean supportsQuery(final TimeSeriesQuery query, 
+  public boolean supportsQuery(final QueryPipelineContext context, 
                                final TimeSeriesDataSourceConfig config) {
     if (config instanceof HAClusterConfig) {
       final HAClusterConfig cluster_config = (HAClusterConfig) config;
@@ -134,7 +131,7 @@ public class HAClusterFactory extends BaseQueryNodeFactory<
         final TimeSeriesDataSourceFactory factory = 
             tsdb.getRegistry().getPlugin(
                 TimeSeriesDataSourceFactory.class, source);
-        if (factory != null && factory.supportsQuery(query, config)) {
+        if (factory != null && factory.supportsQuery(context, config)) {
           return true;
         }
       }
@@ -144,7 +141,7 @@ public class HAClusterFactory extends BaseQueryNodeFactory<
         final TimeSeriesDataSourceFactory factory = 
             tsdb.getRegistry().getPlugin(
                 TimeSeriesDataSourceFactory.class, source.getSourceId());
-        if (factory != null && factory.supportsQuery(query, config)) {
+        if (factory != null && factory.supportsQuery(context, config)) {
           return true;
         }
       }
@@ -158,12 +155,11 @@ public class HAClusterFactory extends BaseQueryNodeFactory<
         final TimeSeriesDataSourceFactory factory = 
             tsdb.getRegistry().getPlugin(
                 TimeSeriesDataSourceFactory.class, source);
-        if (factory != null && factory.supportsQuery(query, config)) {
+        if (factory != null && factory.supportsQuery(context, config)) {
           return true;
         }
       }
     }
-
 
     return false;
   }
@@ -293,7 +289,7 @@ public class HAClusterFactory extends BaseQueryNodeFactory<
               + source.getSourceId());
         }
 
-        if (!factory.supportsQuery(context.query(), source)) {
+        if (!factory.supportsQuery(context, source)) {
           continue;
         }
         if (factory.idType() != Const.TS_STRING_ID) {
@@ -313,7 +309,7 @@ public class HAClusterFactory extends BaseQueryNodeFactory<
                 + source);
       }
       
-      if (!factory.supportsQuery(context.query(), config)) {
+      if (!factory.supportsQuery(context, config)) {
         continue;
       }
 

--- a/core/src/main/java/net/opentsdb/query/processor/dedup/DedupNode.java
+++ b/core/src/main/java/net/opentsdb/query/processor/dedup/DedupNode.java
@@ -130,7 +130,7 @@ public class DedupNode extends AbstractQueryNode {
     public Optional<TypedTimeSeriesIterator<? extends TimeSeriesDataType>> iterator(
         final TypeToken<? extends TimeSeriesDataType> type) {
       if (type == NumericType.TYPE) {
-        return Optional.of(this);
+        return Optional.of((TypedTimeSeriesIterator<? extends TimeSeriesDataType>) this);
       }
       return timeSeries.iterator(type);
     }

--- a/core/src/main/java/net/opentsdb/query/processor/topn/TopNResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/topn/TopNResult.java
@@ -97,7 +97,7 @@ public class TopNResult extends BaseWrappedQueryResult implements Runnable {
         
         if (value.isInteger()) {
           sorted_results.computeIfAbsent(value.toDouble(), k -> new ArrayList<>()).add(ts);
-        } else {
+        } else if (!Double.isNaN(value.doubleValue())){
           sorted_results.computeIfAbsent(value.doubleValue(), k -> new ArrayList<>()).add(ts);
         }
       }

--- a/core/src/main/java/net/opentsdb/storage/MockDataStore.java
+++ b/core/src/main/java/net/opentsdb/storage/MockDataStore.java
@@ -1071,7 +1071,9 @@ public class MockDataStore implements WritableTimeSeriesDataStore {
     public Optional<TypedTimeSeriesIterator<? extends TimeSeriesDataType>> iterator(
         TypeToken<? extends TimeSeriesDataType> type) {
       if (row != null && row.types().contains(type)) {
-        return Optional.of(new LocalIterator(type));
+        final TypedTimeSeriesIterator<? extends TimeSeriesDataType> iterator = 
+            new LocalIterator(type);
+        return Optional.of(iterator);
       }
       return Optional.empty();
     }

--- a/core/src/main/java/net/opentsdb/storage/MockDataStoreFactory.java
+++ b/core/src/main/java/net/opentsdb/storage/MockDataStoreFactory.java
@@ -33,7 +33,6 @@ import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
 import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
-import net.opentsdb.query.TimeSeriesQuery;
 import net.opentsdb.query.plan.QueryPlanner;
 import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.Span;
@@ -44,7 +43,7 @@ import net.opentsdb.stats.Span;
  * @since 3.0
  */
 public class MockDataStoreFactory extends BaseTSDBPlugin 
-                                  implements TimeSeriesDataSourceFactory<TimeSeriesDataSourceConfig, MockDataStore.LocalNode> {
+  implements TimeSeriesDataSourceFactory<TimeSeriesDataSourceConfig, MockDataStore.LocalNode> {
 
   public static final String TYPE = "MockDataStore";
   
@@ -59,7 +58,7 @@ public class MockDataStoreFactory extends BaseTSDBPlugin
   }
 
   @Override
-  public boolean supportsQuery(final TimeSeriesQuery query, 
+  public boolean supportsQuery(final QueryPipelineContext context, 
                                final TimeSeriesDataSourceConfig config) {
     return true;
   }

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/SchemaFactory.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/SchemaFactory.java
@@ -31,7 +31,6 @@ import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
 import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
-import net.opentsdb.query.TimeSeriesQuery;
 import net.opentsdb.query.plan.QueryPlanner;
 import net.opentsdb.query.processor.timeshift.TimeShiftConfig;
 import net.opentsdb.rollup.DefaultRollupConfig;
@@ -81,7 +80,7 @@ public class SchemaFactory extends BaseTSDBPlugin
   }
   
   @Override
-  public boolean supportsQuery(final TimeSeriesQuery query, 
+  public boolean supportsQuery(final QueryPipelineContext context, 
                                final TimeSeriesDataSourceConfig config) {
     // TODO - let the underlying store handle this.
     return true;

--- a/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterFactory.java
+++ b/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterFactory.java
@@ -1173,8 +1173,8 @@ public class TestHAClusterFactory {
         .setMode(QueryMode.SINGLE)
         .addExecutionGraphNode(config)
         .build();
-
-    assertTrue(FACTORY.supportsQuery(query, config));
+    
+    assertTrue(FACTORY.supportsQuery(mock(QueryPipelineContext.class), config));
   }
 
   @Test
@@ -1194,10 +1194,11 @@ public class TestHAClusterFactory {
         .addExecutionGraphNode(config)
         .build();
 
-    assertFalse(FACTORY.supportsQuery(query, config));
+    assertFalse(FACTORY.supportsQuery(mock(QueryPipelineContext.class), config));
   }
 
-  static class MockFactory extends BaseTSDBPlugin implements TimeSeriesDataSourceFactory<TimeSeriesDataSourceConfig, TimeSeriesDataSource> {
+  static class MockFactory extends BaseTSDBPlugin implements 
+      TimeSeriesDataSourceFactory<TimeSeriesDataSourceConfig, TimeSeriesDataSource> {
 
     final List<Class<? extends QueryNodeConfig>> pushdowns;
     final TypeToken<? extends TimeSeriesId> id_type;
@@ -1236,7 +1237,7 @@ public class TestHAClusterFactory {
     }
 
     @Override
-    public boolean supportsQuery(net.opentsdb.query.TimeSeriesQuery query, TimeSeriesDataSourceConfig config) {
+    public boolean supportsQuery(QueryPipelineContext context, TimeSeriesDataSourceConfig config) {
       return supports_query;
     }
 

--- a/core/src/test/java/net/opentsdb/query/router/TestTimeRouterFactory.java
+++ b/core/src/test/java/net/opentsdb/query/router/TestTimeRouterFactory.java
@@ -55,7 +55,6 @@ import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.SemanticQuery;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
-import net.opentsdb.query.TimeSeriesQuery;
 import net.opentsdb.query.filter.MetricLiteralFilter;
 import net.opentsdb.query.plan.DefaultQueryPlanner;
 import net.opentsdb.query.plan.QueryPlanner;
@@ -132,7 +131,7 @@ public class TestTimeRouterFactory {
         .build();
     
     TimeRouterConfigEntry entry = mock(TimeRouterConfigEntry.class);
-    when(entry.match(any(TimeSeriesQuery.class), 
+    when(entry.match(any(QueryPipelineContext.class), 
           any(TimeSeriesDataSourceConfig.class), any(TSDB.class)))
       .thenReturn(MatchType.FULL);
     when(entry.getSourceId()).thenReturn("s1");
@@ -168,7 +167,7 @@ public class TestTimeRouterFactory {
         .build();
     
     TimeRouterConfigEntry entry = mock(TimeRouterConfigEntry.class);
-    when(entry.match(any(TimeSeriesQuery.class), 
+    when(entry.match(any(QueryPipelineContext.class), 
           any(TimeSeriesDataSourceConfig.class), any(TSDB.class)))
       .thenReturn(MatchType.NONE);
     when(context.query()).thenReturn(query);
@@ -196,13 +195,13 @@ public class TestTimeRouterFactory {
         .build();
     
     TimeRouterConfigEntry e1 = mock(TimeRouterConfigEntry.class);
-    when(e1.match(any(TimeSeriesQuery.class), 
+    when(e1.match(any(QueryPipelineContext.class), 
           any(TimeSeriesDataSourceConfig.class), any(TSDB.class)))
       .thenReturn(MatchType.NONE);
     when(e1.getSourceId()).thenReturn("s1");
     
     TimeRouterConfigEntry e2 = mock(TimeRouterConfigEntry.class);
-    when(e2.match(any(TimeSeriesQuery.class), 
+    when(e2.match(any(QueryPipelineContext.class), 
           any(TimeSeriesDataSourceConfig.class), any(TSDB.class)))
       .thenReturn(MatchType.FULL);
     when(e2.getSourceId()).thenReturn("s2");
@@ -238,13 +237,13 @@ public class TestTimeRouterFactory {
         .build();
     
     TimeRouterConfigEntry e1 = mock(TimeRouterConfigEntry.class);
-    when(e1.match(any(TimeSeriesQuery.class), 
+    when(e1.match(any(QueryPipelineContext.class), 
           any(TimeSeriesDataSourceConfig.class), any(TSDB.class)))
       .thenReturn(MatchType.NONE);
     when(e1.getSourceId()).thenReturn("s1");
     
     TimeRouterConfigEntry e2 = mock(TimeRouterConfigEntry.class);
-    when(e2.match(any(TimeSeriesQuery.class), 
+    when(e2.match(any(QueryPipelineContext.class), 
           any(TimeSeriesDataSourceConfig.class), any(TSDB.class)))
       .thenReturn(MatchType.PARTIAL);
     when(e2.getSourceId()).thenReturn("s2");
@@ -280,25 +279,25 @@ public class TestTimeRouterFactory {
         .build();
     
     TimeRouterConfigEntry e1 = mock(TimeRouterConfigEntry.class);
-    when(e1.match(any(TimeSeriesQuery.class), 
+    when(e1.match(any(QueryPipelineContext.class), 
           any(TimeSeriesDataSourceConfig.class), any(TSDB.class)))
       .thenReturn(MatchType.NONE);
     when(e1.getSourceId()).thenReturn("s1");
     
     TimeRouterConfigEntry e2 = mock(TimeRouterConfigEntry.class);
-    when(e2.match(any(TimeSeriesQuery.class), 
+    when(e2.match(any(QueryPipelineContext.class), 
           any(TimeSeriesDataSourceConfig.class), any(TSDB.class)))
       .thenReturn(MatchType.PARTIAL);
     when(e2.getSourceId()).thenReturn("s2");
     
     TimeRouterConfigEntry e3 = mock(TimeRouterConfigEntry.class);
-    when(e3.match(any(TimeSeriesQuery.class), 
+    when(e3.match(any(QueryPipelineContext.class), 
           any(TimeSeriesDataSourceConfig.class), any(TSDB.class)))
       .thenReturn(MatchType.PARTIAL);
     when(e3.getSourceId()).thenReturn("s3");
     
     TimeRouterConfigEntry e4 = mock(TimeRouterConfigEntry.class);
-    when(e4.match(any(TimeSeriesQuery.class), 
+    when(e4.match(any(QueryPipelineContext.class), 
           any(TimeSeriesDataSourceConfig.class), any(TSDB.class)))
       .thenReturn(MatchType.NONE);
     when(context.query()).thenReturn(query);
@@ -332,7 +331,8 @@ public class TestTimeRouterFactory {
         planner.nodeForId("m1")));
   }
   
-  static class MockFactory extends BaseTSDBPlugin implements TimeSeriesDataSourceFactory<TimeSeriesDataSourceConfig ,TimeSeriesDataSource> {
+  static class MockFactory extends BaseTSDBPlugin implements 
+      TimeSeriesDataSourceFactory<TimeSeriesDataSourceConfig ,TimeSeriesDataSource> {
 
     final List<Class<? extends QueryNodeConfig>> pushdowns;
 
@@ -348,7 +348,7 @@ public class TestTimeRouterFactory {
     }
 
     @Override
-    public boolean supportsQuery(final TimeSeriesQuery query, 
+    public boolean supportsQuery(final QueryPipelineContext context, 
                                  final TimeSeriesDataSourceConfig config) {
       return true;
     }

--- a/executors/http/src/main/java/net/opentsdb/query/execution/BaseHttpExecutorFactory.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/BaseHttpExecutorFactory.java
@@ -55,8 +55,9 @@ import net.opentsdb.utils.SharedHttpClient;
  * 
  * @since 3.0
  */
-public abstract class BaseHttpExecutorFactory<C extends TimeSeriesDataSourceConfig, N extends TimeSeriesDataSource> implements
-    TimeSeriesDataSourceFactory<C, N>, TimerTask {
+public abstract class BaseHttpExecutorFactory<C extends TimeSeriesDataSourceConfig, 
+    N extends TimeSeriesDataSource> implements TimeSeriesDataSourceFactory<C, N>, 
+      TimerTask {
   private static final Logger LOG = LoggerFactory.getLogger(
       BaseHttpExecutorFactory.class);
   

--- a/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Factory.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Factory.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2019  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
 import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
-import net.opentsdb.query.TimeSeriesQuery;
 import net.opentsdb.query.plan.QueryPlanner;
 import net.opentsdb.query.processor.timeshift.TimeShiftConfig;
 import net.opentsdb.rollup.DefaultRollupConfig;
@@ -76,7 +75,7 @@ public class HttpQueryV3Factory
 
   @Override
   public boolean supportsQuery(
-      final TimeSeriesQuery query,
+      final QueryPipelineContext context,
       final TimeSeriesDataSourceConfig<
               ? extends TimeSeriesDataSourceConfig.Builder,
               ? extends TimeSeriesDataSourceConfig>

--- a/implementation/protobuf/src/main/java/net/opentsdb/grpc/QueryGRPCClientFactory.java
+++ b/implementation/protobuf/src/main/java/net/opentsdb/grpc/QueryGRPCClientFactory.java
@@ -194,7 +194,7 @@ public class QueryGRPCClientFactory extends BaseTSDBPlugin
   }
 
   @Override
-  public boolean supportsQuery(TimeSeriesQuery query,
+  public boolean supportsQuery(final QueryPipelineContext context,
       TimeSeriesDataSourceConfig config) {
     // TODO Auto-generated method stub
     return true;


### PR DESCRIPTION
- Change the TimeSeriesDataSourceFactory so that it takes a QueryPipelineContext
  in the supportsQuery() call so that method can log to the query.
ALL:
- Support the new change.
- Tweak some casting in the iterator and Java Optional call that Eclipse doesn't like.