### PR TITLE
Status API

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -417,6 +417,7 @@ test_SRC := \
 	test/tsd/TestRTPublisher.java	\
 	test/tsd/TestSearchRpc.java	\
 	test/tsd/TestStatsRpc.java \
+	test/tsd/TestStatusRpc.java \
 	test/tsd/TestSuggestRpc.java	\
 	test/tsd/TestTreeRpc.java	\
 	test/tsd/TestUniqueIdRpc.java	\

--- a/Makefile.am
+++ b/Makefile.am
@@ -325,6 +325,7 @@ test_SRC := \
 	test/core/TestTags.java	\
 	test/core/TestTSDB.java	\
 	test/core/TestTSDBAddPoint.java	\
+	test/core/TestTSDBTableAvailability.java	\
 	test/core/TestTsdbQueryDownsample.java	\
 	test/core/TestTsdbQueryDownsampleSalted.java	\
 	test/core/TestTsdbQuery.java	\

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -829,8 +829,12 @@ public final class TSDB {
                            testKey, testKey.length - PROBE_SUFFIX.length,
                            PROBE_SUFFIX.length);
           LOG.debug("Checking region with start key " + testKey + " end key " + region.stopKey());
-          GetRequest dummy = new GetRequest(table, testKey);
-          available.add(client.get(dummy).addCallbacks(successCB, failureCB));
+          GetRequest probe = new GetRequest(table, testKey);
+          // If we don't get a response within 1 second, assume the region is
+          // unavailable.
+          probe.setTimeout(1000);
+          probe.setFailfast(true);
+          available.add(client.get(probe).addCallbacks(successCB, failureCB));
         }
         return Deferred.group(available).addCallback(new TableAvailabilityCB());
       }

--- a/test/core/TestTSDBTableAvailability.java
+++ b/test/core/TestTSDBTableAvailability.java
@@ -14,6 +14,9 @@ package net.opentsdb.core;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -98,12 +101,19 @@ public final class TestTSDBTableAvailability extends BaseTsdbTest {
   @Test
   public void allRegionsAvailable() throws Exception {
     TSDB original = new TSDB(mock(HBaseClient.class), config);
-    TSDB tsdb = spy(original);
+    TSDB tsdb = PowerMockito.spy(original);
     ArrayList<Boolean> region_availability = new ArrayList<Boolean>();
     region_availability.add(true);
+
     Deferred<ArrayList<Boolean>> get_results = new Deferred<ArrayList<Boolean>>();
     get_results.callback(region_availability);
-    doReturn(get_results).when(tsdb).getTableRegionAvailability(anyString());
+    Deferred<ArrayList<Boolean>> get_results2 = new Deferred<ArrayList<Boolean>>();
+    get_results2.callback(region_availability);
+
+    PowerMockito.doReturn(get_results).when(tsdb)
+      .getTableRegionAvailability("tsd.storage.hbase.uid_table");
+    PowerMockito.doReturn(get_results2).when(tsdb)
+      .getTableRegionAvailability("tsd.storage.hbase.data_table");
 
     assertEquals(tsdb.checkNecessaryTablesAvailability().join(),
                  TSDB.TableAvailability.FULL);

--- a/test/core/TestTSDBTableAvailability.java
+++ b/test/core/TestTSDBTableAvailability.java
@@ -21,7 +21,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import org.hbase.async.AtomicIncrementRequest;
@@ -95,18 +97,13 @@ public final class TestTSDBTableAvailability extends BaseTsdbTest {
   /* If all returned regions return a result, availability is FULL. */
   @Test
   public void allRegionsAvailable() throws Exception {
-    RegionLocation region = mock(RegionLocation.class);
-    byte[] key = {'a'};
-    when(region.startKey()).thenReturn(key);
-    ArrayList<RegionLocation> regions = new ArrayList<RegionLocation>();
-    regions.add(region);
-
-    TSDB tsdb = spy(new TSDB(mock(HBaseClient.class), config));
+    TSDB original = new TSDB(mock(HBaseClient.class), config);
+    TSDB tsdb = spy(original);
     ArrayList<Boolean> region_availability = new ArrayList<Boolean>();
     region_availability.add(true);
-    Deferred<ArrayList<KeyValue>> get_results = new Deferred<ArrayList<KeyValue>>();
+    Deferred<ArrayList<Boolean>> get_results = new Deferred<ArrayList<Boolean>>();
     get_results.callback(region_availability);
-    when(tsdb.getTableRegionAvailability(anyString())).thenReturn(get_results);
+    doReturn(get_results).when(tsdb).getTableRegionAvailability(anyString());
 
     assertEquals(tsdb.checkNecessaryTablesAvailability().join(),
                  TSDB.TableAvailability.FULL);

--- a/test/core/TestTSDBTableAvailability.java
+++ b/test/core/TestTSDBTableAvailability.java
@@ -1,0 +1,98 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2013  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hbase.async.AtomicIncrementRequest;
+import org.hbase.async.GetRequest;
+import org.hbase.async.HBaseClient;
+import org.hbase.async.KeyValue;
+import org.hbase.async.PutRequest;
+import org.hbase.async.Scanner;
+import org.hbase.async.RegionLocation;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.stumbleupon.async.Deferred;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.management.*", "javax.xml.*",
+      "ch.qos.*", "org.slf4j.*",
+      "com.sum.*", "org.xml.*"})
+@PrepareForTest({ TSDB.class, HBaseClient.class,
+      CompactionQueue.class, GetRequest.class, PutRequest.class, KeyValue.class,
+      Scanner.class, AtomicIncrementRequest.class, Const.class, })
+public final class TestTSDBTableAvailability extends BaseTsdbTest {
+
+  private TSDB createTSDB(Deferred<List<RegionLocation>> uid_regions,
+                          Deferred<List<RegionLocation>> data_regions) {
+    TSDB tsdb = new TSDB(mock(HBaseClient.class), config);
+    when(tsdb.getClient()
+         .locateRegions(config.getString("tsd.storage.hbase.uid_table"))
+         ).thenReturn(uid_regions);
+    when(tsdb.getClient()
+         .locateRegions(config.getString("tsd.storage.hbase.data_table"))
+         ).thenReturn(data_regions);
+    return tsdb;
+  }
+
+  /** If locateRegions() throws an exception, availability is NONE */
+  @Test
+  public void failedToGetRegions() throws Exception {
+    Deferred<List<RegionLocation>> d = new Deferred<List<RegionLocation>>();
+    d.callback(new Exception());
+    Deferred<List<RegionLocation>> d2 = new Deferred<List<RegionLocation>>();
+    d2.callback(new Exception());
+    TSDB tsdb = createTSDB(d, d2);
+    assertEquals(tsdb.checkNecessaryTablesAvailability().join(),
+                 TSDB.TableAvailability.NONE);
+  }
+
+  /** If locateRegions() returns empty list, availability is NONE */
+  @Test
+  public void noRegions() throws Exception {
+    Deferred<List<RegionLocation>> d = new Deferred<List<RegionLocation>>();
+    d.callback(new ArrayList<RegionLocation>());
+    Deferred<List<RegionLocation>> d2 = new Deferred<List<RegionLocation>>();
+    d2.callback(new ArrayList<RegionLocation>());
+    TSDB tsdb = createTSDB(d, d2);
+    assertEquals(tsdb.checkNecessaryTablesAvailability().join(),
+                 TSDB.TableAvailability.NONE);
+  }
+
+    // If all returned regions return a result, availability is FULL
+
+    // If a regions returned by locateRegions() throws exception, availability
+    // is PARTIAL.
+
+    // If one table returns PARTIAL and the other returns FULL, final result is
+    // PARTIAL
+
+    // If one table returns NONE and the other returns FULL, final result is
+    // NONE
+
+}

--- a/test/tsd/TestStatusRpc.java
+++ b/test/tsd/TestStatusRpc.java
@@ -1,0 +1,97 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2015  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.tsd;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import com.stumbleupon.async.Deferred;
+
+import java.nio.charset.Charset;
+
+import net.opentsdb.core.TSDB;
+import net.opentsdb.stats.StatsCollector;
+import net.opentsdb.utils.Config;
+
+import org.hbase.async.HBaseClient;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({HttpJsonSerializer.class, TSDB.class, Config.class, 
+  HttpQuery.class, Thread.class, HBaseClient.class })
+public class TestStatusRpc {
+  private TSDB tsdb;
+  private HBaseClient client;
+  private RpcManager.Status rpc;
+
+  @Before
+  public void before() throws Exception {
+    rpc = new RpcManager.Status();
+    tsdb = NettyMocks.getMockedHTTPTSDB();
+    client = mock(HBaseClient.class);
+    when(tsdb.getClient()).thenReturn(client);
+  }
+
+  private String getStatus() throws Exception {
+    HttpQuery query = NettyMocks.getQuery(tsdb, "/api/status");
+    rpc.execute(tsdb, query);
+    assertEquals(HttpResponseStatus.OK, query.response().getStatus());
+    final String json =
+      query.response().getContent().toString(Charset.forName("UTF-8"));
+    assertNotNull(json);
+    return json;
+  }
+
+  @Test
+  public void printStatus() throws Exception {
+    // Initial status is "startup"
+    when(tsdb.checkNecessaryTablesAvailability()).
+      thenReturn(Deferred.fromResult(TSDB.TableAvailability.NONE));
+    assertEquals(getStatus(), "{\"status\":\"startup\"}");
+
+    // Partial availability:
+    when(tsdb.checkNecessaryTablesAvailability()).
+      thenReturn(Deferred.fromResult(TSDB.TableAvailability.PARTIAL));
+    assertEquals(getStatus(), "{\"status\":\"partial\"}");
+
+    // Full availibility:
+    when(tsdb.checkNecessaryTablesAvailability()).
+      thenReturn(Deferred.fromResult(TSDB.TableAvailability.FULL));
+    assertEquals(getStatus(), "{\"status\":\"ok\"}");
+
+    // No availability (after having seen some in the past):
+    when(tsdb.checkNecessaryTablesAvailability()).
+      thenReturn(Deferred.fromResult(TSDB.TableAvailability.NONE));
+    assertEquals(getStatus(), "{\"status\":\"error\"}");
+
+    // After shutdown status is "shutting-down", regardless of availability:
+    rpc.shutdown();
+    when(tsdb.checkNecessaryTablesAvailability()).
+      thenReturn(Deferred.fromResult(TSDB.TableAvailability.NONE));
+    assertEquals(getStatus(), "{\"status\":\"shutting-down\"}");
+    when(tsdb.checkNecessaryTablesAvailability()).
+      thenReturn(Deferred.fromResult(TSDB.TableAvailability.PARTIAL));
+    assertEquals(getStatus(), "{\"status\":\"shutting-down\"}");
+    when(tsdb.checkNecessaryTablesAvailability()).
+      thenReturn(Deferred.fromResult(TSDB.TableAvailability.FULL));
+    assertEquals(getStatus(), "{\"status\":\"shutting-down\"}");
+  }
+}


### PR DESCRIPTION
Fixes #1584.

This is still a sketch, albeit a working one, but I would appreciate some feedback.

* [x] I have tested this manually on single-node-HBase-in-Docker, but not against multi-node HBase where the output would be more interesting, e.g. allow "partial".
* [x] Redo manual test now that is code is refactored.
* [x] Unit testing.
* [ ] Is this OK? If the HBase cluster is _completely_ down, the status API never responds. Which ... is maybe OK, cause that's a clear "nope this isn't usable" signal a client/loadbalancer would have to handle too.

@johann8384 maybe you have a little time too look at this?