### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/processor/expressions/BaseExpressionNumericIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/BaseExpressionNumericIterator.java
@@ -1,5 +1,5 @@
 //This file is part of OpenTSDB.
-//Copyright (C) 2018  The OpenTSDB Authors.
+//Copyright (C) 2018-2019  The OpenTSDB Authors.
 //
 //Licensed under the Apache License, Version 2.0 (the "License");
 //you may getNot use this file except in compliance with the License.
@@ -45,6 +45,10 @@ public abstract class BaseExpressionNumericIterator<T extends TimeSeriesDataType
 
   /** Epsilon used for floating point calculations. */
   public static final double EPSILON = Math.ulp(1.0);
+  public static final MutableNumericType ZERO_SUBSTITUTE = 
+      new MutableNumericType(0);
+  public static final MutableNumericType ONE_SUBSTITUTE = 
+      new MutableNumericType(1);
   
   /** The node we belong to */
   protected final BinaryExpressionNode node;
@@ -166,9 +170,17 @@ public abstract class BaseExpressionNumericIterator<T extends TimeSeriesDataType
    * @param right The right operand.
    * @return The {@link #value} or null if either operand was null.
    */
-  NumericType relation(final NumericType left, final NumericType right) {
+  NumericType relation(NumericType left, NumericType right) {
     if (left == null || right == null) {
-      return null;
+      if (!node.expressionConfig().getSubstituteMissing()) {
+        return null;
+      }
+      if (left == null) {
+        left = ZERO_SUBSTITUTE;
+      }
+      if (right == null) {
+        right = ZERO_SUBSTITUTE;
+      }
     }
     
     if (left.isInteger() && right.isInteger()) {
@@ -292,7 +304,14 @@ public abstract class BaseExpressionNumericIterator<T extends TimeSeriesDataType
    * @param right The right operand.
    * @return The {@link #value}.
    */
-  NumericType logical(final NumericType left, final NumericType right) {
+  NumericType logical(NumericType left, NumericType right) {
+    if (node.expressionConfig().getSubstituteMissing() && left == null) {
+      left = ZERO_SUBSTITUTE;
+    }
+    if (node.expressionConfig().getSubstituteMissing() && right == null) {
+      right = ZERO_SUBSTITUTE;
+    }
+    
     switch (((ExpressionParseNode) node.config()).getOperator()) {
     case OR:
       if (left == null) {
@@ -361,9 +380,17 @@ public abstract class BaseExpressionNumericIterator<T extends TimeSeriesDataType
    * @param right The right operand.
    * @return The {@link #value} or null if either operand was null.
    */
-  NumericType additive(final NumericType left, final NumericType right) {
+  NumericType additive(NumericType left, NumericType right) {
     if (left == null || right == null) {
-      return null;
+      if (!node.expressionConfig().getSubstituteMissing()) {
+        return null;
+      }
+      if (left == null) {
+        left = ZERO_SUBSTITUTE;
+      }
+      if (right == null) {
+        right = ZERO_SUBSTITUTE;
+      }
     }
     
     if (left.isInteger() && right.isInteger()) {
@@ -429,9 +456,17 @@ public abstract class BaseExpressionNumericIterator<T extends TimeSeriesDataType
    * @param right The right operand.
    * @return The {@link #value} or null if either operand was null.
    */
-  NumericType divide(final NumericType left, final NumericType right) {
+  NumericType divide(NumericType left, NumericType right) {
     if (left == null || right == null) {
-      return null;
+      if (!node.expressionConfig().getSubstituteMissing()) {
+        return null;
+      }
+      if (left == null) {
+        left = ZERO_SUBSTITUTE;
+      }
+      if (right == null) {
+        right = ONE_SUBSTITUTE;
+      }
     }
     
     if (left.isInteger() && right.isInteger() && 
@@ -485,9 +520,17 @@ public abstract class BaseExpressionNumericIterator<T extends TimeSeriesDataType
    * @param right The right operand.
    * @return The {@link #value} or null if either operand was null.
    */
-  NumericType multiply(final NumericType left, final NumericType right) {
+  NumericType multiply(NumericType left, NumericType right) {
     if (left == null || right == null) {
-      return null;
+      if (!node.expressionConfig().getSubstituteMissing()) {
+        return null;
+      }
+      if (left == null) {
+        left = ONE_SUBSTITUTE;
+      }
+      if (right == null) {
+        right = ONE_SUBSTITUTE;
+      }
     }
     
     if (left.isInteger() && right.isInteger()) {
@@ -531,9 +574,17 @@ public abstract class BaseExpressionNumericIterator<T extends TimeSeriesDataType
    * @param right The right operand.
    * @return The {@link #value} or null if either operand was null.
    */
-  NumericType mod(final NumericType left, final NumericType right) {
+  NumericType mod(NumericType left, NumericType right) {
     if (left == null || right == null) {
-      return null;
+      if (!node.expressionConfig().getSubstituteMissing()) {
+        return null;
+      }
+      if (left == null) {
+        left = ZERO_SUBSTITUTE;
+      }
+      if (right == null) {
+        right = ONE_SUBSTITUTE;
+      }
     }
     
     if (left.isInteger() && right.isInteger()) {

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionConfig.java
@@ -72,6 +72,9 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
   /** The resulting metric name. */
   private final String as;
   
+  /** Whether or not to substitute missing metrics with somewhat useful values. */
+  private final boolean substitute_missing;
+  
   /**
    * Protected ctor.
    * @param builder The non-null builder.
@@ -96,6 +99,7 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
     } else {
       as = builder.as;
     }
+    substitute_missing = builder.substituteMissing;
   }
   
   /** @return The raw expression string to be parsed. */
@@ -121,6 +125,11 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
   /** @return The new name for the metric. */
   public String getAs() {
     return as;
+  }
+  
+  /** @return Whether or not to substitute values for missing time series. */
+  public boolean getSubstituteMissing() {
+    return substitute_missing;
   }
   
   /**
@@ -180,6 +189,7 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
         .putString(id == null ? "null" : id, Const.UTF8_CHARSET)
         .putString(expression, Const.UTF8_CHARSET)
         .putString(as == null ? "null" : as, Const.UTF8_CHARSET)
+        .putBoolean(substitute_missing)
         .hash());
     if (variable_interpolators != null && !variable_interpolators.isEmpty()) {
       final Map<String, List<QueryInterpolatorConfig>> sorted = 
@@ -223,6 +233,7 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
         .compare(interpolator_configs, o.interpolator_configs, INTERPOLATOR_CMP)
         .compare(infectious_nan, o.infectious_nan)
         .compare(as, o.as)
+        .compare(substitute_missing, o.substitute_missing)
         .result();
   }
 
@@ -249,7 +260,8 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
            Objects.equals(variable_interpolators, other.variable_interpolators) &&
            Objects.equals(interpolator_configs, other.interpolator_configs) &&
            Objects.equals(infectious_nan, other.infectious_nan) &&
-           Objects.equals(as, other.as);
+           Objects.equals(as, other.as) &&
+           Objects.equals(substitute_missing, other.substitute_missing);
   }
 
   @Override
@@ -288,6 +300,11 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
     n = node.get("id");
     if (n != null) {
       builder.setId(n.asText());
+    }
+    
+    n = node.get("substituteMissing");
+    if (n != null && !n.isNull()) {
+      builder.setSubstituteMissing(n.asBoolean());
     }
     
     n = node.get("variableInterpolators");
@@ -382,6 +399,8 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
     private boolean infectiousNan;
     @JsonProperty
     private String as;
+    @JsonProperty
+    private boolean substituteMissing;
     
     Builder() {
       setType(ExpressionFactory.TYPE);
@@ -424,6 +443,11 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
     
     public Builder setAs(final String as) {
       this.as = as;
+      return this;
+    }
+    
+    public Builder setSubstituteMissing(final boolean substitute_missing) {
+      this.substituteMissing = substitute_missing;
       return this;
     }
     

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorAdditive.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorAdditive.java
@@ -854,6 +854,60 @@ public class TestExpressionNumericArrayIteratorAdditive extends BaseNumericTest 
             (Map) ImmutableMap.builder()
               .put(ExpressionTimeSeries.RIGHT_KEY, right)
               .build());
+    assertFalse(iterator.hasNext());
+    
+    // subtract
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void nullLeftSubstitute() throws Exception {
+    right = new NumericArrayTimeSeries(RIGHT_ID, 
+        new SecondTimeStamp(60));
+    ((NumericArrayTimeSeries) right).add(4);
+    ((NumericArrayTimeSeries) right).add(10);
+    ((NumericArrayTimeSeries) right).add(8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a + b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericArrayIterator iterator = 
+        new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
     assertTrue(iterator.hasNext());
     TimeSeriesValue<NumericArrayType> value = 
         (TimeSeriesValue<NumericArrayType>) iterator.next();
@@ -908,6 +962,60 @@ public class TestExpressionNumericArrayIteratorAdditive extends BaseNumericTest 
         .setId("expression")
         .build();
     when(node.config()).thenReturn(expression_config);
+    
+    ExpressionNumericArrayIterator iterator = 
+        new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertFalse(iterator.hasNext());
+    
+    // subtract
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.SUBTRACT)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void nullRightSubstitute() throws Exception {
+    left = new NumericArrayTimeSeries(LEFT_ID, 
+        new SecondTimeStamp(60));
+    ((NumericArrayTimeSeries) left).add(1);
+    ((NumericArrayTimeSeries) left).add(5);
+    ((NumericArrayTimeSeries) left).add(2);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a + b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
     
     ExpressionNumericArrayIterator iterator = 
         new ExpressionNumericArrayIterator(node, RESULT, 

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorDivide.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorDivide.java
@@ -614,6 +614,42 @@ public class TestExpressionNumericArrayIteratorDivide extends BaseNumericTest {
             (Map) ImmutableMap.builder()
               .put(ExpressionTimeSeries.RIGHT_KEY, right)
               .build());
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void nullLeftSubstitute() throws Exception {
+    right = new NumericArrayTimeSeries(RIGHT_ID, 
+        new SecondTimeStamp(60));
+    ((NumericArrayTimeSeries) right).add(4);
+    ((NumericArrayTimeSeries) right).add(10);
+    ((NumericArrayTimeSeries) right).add(8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a / b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericArrayIterator iterator = 
+        new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
     assertTrue(iterator.hasNext());
     TimeSeriesValue<NumericArrayType> value = 
         (TimeSeriesValue<NumericArrayType>) iterator.next();
@@ -643,6 +679,42 @@ public class TestExpressionNumericArrayIteratorDivide extends BaseNumericTest {
         .setId("expression")
         .build();
     when(node.config()).thenReturn(expression_config);
+    
+    ExpressionNumericArrayIterator iterator = 
+        new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void nullRightSubstitute() throws Exception {
+    left = new NumericArrayTimeSeries(LEFT_ID, 
+        new SecondTimeStamp(60));
+    ((NumericArrayTimeSeries) left).add(4);
+    ((NumericArrayTimeSeries) left).add(10);
+    ((NumericArrayTimeSeries) left).add(8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a / b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
     
     ExpressionNumericArrayIterator iterator = 
         new ExpressionNumericArrayIterator(node, RESULT, 

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorLogical.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorLogical.java
@@ -912,6 +912,60 @@ public class TestExpressionNumericArrayIteratorLogical extends BaseNumericTest {
             (Map) ImmutableMap.builder()
               .put(ExpressionTimeSeries.RIGHT_KEY, right)
               .build());
+    assertFalse(iterator.hasNext());
+    
+    // AND
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void nullLeftSubstitute() throws Exception {
+    right = new NumericArrayTimeSeries(RIGHT_ID, 
+        new SecondTimeStamp(60));
+    ((NumericArrayTimeSeries) right).add(4);
+    ((NumericArrayTimeSeries) right).add(0);
+    ((NumericArrayTimeSeries) right).add(-1);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a || b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericArrayIterator iterator = 
+        new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
     assertTrue(iterator.hasNext());
     TimeSeriesValue<NumericArrayType> value = 
         (TimeSeriesValue<NumericArrayType>) iterator.next();
@@ -929,7 +983,7 @@ public class TestExpressionNumericArrayIteratorLogical extends BaseNumericTest {
         .setRight("b")
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.AND)
-        .setExpressionConfig(CONFIG)
+        .setExpressionConfig(cfg)
         .setId("expression")
         .build();
     when(node.config()).thenReturn(expression_config);
@@ -966,6 +1020,60 @@ public class TestExpressionNumericArrayIteratorLogical extends BaseNumericTest {
         .setId("expression")
         .build();
     when(node.config()).thenReturn(expression_config);
+    
+    ExpressionNumericArrayIterator iterator = 
+        new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertFalse(iterator.hasNext());
+    
+    // AND
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void nullRightSubstitute() throws Exception {
+    left = new NumericArrayTimeSeries(LEFT_ID, 
+        new SecondTimeStamp(60));
+    ((NumericArrayTimeSeries) left).add(1);
+    ((NumericArrayTimeSeries) left).add(0);
+    ((NumericArrayTimeSeries) left).add(2);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a || b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
     
     ExpressionNumericArrayIterator iterator = 
         new ExpressionNumericArrayIterator(node, RESULT, 

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorMod.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorMod.java
@@ -522,6 +522,42 @@ public class TestExpressionNumericArrayIteratorMod extends BaseNumericTest {
             (Map) ImmutableMap.builder()
               .put(ExpressionTimeSeries.RIGHT_KEY, right)
               .build());
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void nullLeftSubstitute() throws Exception {
+    right = new NumericArrayTimeSeries(RIGHT_ID, 
+        new SecondTimeStamp(60));
+    ((NumericArrayTimeSeries) right).add(4);
+    ((NumericArrayTimeSeries) right).add(10);
+    ((NumericArrayTimeSeries) right).add(8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a % b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericArrayIterator iterator = 
+        new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
     assertTrue(iterator.hasNext());
     TimeSeriesValue<NumericArrayType> value = 
         (TimeSeriesValue<NumericArrayType>) iterator.next();
@@ -551,6 +587,42 @@ public class TestExpressionNumericArrayIteratorMod extends BaseNumericTest {
         .setId("expression")
         .build();
     when(node.config()).thenReturn(expression_config);
+    
+    ExpressionNumericArrayIterator iterator = 
+        new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void nullRightSubstitute() throws Exception {
+    left = new NumericArrayTimeSeries(LEFT_ID, 
+        new SecondTimeStamp(60));
+    ((NumericArrayTimeSeries) left).add(1);
+    ((NumericArrayTimeSeries) left).add(5);
+    ((NumericArrayTimeSeries) left).add(2);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a % b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
     
     ExpressionNumericArrayIterator iterator = 
         new ExpressionNumericArrayIterator(node, RESULT, 

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorMultiply.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorMultiply.java
@@ -537,6 +537,42 @@ public class TestExpressionNumericArrayIteratorMultiply extends BaseNumericTest 
             (Map) ImmutableMap.builder()
               .put(ExpressionTimeSeries.RIGHT_KEY, right)
               .build());
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void nullLeftSubstitute() throws Exception {
+    right = new NumericArrayTimeSeries(RIGHT_ID, 
+        new SecondTimeStamp(60));
+    ((NumericArrayTimeSeries) right).add(4);
+    ((NumericArrayTimeSeries) right).add(10);
+    ((NumericArrayTimeSeries) right).add(8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a * b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.MULTIPLY)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericArrayIterator iterator = 
+        new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
     assertTrue(iterator.hasNext());
     TimeSeriesValue<NumericArrayType> value = 
         (TimeSeriesValue<NumericArrayType>) iterator.next();
@@ -566,6 +602,42 @@ public class TestExpressionNumericArrayIteratorMultiply extends BaseNumericTest 
         .setId("expression")
         .build();
     when(node.config()).thenReturn(expression_config);
+    
+    ExpressionNumericArrayIterator iterator = 
+        new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void nullRightSubstitute() throws Exception {
+    left = new NumericArrayTimeSeries(LEFT_ID, 
+        new SecondTimeStamp(60));
+    ((NumericArrayTimeSeries) left).add(4);
+    ((NumericArrayTimeSeries) left).add(10);
+    ((NumericArrayTimeSeries) left).add(8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a % b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.MULTIPLY)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
     
     ExpressionNumericArrayIterator iterator = 
         new ExpressionNumericArrayIterator(node, RESULT, 

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorRelational.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorRelational.java
@@ -1908,6 +1908,133 @@ public class TestExpressionNumericArrayIteratorRelational extends BaseNumericTes
             (Map) ImmutableMap.builder()
               .put(ExpressionTimeSeries.RIGHT_KEY, right)
               .build());
+    assertFalse(iterator.hasNext());
+    
+    // NE
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
+    assertFalse(iterator.hasNext());
+    
+    // LT
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
+    assertFalse(iterator.hasNext());
+    
+    // GT
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
+    assertFalse(iterator.hasNext());
+    
+    // LE
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
+    assertFalse(iterator.hasNext());
+    
+    // GE
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void nullLeftSubstitute() throws Exception {
+    right = new NumericArrayTimeSeries(RIGHT_ID, 
+        new SecondTimeStamp(60));
+    ((NumericArrayTimeSeries) right).add(4);
+    ((NumericArrayTimeSeries) right).add(5);
+    ((NumericArrayTimeSeries) right).add(8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a + b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    // EQ
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericArrayIterator iterator = 
+        new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
     assertTrue(iterator.hasNext());
     TimeSeriesValue<NumericArrayType> value = 
         (TimeSeriesValue<NumericArrayType>) iterator.next();
@@ -2069,6 +2196,133 @@ public class TestExpressionNumericArrayIteratorRelational extends BaseNumericTes
             (Map) ImmutableMap.builder()
               .put(ExpressionTimeSeries.LEFT_KEY, left)
               .build());
+    assertFalse(iterator.hasNext());
+    
+    // NE
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.NE)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertFalse(iterator.hasNext());
+    
+    // LT
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.LT)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertFalse(iterator.hasNext());
+    
+    // GT
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.GT)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertFalse(iterator.hasNext());
+    
+    // LE
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.LE)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertFalse(iterator.hasNext());
+    
+    // GE
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.GE)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void nullRightSubstitute() throws Exception {
+    left = new NumericArrayTimeSeries(LEFT_ID, 
+        new SecondTimeStamp(60));
+    ((NumericArrayTimeSeries) left).add(1);
+    ((NumericArrayTimeSeries) left).add(5);
+    ((NumericArrayTimeSeries) left).add(37);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a + b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    // EQ
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericArrayIterator iterator = 
+        new ExpressionNumericArrayIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
     assertTrue(iterator.hasNext());
     TimeSeriesValue<NumericArrayType> value = 
         (TimeSeriesValue<NumericArrayType>) iterator.next();
@@ -2204,4 +2458,5 @@ public class TestExpressionNumericArrayIteratorRelational extends BaseNumericTes
     assertEquals(3, value.value().end());
     assertFalse(iterator.hasNext());
   }
+  
 }

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorAdditive.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorAdditive.java
@@ -949,6 +949,54 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
   }
   
   @Test
+  public void nullLeftSubstitute() throws Exception {
+    right = new NumericMillisecondShard(RIGHT_ID, 
+        new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
+    ((NumericMillisecondShard) right).add(1000, 4);
+    ((NumericMillisecondShard) right).add(3000, 10);
+    ((NumericMillisecondShard) right).add(5000, 8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a + b + c")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericIterator iterator = 
+        new ExpressionNumericIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(1000, value.timestamp().msEpoch());
+    assertEquals(4, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(3000, value.timestamp().msEpoch());
+    assertEquals(10, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(5000, value.timestamp().msEpoch());
+    assertEquals(8, value.value().longValue());
+  }
+  
+  @Test
   public void nullRight() throws Exception {
     left = new NumericMillisecondShard(LEFT_ID, 
         new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
@@ -986,4 +1034,53 @@ public class TestExpressionNumericIteratorAdditive extends BaseNumericTest {
     assertEquals(5000, value.timestamp().msEpoch());
     assertNull(value.value());
   }
+  
+  @Test
+  public void nullRightSubstitute() throws Exception {
+    left = new NumericMillisecondShard(LEFT_ID, 
+        new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
+    ((NumericMillisecondShard) left).add(1000, 4);
+    ((NumericMillisecondShard) left).add(3000, 10);
+    ((NumericMillisecondShard) left).add(5000, 8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a + b + c")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.ADD)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericIterator iterator = 
+        new ExpressionNumericIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(1000, value.timestamp().msEpoch());
+    assertEquals(4, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(3000, value.timestamp().msEpoch());
+    assertEquals(10, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(5000, value.timestamp().msEpoch());
+    assertEquals(8, value.value().longValue());
+  }
+  
 }

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorDivide.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorDivide.java
@@ -691,6 +691,54 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
   }
   
   @Test
+  public void nullLeftSubstitute() throws Exception {
+    right = new NumericMillisecondShard(RIGHT_ID, 
+        new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
+    ((NumericMillisecondShard) right).add(1000, 4);
+    ((NumericMillisecondShard) right).add(3000, 10);
+    ((NumericMillisecondShard) right).add(5000, 8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a / b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericIterator iterator = 
+        new ExpressionNumericIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(1000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(3000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(5000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+  }
+  
+  @Test
   public void nullRight() throws Exception {
     left = new NumericMillisecondShard(LEFT_ID, 
         new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
@@ -728,4 +776,53 @@ public class TestExpressionNumericIteratorDivide extends BaseNumericTest {
     assertEquals(5000, value.timestamp().msEpoch());
     assertNull(value.value());
   }
+  
+  @Test
+  public void nullRightSubstitute() throws Exception {
+    left = new NumericMillisecondShard(LEFT_ID, 
+        new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
+    ((NumericMillisecondShard) left).add(1000, 4);
+    ((NumericMillisecondShard) left).add(3000, 10);
+    ((NumericMillisecondShard) left).add(5000, 8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a / b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.DIVIDE)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericIterator iterator = 
+        new ExpressionNumericIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(1000, value.timestamp().msEpoch());
+    assertEquals(4, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(3000, value.timestamp().msEpoch());
+    assertEquals(10, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(5000, value.timestamp().msEpoch());
+    assertEquals(8, value.value().longValue());
+  }
+  
 }

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorLogical.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorLogical.java
@@ -1105,6 +1105,83 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
   }
   
   @Test
+  public void nullLeftSubstitute() throws Exception {
+    right = new NumericMillisecondShard(RIGHT_ID, 
+        new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
+    ((NumericMillisecondShard) right).add(1000, 4);
+    ((NumericMillisecondShard) right).add(3000, 0);
+    ((NumericMillisecondShard) right).add(5000, -1);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a || b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericIterator iterator = 
+        new ExpressionNumericIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(1000, value.timestamp().msEpoch());
+    assertEquals(1, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(3000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(5000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    // AND
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
+    assertTrue(iterator.hasNext());
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(1000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(3000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(5000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue()); 
+  }
+  
+  @Test
   public void nullRight() throws Exception {
     left = new NumericMillisecondShard(LEFT_ID, 
         new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
@@ -1171,4 +1248,82 @@ public class TestExpressionNumericIteratorLogical extends BaseNumericTest {
     assertEquals(5000, value.timestamp().msEpoch());
     assertEquals(0, value.value().longValue());
   }
+  
+  @Test
+  public void nullRightSubstitute() throws Exception {
+    left = new NumericMillisecondShard(LEFT_ID, 
+        new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
+    ((NumericMillisecondShard) left).add(1000, 4);
+    ((NumericMillisecondShard) left).add(3000, 0);
+    ((NumericMillisecondShard) left).add(5000, -1);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a || b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.OR)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericIterator iterator = 
+        new ExpressionNumericIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(1000, value.timestamp().msEpoch());
+    assertEquals(1, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(3000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(5000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    // AND
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.AND)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    
+    iterator = new ExpressionNumericIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertTrue(iterator.hasNext());
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(1000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(3000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(5000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+  }
+  
 }

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorMod.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorMod.java
@@ -650,6 +650,54 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
   }
   
   @Test
+  public void nullLeftSubstitute() throws Exception {
+    right = new NumericMillisecondShard(RIGHT_ID, 
+        new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
+    ((NumericMillisecondShard) right).add(1000, 4);
+    ((NumericMillisecondShard) right).add(3000, 10);
+    ((NumericMillisecondShard) right).add(5000, 8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a % b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericIterator iterator = 
+        new ExpressionNumericIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(1000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(3000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(5000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+  }
+  
+  @Test
   public void nullRight() throws Exception {
     left = new NumericMillisecondShard(LEFT_ID, 
         new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
@@ -687,4 +735,53 @@ public class TestExpressionNumericIteratorMod extends BaseNumericTest {
     assertEquals(5000, value.timestamp().msEpoch());
     assertNull(value.value());
   }
+  
+  @Test
+  public void nullRightSubstitute() throws Exception {
+    left = new NumericMillisecondShard(LEFT_ID, 
+        new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
+    ((NumericMillisecondShard) left).add(1000, 4);
+    ((NumericMillisecondShard) left).add(3000, 10);
+    ((NumericMillisecondShard) left).add(5000, 8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a % b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.MOD)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericIterator iterator = 
+        new ExpressionNumericIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(1000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(3000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(5000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+  }
+  
 }

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorRelational.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericIteratorRelational.java
@@ -2389,6 +2389,54 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
   }
   
   @Test
+  public void nullLeftSubstitute() throws Exception {
+    right = new NumericMillisecondShard(RIGHT_ID, 
+        new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
+    ((NumericMillisecondShard) right).add(1000, 4);
+    ((NumericMillisecondShard) right).add(3000, 10);
+    ((NumericMillisecondShard) right).add(5000, 8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a == b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft(null)
+        .setLeftType(OperandType.NULL)
+        .setRight("b")
+        .setRightType(OperandType.VARIABLE)
+        .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(CONFIG)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericIterator iterator = 
+        new ExpressionNumericIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.RIGHT_KEY, right)
+              .build());
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(1000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(3000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(5000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+  }
+  
+  @Test
   public void nullRight() throws Exception {
     left = new NumericMillisecondShard(LEFT_ID, 
         new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
@@ -2425,6 +2473,54 @@ public class TestExpressionNumericIteratorRelational extends BaseNumericTest {
     value = (TimeSeriesValue<NumericType>) iterator.next();
     assertEquals(5000, value.timestamp().msEpoch());
     assertNull(value.value());
+  }
+  
+  @Test
+  public void nullRightSubstitute() throws Exception {
+    left = new NumericMillisecondShard(LEFT_ID, 
+        new MillisecondTimeStamp(1000), new MillisecondTimeStamp(7000));
+    ((NumericMillisecondShard) left).add(1000, 4);
+    ((NumericMillisecondShard) left).add(3000, 10);
+    ((NumericMillisecondShard) left).add(5000, 8);
+    
+    ExpressionConfig cfg = ExpressionConfig.newBuilder()
+        .setExpression("a == b")
+        .setJoinConfig(JOIN_CONFIG)
+        .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setSubstituteMissing(true)
+        .setId("e1")
+        .build();
+    
+    expression_config = (ExpressionParseNode) ExpressionParseNode.newBuilder()
+        .setLeft("a")
+        .setLeftType(OperandType.VARIABLE)
+        .setRight(null)
+        .setRightType(OperandType.NULL)
+        .setExpressionOp(ExpressionOp.EQ)
+        .setExpressionConfig(cfg)
+        .setId("expression")
+        .build();
+    when(node.config()).thenReturn(expression_config);
+    when(node.expressionConfig()).thenReturn(cfg);
+    
+    ExpressionNumericIterator iterator = 
+        new ExpressionNumericIterator(node, RESULT, 
+            (Map) ImmutableMap.builder()
+              .put(ExpressionTimeSeries.LEFT_KEY, left)
+              .build());
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(1000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(3000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(5000, value.timestamp().msEpoch());
+    assertEquals(0, value.value().longValue());
   }
   
 }


### PR DESCRIPTION
- Add the substituteMissing flag to the expression config. This will fill
  in missing time series with zeros or ones when appropriate so the results
  aren't null.
- Fixed the expression arrays and sumaries to properly return null when
  a series is missing and the substitute flag is false.