### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/threadpools/UserAwareThreadPoolExecutor.java
+++ b/core/src/main/java/net/opentsdb/threadpools/UserAwareThreadPoolExecutor.java
@@ -653,9 +653,11 @@ public class UserAwareThreadPoolExecutor implements TSDBThreadPoolExecutor, Time
     }
   }
 
-  private String getUser(QueryContext qctx) {
-    final String user = qctx.authState().getUser() == null ? "Unknown" : qctx.authState().getUser();
-    return user;
+  private String getUser(final QueryContext qctx) {
+    if (qctx.authState() == null) {
+      return "Unknown";
+    }
+    return qctx.authState().getUser() == null ? "Unknown" : qctx.authState().getUser();
   }
 
   @Override

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/ExpressionRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/ExpressionRpc.java
@@ -304,7 +304,7 @@ public class ExpressionRpc {
     
     LOG.info("Creating async query");
 
-    tsdb.getQueryThreadPool().submit(runTsdQuery, null, TSDTask.QUERY).get();
+    tsdb.getQueryThreadPool().submit(runTsdQuery, null, TSDTask.QUERY);
     
     return null;
   }

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/QueryRpc.java
@@ -382,7 +382,7 @@ final public class QueryRpc {
     
     LOG.info("Creating async query");
 
-    tsdb.getQueryThreadPool().submit(runTsdQuery, null, TSDTask.QUERY).get();
+    tsdb.getQueryThreadPool().submit(runTsdQuery, null, TSDTask.QUERY);
     
     return null;
   }

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/RawQueryRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/RawQueryRpc.java
@@ -269,7 +269,7 @@ public class RawQueryRpc {
     
     LOG.info("Creating async query");
 
-    tsdb.getQueryThreadPool().submit(runTsdQuery, null, TSDTask.QUERY).get();
+    tsdb.getQueryThreadPool().submit(runTsdQuery, context, TSDTask.QUERY);
     
     return null;
   }


### PR DESCRIPTION
- Fix an NPE if auth is disabled in the UserAwareThreadPoolExecutor.

SERVLET:
- Don't join on the query futures in the query RPC classes.