### PR TITLE
Add unit test for rollup filter fix for #1083

### DIFF
--- a/test/core/TestTsdbQueryQueries.java
+++ b/test/core/TestTsdbQueryQueries.java
@@ -30,6 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.opentsdb.query.filter.TagVLiteralOrFilter;
+import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.rollup.RollupInterval;
 import org.hbase.async.Bytes;
 import org.hbase.async.FilterList;
@@ -1551,6 +1553,75 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     verify(tag_values, atLeast(1)).getNameAsync(TAGV_BYTES);
     verify(tag_values, atLeast(1)).getNameAsync(TAGV_B_BYTES);
     assertEquals(0, dps.length);
+  }
+  @Test
+  public void runRollupFiltering() throws Exception {
+    storeLongTimeSeriesSeconds(false, false);
+    final List<byte[]> families = new ArrayList<byte[]>();
+    families.add("t".getBytes(MockBase.ASCII()));
+    storage.addTable("tsdb-agg".getBytes(), families);
+    setupGroupByTagValues();
+    long start_timestamp = 1559347200L;
+
+
+    RollupInterval defaultInterval = RollupInterval.builder()
+            .setTable("tsdb")
+            .setPreAggregationTable("tsdb-agg")
+            .setInterval("1m")
+            .setRowSpan("1h")
+            .build();
+
+    RollupInterval rollupInterval = RollupInterval.builder()
+            .setTable("tsdb-agg")
+            .setPreAggregationTable("tsdb-agg")
+            .setInterval("1h")
+            .setRowSpan("1d")
+            .build();
+    Whitebox.setInternalState(tsdb, "default_interval", defaultInterval);
+
+    RollupConfig rollupConfig = RollupConfig.builder().setAggregationIds(new HashMap<String, Integer>() {{
+      put("sum", 0);
+      put("count", 1);
+      put("min", 2);
+      put("max", 3);
+      put("avg", 4);
+    }}).setIntervals(Arrays.asList(defaultInterval, rollupInterval)).build();
+
+    Whitebox.setInternalState(tsdb, "default_interval", defaultInterval);
+    Whitebox.setInternalState(tsdb,"rollup_config", rollupConfig);
+
+    this.tsdb.addAggregatePoint(METRIC_STRING, start_timestamp, 42L, new HashMap<String, String>() {{ put("host", "web01");}}, false, "1h", "sum", null);
+    this.tsdb.addAggregatePoint(METRIC_STRING, start_timestamp, 42L, new HashMap<String, String>() {{ put("host", "web02");}}, false, "1h", "sum", null);
+    this.tsdb.addAggregatePoint(METRIC_STRING, start_timestamp, 42L, new HashMap<String, String>() {{ put("host", "web01");}}, false, "1h", "count", null);
+    this.tsdb.addAggregatePoint(METRIC_STRING, start_timestamp, 42L, new HashMap<String, String>() {{ put("host", "web02");}}, false, "1h", "count", null);
+
+    TSQuery ts_query = new TSQuery();
+    ts_query.setStart("1559343600");
+    ts_query.setEnd("1559350800");
+
+    final TSSubQuery sub = new TSSubQuery();
+    sub.setMetric(METRIC_STRING);
+    sub.setAggregator("sum");
+    sub.setDownsample("1h-sum");
+    sub.setFilters(Arrays.asList(new TagVLiteralOrFilter("host", TAGV_STRING)));
+
+    ts_query.setQueries(Arrays.asList(sub));
+    ts_query.validateAndSetQuery();
+    query.configureFromQuery(ts_query, 0);
+
+    final DataPoints[] dps = query.run();
+    assertEquals(1, dps.length);
+    assertEquals(1, dps[0].aggregatedSize());
+    assertEquals(METRIC_STRING, dps[0].metricName());
+    assertTrue(dps[0].getAggregatedTags().isEmpty());
+    assertNull(dps[0].getAnnotations());
+    assertEquals(TAGV_STRING, dps[0].getTags().get(TAGK_STRING));
+
+    long ts = start_timestamp * 1000;
+    final DataPoint dp = dps[0].iterator().next();
+    assertEquals(42, dp.doubleValue(), 0);
+    assertEquals(ts, dp.timestamp());
+    assertEquals(1, dps[0].size());
   }
 
   @Test

--- a/test/storage/MockBase.java
+++ b/test/storage/MockBase.java
@@ -1673,7 +1673,14 @@ public final class MockBase {
         if (pattern != null) {
           final String from_bytes = new String(last_row, regex_charset);
           if (!pattern.matcher(from_bytes).find()) {
-            continue;
+            if (filter instanceof FilterList) {
+              FilterList.Operator op = Whitebox.getInternalState(filter, "op");
+              if (op == FilterList.Operator.MUST_PASS_ALL) {
+                continue;
+              }
+            } else {
+              continue;
+            }
           }
         }
 


### PR DESCRIPTION
I was looking into exactly the same issue as #1083 on a fork before spotting that it was already addressed by d342301898ccc3edaee18d711a6d9684007d16b8.  It seems like reasonably complicated logic and I noticed adding some tests is on the todo list https://github.com/OpenTSDB/opentsdb/blob/master/src/core/TsdbQuery.java#L1419.  Since I wrote the unit test before I noticed the fix, I thought I might as well offer it back.  