### PR TITLE
Force Sunday as first day of week in tests.

### DIFF
--- a/test/core/TestDownsampler.java
+++ b/test/core/TestDownsampler.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Calendar;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import com.google.common.collect.Lists;
@@ -591,6 +592,9 @@ public class TestDownsampler {
   
   @Test
   public void testDownsampler_calendarWeek() {
+    // Test assumes Sunday is first day of week.
+    Locale.setDefault(Locale.US);
+
     source = SeekableViewsForTest.fromArray(new DataPoint[] {
         MutableDataPoint.ofLongValue(DST_TS, 1), // a Tuesday in UTC land
         MutableDataPoint.ofLongValue(DST_TS + (86400000L * 7), 2),
@@ -901,7 +905,9 @@ public class TestDownsampler {
         MutableDataPoint.ofLongValue(1357430400000L, 4),
         MutableDataPoint.ofLongValue(1357732800000L, 8)
     }));
-    
+
+    // Test assumes Sunday is first day of week.
+    Locale.setDefault(Locale.US);
     specification = new DownsamplingSpecification("1wc-sum");
     downsampler = new Downsampler(source, specification, 0, Long.MAX_VALUE);
     verify(source, never()).next();
@@ -925,7 +931,9 @@ public class TestDownsampler {
         MutableDataPoint.ofLongValue(1357448400000L, 4),
         MutableDataPoint.ofLongValue(1357750800000L, 8)
     }));
-    
+
+    // Test assumes Sunday is first day of week.
+    Locale.setDefault(Locale.US);
     specification = new DownsamplingSpecification("1wc-sum");
     specification.setTimezone(EST_TIME_ZONE);
     downsampler = new Downsampler(source, specification, 0, Long.MAX_VALUE);

--- a/test/utils/TestDateTime.java
+++ b/test/utils/TestDateTime.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import org.junit.Before;
@@ -782,6 +783,9 @@ public final class TestDateTime {
   
   @Test
   public void previousIntervalWeeks() {
+    // Test assumes Sunday is first day of week.
+    Locale.setDefault(Locale.US);
+
     // interval 1 DST_TS starts on 13th of Dec, NON starts on the 10th of May
     assertEquals(1449964800000L, DateTime.previousInterval(DST_TS, 
         1, Calendar.DAY_OF_WEEK).getTimeInMillis());


### PR DESCRIPTION
Week based tests fails when running on locales that uses ISO weeks, as the tests assumes that Sunday is the first day of the week.

It would probably be even better to accept locale as a parameter on the query in the same way as timezone, but that is a much larger change.