### PR TITLE
Synchronise the KVs list for scanner results

### DIFF
--- a/src/core/SaltScanner.java
+++ b/src/core/SaltScanner.java
@@ -464,7 +464,7 @@ public class SaltScanner {
     ArrayList<ArrayList<KeyValue>>> {
     private final Scanner scanner;
     private final int index;
-    private final List<KeyValue> kvs = new ArrayList<KeyValue>();
+    private final List<KeyValue> kvs = Collections.synchronizedList(new ArrayList<KeyValue>());
     private final ByteMap<List<Annotation>> annotations = 
             new ByteMap<List<Annotation>>();
     private final Set<String> skips = Collections.newSetFromMap(


### PR DESCRIPTION
Synchronises the list that holds the KeyValues that have been produced by the scanner callbacks. The list is accessed from multiple threads at a time and wasn't thread-safe, causing inconsistent results and partial loss of data in the response when the UID cache is cold.
Subsequent queries with a warm cache are less susceptible to this bug.

Relates to: #1753
Resolves: #1760