### PR TITLE
CORE:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/TimeSeriesDataSourceConfig.java
+++ b/common/src/main/java/net/opentsdb/query/TimeSeriesDataSourceConfig.java
@@ -15,6 +15,7 @@
 package net.opentsdb.query;
 
 import java.time.temporal.TemporalAmount;
+import java.util.Collection;
 import java.util.List;
 
 import net.opentsdb.query.filter.MetricFilter;
@@ -31,6 +32,10 @@ public interface TimeSeriesDataSourceConfig<
     extends QueryNodeConfig<B, C> {
 
   public static final String DEFAULT = "TimeSeriesDataSource";
+  
+  /** @return The ID of the node as set by the user and populates the 
+   * {@link QueryResult#dataSource()} field. May be the same as the ID. */
+  public String getDataSourceId();
   
   /** @return The source ID. May be null in which case we use the default. */
   public String getSourceId();
@@ -70,7 +75,9 @@ public interface TimeSeriesDataSourceConfig<
   public List<String> getRollupIntervals();
 
   /** @return An optional list of push down nodes. May be null. */
-  List<QueryNodeConfig> getPushDownNodes();
+  public List<QueryNodeConfig> getPushDownNodes();
+  
+  public Collection<String> pushDownSinks();
   
   /** @return An optional pre-query start time padding string as a duration. */
   public String getPrePadding();
@@ -94,7 +101,11 @@ public interface TimeSeriesDataSourceConfig<
   /**
    * A base builder interface for data source configs.
    */
-  interface Builder<B extends Builder<B, C>, C extends TimeSeriesDataSourceConfig> extends QueryNodeConfig.Builder<B, C> {
+  interface Builder<B extends Builder<B, C>, 
+      C extends TimeSeriesDataSourceConfig> extends QueryNodeConfig.Builder<B, C> {
+    
+    B setDataSourceId(final String data_source_id);
+    
     B setSourceId(final String source_id);
     
     B setTypes(final List<String> types);

--- a/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
+++ b/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
@@ -607,25 +607,17 @@ public abstract class AbstractQueryPipelineContext implements
     
     @Override
     public void close() {
-      if (result.source().config() instanceof TimeSeriesDataSourceConfig ||
-          result.source().config().joins()) {
-        AtomicInteger cntr = countdowns.get(result.dataSource());
-        if (cntr == null) {
-          LOG.error("Unexpected result source, no counter for: " 
-              + result.dataSource());
-        } else {
-          cntr.decrementAndGet();
-        }
+      AtomicInteger cntr = countdowns.get(result.dataSource());
+      if (cntr == null) {
+        cntr = countdowns.get(result.source().config().getId() + ":" + result.dataSource());
+      }
+      
+      if (cntr == null ) {
+        LOG.error("Unexpected result source, no counter for: " 
+            + result.source().config().getId() + ":" 
+            + result.dataSource() + ". WANT: " + countdowns.keySet());
       } else {
-        AtomicInteger cntr = countdowns.get(result.source().config().getId() + ":" 
-            + result.dataSource());
-        if (cntr == null) {
-          LOG.error("Unexpected result source, noo counter for: " 
-              + result.source().config().getId() + ":" 
-              + result.dataSource());
-        } else {
-          cntr.decrementAndGet();
-        }
+        cntr.decrementAndGet();
       }
       checkComplete();
       try {

--- a/core/src/main/java/net/opentsdb/query/WrappedTimeSeriesDataSourceConfig.java
+++ b/core/src/main/java/net/opentsdb/query/WrappedTimeSeriesDataSourceConfig.java
@@ -15,6 +15,7 @@
 package net.opentsdb.query;
 
 import java.time.temporal.TemporalAmount;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -74,6 +75,11 @@ public class WrappedTimeSeriesDataSourceConfig implements TimeSeriesDataSourceCo
     return config.getType();
   }
 
+  @Override
+  public String getDataSourceId() {
+    return config.getDataSourceId();
+  }
+  
   @Override
   public List<String> getSources() {
     return config.getSources();
@@ -233,6 +239,11 @@ public class WrappedTimeSeriesDataSourceConfig implements TimeSeriesDataSourceCo
     return config.getPushDownNodes();
   }
 
+  @Override
+  public Collection<String> pushDownSinks() {
+    return config.pushDownSinks();
+  }
+  
   @Override
   public String getSummaryInterval() {
     return config.getSummaryInterval();

--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
@@ -129,6 +129,7 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes {
   @Override
   public Deferred<Object> serialize(final QueryResult result,
                                     final Span span) {
+    System.out.println("   ****** SERIALIZING: " + result.getClass());
     if (result == null) {
       throw new IllegalArgumentException("Data may not be null.");
     }

--- a/core/src/main/java/net/opentsdb/query/joins/Joiner.java
+++ b/core/src/main/java/net/opentsdb/query/joins/Joiner.java
@@ -132,7 +132,7 @@ public class Joiner {
     }
     
     final KeyedHashedJoinSet join_set = 
-        new KeyedHashedJoinSet(config.type);
+        new KeyedHashedJoinSet(config.getJoinType());
     
     // calculate the hash for every series and let the hasher kick out
     // inapplicable series.
@@ -265,7 +265,6 @@ public class Joiner {
       }
       
       for (final TimeSeries ts : result.timeSeries()) {
-        
         if (ts.id().type() == Const.TS_BYTE_ID) {
           final TimeSeriesByteId id = (TimeSeriesByteId) ts.id();
           final byte[] key;

--- a/core/src/main/java/net/opentsdb/query/processor/merge/MergerConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/merge/MergerConfig.java
@@ -34,6 +34,9 @@ import java.util.List;
 @JsonDeserialize(builder = MergerConfig.Builder.class)
 public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerConfig.Builder, MergerConfig> {
 
+  /** The data source we'll send up. */
+  private final String data_source;
+  
   /** The raw aggregator. */
   private final String aggregator;
   
@@ -45,8 +48,16 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
     if (Strings.isNullOrEmpty(builder.aggregator)) {
       throw new IllegalArgumentException("Aggregator cannot be null or empty.");
     }
+    if (Strings.isNullOrEmpty(builder.dataSource)) {
+      throw new IllegalArgumentException("Data source cannot be null or empty.");
+    }
+    data_source = builder.dataSource;
     aggregator = builder.aggregator;
     infectious_nan = builder.infectious_nan;
+  }
+  
+  public String getDataSource() {
+    return data_source;
   }
 
   /** @return The non-null and non-empty aggregation function name. */
@@ -63,12 +74,12 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
   @Override
   public Builder toBuilder() {
     return new Builder()
+        .setDataSource(data_source)
         .setAggregator(aggregator)
         .setInfectiousNan(infectious_nan)
         .setInterpolatorConfigs(Lists.newArrayList(interpolator_configs.values()))
         .setId(id);
   }
-
 
   @Override
   public boolean equals(final Object o) {
@@ -84,7 +95,8 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
 
     final MergerConfig merger = (MergerConfig) o;
 
-    return Objects.equal(aggregator, merger.getAggregator())
+    return Objects.equal(id, merger.getId()) &&
+            Objects.equal(aggregator, merger.getAggregator())
             && Objects.equal(infectious_nan, merger.getInfectiousNan());
 
   }
@@ -134,12 +146,19 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Builder extends BaseQueryNodeConfigWithInterpolators.Builder<Builder, MergerConfig> {
     @JsonProperty
+    private String dataSource;
+    @JsonProperty
     private String aggregator;
     @JsonProperty
     private boolean infectious_nan;
     
     Builder() {
       setType(MergerFactory.TYPE);
+    }
+    
+    public Builder setDataSource(final String data_source) {
+      dataSource = data_source;
+      return this;
     }
     
     /**

--- a/core/src/main/java/net/opentsdb/query/processor/merge/MergerResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/merge/MergerResult.java
@@ -163,7 +163,7 @@ public class MergerResult implements QueryResult {
 
   @Override
   public String dataSource() {
-    return node.config().getId();
+    return ((MergerConfig) node.config()).getDataSource();
   }
   
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizedTimeSeries.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizedTimeSeries.java
@@ -1,0 +1,150 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2019  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.processor.summarizer;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Map.Entry;
+
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesDataType;
+import net.opentsdb.data.TimeSeriesId;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.TypedTimeSeriesIterator;
+import net.opentsdb.data.types.numeric.MutableNumericSummaryValue;
+import net.opentsdb.data.types.numeric.MutableNumericValue;
+import net.opentsdb.data.types.numeric.NumericSummaryType;
+import net.opentsdb.data.types.numeric.aggregators.NumericAggregator;
+import net.opentsdb.query.QueryIterator;
+
+/**
+ * A time series that travels to pass-through iterators and is updated as
+ * the iteration occurs on the source.
+ * 
+ * @since 3.0
+ */
+public class SummarizedTimeSeries implements TimeSeries {
+  /** The pass through result. */
+  protected final SummarizerPassThroughResult result;
+  
+  /** The non-null source. */
+  protected final TimeSeries source;
+  
+  /** The summary updated by the pass through iterator. */
+  protected final MutableNumericSummaryValue summary;
+  
+  /**
+   * The package private ctor.
+   * @param result The non-null result.
+   * @param source The non-null source.
+   */
+  SummarizedTimeSeries(final SummarizerPassThroughResult result, 
+                       final TimeSeries source) {
+    this.result = result;
+    this.source = source;
+    summary = new MutableNumericSummaryValue();
+  }
+  
+  @Override
+  public TimeSeriesId id() {
+    return source.id();
+  }
+  
+  @Override
+  public Optional<TypedTimeSeriesIterator<? extends TimeSeriesDataType>> iterator(
+      final TypeToken<? extends TimeSeriesDataType> type) {
+    if (type == NumericSummaryType.TYPE) {
+      final TypedTimeSeriesIterator iterator = new SummarizedIterator();
+      return Optional.of(iterator);
+    }
+    return Optional.empty();
+  }
+  
+  @Override
+  public Collection<TypedTimeSeriesIterator<? extends TimeSeriesDataType>> iterators() {
+    final List<TypedTimeSeriesIterator<? extends TimeSeriesDataType>> iterators =
+        Lists.newArrayListWithCapacity(1);
+    iterators.add(new SummarizedIterator());
+    return iterators;
+  }
+
+  @Override
+  public Collection<TypeToken<? extends TimeSeriesDataType>> types() {
+    return Lists.newArrayList(NumericSummaryType.TYPE);
+  }
+
+  @Override
+  public void close() {
+    source.close();
+  }
+  
+  void fillEmpty() {
+    summary.resetNull(result.source().pipelineContext().query().startTime());
+  }
+  
+  void summarize(final long[] values, int offset, int end) {
+    summary.resetTimestamp(result.source().pipelineContext().query().startTime());
+    final MutableNumericValue number = new MutableNumericValue();
+    for (Entry<String, NumericAggregator> entry : 
+      ((Summarizer) result.summarizerNode()).aggregators().entrySet()) {
+      entry.getValue().run(values, offset, end, number);
+      summary.resetValue(result.rollupConfig()
+          .getIdForAggregator(entry.getKey()), number.value());
+    }
+  }
+  
+  void summarize(final double[] values, int offset, int end) {
+    summary.resetTimestamp(result.source().pipelineContext().query().startTime());
+    final MutableNumericValue number = new MutableNumericValue();
+    for (Entry<String, NumericAggregator> entry : 
+      ((Summarizer) result.summarizerNode()).aggregators().entrySet()) {
+      entry.getValue().run(values, offset, end, 
+          ((SummarizerConfig) result.summarizerNode().config()).getInfectiousNan(), number);
+      summary.resetValue(result.rollupConfig()
+          .getIdForAggregator(entry.getKey()), number.value());
+    }
+  }
+  
+  /**
+   * Simple iterator that just returns the summary value.
+   */
+  class SummarizedIterator implements QueryIterator {
+    boolean has_next = true;
+    
+    @Override
+    public boolean hasNext() {
+      if (has_next) {
+        has_next = false;
+        return true;
+      }
+      return false;
+    }
+    
+    @Override
+    public TimeSeriesValue<? extends TimeSeriesDataType> next() {
+      return summary;
+    }
+    
+    @Override
+    public TypeToken<? extends TimeSeriesDataType> getType() {
+      return NumericSummaryType.TYPE;
+    }
+    
+  }
+}

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2019  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,6 +42,9 @@ public class SummarizerConfig extends BaseQueryNodeConfig<SummarizerConfig.Build
   /** Whether or not NaNs are infectious. */
   private final boolean infectious_nan;
   
+  /** Whether or not we only summarize or pass through as well. */
+  private final boolean pass_through;
+  
   protected SummarizerConfig(final Builder builder) {
     super(builder);
     if (builder.summaries == null || builder.summaries.isEmpty()) {
@@ -50,6 +53,7 @@ public class SummarizerConfig extends BaseQueryNodeConfig<SummarizerConfig.Build
     }
     summaries = builder.summaries;
     infectious_nan = builder.infectiousNan;
+    pass_through = builder.pass_through;
   }
   
   /** @return The non-null and non-empty list of summaries to record. */
@@ -63,6 +67,11 @@ public class SummarizerConfig extends BaseQueryNodeConfig<SummarizerConfig.Build
     return infectious_nan;
   }
 
+  /** @return Whether or not we summarize only or pass through too. */
+  public boolean passThrough() {
+    return pass_through;
+  }
+  
   @Override
   public int compareTo(SummarizerConfig o) {
     // TODO Auto-generated method stub
@@ -82,8 +91,7 @@ public class SummarizerConfig extends BaseQueryNodeConfig<SummarizerConfig.Build
     }
 
     final SummarizerConfig sconfig = (SummarizerConfig) o;
-
-
+    
     final boolean result = Objects.equal(infectious_nan, sconfig.getInfectiousNan());
 
     if (!result) {
@@ -137,7 +145,10 @@ public class SummarizerConfig extends BaseQueryNodeConfig<SummarizerConfig.Build
 
   @Override
   public Builder toBuilder() {
-    return null;
+    return newBuilder()
+        .setSummaries(Lists.newArrayList(summaries))
+        .setInfectiousNan(infectious_nan)
+        .setId(id);
   }
 
   public static Builder newBuilder() {
@@ -150,6 +161,7 @@ public class SummarizerConfig extends BaseQueryNodeConfig<SummarizerConfig.Build
     private boolean infectiousNan;
     @JsonProperty
     protected List<String> summaries;
+    protected boolean pass_through;
     
     Builder() {
       setType(SummarizerFactory.TYPE);
@@ -175,6 +187,11 @@ public class SummarizerConfig extends BaseQueryNodeConfig<SummarizerConfig.Build
      */
     public Builder setInfectiousNan(final boolean infectious_nan) {
       infectiousNan = infectious_nan;
+      return this;
+    }
+    
+    public Builder setPassThrough(final boolean pass_through) {
+      this.pass_through = pass_through;
       return this;
     }
     

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerNonPassThroughResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerNonPassThroughResult.java
@@ -37,7 +37,7 @@ import net.opentsdb.query.processor.ProcessorFactory;
  * 
  * @since 3.0
  */
-public class SummarizerResult extends BaseWrappedQueryResult {
+public class SummarizerNonPassThroughResult extends BaseWrappedQueryResult {
 
   /** The non-null parent node. */
   private final Summarizer node;
@@ -50,7 +50,7 @@ public class SummarizerResult extends BaseWrappedQueryResult {
    * @param node The non-null node.
    * @param results The non-null results to source from.
    */
-  SummarizerResult(final Summarizer node, final QueryResult results) {
+  SummarizerNonPassThroughResult(final Summarizer node, final QueryResult results) {
     super(results);
     this.node = node;
     series = Lists.newArrayList();
@@ -108,7 +108,7 @@ public class SummarizerResult extends BaseWrappedQueryResult {
           ((ProcessorFactory) node.factory()).newTypedIterator(
               type, 
               node, 
-              SummarizerResult.this,
+              SummarizerNonPassThroughResult.this,
               Lists.newArrayList(source));
       if (iterator != null) {
         return Optional.of(iterator);
@@ -128,7 +128,7 @@ public class SummarizerResult extends BaseWrappedQueryResult {
         iterators.add(((ProcessorFactory) node.factory()).newTypedIterator(
             NumericSummaryType.TYPE, 
             node, 
-            SummarizerResult.this,
+            SummarizerNonPassThroughResult.this,
             Lists.newArrayList(source)));
       }
       return iterators;

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughNumericArrayIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughNumericArrayIterator.java
@@ -1,0 +1,63 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2018-2019  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.processor.summarizer;
+
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.data.TimeSeriesDataType;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.TypedTimeSeriesIterator;
+import net.opentsdb.data.types.numeric.NumericArrayType;
+import net.opentsdb.query.QueryIterator;
+
+public class SummarizerPassThroughNumericArrayIterator implements QueryIterator {
+  SummarizedTimeSeries sts;
+  
+  /** The source iterator. */
+  private TypedTimeSeriesIterator<? extends TimeSeriesDataType> iterator;
+
+  SummarizerPassThroughNumericArrayIterator(final SummarizedTimeSeries sts) {
+    this.sts = sts;
+    iterator = sts.source.iterator(NumericArrayType.TYPE).get();
+    if (!iterator.hasNext()) {
+      sts.fillEmpty();
+    }
+  }
+  
+  @Override
+  public boolean hasNext() {
+    return iterator.hasNext();
+  }
+  
+  @Override
+  public Object next() {
+    final TimeSeriesValue<NumericArrayType> value = 
+        (TimeSeriesValue<NumericArrayType>) iterator.next();
+    if (value.value() != null) {
+      if (value.value().isInteger()) {
+        sts.summarize(value.value().longArray(), value.value().offset(), value.value().end());
+      } else {
+        sts.summarize(value.value().doubleArray(), value.value().offset(), value.value().end());
+      }
+    }
+    return value;
+  }
+  
+  @Override
+  public TypeToken getType() {
+    return NumericArrayType.TYPE;
+  }
+  
+}

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughNumericIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughNumericIterator.java
@@ -1,0 +1,126 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2019  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.processor.summarizer;
+
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.data.TimeSeriesDataType;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.TypedTimeSeriesIterator;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.QueryIterator;
+
+public class SummarizerPassThroughNumericIterator implements QueryIterator {
+  SummarizedTimeSeries sts;
+  
+  /** The source iterator. */
+  private TypedTimeSeriesIterator<? extends TimeSeriesDataType> iterator;
+  
+  /** Results from the source. */
+  private long[] long_values;
+  private double[] double_values;
+  
+  /** The index into the results. */
+  private int idx;
+  
+  SummarizerPassThroughNumericIterator(final SummarizedTimeSeries sts) {
+    this.sts = sts;
+    iterator = sts.source.iterator(NumericType.TYPE).get();
+    if (!iterator.hasNext()) {
+      sts.fillEmpty();
+    } else {
+      long_values = new long[8];
+    }
+  }
+  
+  @Override
+  public boolean hasNext() {
+    if (!iterator.hasNext()) {
+      if (long_values != null) {
+        sts.summarize(long_values, 0, idx);
+      } else {
+        sts.summarize(double_values, 0, idx);
+      }
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public Object next() {
+    final TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    if (value.value() != null) {
+      if (value.value().isInteger()) {
+        store(value.value().longValue());
+      } else {
+        store(value.value().doubleValue());
+      }
+    }
+    return value;
+  }
+  
+  @Override
+  public TypeToken getType() {
+    return NumericType.TYPE;
+  }
+  
+  /**
+   * Stores a long.
+   * @param value The value.
+   */
+  void store(final long value) {
+    if (long_values == null) {
+      store((double) value);
+      return;
+    }
+    
+    if (idx >= long_values.length) {
+      long[] temp = new long[long_values.length + 16];
+      for (int i = 0; i < long_values.length; i++) {
+        temp[i] = long_values[i];
+      }
+      long_values = temp;
+    }
+    long_values[idx++] = value;
+  }
+  
+  /**
+   * Stores a double.
+   * @param value The value.
+   */
+  void store(final double value) {
+    if (long_values != null) {
+      double_values = new double[long_values.length];
+      for (int i = 0; i < long_values.length; i++) {
+        double_values[i] = long_values[i];
+      }
+      long_values = null;
+    }
+    
+    if (double_values == null) {
+      double_values = new double[8];
+    }
+    
+    if (idx >= double_values.length) {
+      double[] temp = new double[double_values.length + 16];
+      for (int i = 0; i < double_values.length; i++) {
+        temp[i] = double_values[i];
+      }
+      double_values = temp;
+    }
+    double_values[idx++] = value;
+  }
+}

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughNumericSummaryIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughNumericSummaryIterator.java
@@ -1,0 +1,144 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2019  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.processor.summarizer;
+
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.data.TimeSeriesDataType;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.TypedTimeSeriesIterator;
+import net.opentsdb.data.types.numeric.NumericSummaryType;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.QueryIterator;
+
+public class SummarizerPassThroughNumericSummaryIterator implements QueryIterator {
+  SummarizedTimeSeries sts;
+  
+  /** The source iterator. */
+  private TypedTimeSeriesIterator<? extends TimeSeriesDataType> iterator;
+  
+  /** Results from the source. */
+  private long[] long_values;
+  private double[] double_values;
+  
+  /** The index into the results. */
+  private int idx;
+  private int summary = -1;
+  
+  SummarizerPassThroughNumericSummaryIterator(final SummarizedTimeSeries sts) {
+    this.sts = sts;
+    iterator = sts.source.iterator(NumericSummaryType.TYPE).get();
+    if (!iterator.hasNext()) {
+      sts.fillEmpty();
+    } else {
+      long_values = new long[8];
+    }
+  }
+  
+  @Override
+  public boolean hasNext() {
+    if (!iterator.hasNext()) {
+      if (long_values != null) {
+        sts.summarize(long_values, 0, idx);
+      } else {
+        sts.summarize(double_values, 0, idx);
+      }
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public Object next() {
+    final TimeSeriesValue<NumericSummaryType> value = 
+        (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    if (value.value() != null) {
+      if (value.value().summariesAvailable().size() == 1) {
+        if (summary < 0) {
+          summary = value.value().summariesAvailable().iterator().next();
+        }
+        NumericType val = value.value().value(summary);
+        if (val.isInteger()) {
+          store(val.longValue());
+        } else {
+          store(val.doubleValue());
+        }
+        // TODO - actual rollup config
+      } else if (value.value().summariesAvailable().size() == 2 && 
+          value.value().summariesAvailable().contains(0) && 
+          value.value().summariesAvailable().contains(1)) {
+        NumericType sum = value.value().value(0);
+        NumericType count = value.value().value(1);
+        if (sum != null && count != null) {          
+          store(sum.toDouble() / count.toDouble());
+        }
+      }
+    }
+    return value;
+  }
+  
+  @Override
+  public TypeToken getType() {
+    return NumericSummaryType.TYPE;
+  }
+  
+  /**
+   * Stores a long.
+   * @param value The value.
+   */
+  void store(final long value) {
+    if (long_values == null) {
+      store((double) value);
+      return;
+    }
+    
+    if (idx >= long_values.length) {
+      long[] temp = new long[long_values.length + 16];
+      for (int i = 0; i < long_values.length; i++) {
+        temp[i] = long_values[i];
+      }
+      long_values = temp;
+    }
+    long_values[idx++] = value;
+  }
+  
+  /**
+   * Stores a double.
+   * @param value The value.
+   */
+  void store(final double value) {
+    if (long_values != null) {
+      double_values = new double[long_values.length];
+      for (int i = 0; i < long_values.length; i++) {
+        double_values[i] = long_values[i];
+      }
+      long_values = null;
+    }
+    
+    if (double_values == null) {
+      double_values = new double[8];
+    }
+    
+    if (idx >= double_values.length) {
+      double[] temp = new double[double_values.length + 16];
+      for (int i = 0; i < double_values.length; i++) {
+        temp[i] = double_values[i];
+      }
+      double_values = temp;
+    }
+    double_values[idx++] = value;
+  }
+
+}

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughResult.java
@@ -1,0 +1,204 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2019  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.processor.summarizer;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesDataType;
+import net.opentsdb.data.TimeSeriesId;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.TimeSpecification;
+import net.opentsdb.data.TypedTimeSeriesIterator;
+import net.opentsdb.data.types.numeric.MutableNumericSummaryValue;
+import net.opentsdb.data.types.numeric.NumericArrayType;
+import net.opentsdb.data.types.numeric.NumericSummaryType;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.BaseWrappedQueryResult;
+import net.opentsdb.query.QueryIterator;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.processor.ProcessorFactory;
+import net.opentsdb.query.processor.summarizer.SummarizerNonPassThroughResult.SummarizerTimeSeries;
+
+public class SummarizerPassThroughResult extends BaseWrappedQueryResult {
+
+  /** The non-null parent node. */
+  final Summarizer node;
+  
+  private final QueryResult results;
+  
+  /** The non-null list of summarizer time series. */
+  private final List<TimeSeries> series;
+  
+  final Map<Long, TimeSeries> summarized_series;
+  
+  SummarizerPassThroughResult(final Summarizer node, final QueryResult results) {
+    super(results);
+    this.node = node;
+    this.results = results;
+    series = Lists.newArrayList();
+    summarized_series = Maps.newConcurrentMap();
+    for (final TimeSeries ts : results.timeSeries()) {
+      series.add(new SummarizerPassThroughTimeSeries(ts));
+    }
+  }
+  
+  @Override
+  public Collection<TimeSeries> timeSeries() {
+    return series;
+  }
+  
+  @Override
+  public QueryNode source() {
+    return results.source();
+  }
+  
+  @Override
+  public void close() {
+    results.close();
+    node.onNext(new SummarizerSummarizedResult());
+  }
+  
+  Summarizer summarizerNode() {
+    return node;
+  }
+  
+  /**
+   * Summarizer time series. 
+   */
+  class SummarizerPassThroughTimeSeries implements TimeSeries {
+    /** The non-null source. */
+    private final TimeSeries source;
+    
+    /**
+     * Default ctor.
+     * @param source The non-null source to pull data from.
+     */
+    private SummarizerPassThroughTimeSeries(final TimeSeries source) {
+      this.source = source;
+    }
+    
+    @Override
+    public TimeSeriesId id() {
+      return source.id();
+    }
+
+    @Override
+    public Optional<TypedTimeSeriesIterator<? extends TimeSeriesDataType>> iterator(
+        final TypeToken<? extends TimeSeriesDataType> type) {
+      if (type == null) {
+        throw new IllegalArgumentException("Type cannot be null.");
+      }
+      if (!source.types().contains(type)) {
+        return Optional.empty();
+      }
+      
+      // if we already have a summary then we just return a new underlying
+      // iterator otherwise we need a new pass-through.
+      final SummarizedTimeSeries sts = new SummarizedTimeSeries(
+          SummarizerPassThroughResult.this, source);
+      if (summarized_series.putIfAbsent(source.id().buildHashCode(), sts) != null) {
+        return source.iterator(type);
+      } else {
+        if (type == NumericType.TYPE) {
+          final TypedTimeSeriesIterator<? extends TimeSeriesDataType> it = 
+              new SummarizerPassThroughNumericIterator(sts);
+          return Optional.of(it);
+        } else if (type == NumericArrayType.TYPE) {
+          final TypedTimeSeriesIterator<? extends TimeSeriesDataType> it = 
+              new SummarizerPassThroughNumericArrayIterator(sts);
+          return Optional.of(it);
+        } else if (type == NumericSummaryType.TYPE) {
+          final TypedTimeSeriesIterator<? extends TimeSeriesDataType> it = 
+              new SummarizerPassThroughNumericSummaryIterator(sts);
+          return Optional.of(it);
+        }
+        return Optional.empty();
+      }
+    }
+    
+    @Override
+    public Collection<TypedTimeSeriesIterator<? extends TimeSeriesDataType>> iterators() {
+      final Collection<TypeToken<? extends TimeSeriesDataType>> types = source.types();
+      final List<TypedTimeSeriesIterator<? extends TimeSeriesDataType>> iterators =
+          Lists.newArrayListWithCapacity(types.size());
+      for (final TypeToken<? extends TimeSeriesDataType> type : types) {
+        if (!((SummarizerFactory) node.factory()).types().contains(type)) {
+          continue;
+        }
+        final SummarizedTimeSeries sts = new SummarizedTimeSeries(
+            SummarizerPassThroughResult.this, source);
+        if (summarized_series.putIfAbsent(source.id().buildHashCode(), sts) != null) {
+          iterators.add(source.iterator(type).get());
+        } else {
+          if (type == NumericType.TYPE) {
+            iterators.add(new SummarizerPassThroughNumericIterator(sts));
+          } else if (type == NumericArrayType.TYPE) {
+            iterators.add(new SummarizerPassThroughNumericArrayIterator(sts));
+          } else if (type == NumericSummaryType.TYPE) {
+            iterators.add(new SummarizerPassThroughNumericSummaryIterator(sts));
+          }
+        }
+      }
+      return iterators;
+    }
+
+    @Override
+    public Collection<TypeToken<? extends TimeSeriesDataType>> types() {
+      return source.types();
+    }
+
+    @Override
+    public void close() {
+      //source.close(); // waiting for the summarized series to close
+    }
+  }
+  
+  public class SummarizerSummarizedResult extends BaseWrappedQueryResult {
+    
+    SummarizerSummarizedResult() {
+      super(results);
+    }
+
+    @Override
+    public QueryNode source() {
+      return node;
+    }
+    
+    @Override
+    public Collection<TimeSeries> timeSeries() {
+      return summarized_series.values();
+    }
+    
+    @Override
+    public void close() {
+      // no-op
+    }
+    
+    @Override
+    public TimeSpecification timeSpecification() {
+      // always null
+      return null;
+    }
+  }
+}

--- a/core/src/main/java/net/opentsdb/query/router/TimeRouterFactory.java
+++ b/core/src/main/java/net/opentsdb/query/router/TimeRouterFactory.java
@@ -153,6 +153,7 @@ public class TimeRouterFactory extends BaseTSDBPlugin implements
           .setRealFillPolicy(FillWithRealPolicy.NONE)
           .setDataType(NumericType.TYPE.toString())
           .build())
+        .setDataSource(config.getId())
         .setId(config.getId())
         .build();
     planner.replace(config, merger);

--- a/core/src/test/java/net/opentsdb/query/hacluster/TestHACluster.java
+++ b/core/src/test/java/net/opentsdb/query/hacluster/TestHACluster.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import net.opentsdb.query.BaseTimeSeriesDataSourceConfig;
-import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -148,6 +147,9 @@ public class TestHACluster {
     QueryNode n1 = mock(TimeSeriesDataSource.class);
     when(r1.source()).thenReturn(n1);
     when(r1.dataSource()).thenReturn("s1");
+    QueryNodeConfig c1 = mock(QueryNodeConfig.class);
+    when(c1.getId()).thenReturn("s1");
+    when(n1.config()).thenReturn(c1);
     
     node.onNext(r1);
     assertSame(r1, node.results.get("s1"));
@@ -161,6 +163,9 @@ public class TestHACluster {
     QueryNode n2 = mock(TimeSeriesDataSource.class);
     when(r2.source()).thenReturn(n2);
     when(r2.dataSource()).thenReturn("s2");
+    QueryNodeConfig c2 = mock(QueryNodeConfig.class);
+    when(c2.getId()).thenReturn("s2");
+    when(n2.config()).thenReturn(c2);
     
     node.onNext(r2);
     assertSame(r1, node.results.get("s1"));
@@ -184,6 +189,9 @@ public class TestHACluster {
     QueryNode n2 = mock(TimeSeriesDataSource.class);
     when(r2.source()).thenReturn(n2);
     when(r2.dataSource()).thenReturn("s2");
+    QueryNodeConfig c2 = mock(QueryNodeConfig.class);
+    when(c2.getId()).thenReturn("s2");
+    when(n2.config()).thenReturn(c2);
     
     node.onNext(r2);
     assertSame(r2, node.results.get("s2"));
@@ -198,6 +206,9 @@ public class TestHACluster {
     QueryNode n1 = mock(TimeSeriesDataSource.class);
     when(r1.source()).thenReturn(n1);
     when(r1.dataSource()).thenReturn("s1");
+    QueryNodeConfig c1 = mock(QueryNodeConfig.class);
+    when(c1.getId()).thenReturn("s1");
+    when(n1.config()).thenReturn(c1);
     
     node.onNext(r1);
     assertSame(r1, node.results.get("s1"));
@@ -314,6 +325,9 @@ public class TestHACluster {
     QueryNode n1 = mock(TimeSeriesDataSource.class);
     when(r1.source()).thenReturn(n1);
     when(r1.dataSource()).thenReturn("s1");
+    QueryNodeConfig c1 = mock(QueryNodeConfig.class);
+    when(c1.getId()).thenReturn("s1");
+    when(n1.config()).thenReturn(c1);
     
     node.onNext(r1);
     assertSame(r1, node.results.get("s1"));
@@ -326,6 +340,9 @@ public class TestHACluster {
     QueryNode n2 = mock(TimeSeriesDataSource.class);
     when(r2.source()).thenReturn(n2);
     when(r2.dataSource()).thenReturn("s2");
+    QueryNodeConfig c2 = mock(QueryNodeConfig.class);
+    when(c2.getId()).thenReturn("s2");
+    when(n2.config()).thenReturn(c2);
     
     node.onNext(r2);
     assertSame(r1, node.results.get("s1"));
@@ -349,6 +366,9 @@ public class TestHACluster {
     QueryNode n2 = mock(TimeSeriesDataSource.class);
     when(r2.source()).thenReturn(n2);
     when(r2.dataSource()).thenReturn("s2");
+    QueryNodeConfig c2 = mock(QueryNodeConfig.class);
+    when(c2.getId()).thenReturn("s2");
+    when(n2.config()).thenReturn(c2);
     
     node.onNext(r2);
     assertSame(r2, node.results.get("s2"));
@@ -362,6 +382,9 @@ public class TestHACluster {
     QueryNode n1 = mock(TimeSeriesDataSource.class);
     when(r1.source()).thenReturn(n1);
     when(r1.dataSource()).thenReturn("s1");
+    QueryNodeConfig c1 = mock(QueryNodeConfig.class);
+    when(c1.getId()).thenReturn("s1");
+    when(n1.config()).thenReturn(c1);
     
     node.onNext(r1);
     assertSame(r1, node.results.get("s1"));

--- a/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterFactory.java
+++ b/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterFactory.java
@@ -49,6 +49,7 @@ import net.opentsdb.query.processor.downsample.DownsampleConfig;
 import net.opentsdb.query.processor.groupby.GroupBy;
 import net.opentsdb.query.processor.groupby.GroupByConfig;
 import net.opentsdb.query.processor.merge.Merger;
+import net.opentsdb.query.processor.merge.MergerConfig;
 import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.stats.QueryStats;
 import net.opentsdb.stats.Span;
@@ -168,8 +169,11 @@ public class TestHAClusterFactory {
     assertEquals("s2", ((TimeSeriesDataSourceConfig) node.config()).getSourceId());
     assertNull(((TimeSeriesDataSourceConfig) node.config()).getFilterId());
 
+    node = planner.nodeForId("m1");
+    assertTrue(node instanceof Merger);
+    assertEquals("m1", ((MergerConfig) node.config()).getDataSource());
+    
     assertTrue(planner.nodeForId("ha_m1") instanceof HACluster);
-    assertTrue(planner.nodeForId("m1") instanceof Merger);
 
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"),
         planner.nodeForId("ha_m1_s1")));
@@ -281,8 +285,11 @@ public class TestHAClusterFactory {
     assertEquals("s3", ((TimeSeriesDataSourceConfig) node.config()).getSourceId());
     assertEquals("f2", ((TimeSeriesDataSourceConfig) node.config()).getFilterId());
 
+    node = planner.nodeForId("m1");
+    assertTrue(node instanceof Merger);
+    assertEquals("m1", ((MergerConfig) node.config()).getDataSource());
+    
     assertTrue(planner.nodeForId("ha_m1") instanceof HACluster);
-    assertTrue(planner.nodeForId("m1") instanceof Merger);
 
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"),
         planner.nodeForId("ha_m1_s1")));
@@ -384,8 +391,11 @@ public class TestHAClusterFactory {
     assertEquals("s2", ((TimeSeriesDataSourceConfig) node.config()).getSourceId());
     assertNull(((TimeSeriesDataSourceConfig) node.config()).getFilterId());
 
+    node = planner.nodeForId("m1");
+    assertTrue(node instanceof Merger);
+    assertEquals("m1", ((MergerConfig) node.config()).getDataSource());
+    
     assertTrue(planner.nodeForId("ha_m1") instanceof HACluster);
-    assertTrue(planner.nodeForId("m1") instanceof Merger);
 
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"),
         planner.nodeForId("ha_m1_s1")));
@@ -450,8 +460,11 @@ public class TestHAClusterFactory {
     assertEquals("s3", ((TimeSeriesDataSourceConfig) node.config()).getSourceId());
     assertNull(((TimeSeriesDataSourceConfig) node.config()).getFilterId());
 
+    node = planner.nodeForId("m1");
+    assertTrue(node instanceof Merger);
+    assertEquals("m1", ((MergerConfig) node.config()).getDataSource());
+    
     assertTrue(planner.nodeForId("ha_m1") instanceof HACluster);
-    assertTrue(planner.nodeForId("m1") instanceof Merger);
 
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"),
         planner.nodeForId("ha_m1_s1")));
@@ -617,9 +630,12 @@ public class TestHAClusterFactory {
         .getPushDownNodes().get(0) instanceof DownsampleConfig);
     List<QueryNodeConfig> pushDownNodes = ((TimeSeriesDataSourceConfig)node.config()).getPushDownNodes();
     assertEquals("ha_m1_s2", pushDownNodes.get(0).getSources().get(0));
+    
+    node = planner.nodeForId("ds");
+    assertTrue(node instanceof Merger);
+    assertEquals("m1", ((MergerConfig) node.config()).getDataSource());
 
     assertTrue(planner.nodeForId("ha_m1") instanceof HACluster);
-    assertTrue(planner.nodeForId("m1") instanceof Merger);
     assertTrue(planner.nodeForId("ha_m1_ds") instanceof Downsample);
 
     assertFalse(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"),
@@ -630,10 +646,10 @@ public class TestHAClusterFactory {
         planner.nodeForId("ha_m1_ds")));
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"),
         planner.nodeForId("ha_m1_s2")));
-    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("m1"),
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ds"),
         planner.nodeForId("ha_m1")));
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("gb"),
-        planner.nodeForId("m1")));
+        planner.nodeForId("ds")));
     assertTrue(planner.graph().hasEdgeConnecting(ctx_node,
         planner.nodeForId("gb")));
   }
@@ -708,8 +724,11 @@ public class TestHAClusterFactory {
     assertEquals("ha_m1_s3", ((List<QueryNodeConfig>) (((TimeSeriesDataSourceConfig)node.config()))
         .getPushDownNodes()).get(0).getSources().get(0));
 
+    node = planner.nodeForId("gb");
+    assertTrue(node instanceof Merger);
+    assertEquals("m1", ((MergerConfig) node.config()).getDataSource());
+    
     assertTrue(planner.nodeForId("ha_m1") instanceof HACluster);
-    assertTrue(planner.nodeForId("m1") instanceof Merger);
     assertTrue(planner.nodeForId("ha_m1_gb") instanceof GroupBy);
 
     assertFalse(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"),
@@ -720,10 +739,10 @@ public class TestHAClusterFactory {
         planner.nodeForId("ha_m1_gb")));
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"),
         planner.nodeForId("ha_m1_s3")));
-    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("m1"),
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("gb"),
             planner.nodeForId("ha_m1")));
     assertTrue(planner.graph().hasEdgeConnecting(ctx_node,
-            planner.nodeForId("m1")));
+            planner.nodeForId("gb")));
   }
 
   @Test
@@ -808,8 +827,11 @@ public class TestHAClusterFactory {
     assertEquals("ha_m1_s3", ((List<QueryNodeConfig>) (((TimeSeriesDataSourceConfig)node.config()))
         .getPushDownNodes()).get(0).getSources().get(0));
 
+    node = planner.nodeForId("gb");
+    assertTrue(node instanceof Merger);
+    assertEquals("m1", ((MergerConfig) node.config()).getDataSource());
+    
     assertTrue(planner.nodeForId("ha_m1") instanceof HACluster);
-    assertTrue(planner.nodeForId("m1") instanceof Merger);
     assertTrue(planner.nodeForId("ha_m1_ds") instanceof Downsample);
     assertTrue(planner.nodeForId("ha_m1_gb") instanceof GroupBy);
 
@@ -829,10 +851,10 @@ public class TestHAClusterFactory {
         planner.nodeForId("ha_m1_gb")));
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"),
         planner.nodeForId("ha_m1_s3")));
-    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("m1"),
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("gb"),
         planner.nodeForId("ha_m1")));
     assertTrue(planner.graph().hasEdgeConnecting(ctx_node,
-        planner.nodeForId("m1")));
+        planner.nodeForId("gb")));
   }
 
   @Test
@@ -906,17 +928,20 @@ public class TestHAClusterFactory {
     assertEquals("ha_m1_s4", ((List<QueryNodeConfig>) (((TimeSeriesDataSourceConfig)node.config()))
         .getPushDownNodes()).get(0).getSources().get(0));
 
+    node = planner.nodeForId("gb");
+    assertTrue(node instanceof Merger);
+    assertEquals("m1", ((MergerConfig) node.config()).getDataSource());
+    
     assertTrue(planner.nodeForId("ha_m1") instanceof HACluster);
-    assertTrue(planner.nodeForId("m1") instanceof Merger);
 
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"),
         planner.nodeForId("ha_m1_s3")));
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"),
         planner.nodeForId("ha_m1_s4")));
-    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("m1"),
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("gb"),
         planner.nodeForId("ha_m1")));
     assertTrue(planner.graph().hasEdgeConnecting(ctx_node,
-        planner.nodeForId("m1")));
+        planner.nodeForId("gb")));
   }
 
   @Test
@@ -966,7 +991,7 @@ public class TestHAClusterFactory {
     QueryNode ctx_node = mock(QueryNode.class);
     DefaultQueryPlanner planner = new DefaultQueryPlanner(context, ctx_node);
     planner.plan(null).join(250);
-
+System.out.println(planner.printConfigGraph());
     assertEquals(7, planner.graph().nodes().size());
     assertFalse(planner.configGraph().nodes().contains(query.getExecutionGraph().get(0)));
     QueryNode node = planner.nodeForId("ha_m1_s2");
@@ -993,8 +1018,11 @@ public class TestHAClusterFactory {
     assertTrue(pushDownNodes.get(2) instanceof DownsampleConfig);
     assertEquals("ha_m1_s3", pushDownNodes.get(0).getSources().get(0));
 
+    node = planner.nodeForId("ds2");
+    assertTrue(node instanceof Merger);
+    assertEquals("m1", ((MergerConfig) node.config()).getDataSource());
+    
     assertTrue(planner.nodeForId("ha_m1") instanceof HACluster);
-    assertTrue(planner.nodeForId("m1") instanceof Merger);
     assertTrue(planner.nodeForId("ha_m1_gb") instanceof GroupBy);
     assertTrue(planner.nodeForId("ha_m1_ds2") instanceof Downsample);
 
@@ -1010,10 +1038,10 @@ public class TestHAClusterFactory {
         planner.nodeForId("ha_m1_gb")));
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"),
         planner.nodeForId("ha_m1_s3")));
-    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("m1"),
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ds2"),
         planner.nodeForId("ha_m1")));
     assertTrue(planner.graph().hasEdgeConnecting(ctx_node,
-        planner.nodeForId("m1")));
+        planner.nodeForId("ds2")));
   }
 
   @Test
@@ -1059,8 +1087,11 @@ public class TestHAClusterFactory {
     assertEquals("s5", ((TimeSeriesDataSourceConfig) node.config()).getSourceId());
     assertNull(((TimeSeriesDataSourceConfig) node.config()).getFilterId());
 
+    node = planner.nodeForId("m1");
+    assertTrue(node instanceof Merger);
+    assertEquals("m1", ((MergerConfig) node.config()).getDataSource());
+
     assertTrue(planner.nodeForId("ha_m1") instanceof HACluster);
-    assertTrue(planner.nodeForId("m1") instanceof Merger);
     assertTrue(planner.nodeForId("m1_converter") instanceof ByteToStringIdConverter);
 
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ha_m1"),

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
@@ -209,6 +209,11 @@ public class TestBinaryExpressionNode {
     
     QueryResult r1 = mock(QueryResult.class);
     when(r1.dataSource()).thenReturn("a");
+    QueryNode n1 = mock(QueryNode.class);
+    QueryNodeConfig c1 = mock(QueryNodeConfig.class);
+    when(c1.getId()).thenReturn("a");
+    when(n1.config()).thenReturn(c1);
+    when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
     when(r2.dataSource()).thenReturn("b");
     QueryNodeConfig c2 = mock(QueryNodeConfig.class);
@@ -246,6 +251,11 @@ public class TestBinaryExpressionNode {
     
     QueryResult r1 = mock(QueryResult.class);
     when(r1.dataSource()).thenReturn("a");
+    QueryNode n1 = mock(QueryNode.class);
+    QueryNodeConfig c1 = mock(QueryNodeConfig.class);
+    when(c1.getId()).thenReturn("a");
+    when(n1.config()).thenReturn(c1);
+    when(r1.source()).thenReturn(n1);
     
     node.onNext(r1);
     assertSame(r1, node.results.getKey());
@@ -372,6 +382,11 @@ public class TestBinaryExpressionNode {
     
     QueryResult r1 = mock(QueryResult.class);
     when(r1.dataSource()).thenReturn("a");
+    QueryNode n1 = mock(QueryNode.class);
+    QueryNodeConfig c1 = mock(QueryNodeConfig.class);
+    when(c1.getId()).thenReturn("a");
+    when(n1.config()).thenReturn(c1);
+    when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
     when(r2.dataSource()).thenReturn("ignored");
     when(r2.source()).thenReturn(n2);
@@ -560,6 +575,11 @@ public class TestBinaryExpressionNode {
     
     QueryResult r1 = mock(QueryResult.class);
     when(r1.dataSource()).thenReturn("b");
+    QueryNode n1 = mock(QueryNode.class);
+    QueryNodeConfig c1 = mock(QueryNodeConfig.class);
+    when(c1.getId()).thenReturn("a");
+    when(n1.config()).thenReturn(c1);
+    when(r1.source()).thenReturn(n1);
     when(r1.idType()).thenAnswer(new Answer<TypeToken<?>>() {
       @Override
       public TypeToken<?> answer(InvocationOnMock invocation) throws Throwable {
@@ -643,6 +663,11 @@ public class TestBinaryExpressionNode {
     
     QueryResult r1 = mock(QueryResult.class);
     when(r1.dataSource()).thenReturn("a");
+    QueryNode n1 = mock(QueryNode.class);
+    QueryNodeConfig c1 = mock(QueryNodeConfig.class);
+    when(c1.getId()).thenReturn("a");
+    when(n1.config()).thenReturn(c1);
+    when(r1.source()).thenReturn(n1);
     when(r1.idType()).thenAnswer(new Answer<TypeToken<?>>() {
       @Override
       public TypeToken<?> answer(InvocationOnMock invocation) throws Throwable {
@@ -716,8 +741,18 @@ public class TestBinaryExpressionNode {
     
     QueryResult r1 = mock(QueryResult.class);
     when(r1.dataSource()).thenReturn("a");
+    QueryNode n1 = mock(QueryNode.class);
+    QueryNodeConfig c1 = mock(QueryNodeConfig.class);
+    when(c1.getId()).thenReturn("a");
+    when(n1.config()).thenReturn(c1);
+    when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
     when(r2.dataSource()).thenReturn("b");
+    QueryNode n2 = mock(QueryNode.class);
+    QueryNodeConfig c2 = mock(QueryNodeConfig.class);
+    when(c2.getId()).thenReturn("b");
+    when(n2.config()).thenReturn(c1);
+    when(r2.source()).thenReturn(n1);
     when(r1.idType()).thenAnswer(new Answer<TypeToken<?>>() {
       @Override
       public TypeToken<?> answer(InvocationOnMock invocation) throws Throwable {
@@ -786,8 +821,18 @@ public class TestBinaryExpressionNode {
     
     QueryResult r1 = mock(QueryResult.class);
     when(r1.dataSource()).thenReturn("a");
+    QueryNode n1 = mock(QueryNode.class);
+    QueryNodeConfig c1 = mock(QueryNodeConfig.class);
+    when(c1.getId()).thenReturn("a");
+    when(n1.config()).thenReturn(c1);
+    when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
     when(r2.dataSource()).thenReturn("b");
+    QueryNode n2 = mock(QueryNode.class);
+    QueryNodeConfig c2 = mock(QueryNodeConfig.class);
+    when(c2.getId()).thenReturn("a");
+    when(n2.config()).thenReturn(c2);
+    when(r2.source()).thenReturn(n2);
     when(r1.idType()).thenAnswer(new Answer<TypeToken<?>>() {
       @Override
       public TypeToken<?> answer(InvocationOnMock invocation) throws Throwable {
@@ -866,8 +911,18 @@ public class TestBinaryExpressionNode {
     
     QueryResult r1 = mock(QueryResult.class);
     when(r1.dataSource()).thenReturn("a");
+    QueryNode n1 = mock(QueryNode.class);
+    QueryNodeConfig c1 = mock(QueryNodeConfig.class);
+    when(c1.getId()).thenReturn("a");
+    when(n1.config()).thenReturn(c1);
+    when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
     when(r2.dataSource()).thenReturn("b");
+    QueryNode n2 = mock(QueryNode.class);
+    QueryNodeConfig c2 = mock(QueryNodeConfig.class);
+    when(c2.getId()).thenReturn("a");
+    when(n2.config()).thenReturn(c2);
+    when(r2.source()).thenReturn(n2);
     when(r1.idType()).thenAnswer(new Answer<TypeToken<?>>() {
       @Override
       public TypeToken<?> answer(InvocationOnMock invocation) throws Throwable {
@@ -946,6 +1001,11 @@ public class TestBinaryExpressionNode {
     
     QueryResult r1 = mock(QueryResult.class);
     when(r1.dataSource()).thenReturn("a");
+    QueryNode n1 = mock(QueryNode.class);
+    QueryNodeConfig c1 = mock(QueryNodeConfig.class);
+    when(c1.getId()).thenReturn("a");
+    when(n1.config()).thenReturn(c1);
+    when(r1.source()).thenReturn(n1);
     when(r1.error()).thenReturn("Boo!");
     
     node.onNext(r1);

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionFactory.java
@@ -583,6 +583,7 @@ public class TestExpressionFactory {
     QueryNodeConfig merger = MergerConfig.newBuilder()
         .setAggregator("sum")
         .addInterpolatorConfig(NUMERIC_CONFIG)
+        .setDataSource("m1")
         .setId("m1")
         .build();
     QueryNodeConfig ds = DownsampleConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMerger.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMerger.java
@@ -79,6 +79,7 @@ public class TestMerger {
         .setAggregator("sum")
         .addInterpolatorConfig(numeric_config)
         .addInterpolatorConfig(summary_config)
+        .setDataSource("m1")
         .setId("merger")
         .build();
     upstream = mock(QueryNode.class);

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerConfig.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerConfig.java
@@ -14,8 +14,6 @@
 // limitations under the License.
 package net.opentsdb.query.processor.merge;
 
-import com.google.common.collect.Sets;
-import net.opentsdb.query.processor.groupby.GroupByConfig;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,6 +45,7 @@ public class TestMergerConfig {
         .setAggregator("sum")
         .addInterpolatorConfig(numeric_config)
         .addSource("m1")
+        .setDataSource("m1")
         .setId("ClusterMerge")
         .build();
     
@@ -61,6 +60,7 @@ public class TestMergerConfig {
           //.setAggregator("sum")
           .addInterpolatorConfig(numeric_config)
           .addSource("m1")
+          .setDataSource("m1")
           .setId("ClusterMerge")
           .build();
       fail("Expected IllegalArgumentException");
@@ -71,7 +71,19 @@ public class TestMergerConfig {
           .setAggregator("sum")
           .addInterpolatorConfig(numeric_config)
           .addSource("m1")
+          .setDataSource("m1")
           //.setId("ClusterMerge")
+          .build();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) { }
+    
+    try {
+      MergerConfig.newBuilder()
+          .setAggregator("sum")
+          .addInterpolatorConfig(numeric_config)
+          .addSource("m1")
+          //.setDataSource("m1")
+          .setId("ClusterMerge")
           .build();
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) { }
@@ -83,20 +95,24 @@ public class TestMergerConfig {
         .setAggregator("sum")
         .addInterpolatorConfig(numeric_config)
         .addSource("m1")
+        .setDataSource("m1")
         .setId("ClusterMerge")
         .build();
     
     String json = JSON.serializeToString(config);
-    System.out.println(json);
+    assertTrue(json.contains("\"id\":\"ClusterMerge\""));
+    assertTrue(json.contains("\"type\":\"Merger\""));
+    assertTrue(json.contains(",\"sources\":[\"m1\"]"));
+    assertTrue(json.contains("\"aggregator\":\"sum\""));
   }
-
-
+  
   @Test
   public void equality() throws Exception {
     MergerConfig config = (MergerConfig) MergerConfig.newBuilder()
             .setAggregator("sum")
             .addInterpolatorConfig(numeric_config)
             .addSource("m1")
+            .setDataSource("m1")
             .setId("ClusterMerge")
             .build();
 
@@ -104,6 +120,7 @@ public class TestMergerConfig {
             .setAggregator("sum")
             .addInterpolatorConfig(numeric_config)
             .addSource("m1")
+            .setDataSource("m1")
             .setId("ClusterMerge")
             .build();
 
@@ -111,6 +128,7 @@ public class TestMergerConfig {
             .setAggregator("avg")
             .addInterpolatorConfig(numeric_config)
             .addSource("m1")
+            .setDataSource("m1")
             .setId("ClusterMerge")
             .build();
 
@@ -124,6 +142,7 @@ public class TestMergerConfig {
             .setAggregator("sum")
 //            .addInterpolatorConfig(numeric_config)
             .addSource("m1")
+            .setDataSource("m1")
             .setId("ClusterMerge")
             .build();
 
@@ -134,6 +153,7 @@ public class TestMergerConfig {
             .setAggregator("sum")
             .addInterpolatorConfig(numeric_config)
             .addSource("m2")
+            .setDataSource("m1")
             .setId("ClusterMerge")
             .build();
 
@@ -144,6 +164,7 @@ public class TestMergerConfig {
             .setAggregator("sum")
             .addInterpolatorConfig(numeric_config)
             .addSource("m1")
+            .setDataSource("m1")
             .setId("Noncluster")
             .build();
 

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerFactory.java
@@ -114,6 +114,7 @@ public class TestMergerFactory {
         .setAggregator("sum")
         .addInterpolatorConfig(numeric_config)
         .addInterpolatorConfig(summary_config)
+        .setDataSource("m1")
         .setId("Test")
         .build();
     final NumericMillisecondShard source = new NumericMillisecondShard(

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerNumericArrayIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerNumericArrayIterator.java
@@ -81,6 +81,7 @@ public class TestMergerNumericArrayIterator {
     config = (MergerConfig) MergerConfig.newBuilder()
         .setAggregator("sum")
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     
@@ -178,6 +179,7 @@ public class TestMergerNumericArrayIterator {
     config = (MergerConfig) MergerConfig.newBuilder()
         .setAggregator("nosuchagg")
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     when(node.config()).thenReturn(config);
@@ -358,6 +360,7 @@ public class TestMergerNumericArrayIterator {
     config = (MergerConfig) MergerConfig.newBuilder()
         .setAggregator("sum")
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     when(node.config()).thenReturn(config);
@@ -403,6 +406,7 @@ public class TestMergerNumericArrayIterator {
         .setAggregator("sum")
         .setInfectiousNan(true)
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     when(node.config()).thenReturn(config);

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerNumericIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerNumericIterator.java
@@ -86,6 +86,7 @@ public class TestMergerNumericIterator {
     config = (MergerConfig) MergerConfig.newBuilder()
         .setAggregator("sum")
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     node = mock(Merger.class);
@@ -174,6 +175,7 @@ public class TestMergerNumericIterator {
     config = (MergerConfig) MergerConfig.newBuilder()
         .setAggregator("nosuchagg")
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     when(node.config()).thenReturn(config);
@@ -301,6 +303,7 @@ public class TestMergerNumericIterator {
     config = (MergerConfig) MergerConfig.newBuilder()
         .setAggregator("sum")
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     when(node.config()).thenReturn(config);
@@ -587,6 +590,7 @@ public class TestMergerNumericIterator {
     config = (MergerConfig) MergerConfig.newBuilder()
         .setAggregator("sum")
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     when(node.config()).thenReturn(config);
@@ -646,6 +650,7 @@ public class TestMergerNumericIterator {
     config = (MergerConfig) MergerConfig.newBuilder()
         .setAggregator("sum")
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     when(node.config()).thenReturn(config);
@@ -706,6 +711,7 @@ public class TestMergerNumericIterator {
         .setAggregator("sum")
         .setInfectiousNan(true)
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     when(node.config()).thenReturn(config);
@@ -765,6 +771,7 @@ public class TestMergerNumericIterator {
         .setAggregator("sum")
         .setInfectiousNan(false)
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     when(node.config()).thenReturn(config);
@@ -831,6 +838,7 @@ public class TestMergerNumericIterator {
         .setAggregator("sum")
         .setInfectiousNan(true)
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     when(node.config()).thenReturn(config);
@@ -890,6 +898,7 @@ public class TestMergerNumericIterator {
         .setAggregator("sum")
         .setInfectiousNan(true)
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")        
         .build();
     when(node.config()).thenReturn(config);
@@ -951,6 +960,7 @@ public class TestMergerNumericIterator {
         .setAggregator("sum")
         .setInfectiousNan(true)
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     when(node.config()).thenReturn(config);
@@ -1040,6 +1050,7 @@ public class TestMergerNumericIterator {
         .setAggregator("sum")
         .setInfectiousNan(true)
         .addInterpolatorConfig(numeric_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     when(node.config()).thenReturn(config);

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerNumericSummaryIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerNumericSummaryIterator.java
@@ -95,6 +95,7 @@ public class TestMergerNumericSummaryIterator {
     config = (MergerConfig) MergerConfig.newBuilder()
         .setAggregator("sum")
         .addInterpolatorConfig(interpolator_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     result = mock(QueryResult.class);
@@ -190,6 +191,7 @@ public class TestMergerNumericSummaryIterator {
         .setAggregator("sum")
         .setInfectiousNan(true)
         .addInterpolatorConfig(interpolator_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     
@@ -328,6 +330,7 @@ public class TestMergerNumericSummaryIterator {
         .setAggregator("sum")
         .setInfectiousNan(true)
         .addInterpolatorConfig(interpolator_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     
@@ -373,6 +376,7 @@ public class TestMergerNumericSummaryIterator {
         .setAggregator("sum")
         .setInfectiousNan(true)
         .addInterpolatorConfig(interpolator_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     
@@ -418,6 +422,7 @@ public class TestMergerNumericSummaryIterator {
         .setAggregator("sum")
         .setInfectiousNan(true)
         .addInterpolatorConfig(interpolator_config)
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     
@@ -483,6 +488,7 @@ public class TestMergerNumericSummaryIterator {
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setDataType(NumericType.TYPE.toString())
             .build())
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     
@@ -514,6 +520,7 @@ public class TestMergerNumericSummaryIterator {
             .setRealFillPolicy(FillWithRealPolicy.NONE)
             .setDataType(NumericType.TYPE.toString())
             .build())
+        .setDataSource("m1")
         .setId("Testing")
         .build();
     

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerResult.java
@@ -76,6 +76,7 @@ public class TestMergerResult {
         .setAggregator("sum")
         .addInterpolatorConfig(numeric_config)
         .addInterpolatorConfig(summary_config)
+        .setDataSource("MyMetric")
         .setId("Testing")
         .build();
     node = mock(Merger.class);
@@ -136,6 +137,7 @@ public class TestMergerResult {
     
     merger.add(result_a);
     assertSame(time_spec, merger.timeSpecification());
+    assertEquals("MyMetric", merger.dataSource());
   }
   
   @Test

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerTimeSeries.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerTimeSeries.java
@@ -88,6 +88,7 @@ public class TestMergerTimeSeries {
         .setAggregator("sum")
         .addInterpolatorConfig(numeric_config)
         .addInterpolatorConfig(summary_config)
+        .setDataSource("m1")
         .setId("GB")
         .build();
     result = mock(QueryResult.class);

--- a/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerConfig.java
+++ b/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2019  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ import static org.junit.Assert.*;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
 
-import net.opentsdb.query.processor.slidingwindow.SlidingWindowConfig;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -35,6 +34,7 @@ public class TestSummarizerConfig {
         SummarizerConfig.newBuilder()
         .setSummaries(Lists.newArrayList("sum", "avg"))
         .setInfectiousNan(true)
+        .setPassThrough(true)
         .setId("summarizer")
         .build();
     
@@ -42,6 +42,7 @@ public class TestSummarizerConfig {
     assertTrue(config.getSummaries().contains("sum"));
     assertTrue(config.getSummaries().contains("avg"));
     assertTrue(config.getInfectiousNan());
+    assertTrue(config.passThrough());
     assertEquals("summarizer", config.getId());
     
     try {
@@ -94,6 +95,7 @@ public class TestSummarizerConfig {
             SummarizerConfig.newBuilder()
                     .setSummaries(Lists.newArrayList("avg", "sum"))
                     .setInfectiousNan(true)
+                    .setPassThrough(true) // ignored
                     .setId("summarizer")
                     .build();
 
@@ -132,8 +134,6 @@ public class TestSummarizerConfig {
 
 
   }
-
-
   
   @Test
   public void serdes() throws Exception {

--- a/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerFactory.java
@@ -1,5 +1,5 @@
 //This file is part of OpenTSDB.
-//Copyright (C) 2018  The OpenTSDB Authors.
+//Copyright (C) 2018-2019  The OpenTSDB Authors.
 //
 //Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.
@@ -15,23 +15,80 @@
 package net.opentsdb.query.processor.summarizer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
+import com.stumbleupon.async.Deferred;
 
+import net.opentsdb.core.DefaultRegistry;
+import net.opentsdb.core.MockTSDB;
 import net.opentsdb.core.TSDB;
+import net.opentsdb.data.TimeSeriesDataSource;
+import net.opentsdb.data.TimeSeriesDataSourceFactory;
 import net.opentsdb.data.types.numeric.NumericArrayType;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
+import net.opentsdb.query.QueryMode;
 import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.SemanticQuery;
+import net.opentsdb.query.filter.MetricLiteralFilter;
+import net.opentsdb.query.plan.DefaultQueryPlanner;
+import net.opentsdb.query.serdes.SerdesOptions;
+import net.opentsdb.stats.Span;
 
 public class TestSummarizerFactory {
 
+  private static MockTSDB TSDB;
+  private static TimeSeriesDataSource SRC_MOCK;
+  private QueryPipelineContext context;
+  private QueryNode ctx_node;
+  private SummarizerConfig config;
+  
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    TSDB = new MockTSDB();
+    TSDB.registry = spy(new DefaultRegistry(TSDB));
+    SRC_MOCK = mock(TimeSeriesDataSource.class);
+
+    ((DefaultRegistry) TSDB.registry).initialize(true).join(60_000);
+    TimeSeriesDataSourceFactory ts_factory = mock(TimeSeriesDataSourceFactory.class);
+    TSDB.registry.registerPlugin(TimeSeriesDataSourceFactory.class, null, ts_factory);
+    when(ts_factory.newNode(any(QueryPipelineContext.class), any(QueryNodeConfig.class)))
+      .thenReturn(SRC_MOCK);
+    
+    QueryNodeConfig config = mock(QueryNodeConfig.class);
+    when(config.getId()).thenReturn("mock");
+    when(SRC_MOCK.config()).thenReturn(config);
+    when(SRC_MOCK.initialize(any(Span.class))).thenReturn(Deferred.fromResult(null));
+  }
+  
+  @Before
+  public void before() throws Exception {
+    config = (SummarizerConfig) 
+        SummarizerConfig.newBuilder()
+        .setSummaries(Lists.newArrayList("sum", "avg"))
+        .setInfectiousNan(true)
+        .setId("summarizer")
+        .build();
+    context = mock(QueryPipelineContext.class);
+    when(context.tsdb()).thenReturn(TSDB);
+    ctx_node = mock(QueryNode.class);
+  }
+  
   @Test
   public void ctor() throws Exception {
     SummarizerFactory factory = new SummarizerFactory();
@@ -45,13 +102,6 @@ public class TestSummarizerFactory {
   
   @Test
   public void newIterator() throws Exception {
-    SummarizerConfig config = (SummarizerConfig) 
-        SummarizerConfig.newBuilder()
-        .setSummaries(Lists.newArrayList("sum", "avg"))
-        .setInfectiousNan(true)
-        .setId("summarizer")
-        .build();
-    
     final QueryNode node = mock(QueryNode.class);
     when(node.config()).thenReturn(config);
     final QueryPipelineContext context = mock(QueryPipelineContext.class);
@@ -61,5 +111,83 @@ public class TestSummarizerFactory {
     
     QueryNode summarizer = factory.newNode(context, config);
     assertTrue(summarizer instanceof Summarizer);
+  }
+  
+  @Test
+  public void setupNoPassThrough() throws Exception {
+    SummarizerFactory factory = new SummarizerFactory();
+    
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setStart("1h-ago")
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.if.in")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .setSummaries(Lists.newArrayList("sum"))
+            .addSource("m1")
+            .setId("summary")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    DefaultQueryPlanner planner = new DefaultQueryPlanner(context, ctx_node);
+    planner.plan(null).join(250);
+    
+    assertEquals(3, planner.graph().nodes().size());
+    QueryNode node = planner.nodeForId("summary");
+    assertFalse(((SummarizerConfig) node.config()).passThrough());
+    assertEquals(1, planner.serializationSources().size());
+    assertTrue(planner.serializationSources().contains("summary:m1"));
+    assertTrue(planner.graph().hasEdgeConnecting(ctx_node,
+        planner.nodeForId("summary")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("summary"),
+        planner.nodeForId("mock")));
+  }
+  
+  @Test
+  public void setupPassThrough() throws Exception {
+    SummarizerFactory factory = new SummarizerFactory();
+    
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setStart("1h-ago")
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.if.in")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .setSummaries(Lists.newArrayList("sum"))
+            .addSource("m1")
+            .setId("summary")
+            .build())
+        .addSerdesConfig(serdesConfigs(Lists.newArrayList("m1", "summary")))
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    DefaultQueryPlanner planner = new DefaultQueryPlanner(context, ctx_node);
+    planner.plan(null).join(250);
+    
+    assertEquals(3, planner.graph().nodes().size());
+    QueryNode node = planner.nodeForId("summary");
+    assertTrue(((SummarizerConfig) node.config()).passThrough());
+    assertEquals(2, planner.serializationSources().size());
+    assertTrue(planner.serializationSources().contains("summary:m1"));
+    assertTrue(planner.serializationSources().contains("m1:m1"));
+    assertTrue(planner.graph().hasEdgeConnecting(ctx_node,
+        planner.nodeForId("summary")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("summary"),
+        planner.nodeForId("mock")));
+  }
+  
+  private SerdesOptions serdesConfigs(final List<String> filter) {
+    final SerdesOptions config = mock(SerdesOptions.class);
+    when(config.getFilter()).thenReturn(filter);
+    return config;
   }
 }

--- a/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerResult.java
@@ -33,7 +33,7 @@ import net.opentsdb.data.SecondTimeStamp;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.types.numeric.MutableNumericValue;
 import net.opentsdb.query.QueryResult;
-import net.opentsdb.query.processor.summarizer.SummarizerResult.SummarizerTimeSeries;
+import net.opentsdb.query.processor.summarizer.SummarizerNonPassThroughResult.SummarizerTimeSeries;
 
 public class TestSummarizerResult {
 
@@ -70,7 +70,7 @@ public class TestSummarizerResult {
   
   @Test
   public void ctor() throws Exception {
-    SummarizerResult result = new SummarizerResult(node, results);
+    SummarizerNonPassThroughResult result = new SummarizerNonPassThroughResult(node, results);
     assertNull(result.timeSpecification());
     assertEquals(1, result.timeSeries().size());
     assertTrue(result.timeSeries().iterator().next() instanceof SummarizerTimeSeries);

--- a/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Factory.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Factory.java
@@ -134,8 +134,7 @@ public class HttpQueryV3Factory
     if (config.timeShifts() == null) {
       return;
     }
-
-
+    
     TimeSeriesDataSourceConfig.Builder<
             ? extends TimeSeriesDataSourceConfig.Builder,
             ? extends TimeSeriesDataSourceConfig>
@@ -148,9 +147,7 @@ public class HttpQueryV3Factory
         .build();
 
     planner.replace(config, new_config);
-
-    planner.replace(config, new_config);
-
+    
     // Add timeshift node as a push down
     final TimeShiftConfig shift_config = TimeShiftConfig.newBuilder()
         .setTimeshiftInterval(new_config.getTimeShiftInterval())
@@ -171,9 +168,10 @@ public class HttpQueryV3Factory
       List<QueryNodeConfig> pushdown = new ArrayList<>();
       pushdown.add(shift_config);
 
-
-      BaseTimeSeriesDataSourceConfig.Builder b = (BaseTimeSeriesDataSourceConfig.Builder) new_config.toBuilder();
-      ((BaseTimeSeriesDataSourceConfig)new_config).cloneBuilder((BaseTimeSeriesDataSourceConfig) new_config, b);
+      final BaseTimeSeriesDataSourceConfig.Builder b = 
+          (BaseTimeSeriesDataSourceConfig.Builder) new_config.toBuilder();
+      ((BaseTimeSeriesDataSourceConfig)new_config)
+        .cloneBuilder((BaseTimeSeriesDataSourceConfig) new_config, b);
       b.setPushDownNodes(pushdown);
     } else {
       pushDownNodes.add(shift_config);

--- a/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Result.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Result.java
@@ -52,6 +52,7 @@ import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.TimeSeriesDataSourceConfig;
 import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.utils.DateTime;
 
@@ -117,6 +118,11 @@ public class HttpQueryV3Result implements QueryResult {
     if (exception == null && root != null) {
       String temp = root.get("source").asText();
       data_source = temp.substring(temp.indexOf(":") + 1);
+      
+      TimeSeriesDataSourceConfig cfg = (TimeSeriesDataSourceConfig) node.config();
+      if (!cfg.getId().equals(cfg.getDataSourceId())) {
+        data_source = cfg.getDataSourceId();
+      }
       
       JsonNode n = root.get("timeSpecification");
       if (n != null && !n.isNull()) {

--- a/executors/http/src/test/java/net/opentsdb/query/execution/TestHttpQueryV3Result.java
+++ b/executors/http/src/test/java/net/opentsdb/query/execution/TestHttpQueryV3Result.java
@@ -67,6 +67,7 @@ public class TestHttpQueryV3Result {
                 .setMetric("system.cpu.user")
                 .build())
             .setFilterId(null)
+            .setDataSourceId("otherMetric")
             .setId("m1")
             .build();
 
@@ -77,6 +78,7 @@ public class TestHttpQueryV3Result {
         .build();
     
     when(query_node.pipelineContext()).thenReturn(context);
+    when(query_node.config()).thenReturn(config);
     when(context.query()).thenReturn(query);
   }
   
@@ -99,7 +101,7 @@ public class TestHttpQueryV3Result {
     assertEquals(2, result.timeSeries().size());
     assertNull(result.error());
     assertNull(result.exception());
-    assertEquals("m0", result.dataSource());
+    assertEquals("otherMetric", result.dataSource());
     assertEquals(Const.TS_STRING_ID, result.idType());
     
     Iterator<TimeSeries> ts_iterator = result.timeSeries().iterator();
@@ -179,7 +181,7 @@ public class TestHttpQueryV3Result {
     assertEquals(2, result.timeSeries().size());
     assertNull(result.error());
     assertNull(result.exception());
-    assertEquals("m1", result.dataSource());
+    assertEquals("otherMetric", result.dataSource());
     assertEquals(Const.TS_STRING_ID, result.idType());
     
     Iterator<TimeSeries> ts_iterator = result.timeSeries().iterator();
@@ -248,7 +250,7 @@ public class TestHttpQueryV3Result {
     assertNull(result.timeSpecification());
     assertNull(result.error());
     assertNull(result.exception());
-    assertEquals("m1", result.dataSource());
+    assertEquals("otherMetric", result.dataSource());
     assertEquals(Const.TS_STRING_ID, result.idType());
     
     RollupConfig rollup_config = result.rollupConfig();
@@ -336,7 +338,7 @@ public class TestHttpQueryV3Result {
     assertNull(result.timeSpecification());
     assertNull(result.error());
     assertNull(result.exception());
-    assertEquals("m1", result.dataSource());
+    assertEquals("otherMetric", result.dataSource());
     assertEquals(Const.TS_STRING_ID, result.idType());
     
     rollup_config = result.rollupConfig();
@@ -383,7 +385,7 @@ public class TestHttpQueryV3Result {
     assertEquals(2, result.timeSeries().size());
     assertNull(result.error());
     assertNull(result.exception());
-    assertEquals("m1", result.dataSource());
+    assertEquals("otherMetric", result.dataSource());
     assertEquals(Const.TS_STRING_ID, result.idType());
     
     Iterator<TimeSeries> ts_iterator = result.timeSeries().iterator();
@@ -464,7 +466,7 @@ public class TestHttpQueryV3Result {
     assertEquals(2, result.timeSeries().size());
     assertNull(result.error());
     assertNull(result.exception());
-    assertEquals("m1", result.dataSource());
+    assertEquals("otherMetric", result.dataSource());
     assertEquals(Const.TS_STRING_ID, result.idType());
     
     Iterator<TimeSeries> ts_iterator = result.timeSeries().iterator();


### PR DESCRIPTION
- Modify the Summarizer so that it can pass-through the iterators and summarize
  on top instead of having to re-instantiate and compute the data source
  iterators. Can save a lot of work for results with many time series.
- Fix result IDs wherein previously for HA configs the node name was the metric
  ID when pushdowns were in effect (e.g. if downsample was pushed down we
  should have emitted the downsample node ID.)
- Modify the query planner on a temporary basis to handle the pass-through
  summarizer case.
- Add trace logging to the BinaryExpression node.
- Add temporary handling of the Merge node in ExpressionFactory.
- Change Merger node to use the ID instead of the data source and add some
  trace logging.
- Add dataSource() to the MergerConfig so we can pass that up in the result
  in case the node is named for a pushed-down node.

HTTP:
- Use the new data source to return the proper node and value in the HTTP query
  results.