### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
+++ b/core/src/main/java/net/opentsdb/query/AbstractQueryPipelineContext.java
@@ -595,8 +595,8 @@ public abstract class AbstractQueryPipelineContext implements
         }
       }
     } else {
-      LOG.warn("Called AQPC checkComplete() more than once. Find the leak.", 
-          new RuntimeException("Whoops."));
+//      LOG.warn("Called AQPC checkComplete() more than once. Find the leak.", 
+//          new RuntimeException("Whoops."));
     }
     return true;
   }

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleConfig.java
@@ -418,7 +418,7 @@ public class DownsampleConfig extends BaseQueryNodeConfigWithInterpolators<
   /** @return A HashCode object for deterministic, non-secure hashing */
   public HashCode buildHashCode() {
     final HashCode hc = net.opentsdb.core.Const.HASH_FUNCTION().newHasher()
-            .putString(Strings.nullToEmpty(original_interval), Const.UTF8_CHARSET)
+            .putString(Strings.nullToEmpty(interval), Const.UTF8_CHARSET)
             .putString(Strings.nullToEmpty(timezone.toString()), Const.UTF8_CHARSET)
             .putString(Strings.nullToEmpty(aggregator), Const.UTF8_CHARSET)
             .putBoolean(infectious_nan)


### PR DESCRIPTION
- Remove the exception log on the AQPC multiple stops.
- Add the original query hash to the RCQPC and use that as the hash code
  in order to fix deletes.
- Downsample with Auto would use the same hash for different intervals,
  breaking caching. Use the computed value for the hash.