### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/plan/QueryPlanner.java
+++ b/common/src/main/java/net/opentsdb/query/plan/QueryPlanner.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2019  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 package net.opentsdb.query.plan;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 import com.google.common.graph.MutableGraph;
 import com.stumbleupon.async.Deferred;
@@ -114,5 +116,21 @@ public interface QueryPlanner {
    * @return A list of source nodes for the node. Null until the query has
    * started planning. */
   public Collection<QueryNodeConfig> terminalSourceNodes(final QueryNodeConfig config);
+  
+  /**
+   * Finds the set of data source IDs from the current node in the format
+   * config_id:datasource_id.
+   * @param node The non-null node to start from.
+   * @return A non-null list of source IDs.
+   */
+  public List<String> getDataSourceIds(final QueryNodeConfig node);
+  
+  /**
+   * Finds the name of metrics from the given node.
+   * TODO - won't work in the future if we have other filter types.
+   * @param node The non-null node to start from.
+   * @return A non-null set of metric names.
+   */
+  public Set<String> getMetrics(final QueryNodeConfig node);
   
 }

--- a/common/src/main/java/net/opentsdb/query/readcache/CachedQueryNode.java
+++ b/common/src/main/java/net/opentsdb/query/readcache/CachedQueryNode.java
@@ -40,8 +40,11 @@ public class CachedQueryNode implements QueryNode, QueryNodeConfig {
   /** The ID of this node. */
   protected final String id;
   
-  public CachedQueryNode(final String id) {
+  protected final QueryPipelineContext context;
+  
+  public CachedQueryNode(final String id, final QueryPipelineContext context) {
     this.id = id;
+    this.context = context;
   }
   
   @Override
@@ -129,8 +132,7 @@ public class CachedQueryNode implements QueryNode, QueryNodeConfig {
 
   @Override
   public QueryPipelineContext pipelineContext() {
-    // TODO Auto-generated method stub
-    return null;
+    return context;
   }
 
   @Override

--- a/common/src/main/java/net/opentsdb/query/readcache/ReadCacheSerdes.java
+++ b/common/src/main/java/net/opentsdb/query/readcache/ReadCacheSerdes.java
@@ -17,6 +17,7 @@ package net.opentsdb.query.readcache;
 import java.util.Collection;
 import java.util.Map;
 
+import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 
 /**
@@ -48,10 +49,13 @@ public interface ReadCacheSerdes {
 
   /**
    * Deserializes the given result collection.
+   * @param context The Query pipeline context.
    * @param data A non-null byte array.
    * @return The deserialized cache result map, may be empty, keyed on the
    * result ID.
    */
-  public Map<String, ReadCacheQueryResult> deserialize(final byte[] data);
+  public Map<String, ReadCacheQueryResult> deserialize(
+      final QueryPipelineContext context, 
+      final byte[] data);
 
 }

--- a/core/src/main/java/net/opentsdb/query/DefaultTimeSeriesDataSourceConfig.java
+++ b/core/src/main/java/net/opentsdb/query/DefaultTimeSeriesDataSourceConfig.java
@@ -85,10 +85,6 @@ public class DefaultTimeSeriesDataSourceConfig
 
 
     planner.replace(config, shift_config);
-    // Add the time shift to sink filters too. if they have it
-    if (((DefaultQueryPlanner) planner).sinkFilters().containsKey(config.getId())) {
-      ((DefaultQueryPlanner) planner).sinkFilters().put(shift_config.id, null);
-    }
     
     final Pair<Boolean, TemporalAmount> amounts = config.timeShifts();
     TimeSeriesDataSourceConfig.Builder rebuilt_builder =
@@ -124,12 +120,7 @@ public class DefaultTimeSeriesDataSourceConfig
     for (final QueryNodeConfig predecessor : shift_predecessors) {
       planner.addEdge(predecessor, shift_config);
     }
-
-    // Add the time shift to sink filters too. if they have it
-    if (((DefaultQueryPlanner) planner).sinkFilters().containsKey(merger.id)) {
-      ((DefaultQueryPlanner) planner).sinkFilters().put(shift_config.id, null);
-    }
-
+    
     // now for each time shift we have to duplicate the sub-graph from the
     // merger to the destinations. *sigh*.
     // TODO - make this cleaner some day. This is SUPER ugly. For now we do it

--- a/core/src/main/java/net/opentsdb/query/hacluster/HAClusterFactory.java
+++ b/core/src/main/java/net/opentsdb/query/hacluster/HAClusterFactory.java
@@ -82,7 +82,6 @@ import java.util.Set;
 public class HAClusterFactory extends BaseQueryNodeFactory<
     TimeSeriesDataSourceConfig, HACluster> implements
       TimeSeriesDataSourceFactory<TimeSeriesDataSourceConfig, HACluster> {
-  
   public static final String TYPE = "HACluster";
 
   public static final String KEY_PREFIX = "tsd.query.";
@@ -215,6 +214,8 @@ public class HAClusterFactory extends BaseQueryNodeFactory<
         builder.setDataSources(Lists.newArrayList(default_sources));
       }
     }
+    
+    builder.setDataSourceId(config.getDataSourceId());
 
     final String new_id = "ha_" + config.getId();
     if (context.query().isTraceEnabled()) {

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNode.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNode.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2019  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -143,15 +143,16 @@ public class BinaryExpressionNode extends AbstractQueryNode<ExpressionParseNode>
   
   @Override
   public void onNext(final QueryResult next) {
-    final String id = next.source().config().getId();
+    final String id = next.source().config().getId() + ":" + next.dataSource();
     if (LOG.isTraceEnabled()) {
-      LOG.trace("Result: " + id + ":" + next.dataSource() + " Want<" + left_source + ", " + right_source +">");
+      LOG.trace("Result: " + id + " (" + next.getClass() + ") " 
+        + " Want<" + left_source + ", " + right_source +">");
     }
     
     if (left_source != null && (left_source.equals(next.dataSource()) ||
         left_source.equalsIgnoreCase(id))) {
       if (LOG.isTraceEnabled()) {
-        LOG.trace("Matched left [" + left_source + "] with: " + id + ":" + next.dataSource());
+        LOG.trace("Matched left [" + left_source + "] with: " + id);
       }
       if (!Strings.isNullOrEmpty(next.error()) || next.exception() != null) {
         sendUpstream(new FailedQueryResult(next));
@@ -165,7 +166,7 @@ public class BinaryExpressionNode extends AbstractQueryNode<ExpressionParseNode>
         (right_source.equals(next.dataSource()) || 
             right_source.equals(id))) {
       if (LOG.isTraceEnabled()) {
-        LOG.trace("Matched right [" + right_source + "] with: " + id + ":" + next.dataSource());
+        LOG.trace("Matched right [" + right_source + "] with: " + id);
       }
       if (!Strings.isNullOrEmpty(next.error()) || next.exception() != null) {
         sendUpstream(new FailedQueryResult(next));
@@ -174,9 +175,8 @@ public class BinaryExpressionNode extends AbstractQueryNode<ExpressionParseNode>
       synchronized (this) {
         results.setValue(next);
       }
-      LOG.trace("SET RACE!");
     } else {
-      LOG.debug("Unmatched result: " + id + ":" + next.dataSource());
+      LOG.debug("Unmatched result: " + id);
       return;
     }
     

--- a/core/src/main/java/net/opentsdb/query/readcache/GuavaLRUCache.java
+++ b/core/src/main/java/net/opentsdb/query/readcache/GuavaLRUCache.java
@@ -192,7 +192,7 @@ public class GuavaLRUCache extends BaseTSDBPlugin implements
           } else if (value.value == null) {
             results = Collections.emptyMap();
           } else {
-            results = serdes.deserialize(value.value);
+            results = serdes.deserialize(context, value.value);
           }
         }
         

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2019  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -365,6 +365,7 @@ public class TestBinaryExpressionNode {
         .setLeft("a")
         .setLeftType(OperandType.VARIABLE)
         .setRight("sub")
+        .setRightId("sub:m1")
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
         .setExpressionConfig(config)
@@ -388,7 +389,7 @@ public class TestBinaryExpressionNode {
     when(n1.config()).thenReturn(c1);
     when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
-    when(r2.dataSource()).thenReturn("ignored");
+    when(r2.dataSource()).thenReturn("m1");
     when(r2.source()).thenReturn(n2);
     when(r1.idType()).thenAnswer(new Answer<TypeToken<?>>() {
       @Override
@@ -470,8 +471,10 @@ public class TestBinaryExpressionNode {
   public void onNextByteDoubleTwoSubExp() throws Exception {
     expression_config = ExpressionParseNode.newBuilder()
         .setLeft("sub1")
+        .setLeftId("sub1:m1")
         .setLeftType(OperandType.SUB_EXP)
         .setRight("sub2")
+        .setRightId("sub2:m1")
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
         .setExpressionConfig(config)
@@ -493,10 +496,10 @@ public class TestBinaryExpressionNode {
     when(c2.getId()).thenReturn("sub2");
     
     QueryResult r1 = mock(QueryResult.class);
-    when(r1.dataSource()).thenReturn("ignore");
+    when(r1.dataSource()).thenReturn("m1");
     when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
-    when(r2.dataSource()).thenReturn("ignore");
+    when(r2.dataSource()).thenReturn("m1");
     when(r2.source()).thenReturn(n2);
     when(r1.idType()).thenAnswer(new Answer<TypeToken<?>>() {
       @Override

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionFactory.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.MutableGraph;
 
@@ -101,6 +103,10 @@ public class TestExpressionFactory {
     
     QueryPlanner plan = mock(QueryPlanner.class);
     when(plan.configGraph()).thenReturn(graph);
+    when(plan.getMetrics(any(QueryNodeConfig.class)))
+      .thenReturn(Sets.newHashSet("sys.cpu.user"));
+    when(plan.getDataSourceIds(any(QueryNodeConfig.class)))
+      .thenReturn(Lists.newArrayList("m1:m1"));
     
     graph.putEdge(query.get(1), query.get(0));
     graph.putEdge(SINK, query.get(1));
@@ -119,7 +125,7 @@ public class TestExpressionFactory {
     ExpressionParseNode p1 = (ExpressionParseNode) b1;
     assertEquals("expression", p1.getId());
     assertEquals("sys.cpu.user", p1.getLeft());
-    assertEquals("m1", p1.getLeftId());
+    assertEquals("m1:m1", p1.getLeftId());
     assertEquals(OperandType.VARIABLE, p1.getLeftType());
     assertEquals(42, ((NumericLiteral) p1.getRight()).longValue());
     assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
@@ -156,6 +162,10 @@ public class TestExpressionFactory {
     ExpressionConfig exp = builder.build();
     QueryPlanner plan = mock(QueryPlanner.class);
     when(plan.configGraph()).thenReturn(graph);
+    when(plan.getMetrics(any(QueryNodeConfig.class)))
+      .thenReturn(Sets.newHashSet("sys.cpu.user"));
+    when(plan.getDataSourceIds(any(QueryNodeConfig.class)))
+      .thenReturn(Lists.newArrayList("downsample:m1"));
     
     graph.putEdge(ds, m1);
     graph.putEdge(exp, ds);
@@ -177,465 +187,466 @@ public class TestExpressionFactory {
     ExpressionParseNode p1 = (ExpressionParseNode) b1;
     assertEquals("expression", p1.getId());
     assertEquals("sys.cpu.user", p1.getLeft());
-    assertEquals("m1", p1.getLeftId());
+    assertEquals("downsample:m1", p1.getLeftId());
     assertEquals(OperandType.VARIABLE, p1.getLeftType());
     assertEquals(42, ((NumericLiteral) p1.getRight()).longValue());
     assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
     assertNull(p1.getRightId());
     assertEquals(ExpressionOp.ADD, p1.getOperator());
   }
-  
-  @Test
-  public void setupGraph2MetricsThroughNode() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.user")
-            .build())
-        .setFilterId("f1")
-        .setId("m1")
-        .build();
-    QueryNodeConfig m2 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.sys")
-            .build())
-        .setFilterId("f1")
-        .setId("m2")
-        .build();
-    QueryNodeConfig ds = DownsampleConfig.newBuilder()
-        .setAggregator("sum")
-        .setInterval("1m")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setId("downsample")
-        .build();
-    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
-    builder.setExpression("m1 + m2")
-        .setJoinConfig(JoinConfig.newBuilder()
-            .setJoinType(JoinType.NATURAL)
-            .build())
-        .addInterpolatorConfig(NUMERIC_CONFIG);
-    builder.setId("expression");
-    ExpressionConfig exp = builder.build();
-    QueryPlanner plan = mock(QueryPlanner.class);
-    when(plan.configGraph()).thenReturn(graph);
-    
-    graph.putEdge(ds, m1);
-    graph.putEdge(ds, m2);
-    graph.putEdge(exp, ds);
-    graph.putEdge(SINK, exp);
-    
-    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
-    assertEquals(5, graph.nodes().size());
-    assertTrue(graph.nodes().contains(m1));
-    assertTrue(graph.nodes().contains(m2));
-    assertTrue(graph.nodes().contains(ds));
-    assertFalse(graph.nodes().contains(exp));
-    assertTrue(graph.nodes().contains(SINK));
-    
-    QueryNodeConfig b1 = graph.predecessors(ds).iterator().next();
-    assertEquals("BinaryExpression", b1.getType());
-    assertTrue(graph.hasEdgeConnecting(ds, m1));
-    assertTrue(graph.hasEdgeConnecting(ds, m2));
-    assertTrue(graph.hasEdgeConnecting(b1, ds));
-    assertTrue(graph.hasEdgeConnecting(SINK, b1));
-    
-    ExpressionParseNode p1 = (ExpressionParseNode) b1;
-    assertEquals("expression", p1.getId());
-    assertEquals("sys.cpu.user", p1.getLeft());
-    assertEquals("m1", p1.getLeftId());
-    assertEquals(OperandType.VARIABLE, p1.getLeftType());
-    assertEquals("sys.cpu.sys", p1.getRight());
-    assertEquals("m2", p1.getRightId());
-    assertEquals(OperandType.VARIABLE, p1.getRightType());
-    assertEquals(ExpressionOp.ADD, p1.getOperator());
-  }
-  
-  @Test
-  public void setupGraph2Metrics1ThroughNode() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.user")
-            .build())
-        .setFilterId("f1")
-        .setId("m1")
-        .build();
-    QueryNodeConfig m2 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.sys")
-            .build())
-        .setFilterId("f1")
-        .setId("m2")
-        .build();
-    QueryNodeConfig ds = DownsampleConfig.newBuilder()
-        .setAggregator("sum")
-        .setInterval("1m")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setId("downsample")
-        .build();
-    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
-    builder.setExpression("m1 + m2")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setJoinType(JoinType.NATURAL)
-            .build())
-        .addInterpolatorConfig(NUMERIC_CONFIG);
-    builder.setId("expression");
-    ExpressionConfig exp = builder.build();
-    QueryPlanner plan = mock(QueryPlanner.class);
-    when(plan.configGraph()).thenReturn(graph);
-    
-    graph.putEdge(ds, m1);
-    graph.putEdge(exp, m2);
-    graph.putEdge(exp, ds);
-    graph.putEdge(SINK, exp);
-    
-    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
-    assertEquals(5, graph.nodes().size());
-    assertTrue(graph.nodes().contains(m1));
-    assertTrue(graph.nodes().contains(m2));
-    assertTrue(graph.nodes().contains(ds));
-    assertFalse(graph.nodes().contains(exp));
-    assertTrue(graph.nodes().contains(SINK));
-    
-    QueryNodeConfig b1 = graph.predecessors(ds).iterator().next();
-    assertEquals("BinaryExpression", b1.getType());
-    assertTrue(graph.hasEdgeConnecting(ds, m1));
-    assertTrue(graph.hasEdgeConnecting(b1, m2));
-    assertTrue(graph.hasEdgeConnecting(b1, ds));
-    assertTrue(graph.hasEdgeConnecting(SINK, b1));
-    
-    ExpressionParseNode p1 = (ExpressionParseNode) b1;
-    assertEquals("expression", p1.getId());
-    assertEquals("sys.cpu.user", p1.getLeft());
-    assertEquals("m1", p1.getLeftId());
-    assertEquals(OperandType.VARIABLE, p1.getLeftType());
-    assertEquals("sys.cpu.sys", p1.getRight());
-    assertEquals("m2", p1.getRightId());
-    assertEquals(OperandType.VARIABLE, p1.getRightType());
-    assertEquals(ExpressionOp.ADD, p1.getOperator());
-  }
-  
-  @Test
-  public void setupGraph3MetricsThroughNode() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.user")
-            .build())
-        .setFilterId("f1")
-        .setId("m1")
-        .build();
-    QueryNodeConfig m2 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.sys")
-            .build())
-        .setFilterId("f1")
-        .setId("m2")
-        .build();
-    QueryNodeConfig m3 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.idle")
-            .build())
-        .setFilterId("f1")
-        .setId("m3")
-        .build();
-    QueryNodeConfig ds = DownsampleConfig.newBuilder()
-        .setAggregator("sum")
-        .setInterval("1m")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setId("downsample")
-        .build();
-    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
-    builder.setExpression("m1 + m2 + m3")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setJoinType(JoinType.NATURAL)
-            .build())
-        .addInterpolatorConfig(NUMERIC_CONFIG);
-    builder.setId("expression");
-    ExpressionConfig exp = builder.build();
 
-    QueryPlanner plan = mock(QueryPlanner.class);
-    when(plan.configGraph()).thenReturn(graph);
-    
-    graph.putEdge(ds, m1);
-    graph.putEdge(ds, m2);
-    graph.putEdge(ds, m3);
-    graph.putEdge(exp, ds);
-    graph.putEdge(SINK, exp);
-    
-    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
-    assertEquals(7, graph.nodes().size());
-    assertTrue(graph.nodes().contains(m1));
-    assertTrue(graph.nodes().contains(m2));
-    assertTrue(graph.nodes().contains(m3));
-    assertTrue(graph.nodes().contains(ds));
-    assertFalse(graph.nodes().contains(exp));
-    assertTrue(graph.nodes().contains(SINK));
-    
-    assertTrue(graph.hasEdgeConnecting(ds, m1));
-    assertTrue(graph.hasEdgeConnecting(ds, m2));
-    
-    List<QueryNodeConfig> expressions = Lists.newArrayList(graph.predecessors(ds));
-    assertEquals(2, expressions.size());
-    for (final QueryNodeConfig binary : expressions) {
-      assertTrue(graph.hasEdgeConnecting(binary, ds));
-      assertEquals("BinaryExpression", binary.getType());
-      
-      if (binary.getId().equals("expression_SubExp#0")) {
-        ExpressionParseNode p1 = (ExpressionParseNode) binary;
-        assertEquals("expression_SubExp#0", p1.getId());
-        assertEquals("sys.cpu.user", p1.getLeft());
-        assertEquals("m1", p1.getLeftId());
-        assertEquals(OperandType.VARIABLE, p1.getLeftType());
-        assertEquals("sys.cpu.sys", p1.getRight());
-        assertEquals("m2", p1.getRightId());
-        assertEquals(OperandType.VARIABLE, p1.getRightType());
-        assertEquals(ExpressionOp.ADD, p1.getOperator());
-        
-        assertFalse(graph.hasEdgeConnecting(SINK, binary));
-      } else {
-        assertEquals("expression", binary.getId());
-        ExpressionParseNode p1 = (ExpressionParseNode) binary;
-        assertEquals("expression", p1.getId());
-        assertEquals("expression_SubExp#0", p1.getLeft());
-        assertEquals("expression_SubExp#0", p1.getLeftId());
-        assertEquals(OperandType.SUB_EXP, p1.getLeftType());
-        assertEquals("sys.cpu.idle", p1.getRight());
-        assertEquals("m3", p1.getRightId());
-        assertEquals(OperandType.VARIABLE, p1.getRightType());
-        assertEquals(ExpressionOp.ADD, p1.getOperator());
-        
-        assertTrue(graph.hasEdgeConnecting(SINK, binary));
-      }
-    }
-    
-  }
-  
-  @Test
-  public void setupGraph3MetricsComplexThroughNode() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.user")
-            .build())
-        .setFilterId("f1")
-        .setId("m1")
-        .build();
-    QueryNodeConfig m2 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.sys")
-            .build())
-        .setFilterId("f1")
-        .setId("m2")
-        .build();
-    QueryNodeConfig m3 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.idle")
-            .build())
-        .setFilterId("f1")
-        .setId("m3")
-        .build();
-    QueryNodeConfig ds = DownsampleConfig.newBuilder()
-        .setAggregator("sum")
-        .setInterval("1m")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setId("downsample")
-        .build();
-    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
-    builder.setExpression("(m1 * 1024) + (m2 * 1024) + (m3 * 1024)")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setJoinType(JoinType.NATURAL)
-            .build())
-        .addInterpolatorConfig(NUMERIC_CONFIG);
-        builder.setId("expression");
-    ExpressionConfig exp = builder.build();
-
-    QueryPlanner plan = mock(QueryPlanner.class);
-    when(plan.configGraph()).thenReturn(graph);
-    
-    graph.putEdge(ds, m1);
-    graph.putEdge(ds, m2);
-    graph.putEdge(ds, m3);
-    graph.putEdge(exp, ds);
-    graph.putEdge(SINK, exp);
-    
-    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
-    assertEquals(10, graph.nodes().size());
-    assertTrue(graph.nodes().contains(m1));
-    assertTrue(graph.nodes().contains(m2));
-    assertTrue(graph.nodes().contains(m3));
-    assertTrue(graph.nodes().contains(ds));
-    assertFalse(graph.nodes().contains(exp));
-    assertTrue(graph.nodes().contains(SINK));
-    
-    assertTrue(graph.hasEdgeConnecting(ds, m1));
-    assertTrue(graph.hasEdgeConnecting(ds, m2));
-    
-    List<QueryNodeConfig> expressions = Lists.newArrayList(graph.predecessors(ds));
-    assertEquals(3, expressions.size());
-    for (final QueryNodeConfig binary : expressions) {
-      assertTrue(graph.hasEdgeConnecting(binary, ds));
-      assertEquals("BinaryExpression", binary.getType());
-      if (binary.getId().equals("expression_SubExp#0")) {
-        ExpressionParseNode p1 = (ExpressionParseNode) binary;
-        assertEquals("expression_SubExp#0", p1.getId());
-        assertEquals("sys.cpu.user", p1.getLeft());
-        assertEquals("m1", p1.getLeftId());
-        assertEquals(OperandType.VARIABLE, p1.getLeftType());
-        assertEquals(1024, ((NumericLiteral) p1.getRight()).longValue());
-        assertNull(p1.getRightId());
-        assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
-        assertEquals(ExpressionOp.MULTIPLY, p1.getOperator());
-        
-        assertFalse(graph.hasEdgeConnecting(SINK, binary));
-        assertEquals(1, graph.predecessors(binary).size());
-        assertEquals("expression_SubExp#2", 
-            graph.predecessors(binary).iterator().next().getId());
-      } else if (binary.getId().equals("expression_SubExp#1")) {
-        ExpressionParseNode p1 = (ExpressionParseNode) binary;
-        assertEquals("expression_SubExp#1", p1.getId());
-        assertEquals("sys.cpu.sys", p1.getLeft());
-        assertEquals("m2", p1.getLeftId());
-        assertEquals(OperandType.VARIABLE, p1.getLeftType());
-        assertEquals(1024, ((NumericLiteral) p1.getRight()).longValue());
-        assertNull(p1.getRightId());
-        assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
-        assertEquals(ExpressionOp.MULTIPLY, p1.getOperator());
-        
-        assertFalse(graph.hasEdgeConnecting(SINK, binary));
-        assertEquals(1, graph.predecessors(binary).size());
-        QueryNodeConfig b2 = graph.predecessors(binary).iterator().next();
-        assertEquals("expression_SubExp#2", b2.getId());
-        
-        // validate sub2 here
-        p1 = (ExpressionParseNode) b2;
-        assertEquals("expression_SubExp#2", p1.getId());
-        assertEquals("expression_SubExp#0", p1.getLeft());
-        assertEquals("expression_SubExp#0", p1.getLeftId());
-        assertEquals(OperandType.SUB_EXP, p1.getLeftType());
-        assertEquals("expression_SubExp#1", p1.getRight());
-        assertEquals("expression_SubExp#1", p1.getRightId());
-        assertEquals(OperandType.SUB_EXP, p1.getRightType());
-        assertEquals(ExpressionOp.ADD, p1.getOperator());
-        
-        assertFalse(graph.hasEdgeConnecting(SINK, b2));
-        
-      } else if (binary.getId().equals("expression_SubExp#3")) {
-        ExpressionParseNode p1 = (ExpressionParseNode) binary;
-        assertEquals("expression_SubExp#3", p1.getId());
-        assertEquals("sys.cpu.idle", p1.getLeft());
-        assertEquals("m3", p1.getLeftId());
-        assertEquals(OperandType.VARIABLE, p1.getLeftType());
-        assertEquals(1024, ((NumericLiteral) p1.getRight()).longValue());
-        assertNull(p1.getRightId());
-        assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
-        assertEquals(ExpressionOp.MULTIPLY, p1.getOperator());
-        
-        assertFalse(graph.hasEdgeConnecting(SINK, binary));
-        assertEquals(1, graph.predecessors(binary).size());
-        
-        // validate the expression here
-        QueryNodeConfig b2 = graph.predecessors(binary).iterator().next();
-        assertEquals("expression", b2.getId());
-        
-        // validate parent here
-        p1 = (ExpressionParseNode) b2;
-        assertEquals("expression", p1.getId());
-        assertEquals("expression_SubExp#2", p1.getLeft());
-        assertEquals("expression_SubExp#2", p1.getLeftId());
-        assertEquals(OperandType.SUB_EXP, p1.getLeftType());
-        assertEquals("expression_SubExp#3", p1.getRight());
-        assertEquals("expression_SubExp#3", p1.getRightId());
-        assertEquals(OperandType.SUB_EXP, p1.getRightType());
-        assertEquals(ExpressionOp.ADD, p1.getOperator());
-        
-        assertTrue(graph.hasEdgeConnecting(SINK, b2));
-      }
-    }
-    
-  }
-  
-  @Test
-  public void setupGraphThroughJoinNodeMetricName() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.user")
-            .build())
-        .setFilterId("f1")
-        .setId("ha_m1")
-        .build();
-    QueryNodeConfig merger = MergerConfig.newBuilder()
-        .setAggregator("sum")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setDataSource("m1")
-        .setId("m1")
-        .build();
-    QueryNodeConfig ds = DownsampleConfig.newBuilder()
-        .setAggregator("sum")
-        .setInterval("1m")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setId("downsample")
-        .build();
-    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
-    builder.setExpression("(sys.cpu.user * 1024)")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setJoinType(JoinType.NATURAL)
-            .build())
-        .addInterpolatorConfig(NUMERIC_CONFIG);
-    builder.setId("expression");
-    ExpressionConfig exp = builder.build();
-    
-    QueryPlanner plan = mock(QueryPlanner.class);
-    when(plan.configGraph()).thenReturn(graph);
-    
-    graph.putEdge(merger, m1);
-    graph.putEdge(ds, merger);
-    graph.putEdge(exp, ds);
-    graph.putEdge(SINK, exp);
-    
-    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
-    assertEquals(5, graph.nodes().size());
-    assertTrue(graph.nodes().contains(m1));
-    assertTrue(graph.nodes().contains(merger));
-    assertTrue(graph.nodes().contains(ds));
-    assertFalse(graph.nodes().contains(exp));
-    assertTrue(graph.nodes().contains(SINK));
-    
-    assertTrue(graph.hasEdgeConnecting(merger, m1));
-    
-    List<QueryNodeConfig> expressions = Lists.newArrayList(graph.predecessors(ds));
-    assertEquals(1, expressions.size());
-    ExpressionParseNode p1 = (ExpressionParseNode) expressions.get(0);
-    assertTrue(graph.hasEdgeConnecting(p1, ds));
-    assertEquals("expression", p1.getId());
-    assertEquals("sys.cpu.user", p1.getLeft());
-    assertEquals("m1", p1.getLeftId());
-    assertEquals(OperandType.VARIABLE, p1.getLeftType());
-    assertEquals(1024, ((NumericLiteral) p1.getRight()).longValue());
-    assertNull(p1.getRightId());
-    assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
-    assertEquals(ExpressionOp.MULTIPLY, p1.getOperator());
-    
-    assertTrue(graph.hasEdgeConnecting(SINK, p1));
-    assertEquals(1, graph.predecessors(p1).size());
-  }
-  
+// TODO - restore the through node code. Have to do that in planner.
+//  @Test
+//  public void setupGraph2MetricsThroughNode() throws Exception {
+//    ExpressionFactory factory = new ExpressionFactory();
+//    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
+//        .allowsSelfLoops(false).build();
+//    
+//    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
+//        .setMetric(MetricLiteralFilter.newBuilder()
+//            .setMetric("sys.cpu.user")
+//            .build())
+//        .setFilterId("f1")
+//        .setId("m1")
+//        .build();
+//    QueryNodeConfig m2 = DefaultTimeSeriesDataSourceConfig.newBuilder()
+//        .setMetric(MetricLiteralFilter.newBuilder()
+//            .setMetric("sys.cpu.sys")
+//            .build())
+//        .setFilterId("f1")
+//        .setId("m2")
+//        .build();
+//    QueryNodeConfig ds = DownsampleConfig.newBuilder()
+//        .setAggregator("sum")
+//        .setInterval("1m")
+//        .addInterpolatorConfig(NUMERIC_CONFIG)
+//        .setId("downsample")
+//        .build();
+//    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
+//    builder.setExpression("m1 + m2")
+//        .setJoinConfig(JoinConfig.newBuilder()
+//            .setJoinType(JoinType.NATURAL)
+//            .build())
+//        .addInterpolatorConfig(NUMERIC_CONFIG);
+//    builder.setId("expression");
+//    ExpressionConfig exp = builder.build();
+//    QueryPlanner plan = mock(QueryPlanner.class);
+//    when(plan.configGraph()).thenReturn(graph);
+//    
+//    graph.putEdge(ds, m1);
+//    graph.putEdge(ds, m2);
+//    graph.putEdge(exp, ds);
+//    graph.putEdge(SINK, exp);
+//    
+//    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
+//    assertEquals(5, graph.nodes().size());
+//    assertTrue(graph.nodes().contains(m1));
+//    assertTrue(graph.nodes().contains(m2));
+//    assertTrue(graph.nodes().contains(ds));
+//    assertFalse(graph.nodes().contains(exp));
+//    assertTrue(graph.nodes().contains(SINK));
+//    
+//    QueryNodeConfig b1 = graph.predecessors(ds).iterator().next();
+//    assertEquals("BinaryExpression", b1.getType());
+//    assertTrue(graph.hasEdgeConnecting(ds, m1));
+//    assertTrue(graph.hasEdgeConnecting(ds, m2));
+//    assertTrue(graph.hasEdgeConnecting(b1, ds));
+//    assertTrue(graph.hasEdgeConnecting(SINK, b1));
+//    
+//    ExpressionParseNode p1 = (ExpressionParseNode) b1;
+//    assertEquals("expression", p1.getId());
+//    assertEquals("sys.cpu.user", p1.getLeft());
+//    assertEquals("m1", p1.getLeftId());
+//    assertEquals(OperandType.VARIABLE, p1.getLeftType());
+//    assertEquals("sys.cpu.sys", p1.getRight());
+//    assertEquals("m2", p1.getRightId());
+//    assertEquals(OperandType.VARIABLE, p1.getRightType());
+//    assertEquals(ExpressionOp.ADD, p1.getOperator());
+//  }
+//  
+//  @Test
+//  public void setupGraph2Metrics1ThroughNode() throws Exception {
+//    ExpressionFactory factory = new ExpressionFactory();
+//    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
+//        .allowsSelfLoops(false).build();
+//    
+//    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
+//        .setMetric(MetricLiteralFilter.newBuilder()
+//            .setMetric("sys.cpu.user")
+//            .build())
+//        .setFilterId("f1")
+//        .setId("m1")
+//        .build();
+//    QueryNodeConfig m2 = DefaultTimeSeriesDataSourceConfig.newBuilder()
+//        .setMetric(MetricLiteralFilter.newBuilder()
+//            .setMetric("sys.cpu.sys")
+//            .build())
+//        .setFilterId("f1")
+//        .setId("m2")
+//        .build();
+//    QueryNodeConfig ds = DownsampleConfig.newBuilder()
+//        .setAggregator("sum")
+//        .setInterval("1m")
+//        .addInterpolatorConfig(NUMERIC_CONFIG)
+//        .setId("downsample")
+//        .build();
+//    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
+//    builder.setExpression("m1 + m2")
+//        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+//            .setJoinType(JoinType.NATURAL)
+//            .build())
+//        .addInterpolatorConfig(NUMERIC_CONFIG);
+//    builder.setId("expression");
+//    ExpressionConfig exp = builder.build();
+//    QueryPlanner plan = mock(QueryPlanner.class);
+//    when(plan.configGraph()).thenReturn(graph);
+//    
+//    graph.putEdge(ds, m1);
+//    graph.putEdge(exp, m2);
+//    graph.putEdge(exp, ds);
+//    graph.putEdge(SINK, exp);
+//    
+//    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
+//    assertEquals(5, graph.nodes().size());
+//    assertTrue(graph.nodes().contains(m1));
+//    assertTrue(graph.nodes().contains(m2));
+//    assertTrue(graph.nodes().contains(ds));
+//    assertFalse(graph.nodes().contains(exp));
+//    assertTrue(graph.nodes().contains(SINK));
+//    
+//    QueryNodeConfig b1 = graph.predecessors(ds).iterator().next();
+//    assertEquals("BinaryExpression", b1.getType());
+//    assertTrue(graph.hasEdgeConnecting(ds, m1));
+//    assertTrue(graph.hasEdgeConnecting(b1, m2));
+//    assertTrue(graph.hasEdgeConnecting(b1, ds));
+//    assertTrue(graph.hasEdgeConnecting(SINK, b1));
+//    
+//    ExpressionParseNode p1 = (ExpressionParseNode) b1;
+//    assertEquals("expression", p1.getId());
+//    assertEquals("sys.cpu.user", p1.getLeft());
+//    assertEquals("m1", p1.getLeftId());
+//    assertEquals(OperandType.VARIABLE, p1.getLeftType());
+//    assertEquals("sys.cpu.sys", p1.getRight());
+//    assertEquals("m2", p1.getRightId());
+//    assertEquals(OperandType.VARIABLE, p1.getRightType());
+//    assertEquals(ExpressionOp.ADD, p1.getOperator());
+//  }
+//  
+//  @Test
+//  public void setupGraph3MetricsThroughNode() throws Exception {
+//    ExpressionFactory factory = new ExpressionFactory();
+//    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
+//        .allowsSelfLoops(false).build();
+//    
+//    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
+//        .setMetric(MetricLiteralFilter.newBuilder()
+//            .setMetric("sys.cpu.user")
+//            .build())
+//        .setFilterId("f1")
+//        .setId("m1")
+//        .build();
+//    QueryNodeConfig m2 = DefaultTimeSeriesDataSourceConfig.newBuilder()
+//        .setMetric(MetricLiteralFilter.newBuilder()
+//            .setMetric("sys.cpu.sys")
+//            .build())
+//        .setFilterId("f1")
+//        .setId("m2")
+//        .build();
+//    QueryNodeConfig m3 = DefaultTimeSeriesDataSourceConfig.newBuilder()
+//        .setMetric(MetricLiteralFilter.newBuilder()
+//            .setMetric("sys.cpu.idle")
+//            .build())
+//        .setFilterId("f1")
+//        .setId("m3")
+//        .build();
+//    QueryNodeConfig ds = DownsampleConfig.newBuilder()
+//        .setAggregator("sum")
+//        .setInterval("1m")
+//        .addInterpolatorConfig(NUMERIC_CONFIG)
+//        .setId("downsample")
+//        .build();
+//    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
+//    builder.setExpression("m1 + m2 + m3")
+//        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+//            .setJoinType(JoinType.NATURAL)
+//            .build())
+//        .addInterpolatorConfig(NUMERIC_CONFIG);
+//    builder.setId("expression");
+//    ExpressionConfig exp = builder.build();
+//
+//    QueryPlanner plan = mock(QueryPlanner.class);
+//    when(plan.configGraph()).thenReturn(graph);
+//    
+//    graph.putEdge(ds, m1);
+//    graph.putEdge(ds, m2);
+//    graph.putEdge(ds, m3);
+//    graph.putEdge(exp, ds);
+//    graph.putEdge(SINK, exp);
+//    
+//    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
+//    assertEquals(7, graph.nodes().size());
+//    assertTrue(graph.nodes().contains(m1));
+//    assertTrue(graph.nodes().contains(m2));
+//    assertTrue(graph.nodes().contains(m3));
+//    assertTrue(graph.nodes().contains(ds));
+//    assertFalse(graph.nodes().contains(exp));
+//    assertTrue(graph.nodes().contains(SINK));
+//    
+//    assertTrue(graph.hasEdgeConnecting(ds, m1));
+//    assertTrue(graph.hasEdgeConnecting(ds, m2));
+//    
+//    List<QueryNodeConfig> expressions = Lists.newArrayList(graph.predecessors(ds));
+//    assertEquals(2, expressions.size());
+//    for (final QueryNodeConfig binary : expressions) {
+//      assertTrue(graph.hasEdgeConnecting(binary, ds));
+//      assertEquals("BinaryExpression", binary.getType());
+//      
+//      if (binary.getId().equals("expression_SubExp#0")) {
+//        ExpressionParseNode p1 = (ExpressionParseNode) binary;
+//        assertEquals("expression_SubExp#0", p1.getId());
+//        assertEquals("sys.cpu.user", p1.getLeft());
+//        assertEquals("m1", p1.getLeftId());
+//        assertEquals(OperandType.VARIABLE, p1.getLeftType());
+//        assertEquals("sys.cpu.sys", p1.getRight());
+//        assertEquals("m2", p1.getRightId());
+//        assertEquals(OperandType.VARIABLE, p1.getRightType());
+//        assertEquals(ExpressionOp.ADD, p1.getOperator());
+//        
+//        assertFalse(graph.hasEdgeConnecting(SINK, binary));
+//      } else {
+//        assertEquals("expression", binary.getId());
+//        ExpressionParseNode p1 = (ExpressionParseNode) binary;
+//        assertEquals("expression", p1.getId());
+//        assertEquals("expression_SubExp#0", p1.getLeft());
+//        assertEquals("expression_SubExp#0", p1.getLeftId());
+//        assertEquals(OperandType.SUB_EXP, p1.getLeftType());
+//        assertEquals("sys.cpu.idle", p1.getRight());
+//        assertEquals("m3", p1.getRightId());
+//        assertEquals(OperandType.VARIABLE, p1.getRightType());
+//        assertEquals(ExpressionOp.ADD, p1.getOperator());
+//        
+//        assertTrue(graph.hasEdgeConnecting(SINK, binary));
+//      }
+//    }
+//    
+//  }
+//  
+//  @Test
+//  public void setupGraph3MetricsComplexThroughNode() throws Exception {
+//    ExpressionFactory factory = new ExpressionFactory();
+//    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
+//        .allowsSelfLoops(false).build();
+//    
+//    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
+//        .setMetric(MetricLiteralFilter.newBuilder()
+//            .setMetric("sys.cpu.user")
+//            .build())
+//        .setFilterId("f1")
+//        .setId("m1")
+//        .build();
+//    QueryNodeConfig m2 = DefaultTimeSeriesDataSourceConfig.newBuilder()
+//        .setMetric(MetricLiteralFilter.newBuilder()
+//            .setMetric("sys.cpu.sys")
+//            .build())
+//        .setFilterId("f1")
+//        .setId("m2")
+//        .build();
+//    QueryNodeConfig m3 = DefaultTimeSeriesDataSourceConfig.newBuilder()
+//        .setMetric(MetricLiteralFilter.newBuilder()
+//            .setMetric("sys.cpu.idle")
+//            .build())
+//        .setFilterId("f1")
+//        .setId("m3")
+//        .build();
+//    QueryNodeConfig ds = DownsampleConfig.newBuilder()
+//        .setAggregator("sum")
+//        .setInterval("1m")
+//        .addInterpolatorConfig(NUMERIC_CONFIG)
+//        .setId("downsample")
+//        .build();
+//    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
+//    builder.setExpression("(m1 * 1024) + (m2 * 1024) + (m3 * 1024)")
+//        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+//            .setJoinType(JoinType.NATURAL)
+//            .build())
+//        .addInterpolatorConfig(NUMERIC_CONFIG);
+//        builder.setId("expression");
+//    ExpressionConfig exp = builder.build();
+//
+//    QueryPlanner plan = mock(QueryPlanner.class);
+//    when(plan.configGraph()).thenReturn(graph);
+//    
+//    graph.putEdge(ds, m1);
+//    graph.putEdge(ds, m2);
+//    graph.putEdge(ds, m3);
+//    graph.putEdge(exp, ds);
+//    graph.putEdge(SINK, exp);
+//    
+//    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
+//    assertEquals(10, graph.nodes().size());
+//    assertTrue(graph.nodes().contains(m1));
+//    assertTrue(graph.nodes().contains(m2));
+//    assertTrue(graph.nodes().contains(m3));
+//    assertTrue(graph.nodes().contains(ds));
+//    assertFalse(graph.nodes().contains(exp));
+//    assertTrue(graph.nodes().contains(SINK));
+//    
+//    assertTrue(graph.hasEdgeConnecting(ds, m1));
+//    assertTrue(graph.hasEdgeConnecting(ds, m2));
+//    
+//    List<QueryNodeConfig> expressions = Lists.newArrayList(graph.predecessors(ds));
+//    assertEquals(3, expressions.size());
+//    for (final QueryNodeConfig binary : expressions) {
+//      assertTrue(graph.hasEdgeConnecting(binary, ds));
+//      assertEquals("BinaryExpression", binary.getType());
+//      if (binary.getId().equals("expression_SubExp#0")) {
+//        ExpressionParseNode p1 = (ExpressionParseNode) binary;
+//        assertEquals("expression_SubExp#0", p1.getId());
+//        assertEquals("sys.cpu.user", p1.getLeft());
+//        assertEquals("m1", p1.getLeftId());
+//        assertEquals(OperandType.VARIABLE, p1.getLeftType());
+//        assertEquals(1024, ((NumericLiteral) p1.getRight()).longValue());
+//        assertNull(p1.getRightId());
+//        assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
+//        assertEquals(ExpressionOp.MULTIPLY, p1.getOperator());
+//        
+//        assertFalse(graph.hasEdgeConnecting(SINK, binary));
+//        assertEquals(1, graph.predecessors(binary).size());
+//        assertEquals("expression_SubExp#2", 
+//            graph.predecessors(binary).iterator().next().getId());
+//      } else if (binary.getId().equals("expression_SubExp#1")) {
+//        ExpressionParseNode p1 = (ExpressionParseNode) binary;
+//        assertEquals("expression_SubExp#1", p1.getId());
+//        assertEquals("sys.cpu.sys", p1.getLeft());
+//        assertEquals("m2", p1.getLeftId());
+//        assertEquals(OperandType.VARIABLE, p1.getLeftType());
+//        assertEquals(1024, ((NumericLiteral) p1.getRight()).longValue());
+//        assertNull(p1.getRightId());
+//        assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
+//        assertEquals(ExpressionOp.MULTIPLY, p1.getOperator());
+//        
+//        assertFalse(graph.hasEdgeConnecting(SINK, binary));
+//        assertEquals(1, graph.predecessors(binary).size());
+//        QueryNodeConfig b2 = graph.predecessors(binary).iterator().next();
+//        assertEquals("expression_SubExp#2", b2.getId());
+//        
+//        // validate sub2 here
+//        p1 = (ExpressionParseNode) b2;
+//        assertEquals("expression_SubExp#2", p1.getId());
+//        assertEquals("expression_SubExp#0", p1.getLeft());
+//        assertEquals("expression_SubExp#0", p1.getLeftId());
+//        assertEquals(OperandType.SUB_EXP, p1.getLeftType());
+//        assertEquals("expression_SubExp#1", p1.getRight());
+//        assertEquals("expression_SubExp#1", p1.getRightId());
+//        assertEquals(OperandType.SUB_EXP, p1.getRightType());
+//        assertEquals(ExpressionOp.ADD, p1.getOperator());
+//        
+//        assertFalse(graph.hasEdgeConnecting(SINK, b2));
+//        
+//      } else if (binary.getId().equals("expression_SubExp#3")) {
+//        ExpressionParseNode p1 = (ExpressionParseNode) binary;
+//        assertEquals("expression_SubExp#3", p1.getId());
+//        assertEquals("sys.cpu.idle", p1.getLeft());
+//        assertEquals("m3", p1.getLeftId());
+//        assertEquals(OperandType.VARIABLE, p1.getLeftType());
+//        assertEquals(1024, ((NumericLiteral) p1.getRight()).longValue());
+//        assertNull(p1.getRightId());
+//        assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
+//        assertEquals(ExpressionOp.MULTIPLY, p1.getOperator());
+//        
+//        assertFalse(graph.hasEdgeConnecting(SINK, binary));
+//        assertEquals(1, graph.predecessors(binary).size());
+//        
+//        // validate the expression here
+//        QueryNodeConfig b2 = graph.predecessors(binary).iterator().next();
+//        assertEquals("expression", b2.getId());
+//        
+//        // validate parent here
+//        p1 = (ExpressionParseNode) b2;
+//        assertEquals("expression", p1.getId());
+//        assertEquals("expression_SubExp#2", p1.getLeft());
+//        assertEquals("expression_SubExp#2", p1.getLeftId());
+//        assertEquals(OperandType.SUB_EXP, p1.getLeftType());
+//        assertEquals("expression_SubExp#3", p1.getRight());
+//        assertEquals("expression_SubExp#3", p1.getRightId());
+//        assertEquals(OperandType.SUB_EXP, p1.getRightType());
+//        assertEquals(ExpressionOp.ADD, p1.getOperator());
+//        
+//        assertTrue(graph.hasEdgeConnecting(SINK, b2));
+//      }
+//    }
+//    
+//  }
+//  
+//  @Test
+//  public void setupGraphThroughJoinNodeMetricName() throws Exception {
+//    ExpressionFactory factory = new ExpressionFactory();
+//    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
+//        .allowsSelfLoops(false).build();
+//    
+//    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
+//        .setMetric(MetricLiteralFilter.newBuilder()
+//            .setMetric("sys.cpu.user")
+//            .build())
+//        .setFilterId("f1")
+//        .setId("ha_m1")
+//        .build();
+//    QueryNodeConfig merger = MergerConfig.newBuilder()
+//        .setAggregator("sum")
+//        .addInterpolatorConfig(NUMERIC_CONFIG)
+//        .setDataSource("m1")
+//        .setId("m1")
+//        .build();
+//    QueryNodeConfig ds = DownsampleConfig.newBuilder()
+//        .setAggregator("sum")
+//        .setInterval("1m")
+//        .addInterpolatorConfig(NUMERIC_CONFIG)
+//        .setId("downsample")
+//        .build();
+//    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
+//    builder.setExpression("(sys.cpu.user * 1024)")
+//        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+//            .setJoinType(JoinType.NATURAL)
+//            .build())
+//        .addInterpolatorConfig(NUMERIC_CONFIG);
+//    builder.setId("expression");
+//    ExpressionConfig exp = builder.build();
+//    
+//    QueryPlanner plan = mock(QueryPlanner.class);
+//    when(plan.configGraph()).thenReturn(graph);
+//    
+//    graph.putEdge(merger, m1);
+//    graph.putEdge(ds, merger);
+//    graph.putEdge(exp, ds);
+//    graph.putEdge(SINK, exp);
+//    
+//    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
+//    assertEquals(5, graph.nodes().size());
+//    assertTrue(graph.nodes().contains(m1));
+//    assertTrue(graph.nodes().contains(merger));
+//    assertTrue(graph.nodes().contains(ds));
+//    assertFalse(graph.nodes().contains(exp));
+//    assertTrue(graph.nodes().contains(SINK));
+//    
+//    assertTrue(graph.hasEdgeConnecting(merger, m1));
+//    
+//    List<QueryNodeConfig> expressions = Lists.newArrayList(graph.predecessors(ds));
+//    assertEquals(1, expressions.size());
+//    ExpressionParseNode p1 = (ExpressionParseNode) expressions.get(0);
+//    assertTrue(graph.hasEdgeConnecting(p1, ds));
+//    assertEquals("expression", p1.getId());
+//    assertEquals("sys.cpu.user", p1.getLeft());
+//    assertEquals("m1", p1.getLeftId());
+//    assertEquals(OperandType.VARIABLE, p1.getLeftType());
+//    assertEquals(1024, ((NumericLiteral) p1.getRight()).longValue());
+//    assertNull(p1.getRightId());
+//    assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
+//    assertEquals(ExpressionOp.MULTIPLY, p1.getOperator());
+//    
+//    assertTrue(graph.hasEdgeConnecting(SINK, p1));
+//    assertEquals(1, graph.predecessors(p1).size());
+//  }
+//  
   @Test
   public void setupGraphNestedExpression() throws Exception {
     ExpressionFactory factory = new ExpressionFactory();
@@ -688,7 +699,14 @@ public class TestExpressionFactory {
     
     QueryPlanner plan = mock(QueryPlanner.class);
     when(plan.configGraph()).thenReturn(graph);
-    
+    when(plan.getMetrics(ds1))
+      .thenReturn(Sets.newHashSet("sys.cpu.user"));
+    when(plan.getMetrics(ds2))
+      .thenReturn(Sets.newHashSet("sys.cpu.busy"));
+    when(plan.getDataSourceIds(ds1))
+      .thenReturn(Lists.newArrayList("ds1:m1"));
+    when(plan.getDataSourceIds(ds2))
+      .thenReturn(Lists.newArrayList("ds2:m2"));
     graph.putEdge(ds1, m1);
     graph.putEdge(ds2, m2);
     graph.putEdge(exp, ds1);

--- a/core/src/test/java/net/opentsdb/query/readcache/TestGuavaLRUCache.java
+++ b/core/src/test/java/net/opentsdb/query/readcache/TestGuavaLRUCache.java
@@ -106,12 +106,12 @@ public class TestGuavaLRUCache {
       }
     });
     
-    when(serdes.deserialize(any(byte[].class))).thenAnswer(
+    when(serdes.deserialize(any(QueryPipelineContext.class), any(byte[].class))).thenAnswer(
         new Answer<Map<String, ReadCacheQueryResult>>() {
           @Override
           public Map<String, ReadCacheQueryResult> answer(
               InvocationOnMock invocation) throws Throwable {
-            SerdesObj obj = serdes_calls.get((byte[]) invocation.getArguments()[0]);
+            SerdesObj obj = serdes_calls.get((byte[]) invocation.getArguments()[1]);
             return obj.deserialized;
           }
     });
@@ -289,7 +289,8 @@ public class TestGuavaLRUCache {
       fail("Expected UnitTestException");
     } catch (UnitTestException e) { }
     
-    doThrow(new UnitTestException()).when(serdes).deserialize(any(byte[].class));
+    doThrow(new UnitTestException()).when(serdes).deserialize(
+        any(QueryPipelineContext.class), any(byte[].class));
     ReadCacheQueryResultSet[] results = new ReadCacheQueryResultSet[2];
     Throwable[] errors = new Throwable[2];
     class CB implements ReadCacheCallback {

--- a/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Result.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Result.java
@@ -53,6 +53,7 @@ import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
+import net.opentsdb.query.readcache.CachedQueryNode;
 import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.utils.DateTime;
 
@@ -112,17 +113,14 @@ public class HttpQueryV3Result implements QueryResult {
                     final JsonNode root, 
                     final RollupConfig rollup_config,
                     final Exception exception) {
-    this.node = node;
     this.exception = exception;
     this.rollup_config = rollup_config;
+    this.node = new CachedQueryNode(node.config().getId(), node.pipelineContext());
     if (exception == null && root != null) {
       String temp = root.get("source").asText();
-      data_source = temp.substring(temp.indexOf(":") + 1);
-      
+      // TEMP - old versions didn't handle IDs correctly so we override the result.
       TimeSeriesDataSourceConfig cfg = (TimeSeriesDataSourceConfig) node.config();
-      if (!cfg.getId().equals(cfg.getDataSourceId())) {
-        data_source = cfg.getDataSourceId();
-      }
+      data_source = cfg.getDataSourceId();
       
       JsonNode n = root.get("timeSpecification");
       if (n != null && !n.isNull()) {

--- a/executors/http/src/test/java/net/opentsdb/query/execution/TestHttpQueryV3Source.java
+++ b/executors/http/src/test/java/net/opentsdb/query/execution/TestHttpQueryV3Source.java
@@ -239,6 +239,7 @@ public class TestHttpQueryV3Source {
     assertEquals("application/json", request.getFirstHeader("Content-Type").getValue());
     assertNull(request.getFirstHeader("Cookie"));
     String json = EntityUtils.toString(((HttpPost) request).getEntity());
+    System.out.println(json);
     assertTrue(json.matches(".*\"start\":\"\\d{13}\".*"));
     assertTrue(json.matches(".*\"end\":\"\\d{13}\".*"));
     assertTrue(json.contains("\"mode\":\"SINGLE\""));

--- a/implementation/redis/src/main/java/net/opentsdb/query/execution/cache/RedisClusterQueryCache.java
+++ b/implementation/redis/src/main/java/net/opentsdb/query/execution/cache/RedisClusterQueryCache.java
@@ -334,7 +334,7 @@ public class RedisClusterQueryCache extends BaseTSDBPlugin
         if (raw == null) {
           results = null;
         } else {
-          results = serdes.deserialize(raw);
+          results = serdes.deserialize(context, raw);
         }
       }
       


### PR DESCRIPTION
- Add getDataSourceIds() and getMetrics() to the Query Planner interface for
  now to reduce some code duplication.
- Pass the QueryPipelineContext in the CachedQueryNode ctor so we can use it
  in nodes that need it.
- Add QPC in the ReadCacheSerdes deserialize method.

CORE:
- Don't change node ID in the time shift setup.
- Fix the HACluster node so that it handles the proper node config ID instead
  of mixing up the data source ID. And the timeout results will now return the
  right node ID and data source IDs.
- Set the data source ID in the HAClusterFactory.
- Rename the source node in the DefaultQueryPlanner with the last push-down's
  ID and fix the ID of the summarizer pass through node.
- Add getDataSourceIds() and getMetrics() to the DefaultQueryPlanner.
  TODO - test these.
- Tweak BinaryExpressionNode to use the full result ID.
- Modify ExpressionFactory to use the full source IDs and the new planner
  methods, simplifies the code a bunch.
- Use the context in JsonReadCacheSerdes and add an exception catcher.

HTTP:
- Have the HttpV3QueryResult return the node's ID and data source.
- Modify HttpQueryV3Source to flip the ID and data source ID. And for now
  it will modify the push-downs in-place. TODO - verify that's ok or make
  copies.