### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
@@ -864,6 +864,9 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes {
         long ts = (options != null && options.getMsResolution())
             ? value.timestamp().msEpoch()
             : value.timestamp().msEpoch() / 1000;
+        if (value.timestamp().epoch() == 0) {
+          ts = start.epoch();
+        }
 
         if (!wrote_values) {
           json.writeStartObject();
@@ -939,6 +942,9 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes {
         long ts = (options != null && options.getMsResolution())
             ? value.timestamp().msEpoch()
             : value.timestamp().msEpoch() / 1000;
+        if (value.timestamp().epoch() == 0) {
+          ts = value.timestamp().epoch();
+        }
         final String ts_string = Long.toString(ts);
 
         if (!wrote_values) {


### PR DESCRIPTION
- Set summary timestamp to the query start if it was 0 for a cached result
  in Jsonv3QuerySerdes.