### PR TITLE
CORE:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/filter/NotFilterFactory.java
+++ b/common/src/main/java/net/opentsdb/query/filter/NotFilterFactory.java
@@ -17,6 +17,7 @@ package net.opentsdb.query.filter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.core.BaseTSDBPlugin;
 import net.opentsdb.core.TSDB;
@@ -36,6 +37,12 @@ public class NotFilterFactory extends BaseTSDBPlugin implements
     return TYPE;
   }
 
+  @Override
+  public Deferred<Object> initialize(final TSDB tsdb, final String id) {
+    this.id = Strings.isNullOrEmpty(id) ? TYPE : id;
+    return Deferred.fromResult(null);
+  }
+  
   @Override
   public QueryFilter parse(final TSDB tsdb, 
                            final ObjectMapper mapper, 
@@ -68,8 +75,7 @@ public class NotFilterFactory extends BaseTSDBPlugin implements
         .setFilter(factory.parse(tsdb, mapper, filter))
         .build();
   }
-
-
+  
   @Override
   public String type() {
     return TYPE;

--- a/core/src/main/java/net/opentsdb/query/plan/DefaultQueryPlanner.java
+++ b/core/src/main/java/net/opentsdb/query/plan/DefaultQueryPlanner.java
@@ -681,7 +681,13 @@ public class DefaultQueryPlanner implements QueryPlanner {
           ids.add(downstream.getId() + ":" 
               + ((TimeSeriesDataSourceConfig) downstream).getDataSourceId());
         } else if (downstream.joins()) {
-          ids.addAll(downstream_ids);
+          if (downstream instanceof ExpressionConfig) {
+            ids.add(downstream.getId() + ":" + ((ExpressionConfig) downstream).getAs());
+          } else if (downstream instanceof ExpressionParseNode) {
+            ids.add(downstream.getId() + ":" + ((ExpressionParseNode) downstream).getAs());
+          } else {
+            ids.addAll(downstream_ids);
+          }
         } else if (downstream instanceof SummarizerConfig &&
             ((SummarizerConfig) downstream).passThrough()) {
           for (final QueryNodeConfig successor : config_graph.successors(downstream)) {

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionNumericArrayIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionNumericArrayIterator.java
@@ -1109,8 +1109,8 @@ public class ExpressionNumericArrayIterator extends
     
     LiteralArray(final int length, final NumericType literal) {
       if (literal == null) {
-        // TODO - dunno if this is right.
-        long_values = new long[length];
+        double_values = new double[length];
+        Arrays.fill(double_values, Double.NaN);
       } else if (literal.isInteger()) {
         long_values = new long[length];
         Arrays.fill(long_values, literal.longValue());

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerFactory.java
@@ -101,7 +101,6 @@ public class SummarizerFactory extends BaseQueryNodeFactory<SummarizerConfig, Su
     final Map<String, String> sink_filters = ((DefaultQueryPlanner) plan).sinkFilters();
     for (final QueryNodeConfig successor : plan.configGraph().successors(config)) {
       if (sink_filters.containsKey(successor.getId())) {
-        sink_filters.remove(successor.getId());
         pass_through = true;
       }
     }

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorAdditive.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorAdditive.java
@@ -911,8 +911,8 @@ public class TestExpressionNumericArrayIteratorAdditive extends BaseNumericTest 
     assertTrue(iterator.hasNext());
     TimeSeriesValue<NumericArrayType> value = 
         (TimeSeriesValue<NumericArrayType>) iterator.next();
-    assertArrayEquals(new long[] { 4, 10, 8 },
-        value.value().longArray());
+    assertArrayEquals(new double[] { 4, 10, 8 },
+        value.value().doubleArray(), 0.001);
     assertEquals(60, value.timestamp().epoch());
     assertEquals(0, value.value().offset());
     assertEquals(3, value.value().end());
@@ -936,8 +936,8 @@ public class TestExpressionNumericArrayIteratorAdditive extends BaseNumericTest 
               .build());
     assertTrue(iterator.hasNext());
     value =  (TimeSeriesValue<NumericArrayType>) iterator.next();
-    assertArrayEquals(new long[] { -4, -10, -8 },
-        value.value().longArray());
+    assertArrayEquals(new double[] { 4, 10, 8 },
+        value.value().doubleArray(), 0.001);
     assertEquals(60, value.timestamp().epoch());
     assertEquals(0, value.value().offset());
     assertEquals(3, value.value().end());
@@ -1025,8 +1025,8 @@ public class TestExpressionNumericArrayIteratorAdditive extends BaseNumericTest 
     assertTrue(iterator.hasNext());
     TimeSeriesValue<NumericArrayType> value = 
         (TimeSeriesValue<NumericArrayType>) iterator.next();
-    assertArrayEquals(new long[] { 1, 5, 2 },
-        value.value().longArray());
+    assertArrayEquals(new double[] { 1, 5, 2 },
+        value.value().doubleArray(), 0.001);
     assertEquals(60, value.timestamp().epoch());
     assertEquals(0, value.value().offset());
     assertEquals(3, value.value().end());
@@ -1050,8 +1050,8 @@ public class TestExpressionNumericArrayIteratorAdditive extends BaseNumericTest 
               .build());
     assertTrue(iterator.hasNext());
     value =  (TimeSeriesValue<NumericArrayType>) iterator.next();
-    assertArrayEquals(new long[] { 1, 5, 2 },
-        value.value().longArray());
+    assertArrayEquals(new double[] { 1, 5, 2 },
+        value.value().doubleArray(), 0.001);
     assertEquals(60, value.timestamp().epoch());
     assertEquals(0, value.value().offset());
     assertEquals(3, value.value().end());

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorMod.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorMod.java
@@ -561,8 +561,8 @@ public class TestExpressionNumericArrayIteratorMod extends BaseNumericTest {
     assertTrue(iterator.hasNext());
     TimeSeriesValue<NumericArrayType> value = 
         (TimeSeriesValue<NumericArrayType>) iterator.next();
-    assertArrayEquals(new long[] { 0, 0, 0 },
-        value.value().longArray());
+    assertArrayEquals(new double[] { 0, 0, 0 },
+        value.value().doubleArray(), 0.001);
     assertEquals(60, value.timestamp().epoch());
     assertEquals(0, value.value().offset());
     assertEquals(3, value.value().end());
@@ -632,8 +632,8 @@ public class TestExpressionNumericArrayIteratorMod extends BaseNumericTest {
     assertTrue(iterator.hasNext());
     TimeSeriesValue<NumericArrayType> value = 
         (TimeSeriesValue<NumericArrayType>) iterator.next();
-    assertArrayEquals(new long[] { 0, 0, 0 },
-        value.value().longArray());
+    assertArrayEquals(new double[] { 0, 0, 0 },
+        value.value().doubleArray(), 0.001);
     assertEquals(60, value.timestamp().epoch());
     assertEquals(0, value.value().offset());
     assertEquals(3, value.value().end());

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorMultiply.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorMultiply.java
@@ -576,8 +576,8 @@ public class TestExpressionNumericArrayIteratorMultiply extends BaseNumericTest 
     assertTrue(iterator.hasNext());
     TimeSeriesValue<NumericArrayType> value = 
         (TimeSeriesValue<NumericArrayType>) iterator.next();
-    assertArrayEquals(new long[] { 0, 0, 0 },
-        value.value().longArray());
+    assertArrayEquals(new double[] { 0, 0, 0 },
+        value.value().doubleArray(), 0.001);
     assertEquals(60, value.timestamp().epoch());
     assertEquals(0, value.value().offset());
     assertEquals(3, value.value().end());
@@ -647,8 +647,8 @@ public class TestExpressionNumericArrayIteratorMultiply extends BaseNumericTest 
     assertTrue(iterator.hasNext());
     TimeSeriesValue<NumericArrayType> value = 
         (TimeSeriesValue<NumericArrayType>) iterator.next();
-    assertArrayEquals(new long[] { 0, 0, 0 },
-        value.value().longArray());
+    assertArrayEquals(new double[] { 0, 0, 0 },
+        value.value().doubleArray(), 0.001);
     assertEquals(60, value.timestamp().epoch());
     assertEquals(0, value.value().offset());
     assertEquals(3, value.value().end());

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorRelational.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionNumericArrayIteratorRelational.java
@@ -2088,7 +2088,7 @@ public class TestExpressionNumericArrayIteratorRelational extends BaseNumericTes
               .build());
     assertTrue(iterator.hasNext());
     value =  (TimeSeriesValue<NumericArrayType>) iterator.next();
-    assertArrayEquals(new long[] { 1, 1, 1 },
+    assertArrayEquals(new long[] { 0, 0, 0 },
         value.value().longArray());
     assertEquals(60, value.timestamp().epoch());
     assertEquals(0, value.value().offset());
@@ -2138,7 +2138,7 @@ public class TestExpressionNumericArrayIteratorRelational extends BaseNumericTes
               .build());
     assertTrue(iterator.hasNext());
     value =  (TimeSeriesValue<NumericArrayType>) iterator.next();
-    assertArrayEquals(new long[] { 1, 1, 1 },
+    assertArrayEquals(new long[] { 0, 0, 0 },
         value.value().longArray());
     assertEquals(60, value.timestamp().epoch());
     assertEquals(0, value.value().offset());
@@ -2401,7 +2401,7 @@ public class TestExpressionNumericArrayIteratorRelational extends BaseNumericTes
               .build());
     assertTrue(iterator.hasNext());
     value =  (TimeSeriesValue<NumericArrayType>) iterator.next();
-    assertArrayEquals(new long[] { 1, 1, 1 },
+    assertArrayEquals(new long[] { 0, 0, 0 },
         value.value().longArray());
     assertEquals(60, value.timestamp().epoch());
     assertEquals(0, value.value().offset());
@@ -2451,7 +2451,7 @@ public class TestExpressionNumericArrayIteratorRelational extends BaseNumericTes
               .build());
     assertTrue(iterator.hasNext());
     value =  (TimeSeriesValue<NumericArrayType>) iterator.next();
-    assertArrayEquals(new long[] { 1, 1, 1 },
+    assertArrayEquals(new long[] { 0, 0, 0 },
         value.value().longArray());
     assertEquals(60, value.timestamp().epoch());
     assertEquals(0, value.value().offset());


### PR DESCRIPTION
- Default to NaN fills if expression substitute missing is true and the
  literal is missing.