### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/BaseQueryContext.java
+++ b/core/src/main/java/net/opentsdb/query/BaseQueryContext.java
@@ -223,7 +223,8 @@ public abstract class BaseQueryContext implements QueryContext {
           .addCallbackDeferring(new FilterCB());
     } else {
       if (query.getCacheMode() == null || 
-          query.getCacheMode() == CacheMode.BYPASS) {
+          query.getCacheMode() == CacheMode.BYPASS ||
+          tsdb.getRegistry().getDefaultPlugin(ReadCacheQueryPipelineContext.class) == null) {
         pipeline = new LocalPipeline(BaseQueryContext.this, builder_sinks);
         return pipeline.initialize(local_span);
       } else {

--- a/core/src/main/java/net/opentsdb/storage/MockDataStore.java
+++ b/core/src/main/java/net/opentsdb/storage/MockDataStore.java
@@ -226,10 +226,8 @@ public class MockDataStore implements WritableTimeSeriesDataStore {
     }
     
     public void addValue(TimeSeriesValue<?> value) {
-      
       long base_time = value.timestamp().msEpoch() - 
           (value.timestamp().msEpoch() % ROW_WIDTH);
-      
       for (final MockRow row : rows) {
         if (row.base_timestamp == base_time) {
           row.addValue(value);
@@ -417,7 +415,7 @@ public class MockDataStore implements WritableTimeSeriesDataStore {
       try {
         if (completed.get()) {
           if (LOG.isDebugEnabled()) {
-            LOG.debug("Already completed by 'fetchNext()' wsa called.");
+            LOG.debug("Already completed by 'fetchNext()' was called.");
           }
           return;
         }

--- a/distribution/src/resources/docker/opentsdb_dev.yaml
+++ b/distribution/src/resources/docker/opentsdb_dev.yaml
@@ -50,3 +50,6 @@ tsd.plugin.config:
   pluginLocations:
   continueOnError: true
   loadDefaultInstances: true
+
+# Mock Data Store Settings
+MockDataStore.register.writer: true

--- a/distribution/src/resources/opentsdb_dev.yaml
+++ b/distribution/src/resources/opentsdb_dev.yaml
@@ -50,3 +50,6 @@ tsd.plugin.config:
   pluginLocations:
   continueOnError: true
   loadDefaultInstances: true
+
+# Mock Data Store Settings
+MockDataStore.register.writer: true

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/PutDataPointRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/PutDataPointRpc.java
@@ -327,6 +327,15 @@ public class PutDataPointRpc {
         // TODO Auto-generated method stub
         return 0;
       }
+      
+      @Override
+      public String toString() {
+        return new StringBuilder()
+            .append(dp.getMetric())
+            .append(" ")
+            .append(dp.getTags())
+            .toString();
+      }
 
     }
 


### PR DESCRIPTION
- Tweak the BaseQueryContext to not run the read cache pipeline if the query
  has a cache flag other than bypass or null AND the cache hasn't been
  configured.
- Fix the MockDataStoreFactory to implement the write path.

DIST:
- Change the dev yaml config to enable writing to the in-mem.