### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/plan/QueryPlanner.java
+++ b/common/src/main/java/net/opentsdb/query/plan/QueryPlanner.java
@@ -133,4 +133,12 @@ public interface QueryPlanner {
    */
   public Set<String> getMetrics(final QueryNodeConfig node);
   
+  /**
+   * A recursive look for the metric matching the given data source Id.
+   * @param node The start node for the recursive search.
+   * @param data_source_id The non-null data source to match.
+   * @return The matched metric name in the format <metric>
+   */
+  public String getMetricForDataSource(final QueryNodeConfig node, 
+                                       final String data_source_id);
 }

--- a/core/src/main/java/net/opentsdb/query/BaseQueryNodeConfig.java
+++ b/core/src/main/java/net/opentsdb/query/BaseQueryNodeConfig.java
@@ -242,9 +242,9 @@ public abstract class BaseQueryNodeConfig<B extends BaseQueryNodeConfig.Builder<
     @JsonProperty
     protected String id;
     @JsonProperty
-    private String type;
+    protected String type;
     @JsonProperty
-    private List<String> sources;
+    protected List<String> sources;
     @JsonProperty
     protected Map<String, String> overrides;
 

--- a/core/src/main/java/net/opentsdb/query/joins/NaturalOuterJoin.java
+++ b/core/src/main/java/net/opentsdb/query/joins/NaturalOuterJoin.java
@@ -14,9 +14,6 @@
 // limitations under the License.
 package net.opentsdb.query.joins;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import gnu.trove.set.hash.TLongHashSet;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.utils.Pair;
@@ -57,7 +54,6 @@ public class NaturalOuterJoin extends BaseJoin {
   
   @Override
   protected void advance() {
-    Logger LOG = LoggerFactory.getLogger(this.getClass());
     // exhaust the left hand side first.
     if (left_iterator != null) {
       while (left_iterator.hasNext() || 
@@ -88,7 +84,6 @@ public class NaturalOuterJoin extends BaseJoin {
             // null check
             if (left_series == null || left_series.isEmpty()) {
               left_series = null;
-              LOG.info("LEFT WAS NULL, skipping");
               continue;
             }
           } else {
@@ -185,7 +180,6 @@ public class NaturalOuterJoin extends BaseJoin {
             // them as we go.
             if (completed.contains(right_iterator.key())) {
               right_series = null;
-              LOG.info("RIGHT was marked complete?, skipping");
               continue;
             }
           } else {

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNode.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNode.java
@@ -161,7 +161,7 @@ public class BinaryExpressionNode extends AbstractQueryNode<ExpressionParseNode>
       synchronized (this) {
         results.setKey(next);
       }
-      LOG.trace("SET LEFT!");
+      LOG.trace("[" + config.getId() + "] Matched left source: " + id);
     } else if (right_source != null && 
         (right_source.equals(next.dataSource()) || 
             right_source.equals(id))) {
@@ -175,6 +175,7 @@ public class BinaryExpressionNode extends AbstractQueryNode<ExpressionParseNode>
       synchronized (this) {
         results.setValue(next);
       }
+      LOG.trace("[" + config.getId() + "] Matched right source: " + id);
     } else {
       LOG.debug("Unmatched result: " + id);
       return;

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParseNode.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParseNode.java
@@ -307,30 +307,40 @@ public class ExpressionParseNode extends BaseQueryNodeConfig<ExpressionParseNode
 
   static class Builder extends BaseQueryNodeConfig.Builder<Builder, ExpressionParseNode> {
     @JsonProperty
-    private Object left;
+    protected Object left;
     @JsonProperty
-    private OperandType leftType;
+    protected OperandType leftType;
     @JsonProperty
-    private Object right;
+    protected Object right;
     @JsonProperty
-    private OperandType rightType;
+    protected OperandType rightType;
     @JsonProperty
-    private ExpressionOp op;
+    protected ExpressionOp op;
     @JsonProperty
-    private boolean negate;
+    protected boolean negate;
     @JsonProperty
-    private boolean not;
+    protected boolean not;
     @JsonProperty
-    private ExpressionConfig expressionConfig;
+    protected ExpressionConfig expressionConfig;
     @JsonProperty
-    private String as;
+    protected String as;
     @JsonProperty
-    private String leftId;
+    protected String leftId;
     @JsonProperty
-    private String rightId;
+    protected String rightId;
     
     Builder() {
       setType(BinaryExpressionNodeFactory.TYPE);
+    }
+    
+    public Builder addSource(final String source) {
+      if (sources == null) {
+        sources = Lists.newArrayListWithExpectedSize(1);
+      }
+      if (!sources.contains(source)) {
+        sources.add(source);
+      }
+      return this;
     }
     
     public Builder setLeft(final Object left) {

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionResult.java
@@ -101,7 +101,7 @@ public class ExpressionResult implements QueryResult {
       joins = node.joiner().join(
           results, 
           node.rightMetric() != null ? node.rightMetric() :
-            ((String)  config.getRight()).getBytes(Const.UTF8_CHARSET), 
+            ((String) config.getRight()).getBytes(Const.UTF8_CHARSET), 
           false, 
           use_alias);
     }

--- a/core/src/test/java/net/opentsdb/query/plan/TestDefaultQueryPlanner.java
+++ b/core/src/test/java/net/opentsdb/query/plan/TestDefaultQueryPlanner.java
@@ -938,7 +938,7 @@ public class TestDefaultQueryPlanner {
 //    DefaultQueryPlanner planner = 
 //        new DefaultQueryPlanner(context, SINK);
 //    planner.plan(null).join();
-//    System.out.println(planner.printConfigGraph());
+//    
 //    // validate
 //    assertEquals(2, planner.sources().size());
 //    assertTrue(planner.sources().contains(STORE_NODES.get(0)));
@@ -1149,7 +1149,7 @@ public class TestDefaultQueryPlanner {
 //    planner.plan(null).join();
 //    assertEquals(2, planner.serializationSources().size());
 //  }
-//  
+  
   @Test
   public void twoMetricsTwoGraphs() throws Exception {
     List<QueryNodeConfig> graph = Lists.newArrayList(
@@ -1307,161 +1307,161 @@ public class TestDefaultQueryPlanner {
     assertEquals(2, planner.serializationSources().size());
   }
   
-//  @Test
-//  public void twoMetricsExpression() throws Exception {
-//    List<QueryNodeConfig> graph = Lists.newArrayList(
-//        DefaultTimeSeriesDataSourceConfig.newBuilder()
-//            .setMetric(MetricLiteralFilter.newBuilder()
-//                .setMetric("sys.cpu.user")
-//                .build())
-//            .setFilterId("f1")
-//            .setId("m1")
-//            .build(),
-//        DefaultTimeSeriesDataSourceConfig.newBuilder()
-//            .setMetric(MetricLiteralFilter.newBuilder()
-//                .setMetric("sys.cpu.sys")
-//                .build())
-//            .setFilterId("f1")
-//            .setId("m2")
-//            .build(),
-//        DownsampleConfig.newBuilder()
-//            .setAggregator("sum")
-//            .setInterval("1m")
-//            .addInterpolatorConfig(NUMERIC_CONFIG)
-//            .setId("downsample")
-//            .addSource("m1")
-//            .addSource("m2")
-//            .build(),
-//        GroupByConfig.newBuilder()
-//            .setAggregator("sum")
-//            .addTagKey("host")
-//            .addInterpolatorConfig(NUMERIC_CONFIG)
-//            .setId("groupby")
-//            .addSource("downsample")
-//            .build(),
-//       ExpressionConfig.newBuilder()
-//            .setExpression("sys.cpu.user + sys.cpu.sys")
-//            .setAs("sys.tot")
-//            .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-//                .setJoinType(JoinType.NATURAL)
-//                .build())
-//            .addInterpolatorConfig(NUMERIC_CONFIG)
-//            .setId("expression")
-//            .addSource("groupby")
-//            .build());
-//    
-//    SemanticQuery query = SemanticQuery.newBuilder()
-//        .setMode(QueryMode.SINGLE)
-//        .setStart("1514764800")
-//        .setEnd("1514768400")
-//        .setExecutionGraph(graph)
-//        .addSerdesConfig(serdesConfigs(Lists.newArrayList("expression")))
-//        .build();
-//    
-//    when(context.query()).thenReturn(query);
-//
-//    DefaultQueryPlanner planner = 
-//        new DefaultQueryPlanner(context, SINK);
-//    planner.plan(null).join();
-//    
-//    // validate
-//    assertEquals(2, planner.sources().size());
-//    assertTrue(planner.sources().contains(STORE_NODES.get(0)));
-//    assertTrue(planner.sources().contains(STORE_NODES.get(1)));
-//    assertEquals(6, planner.graph().nodes().size());
-//
-//    assertEquals(1, planner.serializationSources().size());
-//    
-//    // no filter
-//    query = SemanticQuery.newBuilder()
-//        .setMode(QueryMode.SINGLE)
-//        .setStart("1514764800")
-//        .setEnd("1514768400")
-//        .setExecutionGraph(graph)
-//        .build();
-//    when(context.query()).thenReturn(query);
-//    planner = new DefaultQueryPlanner(context, SINK);
-//    planner.plan(null).join();
-//    assertEquals(1, planner.serializationSources().size());
-//  }
+  @Test
+  public void twoMetricsExpression() throws Exception {
+    List<QueryNodeConfig> graph = Lists.newArrayList(
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setFilterId("f1")
+            .setId("m1")
+            .build(),
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.sys")
+                .build())
+            .setFilterId("f1")
+            .setId("m2")
+            .build(),
+        DownsampleConfig.newBuilder()
+            .setAggregator("sum")
+            .setInterval("1m")
+            .addInterpolatorConfig(NUMERIC_CONFIG)
+            .setId("downsample")
+            .addSource("m1")
+            .addSource("m2")
+            .build(),
+        GroupByConfig.newBuilder()
+            .setAggregator("sum")
+            .addTagKey("host")
+            .addInterpolatorConfig(NUMERIC_CONFIG)
+            .setId("groupby")
+            .addSource("downsample")
+            .build(),
+       ExpressionConfig.newBuilder()
+            .setExpression("sys.cpu.user + sys.cpu.sys")
+            .setAs("sys.tot")
+            .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+                .setJoinType(JoinType.NATURAL)
+                .build())
+            .addInterpolatorConfig(NUMERIC_CONFIG)
+            .setId("expression")
+            .addSource("groupby")
+            .build());
+    
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .addSerdesConfig(serdesConfigs(Lists.newArrayList("expression")))
+        .build();
+    
+    when(context.query()).thenReturn(query);
+
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
+    
+    // validate
+    assertEquals(2, planner.sources().size());
+    assertTrue(planner.sources().contains(STORE_NODES.get(0)));
+    assertTrue(planner.sources().contains(STORE_NODES.get(1)));
+    assertEquals(6, planner.graph().nodes().size());
+
+    assertEquals(1, planner.serializationSources().size());
+    
+    // no filter
+    query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
+    when(context.query()).thenReturn(query);
+    planner = new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
+    assertEquals(1, planner.serializationSources().size());
+  }
   
-//  @Test
-//  public void twoMetricsExpressionWithFilter() throws Exception {
-//    List<QueryNodeConfig> graph = Lists.newArrayList(
-//        DefaultTimeSeriesDataSourceConfig.newBuilder()
-//            .setMetric(MetricLiteralFilter.newBuilder()
-//                .setMetric("sys.cpu.user")
-//                .build())
-//            .setFilterId("f1")
-//            .setId("m1")
-//            .build(),
-//        DefaultTimeSeriesDataSourceConfig.newBuilder()
-//            .setMetric(MetricLiteralFilter.newBuilder()
-//                .setMetric("sys.cpu.sys")
-//                .build())
-//            .setFilterId("f1")
-//            .setId("m2")
-//            .build(),
-//        DownsampleConfig.newBuilder()
-//            .setAggregator("sum")
-//            .setInterval("1m")
-//            .addInterpolatorConfig(NUMERIC_CONFIG)
-//            .setId("downsample")
-//            .addSource("m1")
-//            .addSource("m2")
-//            .build(),
-//        GroupByConfig.newBuilder()
-//            .setAggregator("sum")
-//            .addTagKey("host")
-//            .addInterpolatorConfig(NUMERIC_CONFIG)
-//            .setId("groupby")
-//            .addSource("downsample")
-//            .build(),
-//        ExpressionConfig.newBuilder()
-//            .setExpression("sys.cpu.user + sys.cpu.sys")
-//            .setAs("sys.tot")
-//            .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-//                .setJoinType(JoinType.NATURAL)
-//                .build())
-//            .addInterpolatorConfig(NUMERIC_CONFIG)
-//            .setId("expression")
-//            .addSource("groupby")
-//            .build());
-//    
-//    SemanticQuery query = SemanticQuery.newBuilder()
-//        .setMode(QueryMode.SINGLE)
-//        .setStart("1514764800")
-//        .setEnd("1514768400")
-//        .setExecutionGraph(graph)
-//        .addSerdesConfig(serdesConfigs(Lists.newArrayList("expression", "m1", "m2")))
-//        .build();
-//    
-//    when(context.query()).thenReturn(query);
-//
-//    DefaultQueryPlanner planner = 
-//        new DefaultQueryPlanner(context, SINK);
-//    planner.plan(null).join();
-//    
-//    // validate
-//    assertEquals(2, planner.sources().size());
-//    assertTrue(planner.sources().contains(STORE_NODES.get(0)));
-//    assertTrue(planner.sources().contains(STORE_NODES.get(1)));
-//    assertEquals(6, planner.graph().nodes().size());
-//
-//    assertEquals(3, planner.serializationSources().size());
-//    
-//    // no filter
-//    query = SemanticQuery.newBuilder()
-//        .setMode(QueryMode.SINGLE)
-//        .setStart("1514764800")
-//        .setEnd("1514768400")
-//        .setExecutionGraph(graph)
-//        .build();
-//    when(context.query()).thenReturn(query);
-//    planner = new DefaultQueryPlanner(context, SINK);
-//    planner.plan(null).join();
-//    assertEquals(1, planner.serializationSources().size());
-//  }
+  @Test
+  public void twoMetricsExpressionWithFilter() throws Exception {
+    List<QueryNodeConfig> graph = Lists.newArrayList(
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setFilterId("f1")
+            .setId("m1")
+            .build(),
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.sys")
+                .build())
+            .setFilterId("f1")
+            .setId("m2")
+            .build(),
+        DownsampleConfig.newBuilder()
+            .setAggregator("sum")
+            .setInterval("1m")
+            .addInterpolatorConfig(NUMERIC_CONFIG)
+            .setId("downsample")
+            .addSource("m1")
+            .addSource("m2")
+            .build(),
+        GroupByConfig.newBuilder()
+            .setAggregator("sum")
+            .addTagKey("host")
+            .addInterpolatorConfig(NUMERIC_CONFIG)
+            .setId("groupby")
+            .addSource("downsample")
+            .build(),
+        ExpressionConfig.newBuilder()
+            .setExpression("sys.cpu.user + sys.cpu.sys")
+            .setAs("sys.tot")
+            .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+                .setJoinType(JoinType.NATURAL)
+                .build())
+            .addInterpolatorConfig(NUMERIC_CONFIG)
+            .setId("expression")
+            .addSource("groupby")
+            .build());
+    
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .addSerdesConfig(serdesConfigs(Lists.newArrayList("expression", "m1", "m2")))
+        .build();
+    
+    when(context.query()).thenReturn(query);
+
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
+    
+    // validate
+    assertEquals(2, planner.sources().size());
+    assertTrue(planner.sources().contains(STORE_NODES.get(0)));
+    assertTrue(planner.sources().contains(STORE_NODES.get(1)));
+    assertEquals(6, planner.graph().nodes().size());
+
+    assertEquals(3, planner.serializationSources().size());
+    
+    // no filter
+    query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
+    when(context.query()).thenReturn(query);
+    planner = new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
+    assertEquals(1, planner.serializationSources().size());
+  }
   
   @Test
   public void twoMetricsBranchExpression() throws Exception {
@@ -1633,7 +1633,6 @@ public class TestDefaultQueryPlanner {
         new DefaultQueryPlanner(context, SINK);
     planner.plan(null).join();
     
-    // validate
     assertEquals(2, planner.sources().size());
     assertTrue(planner.sources().contains(STORE_NODES.get(0)));
     assertTrue(planner.sources().contains(STORE_NODES.get(1)));

--- a/executors/http/src/main/java/net/opentsdb/query/execution/BaseHttpExecutorFactory.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/BaseHttpExecutorFactory.java
@@ -172,7 +172,8 @@ public abstract class BaseHttpExecutorFactory<C extends TimeSeriesDataSourceConf
    * @param code An HTTP status code for debugging.
    */
   public void markHostAsBad(final String host, final int code) {
-    if (!tsdb.getConfig().getBoolean(getConfigKey(HEALTH_ENABLE_KEY))) {
+    if (tsdb == null || 
+        !tsdb.getConfig().getBoolean(getConfigKey(HEALTH_ENABLE_KEY))) {
       return;
     }
     


### PR DESCRIPTION
- Add another utility to QueryPlanner to get the metric for a source from
  downstream.

CORE:
- Clean out errant logs in NaturalOrderJoin.
- Add ID hashes to the query planner print config.
- Fix multi-metrics through single node expressions.