### PR TITLE
Replace FOREVER with a valid value in table creation

### DIFF
--- a/src/create_table.sh
+++ b/src/create_table.sh
@@ -23,7 +23,7 @@ COMPRESSION=`echo "$COMPRESSION" | tr a-z A-Z`
 # This can save a lot of storage space.
 DATA_BLOCK_ENCODING=${DATA_BLOCK_ENCODING-'DIFF'}
 DATA_BLOCK_ENCODING=`echo "$DATA_BLOCK_ENCODING" | tr a-z A-Z`
-TSDB_TTL=${TSDB_TTL-'FOREVER'}
+TSDB_TTL=${TSDB_TTL-'2147483647'}
 
 case $COMPRESSION in
   (NONE|LZO|GZIP|SNAPPY)  :;;  # Known good.


### PR DESCRIPTION
FOREVER is not a valid value for Hbase TTL anymore.
In case you want to emulate FOREVER you can use max int.
``` /**
   * Unlimited time-to-live.
   */
//  public static final int FOREVER = -1;
  public static final int FOREVER = Integer.MAX_VALUE;
```

See also:
https://community.cloudera.com/t5/Support-Questions/Hi-Is-anything-changed-on-TTL-gt-FOREVER-on-HDP-2-4/td-p/123763/page/2