### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/processor/rate/RateConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/rate/RateConfig.java
@@ -86,6 +86,11 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
   
   /** Whether we want the rate to count. */
   private boolean rate_to_count;
+  
+  /** For the rate to count, a user given data interval we can use to handle
+   * missing values. */
+  private String data_interval;
+  private long data_interval_ms;
 
   /** Parsed values. */
   private Duration duration;
@@ -101,6 +106,7 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
     counter_max = builder.counterMax;
     reset_value = builder.resetValue;
     interval = builder.interval;
+    data_interval = builder.dataInterval;
     delta_only = builder.deltaOnly;
     rate_to_count = builder.rateToCount;
     
@@ -125,6 +131,10 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
       final long interval_part = DateTime.getDurationInterval(interval);
       units = DateTime.unitsToChronoUnit(DateTime.getDurationUnits(interval));
       duration = Duration.of(interval_part, units);
+    }
+    
+    if (!Strings.isNullOrEmpty(data_interval)) {
+      data_interval_ms = DateTime.parseDuration(data_interval);
     }
   }
   
@@ -154,6 +164,11 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
     return interval;
   }
   
+  /** @return The optional data interval. */
+  public String getDataInterval() {
+    return data_interval;
+  }
+  
   /** @return Whether or not to return the delta only, not rate. */
   public boolean getDeltaOnly() {
     return delta_only;
@@ -175,6 +190,11 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
     return units;
   }
 
+  /** @return The optional data interval in milliseconds. 0 if not set. */
+  public long dataIntervalMs() {
+    return data_interval_ms;
+  }
+  
   @Override
   public Builder toBuilder() {
     return new Builder()
@@ -190,8 +210,7 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
         .setType(type)
         .setId(id);
   }
-
-
+  
   @Override
   public boolean pushDown() {
     return true;
@@ -239,6 +258,7 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
        && Objects.equal(counter_max, options.counter_max)
        && Objects.equal(reset_value, options.reset_value)
        && Objects.equal(interval, options.interval)
+       && Objects.equal(data_interval, options.data_interval)
        && Objects.equal(delta_only, options.delta_only)
        && Objects.equal(id, options.id)
        && Objects.equal(rate_to_count, options.getRateToCount());
@@ -264,6 +284,7 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
     .putLong(counter_max)
     .putLong(reset_value)
     .putString(interval, Const.UTF8_CHARSET)
+    .putString(data_interval == null ? "" : data_interval, Const.UTF8_CHARSET)
     .putBoolean(rate_to_count);
 
     if (id !=null) {
@@ -283,6 +304,8 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
         .compare(counter_max, other.counter_max)
         .compare(reset_value, other.reset_value)
         .compare(interval, other.interval)
+        .compare(data_interval == null ? "" : data_interval, 
+            other.data_interval == null ? "" : other.data_interval)
         .result();
   }
   
@@ -308,6 +331,7 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
         .setResetValue(options.reset_value)
         .setDropResets(options.drop_resets)
         .setInterval(options.interval)
+        .setDataInterval(options.data_interval)
         .setRateToCount(options.rate_to_count);
   }
   
@@ -326,6 +350,8 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
     private long resetValue = DEFAULT_RESET_VALUE;
     @JsonProperty
     private String interval = DEFAULT_INTERVAL;
+    @JsonProperty
+    private String dataInterval;
     @JsonProperty
     private boolean deltaOnly;
     @JsonProperty
@@ -363,6 +389,11 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
       return this;
     }
 
+    public Builder setDataInterval(final String data_interval) {
+      dataInterval = data_interval;
+      return this;
+    }
+    
     public Builder setDeltaOnly(final boolean delta_only) {
       this.deltaOnly = delta_only;
       return this;

--- a/core/src/test/java/net/opentsdb/query/processor/rate/TestRateConfig.java
+++ b/core/src/test/java/net/opentsdb/query/processor/rate/TestRateConfig.java
@@ -53,6 +53,7 @@ public static MockTSDB TSDB;
     RateConfig options = (RateConfig) RateConfig.newBuilder()
         .setCounter(true)
         .setInterval("60s")
+        .setDataInterval("5m")
         .setCounterMax(Integer.MAX_VALUE)
         .setDropResets(true)
         .setDeltaOnly(true)
@@ -62,6 +63,7 @@ public static MockTSDB TSDB;
     String json = JSON.serializeToString(options);
     assertTrue(json.contains("\"counter\":true"));
     assertTrue(json.contains("\"interval\":\"60s\""));
+    assertTrue(json.contains("\"dataInterval\":\"5m\""));
     assertTrue(json.contains("\"counterMax\":" + Integer.MAX_VALUE));
     assertTrue(json.contains("\"dropResets\":true"));
     assertTrue(json.contains("\"deltaOnly\":true"));
@@ -69,11 +71,12 @@ public static MockTSDB TSDB;
     
     json = "{\"id\":\"rate\",\"type\":\"Rate\",\"counter\":true,"
         + "\"interval\":\"60s\",\"dropResets\":true,\"counterMax\":2147483647,"
-        + "\"deltaOnly\":true,\"rateToCount\":true}";
+        + "\"deltaOnly\":true,\"rateToCount\":true,\"dataInterval\":\"5m\"}";
     options = JSON.parseToObject(json, RateConfig.class);
     assertTrue(options.isCounter());
     assertTrue(options.getDropResets());
     assertEquals("60s", options.getInterval());
+    assertEquals("5m", options.getDataInterval());
     assertEquals(Integer.MAX_VALUE, options.getCounterMax());
     assertTrue(options.getDropResets());
     assertTrue(options.getDeltaOnly());
@@ -85,6 +88,7 @@ public static MockTSDB TSDB;
     final RateConfig options = (RateConfig) RateConfig.newBuilder()
         .setCounter(true)
         .setInterval("60s")
+        .setDataInterval("5m")
         .setRateToCount(true)
         .setCounterMax(Integer.MAX_VALUE)
         .setId("rate")
@@ -96,8 +100,10 @@ public static MockTSDB TSDB;
     assertTrue(clone.getRateToCount());
     assertFalse(clone.getDropResets());
     assertEquals("60s", clone.getInterval());
+    assertEquals("5m", clone.getDataInterval());
     assertEquals(0, clone.getResetValue());
     assertEquals(Integer.MAX_VALUE, clone.getCounterMax());
+    assertEquals(300_000, clone.dataIntervalMs());
   }
   
   @Test
@@ -170,6 +176,19 @@ public static MockTSDB TSDB;
     assertNotEquals(r1.hashCode(), r2.hashCode());
     assertNotEquals(r1, r2);
     assertEquals(1, r1.compareTo(r2));
+    
+    r2 = (RateConfig) RateConfig.newBuilder()
+        .setCounter(true)
+        .setDropResets(true)
+        .setInterval("60s")
+        .setDataInterval("5m")  // <-- Diff
+        .setCounterMax(Integer.MAX_VALUE)
+        .setResetValue(-1)
+        .setId("rate")
+        .build();
+    assertNotEquals(r1.hashCode(), r2.hashCode());
+    assertNotEquals(r1, r2);
+    assertEquals(-1, r1.compareTo(r2));
     
     r2 = (RateConfig) RateConfig.newBuilder()
         .setCounter(true)

--- a/core/src/test/java/net/opentsdb/query/processor/rate/TestRateNumericIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/rate/TestRateNumericIterator.java
@@ -998,7 +998,60 @@ public class TestRateNumericIterator {
   }
   
   @Test
-  public void rateToCounterDoubles() {
+  public void rateToCounterDoublesWithDataInterval() {
+    source = new NumericMillisecondShard(BaseTimeSeriesStringId.newBuilder()
+          .setMetric("a")
+          .build(), 
+        new MillisecondTimeStamp(BASE_TIME), 
+        new MillisecondTimeStamp(BASE_TIME + 10000000));
+    ((NumericMillisecondShard) source).add(BASE_TIME, 40.5);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 2000000L, 50.5);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 3600000L, 40.5);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 3605000L, 50.5);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 7200000L, 40.5);
+    ((NumericMillisecondShard) source).add(BASE_TIME + 9200000L, 50.5);
+    
+    config = (RateConfig) RateConfig.newBuilder()
+        .setInterval("1s")
+        .setDataInterval("1m")
+        .setRateToCount(true)
+        .setId("foo")
+        .build();
+    
+    setupMock();
+    RateNumericIterator it = new RateNumericIterator(node, result,
+         Lists.newArrayList(source));
+    
+    assertTrue(it.hasNext());
+    TimeSeriesValue<NumericType> v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 2000000L, v.timestamp().msEpoch());
+    assertEquals(3030, v.value().doubleValue(), 0.001);
+    
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 3600000L, v.timestamp().msEpoch());
+    assertEquals(2430, v.value().doubleValue(), 0.001);
+    
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 3605000L, v.timestamp().msEpoch());
+    assertEquals(252.5, v.value().doubleValue(), 0.001);
+
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 7200000L, v.timestamp().msEpoch());
+    assertEquals(2430, v.value().doubleValue(), 0.001);
+    
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericType>) it.next();
+    assertEquals(BASE_TIME + 9200000L, v.timestamp().msEpoch());
+    assertEquals(3030, v.value().doubleValue(), 0.001);
+    
+    assertFalse(it.hasNext());
+  }
+  
+  @Test
+  public void rateToCounterDoublesAndNormalize() {
     source = new NumericMillisecondShard(BaseTimeSeriesStringId.newBuilder()
           .setMetric("a")
           .build(), 
@@ -1039,7 +1092,7 @@ public class TestRateNumericIterator {
     assertTrue(it.hasNext());
     v = (TimeSeriesValue<NumericType>) it.next();
     assertEquals(BASE_TIME + 7200000L, v.timestamp().msEpoch());
-    assertEquals(145597.5, v.value().doubleValue(), 0.001);
+    assertEquals(81000, v.value().doubleValue(), 0.001);
     
     assertTrue(it.hasNext());
     v = (TimeSeriesValue<NumericType>) it.next();

--- a/core/src/test/java/net/opentsdb/query/processor/rate/TestRateNumericSummaryIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/rate/TestRateNumericSummaryIterator.java
@@ -241,6 +241,71 @@ public class TestRateNumericSummaryIterator {
     assertFalse(it.hasNext());
   }
   
+  @Test
+  public void doublesSumsAsCount() throws Exception {
+    config = (RateConfig) RateConfig.newBuilder()
+        .setInterval("1s")
+        .setRateToCount(true)
+        .setId("foo")
+        .build();
+    
+    setupMock();
+    RateNumericSummaryIterator it = new RateNumericSummaryIterator(node, result,
+        Lists.newArrayList(buildData(true, false, true, false)));
+    assertTrue(it.hasNext());
+    TimeSeriesValue<NumericSummaryType> v = (TimeSeriesValue<NumericSummaryType>) it.next();
+    assertEquals(BASE_TIME + 3600000, v.timestamp().msEpoch());
+    assertEquals(1, v.value().summariesAvailable().size());
+    assertEquals(240, v.value().value(0).doubleValue(), 0.0001);
+    
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericSummaryType>) it.next();
+    assertEquals(BASE_TIME + (3600000 * 2), v.timestamp().msEpoch());
+    assertEquals(1, v.value().summariesAvailable().size());
+    assertEquals(360, v.value().value(0).doubleValue(), 0.0001);
+    
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericSummaryType>) it.next();
+    assertEquals(BASE_TIME + (3600000 * 3), v.timestamp().msEpoch());
+    assertEquals(1, v.value().summariesAvailable().size());
+    assertTrue(Double.isNaN(v.value().value(0).doubleValue()));
+    
+    assertFalse(it.hasNext());
+  }
+  
+  @Test
+  public void doublesSumsAsCountWithDataRate() throws Exception {
+    config = (RateConfig) RateConfig.newBuilder()
+        .setInterval("1s")
+        .setDataInterval("1m")
+        .setRateToCount(true)
+        .setId("foo")
+        .build();
+    
+    setupMock();
+    RateNumericSummaryIterator it = new RateNumericSummaryIterator(node, result,
+        Lists.newArrayList(buildData(true, false, true, false)));
+    assertTrue(it.hasNext());
+    TimeSeriesValue<NumericSummaryType> v = (TimeSeriesValue<NumericSummaryType>) it.next();
+    assertEquals(BASE_TIME + 3600000, v.timestamp().msEpoch());
+    assertEquals(1, v.value().summariesAvailable().size());
+    assertEquals(14400, v.value().value(0).doubleValue(), 0.0001);
+    
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericSummaryType>) it.next();
+    assertEquals(BASE_TIME + (3600000 * 2), v.timestamp().msEpoch());
+    assertEquals(1, v.value().summariesAvailable().size());
+    assertEquals(21600, v.value().value(0).doubleValue(), 0.0001);
+    
+    assertTrue(it.hasNext());
+    v = (TimeSeriesValue<NumericSummaryType>) it.next();
+    assertEquals(BASE_TIME + (3600000 * 3), v.timestamp().msEpoch());
+    assertEquals(1, v.value().summariesAvailable().size());
+    assertTrue(Double.isNaN(v.value().value(0).doubleValue()));
+    
+    assertFalse(it.hasNext());
+  }
+  
   // TODO - more UTS.
   
   void setupMock() {


### PR DESCRIPTION
- Add dataInterval as a flag to the RateConfig. This avoids introducing spikes
  in the output when converting a stored rate to the count if data is missing.
  The setting is required for summary and array types but can be calculated
  from the raw type.