### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughNumericIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughNumericIterator.java
@@ -19,6 +19,7 @@ import com.google.common.reflect.TypeToken;
 import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.TypedTimeSeriesIterator;
+import net.opentsdb.data.TimeStamp.Op;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryIterator;
 
@@ -48,10 +49,12 @@ public class SummarizerPassThroughNumericIterator implements QueryIterator {
   @Override
   public boolean hasNext() {
     if (!iterator.hasNext()) {
-      if (long_values != null) {
-        sts.summarize(long_values, 0, idx);
-      } else if (double_values != null) {
-        sts.summarize(double_values, 0, idx);
+      if (idx > 0) {
+        if (long_values != null) {
+          sts.summarize(long_values, 0, idx);
+        } else if (double_values != null) {
+          sts.summarize(double_values, 0, idx);
+        }
       }
       return false;
     }
@@ -62,7 +65,11 @@ public class SummarizerPassThroughNumericIterator implements QueryIterator {
   public Object next() {
     final TimeSeriesValue<NumericType> value = 
         (TimeSeriesValue<NumericType>) iterator.next();
-    if (value.value() != null) {
+    if (value.value() != null && 
+        value.timestamp().compare(Op.GTE, 
+            sts.result.summarizerNode().pipelineContext().query().startTime()) &&
+        value.timestamp().compare(Op.LT, 
+            sts.result.summarizerNode().pipelineContext().query().endTime())) {
       if (value.value().isInteger()) {
         store(value.value().longValue());
       } else {

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughNumericSummaryIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughNumericSummaryIterator.java
@@ -19,6 +19,7 @@ import com.google.common.reflect.TypeToken;
 import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.TypedTimeSeriesIterator;
+import net.opentsdb.data.TimeStamp.Op;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryIterator;
@@ -50,10 +51,12 @@ public class SummarizerPassThroughNumericSummaryIterator implements QueryIterato
   @Override
   public boolean hasNext() {
     if (!iterator.hasNext()) {
-      if (long_values != null) {
-        sts.summarize(long_values, 0, idx);
-      } else {
-        sts.summarize(double_values, 0, idx);
+      if (idx > 0) {
+        if (long_values != null) {
+          sts.summarize(long_values, 0, idx);
+        } else {
+          sts.summarize(double_values, 0, idx);
+        }
       }
       return false;
     }
@@ -64,18 +67,25 @@ public class SummarizerPassThroughNumericSummaryIterator implements QueryIterato
   public Object next() {
     final TimeSeriesValue<NumericSummaryType> value = 
         (TimeSeriesValue<NumericSummaryType>) iterator.next();
-    if (value.value() != null) {
+    if (value.value() != null && 
+        value.timestamp().compare(Op.GTE, 
+            sts.result.summarizerNode().pipelineContext().query().startTime()) &&
+        value.timestamp().compare(Op.LT, 
+            sts.result.summarizerNode().pipelineContext().query().endTime())) {
       if (value.value().summariesAvailable().size() == 1) {
-        if (summary < 0) {
+        if (summary < 0 && idx <= 0) {
           summary = value.value().summariesAvailable().iterator().next();
         }
         NumericType val = value.value().value(summary);
+        if (val == null) {
+          return value;
+        }
         if (val.isInteger()) {
           store(val.longValue());
         } else {
           store(val.doubleValue());
         }
-        // TODO - actual rollup config
+        // TODO - actual rollup config and eventually proper sum and count
       } else if (value.value().summariesAvailable().size() == 2 && 
           value.value().summariesAvailable().contains(0) && 
           value.value().summariesAvailable().contains(1)) {

--- a/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerNonPassthroughNumericIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerNonPassthroughNumericIterator.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.Map;
 
 import net.opentsdb.data.*;
@@ -42,8 +43,12 @@ import net.opentsdb.data.types.numeric.aggregators.MaxFactory;
 import net.opentsdb.data.types.numeric.aggregators.MinFactory;
 import net.opentsdb.data.types.numeric.aggregators.NumericAggregator;
 import net.opentsdb.data.types.numeric.aggregators.SumFactory;
+import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
+import net.opentsdb.query.QueryMode;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.SemanticQuery;
+import net.opentsdb.query.filter.MetricLiteralFilter;
 import net.opentsdb.rollup.DefaultRollupConfig;
 import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.rollup.RollupInterval;
@@ -51,10 +56,14 @@ import net.opentsdb.rollup.RollupInterval;
 public class TestSummarizerNonPassthroughNumericIterator {
   public static MockTSDB TSDB;
   
+  private static final int BASE_TIME = 1546300800;
+  
   private Summarizer node;
   private QueryResult result;
   private SummarizerConfig config;
   private RollupConfig rollup_config;
+  private SemanticQuery query;
+  private QueryPipelineContext context;
   
   @BeforeClass
   public static void beforeClass() {
@@ -89,9 +98,27 @@ public class TestSummarizerNonPassthroughNumericIterator {
     when(result.source()).thenReturn(node);
     when(result.rollupConfig()).thenReturn(rollup_config);
     when(node.config()).thenReturn(config);
-    QueryPipelineContext context = mock(QueryPipelineContext.class);
+    context = mock(QueryPipelineContext.class);
     when(node.pipelineContext()).thenReturn(context);
     when(context.tsdb()).thenReturn(TSDB);
+    
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME))
+        .setEnd(Integer.toString(BASE_TIME * (3600 * 4)))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
     
     Map<String, NumericAggregator> aggs = Maps.newHashMap();
     when(node.aggregators()).thenReturn(aggs);
@@ -108,9 +135,9 @@ public class TestSummarizerNonPassthroughNumericIterator {
         .setMetric("foo")
         .build());
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(0L), 42));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(60L), 24));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), 24));
     
     SummarizerNonPassthroughNumericIterator iterator = 
         new SummarizerNonPassthroughNumericIterator(node, result, series);
@@ -130,13 +157,13 @@ public class TestSummarizerNonPassthroughNumericIterator {
         .setMetric("foo")
         .build());
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(0L), 42));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(60L), 24));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), 24));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(120L), -8));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), -8));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(240L), 1));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1));
     SummarizerNonPassthroughNumericIterator iterator =
         new SummarizerNonPassthroughNumericIterator(node, result, series);
     assertTrue(iterator.hasNext());
@@ -155,32 +182,152 @@ public class TestSummarizerNonPassthroughNumericIterator {
 
     assertFalse(iterator.hasNext());
   }
+  
+  @Test
+  public void numericTypeLongsFilterMiddle() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME + 60))
+        .setEnd(Integer.toString(BASE_TIME + 240))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), 24));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), -8));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1));
+    SummarizerNonPassthroughNumericIterator iterator =
+        new SummarizerNonPassthroughNumericIterator(node, result, series);
+    assertTrue(iterator.hasNext());
+
+    TimeSeriesValue<NumericSummaryType> value =
+        (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(0, value.timestamp().epoch());
+
+    NumericSummaryType summary = value.value();
+    assertEquals(5, summary.summariesAvailable().size());
+    assertEquals(16, summary.value(0).longValue());
+    assertEquals(2, summary.value(1).longValue());
+    assertEquals(24, summary.value(2).longValue());
+    assertEquals(-8, summary.value(3).longValue());
+    assertEquals(8, summary.value(5).longValue());
+
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void numericTypeLongsFilterEarly() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME + 300))
+        .setEnd(Integer.toString(BASE_TIME + 900))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), 24));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), -8));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1));
+    SummarizerNonPassthroughNumericIterator iterator =
+        new SummarizerNonPassthroughNumericIterator(node, result, series);
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void numericTypeLongsFilterLate() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME - 900))
+        .setEnd(Integer.toString(BASE_TIME - 60))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), 24));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), -8));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1));
+    SummarizerNonPassthroughNumericIterator iterator =
+        new SummarizerNonPassthroughNumericIterator(node, result, series);
+    assertFalse(iterator.hasNext());
+  }
 
   @Test
   public void numericSummaryTypeLongs() throws Exception {
     TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
         .setMetric("foo")
         .build());
-
-    long BASE_TIME = 1000;
-
+    
     MutableNumericSummaryValue v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
     v.resetValue(2, -3);
     ((MockTimeSeries) series).addValue(v);
 
     v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME + (3600 * 1L * 1000L)));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L)));
     v.resetValue(1, 15);
     ((MockTimeSeries) series).addValue(v);
 
     v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME + (3600 * 2L * 1000L)));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L)));
     v.resetValue(1, 12);
     ((MockTimeSeries) series).addValue(v);
     
     v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME + (3600 * 3L * 1000L)));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L)));
     v.resetValue(0, 12);
     ((MockTimeSeries) series).addValue(v);
 
@@ -210,26 +357,24 @@ public class TestSummarizerNonPassthroughNumericIterator {
     TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
         .setMetric("foo")
         .build());
-
-    long BASE_TIME = 1000;
-
+    
     MutableNumericSummaryValue v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
     v.resetValue(2, -3);
     ((MockTimeSeries) series).addValue(v);
 
     v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME + (3600 * 1L * 1000L)));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L)));
     v.resetValue(1, 15);
     ((MockTimeSeries) series).addValue(v);
 
     v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME + (3600 * 2L * 1000L)));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L)));
     v.resetValue(1, 12);
     ((MockTimeSeries) series).addValue(v);
 
     v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME + (3600 * 3L * 1000L)));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L)));
     v.resetValue(0, 12.43);
     ((MockTimeSeries) series).addValue(v);
 
@@ -259,26 +404,24 @@ public class TestSummarizerNonPassthroughNumericIterator {
     TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
         .setMetric("foo")
         .build());
-
-    long BASE_TIME = 1000;
-
+    
     MutableNumericSummaryValue v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME));
-    v.resetNull(new MillisecondTimeStamp(BASE_TIME));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
+    v.resetNull(new SecondTimeStamp(BASE_TIME));
     ((MockTimeSeries) series).addValue(v);
 
     v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME + (3600 * 1L * 1000L)));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L * 1000L)));
     v.resetValue(1, 15);
     ((MockTimeSeries) series).addValue(v);
 
     v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME + (3600 * 2L * 1000L)));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L * 1000L)));
     v.resetValue(1, 12);
     ((MockTimeSeries) series).addValue(v);
 
     v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME + (3600 * 3L * 1000L)));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L * 1000L)));
     v.resetValue(0, 12.43);
     ((MockTimeSeries) series).addValue(v);
 
@@ -310,29 +453,27 @@ public class TestSummarizerNonPassthroughNumericIterator {
     TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
         .setMetric("foo")
         .build());
-
-    long BASE_TIME = 1000;
-
+    
     MutableNumericSummaryValue v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
     v.resetValue(0, 42);
     v.resetValue(1, 6);
     ((MockTimeSeries) series).addValue(v);
 
     v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME + (3600 * 1L * 1000L)));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L)));
     v.resetValue(0, 15);
     v.resetValue(1, 6);
     ((MockTimeSeries) series).addValue(v);
 
     v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME + (3600 * 2L * 1000L)));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L)));
     v.resetValue(0, 42);
     v.resetValue(1, 6);
     ((MockTimeSeries) series).addValue(v);
     
     v = new MutableNumericSummaryValue();
-    v.resetTimestamp(new MillisecondTimeStamp(BASE_TIME + (3600 * 3L * 1000L)));
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L)));
     v.resetValue(0, 12);
     v.resetValue(1, 6);
     ((MockTimeSeries) series).addValue(v);
@@ -359,18 +500,181 @@ public class TestSummarizerNonPassthroughNumericIterator {
   }
   
   @Test
+  public void numericSummaryTypeFilterMiddle() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME + (3600 * 1)))
+        .setEnd(Integer.toString(BASE_TIME + (3600 * 3)))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    
+    MutableNumericSummaryValue v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
+    v.resetValue(2, -3);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L)));
+    v.resetValue(1, 15);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L)));
+    v.resetValue(1, 12);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L)));
+    v.resetValue(0, 12.43);
+    ((MockTimeSeries) series).addValue(v);
+
+    SummarizerNonPassthroughNumericIterator iterator =
+        new SummarizerNonPassthroughNumericIterator(node, result, series);
+    assertTrue(iterator.hasNext());
+
+    TimeSeriesValue<NumericSummaryType> value =
+        (TimeSeriesValue<NumericSummaryType>) iterator.next();
+
+    assertEquals(0, value.timestamp().epoch());
+
+    NumericSummaryType summary = value.value();
+
+    assertEquals(5, summary.summariesAvailable().size());
+    assertEquals(27, summary.value(0).longValue());
+    assertEquals(2, summary.value(1).longValue());
+    assertEquals(15, summary.value(2).longValue());
+    assertEquals(12, summary.value(3).longValue());
+    assertEquals(13.5, summary.value(5).doubleValue(), 0.001);
+
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void numericSummaryTypeFilterEarly() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME + (3600 * 4)))
+        .setEnd(Integer.toString(BASE_TIME + (3600 * 6)))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    
+    MutableNumericSummaryValue v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
+    v.resetValue(2, -3);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L)));
+    v.resetValue(1, 15);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L)));
+    v.resetValue(1, 12);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L)));
+    v.resetValue(0, 12.43);
+    ((MockTimeSeries) series).addValue(v);
+
+    SummarizerNonPassthroughNumericIterator iterator =
+        new SummarizerNonPassthroughNumericIterator(node, result, series);
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void numericSummaryTypeFilterLate() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME - (3600 * 6)))
+        .setEnd(Integer.toString(BASE_TIME - (3600)))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    
+    MutableNumericSummaryValue v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
+    v.resetValue(2, -3);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L)));
+    v.resetValue(1, 15);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L)));
+    v.resetValue(1, 12);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L)));
+    v.resetValue(0, 12.43);
+    ((MockTimeSeries) series).addValue(v);
+
+    SummarizerNonPassthroughNumericIterator iterator =
+        new SummarizerNonPassthroughNumericIterator(node, result, series);
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
   public void numericTypeDoubles() throws Exception {
     TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
         .setMetric("foo")
         .build());
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(0L), 42.5));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42.5));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(60L), 24.75));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), 24.75));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(120L), -8.3));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), -8.3));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(240L), 1.2));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1.2));
     SummarizerNonPassthroughNumericIterator iterator = 
         new SummarizerNonPassthroughNumericIterator(node, result, series);
     assertTrue(iterator.hasNext());
@@ -396,13 +700,13 @@ public class TestSummarizerNonPassthroughNumericIterator {
         .setMetric("foo")
         .build());
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(0L), 42));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(60L), 24));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), 24));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(120L), -8.3));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), -8.3));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(240L), 1.2));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1.2));
     SummarizerNonPassthroughNumericIterator iterator = 
         new SummarizerNonPassthroughNumericIterator(node, result, series);
     assertTrue(iterator.hasNext());
@@ -428,13 +732,13 @@ public class TestSummarizerNonPassthroughNumericIterator {
         .setMetric("foo")
         .build());
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(0L), 42.5));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42.5));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(60L), Double.NaN));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), Double.NaN));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(120L), Double.NaN));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), Double.NaN));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(240L), 1.2));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1.2));
     SummarizerNonPassthroughNumericIterator iterator = 
         new SummarizerNonPassthroughNumericIterator(node, result, series);
     assertTrue(iterator.hasNext());
@@ -468,13 +772,13 @@ public class TestSummarizerNonPassthroughNumericIterator {
         .setMetric("foo")
         .build());
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(0L), 42.5));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42.5));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(60L), Double.NaN));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), Double.NaN));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(120L), Double.NaN));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), Double.NaN));
     ((MockTimeSeries) series).addValue(
-        new MutableNumericValue(new SecondTimeStamp(240L), 1.2));
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1.2));
     SummarizerNonPassthroughNumericIterator iterator = 
         new SummarizerNonPassthroughNumericIterator(node, result, series);
     assertTrue(iterator.hasNext());
@@ -503,6 +807,11 @@ public class TestSummarizerNonPassthroughNumericIterator {
     ((NumericArrayTimeSeries) series).add(24);
     ((NumericArrayTimeSeries) series).add(-8);
     ((NumericArrayTimeSeries) series).add(1);
+    
+    TimeSpecification time_spec = mock(TimeSpecification.class);
+    when(time_spec.start()).thenReturn(new SecondTimeStamp(BASE_TIME));
+    when(time_spec.interval()).thenReturn(Duration.ofSeconds(60));
+    when(result.timeSpecification()).thenReturn(time_spec);
     SummarizerNonPassthroughNumericIterator iterator = 
         new SummarizerNonPassthroughNumericIterator(node, result, series);
     assertTrue(iterator.hasNext());
@@ -531,6 +840,11 @@ public class TestSummarizerNonPassthroughNumericIterator {
     ((NumericArrayTimeSeries) series).add(24.75);
     ((NumericArrayTimeSeries) series).add(-8.3);
     ((NumericArrayTimeSeries) series).add(1.2);
+    
+    TimeSpecification time_spec = mock(TimeSpecification.class);
+    when(time_spec.start()).thenReturn(new SecondTimeStamp(BASE_TIME));
+    when(time_spec.interval()).thenReturn(Duration.ofSeconds(60));
+    when(result.timeSpecification()).thenReturn(time_spec);
     SummarizerNonPassthroughNumericIterator iterator = 
         new SummarizerNonPassthroughNumericIterator(node, result, series);
     assertTrue(iterator.hasNext());
@@ -547,6 +861,131 @@ public class TestSummarizerNonPassthroughNumericIterator {
     assertEquals(-8.3, summary.value(3).doubleValue(), 0.001);
     assertEquals(15.037, summary.value(5).doubleValue(), 0.001);
     
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  public void numericArrayTypeFilterMiddle() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME + 60))
+        .setEnd(Integer.toString(BASE_TIME + 180))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new NumericArrayTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build(), new SecondTimeStamp(0L));
+    ((NumericArrayTimeSeries) series).add(42);
+    ((NumericArrayTimeSeries) series).add(24);
+    ((NumericArrayTimeSeries) series).add(-8);
+    ((NumericArrayTimeSeries) series).add(1);
+    
+    TimeSpecification time_spec = mock(TimeSpecification.class);
+    when(time_spec.start()).thenReturn(new SecondTimeStamp(BASE_TIME));
+    when(time_spec.interval()).thenReturn(Duration.ofSeconds(60));
+    when(result.timeSpecification()).thenReturn(time_spec);
+    SummarizerNonPassthroughNumericIterator iterator = 
+        new SummarizerNonPassthroughNumericIterator(node, result, series);
+    assertTrue(iterator.hasNext());
+    
+    TimeSeriesValue<NumericSummaryType> value = 
+        (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(0, value.timestamp().epoch());
+    
+    NumericSummaryType summary = value.value();
+    assertEquals(5, summary.summariesAvailable().size());
+    assertEquals(16, summary.value(0).longValue());
+    assertEquals(2, summary.value(1).longValue());
+    assertEquals(24, summary.value(2).longValue());
+    assertEquals(-8, summary.value(3).longValue());
+    assertEquals(8, summary.value(5).longValue());
+    
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void numericArrayTypeFilterEarly() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME + 240))
+        .setEnd(Integer.toString(BASE_TIME + 360))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new NumericArrayTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build(), new SecondTimeStamp(0L));
+    ((NumericArrayTimeSeries) series).add(42);
+    ((NumericArrayTimeSeries) series).add(24);
+    ((NumericArrayTimeSeries) series).add(-8);
+    ((NumericArrayTimeSeries) series).add(1);
+    
+    TimeSpecification time_spec = mock(TimeSpecification.class);
+    when(time_spec.start()).thenReturn(new SecondTimeStamp(BASE_TIME));
+    when(time_spec.interval()).thenReturn(Duration.ofSeconds(60));
+    when(result.timeSpecification()).thenReturn(time_spec);
+    SummarizerNonPassthroughNumericIterator iterator = 
+        new SummarizerNonPassthroughNumericIterator(node, result, series);
+    assertFalse(iterator.hasNext());
+  }
+  
+  @Test
+  public void numericArrayTypeFilterLate() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME - 3600))
+        .setEnd(Integer.toString(BASE_TIME - 60))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new NumericArrayTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build(), new SecondTimeStamp(0L));
+    ((NumericArrayTimeSeries) series).add(42);
+    ((NumericArrayTimeSeries) series).add(24);
+    ((NumericArrayTimeSeries) series).add(-8);
+    ((NumericArrayTimeSeries) series).add(1);
+    
+    TimeSpecification time_spec = mock(TimeSpecification.class);
+    when(time_spec.start()).thenReturn(new SecondTimeStamp(BASE_TIME));
+    when(time_spec.interval()).thenReturn(Duration.ofSeconds(60));
+    when(result.timeSpecification()).thenReturn(time_spec);
+    SummarizerNonPassthroughNumericIterator iterator = 
+        new SummarizerNonPassthroughNumericIterator(node, result, series);
     assertFalse(iterator.hasNext());
   }
 }

--- a/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerPassThroughNumericArrayIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerPassThroughNumericArrayIterator.java
@@ -1,0 +1,287 @@
+// This file is part of OpenTSDB.
+// Copyright (C)2019  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.processor.summarizer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import net.opentsdb.data.BaseTimeSeriesStringId;
+import net.opentsdb.data.SecondTimeStamp;
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.TimeSpecification;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.opentsdb.data.types.numeric.NumericArrayTimeSeries;
+import net.opentsdb.data.types.numeric.NumericArrayType;
+import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
+import net.opentsdb.query.QueryMode;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.SemanticQuery;
+import net.opentsdb.query.filter.MetricLiteralFilter;
+
+public class TestSummarizerPassThroughNumericArrayIterator {
+  private static final int BASE_TIME = 1546300800;
+  
+  private SemanticQuery query;
+  private QueryPipelineContext context;
+  private SummarizerPassThroughResult result;
+  
+  @Before
+  public void before() throws Exception {
+    context = mock(QueryPipelineContext.class);
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME))
+        .setEnd(Integer.toString(BASE_TIME * (3600 * 4)))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    result = mock(SummarizerPassThroughResult.class);
+    Summarizer node = mock(Summarizer.class);
+    when(node.pipelineContext()).thenReturn(context);
+    when(result.summarizerNode()).thenReturn(node);
+    
+    TimeSpecification time_spec = mock(TimeSpecification.class);
+    when(time_spec.start()).thenReturn(new SecondTimeStamp(BASE_TIME));
+    when(time_spec.interval()).thenReturn(Duration.ofSeconds(60));
+    when(result.timeSpecification()).thenReturn(time_spec);
+  }
+  
+  @Test
+  public void longArray() throws Exception {
+    TimeSeries series = new NumericArrayTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build(), new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) series).add(42);
+    ((NumericArrayTimeSeries) series).add(24);
+    ((NumericArrayTimeSeries) series).add(-8);
+    ((NumericArrayTimeSeries) series).add(1);
+    
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericArrayIterator iterator = 
+        new SummarizerPassThroughNumericArrayIterator(sts);
+    assertTrue(iterator.hasNext());
+    
+    final TimeSeriesValue<NumericArrayType> value = 
+        (TimeSeriesValue<NumericArrayType>) iterator.next();
+    assertEquals(0, value.value().offset());
+    assertEquals(4, value.value().end());
+    assertArrayEquals(new long[] { 42, 24, -8, 1, 0, 0, 0, 0 }, 
+        value.value().longArray());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, times(1)).summarize(eq(new long[] { 42, 24, -8, 1, 0, 0, 0, 0 }), 
+        eq(0), eq(4));
+  }
+  
+  @Test
+  public void doubleArray() throws Exception {
+    TimeSeries series = new NumericArrayTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build(), new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) series).add(42.75);
+    ((NumericArrayTimeSeries) series).add(24.0);
+    ((NumericArrayTimeSeries) series).add(-8.98);
+    ((NumericArrayTimeSeries) series).add(1.5);
+    
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericArrayIterator iterator = 
+        new SummarizerPassThroughNumericArrayIterator(sts);
+    assertTrue(iterator.hasNext());
+    
+    final TimeSeriesValue<NumericArrayType> value = 
+        (TimeSeriesValue<NumericArrayType>) iterator.next();
+    assertEquals(0, value.value().offset());
+    assertEquals(4, value.value().end());
+    assertArrayEquals(new double[] { 42.75, 24, -8.98, 1.5, 0, 0, 0, 0 }, 
+        value.value().doubleArray(), 0.001);
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, times(1)).summarize(eq(new double[] { 42.75, 24, -8.98, 1.5, 0, 0, 0, 0 }), 
+        eq(0), eq(4));
+  }
+  
+  @Test
+  public void empty() throws Exception {
+    TimeSeries series = new NumericArrayTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build(), new SecondTimeStamp(BASE_TIME));
+    
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericArrayIterator iterator = 
+        new SummarizerPassThroughNumericArrayIterator(sts);
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void longFilterMiddle() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME + 60))
+        .setEnd(Integer.toString(BASE_TIME + 180))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new NumericArrayTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build(), new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) series).add(42);
+    ((NumericArrayTimeSeries) series).add(24);
+    ((NumericArrayTimeSeries) series).add(-8);
+    ((NumericArrayTimeSeries) series).add(1);
+    
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericArrayIterator iterator = 
+        new SummarizerPassThroughNumericArrayIterator(sts);
+    assertTrue(iterator.hasNext());
+    
+    final TimeSeriesValue<NumericArrayType> value = 
+        (TimeSeriesValue<NumericArrayType>) iterator.next();
+    assertEquals(0, value.value().offset());
+    assertEquals(4, value.value().end());
+    assertArrayEquals(new long[] { 42, 24, -8, 1, 0, 0, 0, 0 }, 
+        value.value().longArray());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, times(1)).summarize(eq(new long[] { 42, 24, -8, 1, 0, 0, 0, 0 }), 
+        eq(1), eq(3));
+  }
+  
+  @Test
+  public void longFilterEarly() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME + 300))
+        .setEnd(Integer.toString(BASE_TIME + 900))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new NumericArrayTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build(), new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) series).add(42);
+    ((NumericArrayTimeSeries) series).add(24);
+    ((NumericArrayTimeSeries) series).add(-8);
+    ((NumericArrayTimeSeries) series).add(1);
+    
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericArrayIterator iterator = 
+        new SummarizerPassThroughNumericArrayIterator(sts);
+    assertTrue(iterator.hasNext());
+    
+    final TimeSeriesValue<NumericArrayType> value = 
+        (TimeSeriesValue<NumericArrayType>) iterator.next();
+    assertEquals(0, value.value().offset());
+    assertEquals(4, value.value().end());
+    assertArrayEquals(new long[] { 42, 24, -8, 1, 0, 0, 0, 0 }, 
+        value.value().longArray());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+  }
+  
+  @Test
+  public void longFilterLate() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME - 300))
+        .setEnd(Integer.toString(BASE_TIME - 60))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new NumericArrayTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build(), new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) series).add(42);
+    ((NumericArrayTimeSeries) series).add(24);
+    ((NumericArrayTimeSeries) series).add(-8);
+    ((NumericArrayTimeSeries) series).add(1);
+    
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericArrayIterator iterator = 
+        new SummarizerPassThroughNumericArrayIterator(sts);
+    assertTrue(iterator.hasNext());
+    
+    final TimeSeriesValue<NumericArrayType> value = 
+        (TimeSeriesValue<NumericArrayType>) iterator.next();
+    assertEquals(0, value.value().offset());
+    assertEquals(4, value.value().end());
+    assertArrayEquals(new long[] { 42, 24, -8, 1, 0, 0, 0, 0 }, 
+        value.value().longArray());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+  }
+}

--- a/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerPassThroughNumericIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerPassThroughNumericIterator.java
@@ -1,0 +1,391 @@
+// This file is part of OpenTSDB.
+// Copyright (C)2019  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.processor.summarizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import net.opentsdb.data.BaseTimeSeriesStringId;
+import net.opentsdb.data.MockTimeSeries;
+import net.opentsdb.data.SecondTimeStamp;
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.TimeSpecification;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.opentsdb.data.types.numeric.MutableNumericValue;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
+import net.opentsdb.query.QueryMode;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.SemanticQuery;
+import net.opentsdb.query.filter.MetricLiteralFilter;
+
+public class TestSummarizerPassThroughNumericIterator {
+  private static final int BASE_TIME = 1546300800;
+  
+  private SemanticQuery query;
+  private QueryPipelineContext context;
+  private SummarizerPassThroughResult result;
+  
+  @Before
+  public void before() throws Exception {
+    context = mock(QueryPipelineContext.class);
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME))
+        .setEnd(Integer.toString(BASE_TIME * (3600 * 4)))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    result = mock(SummarizerPassThroughResult.class);
+    Summarizer node = mock(Summarizer.class);
+    when(node.pipelineContext()).thenReturn(context);
+    when(result.summarizerNode()).thenReturn(node);
+    
+    TimeSpecification time_spec = mock(TimeSpecification.class);
+    when(time_spec.start()).thenReturn(new SecondTimeStamp(BASE_TIME));
+    when(time_spec.interval()).thenReturn(Duration.ofSeconds(60));
+    when(result.timeSpecification()).thenReturn(time_spec);
+  }
+  
+  @Test
+  public void longs() throws Exception {
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), 24));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), -8));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1));
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericIterator iterator = 
+        new SummarizerPassThroughNumericIterator(sts);
+    
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME, value.timestamp().epoch());
+    assertEquals(42, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 60, value.timestamp().epoch());
+    assertEquals(24, value.value().longValue());
+   
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 120, value.timestamp().epoch());
+    assertEquals(-8, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 240, value.timestamp().epoch());
+    assertEquals(1, value.value().longValue());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, times(1)).summarize(eq(new long[] { 42, 24, -8, 1, 0, 0, 0, 0 }), 
+        eq(0), eq(4));
+  }
+  
+  @Test
+  public void doubles() throws Exception {
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42.75));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), 24.1));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), -8.98));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1.5));
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericIterator iterator = 
+        new SummarizerPassThroughNumericIterator(sts);
+    
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME, value.timestamp().epoch());
+    assertEquals(42.75, value.value().doubleValue(), 0.001);
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 60, value.timestamp().epoch());
+    assertEquals(24.1, value.value().doubleValue(), 0.001);
+   
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 120, value.timestamp().epoch());
+    assertEquals(-8.98, value.value().doubleValue(), 0.001);
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 240, value.timestamp().epoch());
+    assertEquals(1.5, value.value().doubleValue(), 0.001);
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, times(1)).summarize(eq(new double[] { 42.75, 24.1, -8.98, 1.5, 0, 0, 0, 0 }), 
+        eq(0), eq(4));
+  }
+  
+  @Test
+  public void mixed() throws Exception {
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42.75));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), 24));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), -8));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1.5));
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericIterator iterator = 
+        new SummarizerPassThroughNumericIterator(sts);
+    
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME, value.timestamp().epoch());
+    assertEquals(42.75, value.value().doubleValue(), 0.001);
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 60, value.timestamp().epoch());
+    assertEquals(24, value.value().longValue());
+   
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 120, value.timestamp().epoch());
+    assertEquals(-8, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 240, value.timestamp().epoch());
+    assertEquals(1.5, value.value().doubleValue(), 0.001);
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, times(1)).summarize(eq(new double[] { 42.75, 24, -8, 1.5, 0, 0, 0, 0 }), 
+        eq(0), eq(4));
+  }
+
+  @Test
+  public void filterMiddle() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME + 60))
+        .setEnd(Integer.toString(BASE_TIME + 180))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), 24));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), -8));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1));
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericIterator iterator = 
+        new SummarizerPassThroughNumericIterator(sts);
+    
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME, value.timestamp().epoch());
+    assertEquals(42, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 60, value.timestamp().epoch());
+    assertEquals(24, value.value().longValue());
+   
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 120, value.timestamp().epoch());
+    assertEquals(-8, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 240, value.timestamp().epoch());
+    assertEquals(1, value.value().longValue());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, times(1)).summarize(eq(new long[] { 24, -8, 0, 0, 0, 0, 0, 0 }), 
+        eq(0), eq(2));
+  }
+  
+  @Test
+  public void filterEarly() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME + 300))
+        .setEnd(Integer.toString(BASE_TIME + 900))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), 24));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), -8));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1));
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericIterator iterator = 
+        new SummarizerPassThroughNumericIterator(sts);
+    
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME, value.timestamp().epoch());
+    assertEquals(42, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 60, value.timestamp().epoch());
+    assertEquals(24, value.value().longValue());
+   
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 120, value.timestamp().epoch());
+    assertEquals(-8, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 240, value.timestamp().epoch());
+    assertEquals(1, value.value().longValue());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+  }
+  
+  @Test
+  public void filterLate() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME - 900))
+        .setEnd(Integer.toString(BASE_TIME - 60))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 0L), 42));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 60L), 24));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 120L), -8));
+    ((MockTimeSeries) series).addValue(
+        new MutableNumericValue(new SecondTimeStamp(BASE_TIME + 240L), 1));
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericIterator iterator = 
+        new SummarizerPassThroughNumericIterator(sts);
+    
+    assertTrue(iterator.hasNext());
+    TimeSeriesValue<NumericType> value = 
+        (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME, value.timestamp().epoch());
+    assertEquals(42, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 60, value.timestamp().epoch());
+    assertEquals(24, value.value().longValue());
+   
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 120, value.timestamp().epoch());
+    assertEquals(-8, value.value().longValue());
+    
+    value = (TimeSeriesValue<NumericType>) iterator.next();
+    assertEquals(BASE_TIME + 240, value.timestamp().epoch());
+    assertEquals(1, value.value().longValue());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+  }
+  
+}

--- a/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerPassThroughNumericSummaryIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerPassThroughNumericSummaryIterator.java
@@ -1,0 +1,530 @@
+// This file is part of OpenTSDB.
+// Copyright (C)2019  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.processor.summarizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import net.opentsdb.data.BaseTimeSeriesStringId;
+import net.opentsdb.data.MockTimeSeries;
+import net.opentsdb.data.SecondTimeStamp;
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.TimeSpecification;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.opentsdb.data.types.numeric.MutableNumericSummaryValue;
+import net.opentsdb.data.types.numeric.NumericSummaryType;
+import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
+import net.opentsdb.query.QueryMode;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.SemanticQuery;
+import net.opentsdb.query.filter.MetricLiteralFilter;
+
+public class TestSummarizerPassThroughNumericSummaryIterator {
+private static final int BASE_TIME = 1546300800;
+  
+  private SemanticQuery query;
+  private QueryPipelineContext context;
+  private SummarizerPassThroughResult result;
+  
+  @Before
+  public void before() throws Exception {
+    context = mock(QueryPipelineContext.class);
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME))
+        .setEnd(Integer.toString(BASE_TIME + (3600 * 4)))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    result = mock(SummarizerPassThroughResult.class);
+    Summarizer node = mock(Summarizer.class);
+    when(node.pipelineContext()).thenReturn(context);
+    when(result.summarizerNode()).thenReturn(node);
+    
+    TimeSpecification time_spec = mock(TimeSpecification.class);
+    when(time_spec.start()).thenReturn(new SecondTimeStamp(BASE_TIME));
+    when(time_spec.interval()).thenReturn(Duration.ofSeconds(60));
+    when(result.timeSpecification()).thenReturn(time_spec);
+  }
+  
+  @Test
+  public void longs() throws Exception {
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    
+    MutableNumericSummaryValue v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
+    v.resetValue(1, -3);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L)));
+    v.resetValue(1, 15);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L)));
+    v.resetValue(1, 12);
+    ((MockTimeSeries) series).addValue(v);
+    
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L)));
+    v.resetValue(0, 12);
+    ((MockTimeSeries) series).addValue(v);
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericSummaryIterator iterator = new
+        SummarizerPassThroughNumericSummaryIterator(sts);
+    
+    assertTrue(iterator.hasNext());
+    
+    TimeSeriesValue<NumericSummaryType> value = 
+        (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME, value.timestamp().epoch());
+    assertEquals(-3, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600), value.timestamp().epoch());
+    assertEquals(15, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 2), value.timestamp().epoch());
+    assertEquals(12, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 3), value.timestamp().epoch());
+    assertEquals(12, value.value().value(0).longValue());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, times(1)).summarize(eq(new long[] { -3, 15, 12, 0, 0, 0, 0, 0 }), 
+        eq(0), eq(3));
+  }
+  
+  @Test
+  public void doubles() throws Exception {
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    
+    MutableNumericSummaryValue v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
+    v.resetValue(1, -3.5);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L)));
+    v.resetValue(1, 15.75);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L)));
+    v.resetValue(1, 12.13);
+    ((MockTimeSeries) series).addValue(v);
+    
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L)));
+    v.resetValue(0, 12.99);
+    ((MockTimeSeries) series).addValue(v);
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericSummaryIterator iterator = new
+        SummarizerPassThroughNumericSummaryIterator(sts);
+    
+    assertTrue(iterator.hasNext());
+    
+    TimeSeriesValue<NumericSummaryType> value = 
+        (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME, value.timestamp().epoch());
+    assertEquals(-3.5, value.value().value(1).doubleValue(), 0.001);
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600), value.timestamp().epoch());
+    assertEquals(15.75, value.value().value(1).doubleValue(), 0.001);
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 2), value.timestamp().epoch());
+    assertEquals(12.13, value.value().value(1).doubleValue(), 0.001);
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 3), value.timestamp().epoch());
+    assertEquals(12.99, value.value().value(0).doubleValue(), 0.001);
+    
+    verify(sts, never()).summarize(any(double[].class), anyInt(), anyInt());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, times(1)).summarize(eq(new double[] { -3.5, 15.75, 12.13, 0, 0, 0, 0, 0 }), 
+        eq(0), eq(3));
+  }
+  
+  @Test
+  public void mixed() throws Exception {
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    
+    MutableNumericSummaryValue v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
+    v.resetValue(1, -3.5);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L)));
+    v.resetValue(1, 15);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L)));
+    v.resetValue(1, 12.13);
+    ((MockTimeSeries) series).addValue(v);
+    
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L)));
+    v.resetValue(0, 12.99);
+    ((MockTimeSeries) series).addValue(v);
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericSummaryIterator iterator = new
+        SummarizerPassThroughNumericSummaryIterator(sts);
+    
+    assertTrue(iterator.hasNext());
+    
+    TimeSeriesValue<NumericSummaryType> value = 
+        (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME, value.timestamp().epoch());
+    assertEquals(-3.5, value.value().value(1).doubleValue(), 0.001);
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600), value.timestamp().epoch());
+    assertEquals(15, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 2), value.timestamp().epoch());
+    assertEquals(12.13, value.value().value(1).doubleValue(), 0.001);
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 3), value.timestamp().epoch());
+    assertEquals(12.99, value.value().value(0).doubleValue(), 0.001);
+    
+    verify(sts, never()).summarize(any(double[].class), anyInt(), anyInt());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, times(1)).summarize(eq(new double[] { -3.5, 15, 12.13, 0, 0, 0, 0, 0 }), 
+        eq(0), eq(3));
+  }
+  
+  @Test
+  public void average() throws Exception {
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    
+    MutableNumericSummaryValue v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
+    v.resetValue(0, 6);
+    v.resetValue(1, 2);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L)));
+    v.resetValue(0, 4.8);
+    v.resetValue(1, 1);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L)));
+    v.resetValue(0, 8);
+    v.resetValue(1, 2);
+    ((MockTimeSeries) series).addValue(v);
+    
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L)));
+    v.resetValue(0, 12);
+    ((MockTimeSeries) series).addValue(v);
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericSummaryIterator iterator = new
+        SummarizerPassThroughNumericSummaryIterator(sts);
+    
+    assertTrue(iterator.hasNext());
+    
+    TimeSeriesValue<NumericSummaryType> value = 
+        (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME, value.timestamp().epoch());
+    assertEquals(6, value.value().value(0).longValue());
+    assertEquals(2, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600), value.timestamp().epoch());
+    assertEquals(4.8, value.value().value(0).doubleValue(), 0.001);
+    assertEquals(1, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 2), value.timestamp().epoch());
+    assertEquals(8, value.value().value(0).longValue());
+    assertEquals(2, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 3), value.timestamp().epoch());
+    assertEquals(12, value.value().value(0).longValue());
+    
+    verify(sts, never()).summarize(any(double[].class), anyInt(), anyInt());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, times(1)).summarize(eq(new double[] { 3, 4.8, 4, 0, 0, 0, 0, 0 }), 
+        eq(0), eq(3));
+  }
+
+  @Test
+  public void filterMiddle() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME + 3600))
+        .setEnd(Integer.toString(BASE_TIME + (3600 * 3)))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    
+    MutableNumericSummaryValue v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
+    v.resetValue(1, -3);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L)));
+    v.resetValue(1, 15);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L)));
+    v.resetValue(1, 12);
+    ((MockTimeSeries) series).addValue(v);
+    
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L)));
+    v.resetValue(0, 12);
+    ((MockTimeSeries) series).addValue(v);
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericSummaryIterator iterator = new
+        SummarizerPassThroughNumericSummaryIterator(sts);
+    
+    assertTrue(iterator.hasNext());
+    
+    TimeSeriesValue<NumericSummaryType> value = 
+        (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME, value.timestamp().epoch());
+    assertEquals(-3, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600), value.timestamp().epoch());
+    assertEquals(15, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 2), value.timestamp().epoch());
+    assertEquals(12, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 3), value.timestamp().epoch());
+    assertEquals(12, value.value().value(0).longValue());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, times(1)).summarize(eq(new long[] { 15, 12, 0, 0, 0, 0, 0, 0 }), 
+        eq(0), eq(2));
+  }
+  
+  @Test
+  public void filterEarly() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME + (3600 * 4)))
+        .setEnd(Integer.toString(BASE_TIME + (3600 * 8)))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    
+    MutableNumericSummaryValue v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
+    v.resetValue(1, -3);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L)));
+    v.resetValue(1, 15);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L)));
+    v.resetValue(1, 12);
+    ((MockTimeSeries) series).addValue(v);
+    
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L)));
+    v.resetValue(0, 12);
+    ((MockTimeSeries) series).addValue(v);
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericSummaryIterator iterator = new
+        SummarizerPassThroughNumericSummaryIterator(sts);
+    
+    assertTrue(iterator.hasNext());
+    
+    TimeSeriesValue<NumericSummaryType> value = 
+        (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME, value.timestamp().epoch());
+    assertEquals(-3, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600), value.timestamp().epoch());
+    assertEquals(15, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 2), value.timestamp().epoch());
+    assertEquals(12, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 3), value.timestamp().epoch());
+    assertEquals(12, value.value().value(0).longValue());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+  }
+  
+  @Test
+  public void filterLate() throws Exception {
+    query = SemanticQuery.newBuilder()
+        .setStart(Integer.toString(BASE_TIME - (3600 * 8)))
+        .setEnd(Integer.toString(BASE_TIME - 3600))
+        .setMode(QueryMode.SINGLE)
+        .addExecutionGraphNode(DefaultTimeSeriesDataSourceConfig.newBuilder()
+            .setMetric(MetricLiteralFilter.newBuilder()
+                .setMetric("sys.cpu.user")
+                .build())
+            .setId("m1")
+            .build())
+        .addExecutionGraphNode(SummarizerConfig.newBuilder()
+            .addSummary("sum")
+            .addSource("m1")
+            .setId("summarizer")
+            .build())
+        .build();
+    when(context.query()).thenReturn(query);
+    
+    TimeSeries series = new MockTimeSeries(new BaseTimeSeriesStringId.Builder()
+        .setMetric("foo")
+        .build());
+    
+    MutableNumericSummaryValue v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME));
+    v.resetValue(1, -3);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 1L)));
+    v.resetValue(1, 15);
+    ((MockTimeSeries) series).addValue(v);
+
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 2L)));
+    v.resetValue(1, 12);
+    ((MockTimeSeries) series).addValue(v);
+    
+    v = new MutableNumericSummaryValue();
+    v.resetTimestamp(new SecondTimeStamp(BASE_TIME + (3600 * 3L)));
+    v.resetValue(0, 12);
+    ((MockTimeSeries) series).addValue(v);
+    SummarizedTimeSeries sts = spy(new SummarizedTimeSeries(result, series));
+    SummarizerPassThroughNumericSummaryIterator iterator = new
+        SummarizerPassThroughNumericSummaryIterator(sts);
+    
+    assertTrue(iterator.hasNext());
+    
+    TimeSeriesValue<NumericSummaryType> value = 
+        (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME, value.timestamp().epoch());
+    assertEquals(-3, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600), value.timestamp().epoch());
+    assertEquals(15, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 2), value.timestamp().epoch());
+    assertEquals(12, value.value().value(1).longValue());
+    
+    value = (TimeSeriesValue<NumericSummaryType>) iterator.next();
+    assertEquals(BASE_TIME + (3600 * 3), value.timestamp().epoch());
+    assertEquals(12, value.value().value(0).longValue());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+    assertFalse(iterator.hasNext());
+    
+    verify(sts, never()).summarize(any(long[].class), anyInt(), anyInt());
+  }
+  
+}


### PR DESCRIPTION
- Filter out values from the Summarizer that lay outside the query time range.
- Add UTs for the pass-through summarizer components.