### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/readcache/CachedQueryNode.java
+++ b/common/src/main/java/net/opentsdb/query/readcache/CachedQueryNode.java
@@ -40,11 +40,12 @@ public class CachedQueryNode implements QueryNode, QueryNodeConfig {
   /** The ID of this node. */
   protected final String id;
   
-  protected final QueryPipelineContext context;
+  protected final QueryNode original_node;
   
-  public CachedQueryNode(final String id, final QueryPipelineContext context) {
+  public CachedQueryNode(final String id, 
+                         final QueryNode node) {
     this.id = id;
-    this.context = context;
+    this.original_node = node;
   }
   
   @Override
@@ -132,7 +133,7 @@ public class CachedQueryNode implements QueryNode, QueryNodeConfig {
 
   @Override
   public QueryPipelineContext pipelineContext() {
-    return context;
+    return original_node.pipelineContext();
   }
 
   @Override
@@ -171,4 +172,8 @@ public class CachedQueryNode implements QueryNode, QueryNodeConfig {
     throw new UnsupportedOperationException();
   }
 
+  public QueryNode originalNode() {
+    return original_node;
+  }
+  
 }

--- a/common/src/main/java/net/opentsdb/query/readcache/ReadCacheSerdes.java
+++ b/common/src/main/java/net/opentsdb/query/readcache/ReadCacheSerdes.java
@@ -17,6 +17,7 @@ package net.opentsdb.query.readcache;
 import java.util.Collection;
 import java.util.Map;
 
+import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 
@@ -55,7 +56,7 @@ public interface ReadCacheSerdes {
    * result ID.
    */
   public Map<String, ReadCacheQueryResult> deserialize(
-      final QueryPipelineContext context, 
+      final QueryNode node, 
       final byte[] data);
 
 }

--- a/core/src/main/java/net/opentsdb/query/hacluster/HACluster.java
+++ b/core/src/main/java/net/opentsdb/query/hacluster/HACluster.java
@@ -391,7 +391,7 @@ public class HACluster extends AbstractQueryNode implements TimeSeriesDataSource
                 final QueryNode node, 
                 final String missing_src) {
       super(result);
-      this.node = new CachedQueryNode(missing_src, node.pipelineContext());
+      this.node = new CachedQueryNode(missing_src, node);
       this.missing_src = missing_src;
     }
     

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericToNumericArrayIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericToNumericArrayIterator.java
@@ -77,10 +77,12 @@ import org.slf4j.LoggerFactory;
  * <p>
  * @since 3.0
  */
-public class DownsampleNumericToNumericArrayIterator implements QueryIterator, TimeSeriesValue<NumericArrayType> {
+public class DownsampleNumericToNumericArrayIterator 
+    implements QueryIterator, TimeSeriesValue<NumericArrayType> {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(DownsampleNumericToNumericArrayIterator.class);
+  
   /** The result we belong to. */
   private final DownsampleResult result;
 

--- a/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByFactory.java
@@ -1,4 +1,3 @@
-// This file is part of OpenTSDB.
 // Copyright (C) 2017-2018  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/net/opentsdb/query/readcache/JsonReadCacheSerdes.java
+++ b/core/src/main/java/net/opentsdb/query/readcache/JsonReadCacheSerdes.java
@@ -200,10 +200,10 @@ public class JsonReadCacheSerdes implements ReadCacheSerdes,
 
   @Override
   public Map<String, ReadCacheQueryResult> deserialize(
-      final QueryPipelineContext context, 
+      final QueryNode node, 
       final byte[] data) {
-    if (context.query().isTraceEnabled()) {
-      context.queryContext().logTrace("Parsing cached segment: " 
+    if (node.pipelineContext().query().isTraceEnabled()) {
+      node.pipelineContext().queryContext().logTrace("Parsing cached segment: " 
           + new String(data, Const.UTF8_CHARSET));
     }
     Map<String, ReadCacheQueryResult> map = Maps.newHashMap();
@@ -211,7 +211,7 @@ public class JsonReadCacheSerdes implements ReadCacheSerdes,
       JsonNode results = JSON.getMapper().readTree(data);
       results = results.get("results");
       for (final JsonNode result : results) {
-        ReadCacheQueryResult r = new JsonCachedResult(null, result, ROLLUP_CONFIG);
+        ReadCacheQueryResult r = new JsonCachedResult(node, result, ROLLUP_CONFIG);
         map.put(r.source().config().getId() + ":" + r.dataSource(), r);
       }
     } catch (IOException e) {
@@ -827,10 +827,10 @@ public class JsonReadCacheSerdes implements ReadCacheSerdes,
      * @param context The non-null context.
      * @param root The non-null root node.
      */
-    JsonCachedResult(final QueryPipelineContext context,
+    JsonCachedResult(final QueryNode node,
                      final JsonNode root, 
                      final RollupConfig rollup_config) {
-      this(context, root, rollup_config, null);
+      this(node, root, rollup_config, null);
     }
     
     /**
@@ -840,7 +840,7 @@ public class JsonReadCacheSerdes implements ReadCacheSerdes,
      * @param root The root node. Cannot be null if the exception is null.
      * @param exception An optional exception.
      */
-    JsonCachedResult(final QueryPipelineContext context,
+    JsonCachedResult(final QueryNode node,
                      final JsonNode root, 
                      final RollupConfig rollup_config,
                      final Exception exception) {
@@ -848,7 +848,7 @@ public class JsonReadCacheSerdes implements ReadCacheSerdes,
         String temp = root.get("source").asText();
         data_source = temp.substring(temp.indexOf(":") + 1);
         this.node = new CachedQueryNode(temp.substring(0, temp.indexOf(":")), 
-            context);
+            node);
         
         this.exception = exception;
         this.rollup_config = rollup_config;

--- a/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Result.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Result.java
@@ -115,7 +115,7 @@ public class HttpQueryV3Result implements QueryResult {
                     final Exception exception) {
     this.exception = exception;
     this.rollup_config = rollup_config;
-    this.node = new CachedQueryNode(node.config().getId(), node.pipelineContext());
+    this.node = new CachedQueryNode(node.config().getId(), node);
     if (exception == null && root != null) {
       String temp = root.get("source").asText();
       // TEMP - old versions didn't handle IDs correctly so we override the result.

--- a/implementation/protobuf/src/main/java/net/opentsdb/data/PBufQueryResult.java
+++ b/implementation/protobuf/src/main/java/net/opentsdb/data/PBufQueryResult.java
@@ -77,7 +77,7 @@ public class PBufQueryResult implements QueryResult {
     } catch (IOException e) {
       throw new SerdesException("Failed to parse the query results.", e);
     }
-    this.node = new CachedQueryNode(result.getNodeId(), node.pipelineContext());
+    this.node = new CachedQueryNode(result.getNodeId(), node);
   }
   
   /**


### PR DESCRIPTION
- Rework CachedQueryNode so that we take in the original node. Need it to
  lookup the node in the graph.

CORE:
- Cleanup and share some bits in the DownsampleNumericToNumericArrayIterator