### PR TITLE
Add support for splitting rollup queries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,7 @@ dist_noinst_DATA = pom.xml.in build-aux/rpm/opentsdb.conf \
   build-aux/rpm/logback.xml build-aux/rpm/init.d/opentsdb \
   build-aux/rpm/systemd/opentsdb@.service
 tsdb_SRC := \
+	src/core/AbstractQuery.java \
 	src/core/AggregationIterator.java	\
 	src/core/Aggregator.java	\
 	src/core/Aggregators.java	\

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,7 @@ tsdb_SRC := \
 	src/core/DownsamplingSpecification.java \
 	src/core/FillingDownsampler.java \
 	src/core/FillPolicy.java \
+	src/core/GroupCallback.java \
 	src/core/Histogram.java	\
 	src/core/HistogramAggregation.java	\
 	src/core/HistogramAggregationIterator.java	\
@@ -81,11 +82,14 @@ tsdb_SRC := \
 	src/core/iRowSeq.java	\
 	src/core/SaltScanner.java	\
 	src/core/SeekableView.java	\
+	src/core/SeekableViewChain.java	\
 	src/core/SimpleHistogram.java	\
 	src/core/SimpleHistogramDataPointAdapter.java	\
 	src/core/SimpleHistogramDecoder.java	\
 	src/core/Span.java	\
 	src/core/SpanGroup.java	\
+	src/core/SplitRollupQuery.java  \
+	src/core/SplitRollupSpanGroup.java  \
 	src/core/TSDB.java	\
 	src/core/Tags.java	\
 	src/core/TsdbQuery.java	\
@@ -317,8 +321,11 @@ test_SRC := \
 	test/core/TestRowKey.java	\
 	test/core/TestRowSeq.java	\
 	test/core/TestSaltScanner.java	\
+	test/core/TestSeekableViewChain.java	\
 	test/core/TestSpan.java	\
 	test/core/TestSpanGroup.java	\
+	test/core/TestSplitRollupQuery.java	\
+	test/core/TestSplitRollupSpanGroup.java	\
 	test/core/TestTags.java	\
 	test/core/TestTSDB.java	\
 	test/core/TestTSDBAddPoint.java	\
@@ -376,6 +383,7 @@ test_SRC := \
 	test/query/pojo/TestTimeSpan.java	\
 	test/rollup/TestRollupConfig.java	\
 	test/rollup/TestRollupInterval.java	\
+	test/rollup/TestRollupQuery.java	\
 	test/rollup/TestRollupSeq.java	\
 	test/rollup/TestRollupUtils.java	\
 	test/search/TestSearchPlugin.java	\

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,7 @@ dist_noinst_DATA = pom.xml.in build-aux/rpm/opentsdb.conf \
   build-aux/rpm/logback.xml build-aux/rpm/init.d/opentsdb \
   build-aux/rpm/systemd/opentsdb@.service
 tsdb_SRC := \
+	src/core/AbstractSpanGroup.java \
 	src/core/AbstractQuery.java \
 	src/core/AggregationIterator.java	\
 	src/core/Aggregator.java	\

--- a/src/core/AbstractQuery.java
+++ b/src/core/AbstractQuery.java
@@ -1,0 +1,66 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2012  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import org.hbase.async.HBaseException;
+
+public abstract class AbstractQuery implements Query {
+    /**
+     * Runs this query.
+     *
+     * @return The data points matched by this query.
+     * <p>
+     * Each element in the non-{@code null} but possibly empty array returned
+     * corresponds to one time series for which some data points have been
+     * matched by the query.
+     * @throws HBaseException if there was a problem communicating with HBase to
+     *                        perform the search.
+     */
+    @Override
+    public DataPoints[] run() throws HBaseException {
+        try {
+            return runAsync().joinUninterruptibly();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Should never be here", e);
+        }
+    }
+
+    /**
+     * Runs this query.
+     *
+     * @return The data points matched by this query and applied with percentile calculation
+     * <p>
+     * Each element in the non-{@code null} but possibly empty array returned
+     * corresponds to one time series for which some data points have been
+     * matched by the query.
+     * @throws HBaseException        if there was a problem communicating with HBase to
+     *                               perform the search.
+     * @throws IllegalStateException if the query is not a histogram query
+     */
+    @Override
+    public DataPoints[] runHistogram() throws HBaseException {
+        if (!isHistogramQuery()) {
+            throw new RuntimeException("Should never be here");
+        }
+
+        try {
+            return runHistogramAsync().joinUninterruptibly();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Should never be here", e);
+        }
+    }
+}

--- a/src/core/AbstractSpanGroup.java
+++ b/src/core/AbstractSpanGroup.java
@@ -1,0 +1,70 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2012  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import java.util.*;
+
+import org.hbase.async.Bytes;
+import org.hbase.async.Bytes.ByteMap;
+
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.meta.Annotation;
+import net.opentsdb.rollup.RollupQuery;
+
+/**
+ * Groups multiple spans together and offers a dynamic "view" on them.
+ * <p>
+ * This is used for queries to the TSDB, where we might group multiple
+ * {@link Span}s that are for the same time series but different tags
+ * together.  We need to "hide" data points that are outside of the
+ * time period of the query and do on-the-fly aggregation of the data
+ * points coming from the different Spans, using an {@link Aggregator}.
+ * Since not all the Spans will have their data points at exactly the
+ * same time, we also do on-the-fly linear interpolation.  If needed,
+ * this view can also return the rate of change instead of the actual
+ * data points.
+ * <p>
+ * This is one of the rare (if not the only) implementations of
+ * {@link DataPoints} for which {@link #getTags} can potentially return
+ * an empty map.
+ * <p>
+ * The implementation can also dynamically downsample the data when a
+ * sampling interval a downsampling function (in the form of an
+ * {@link Aggregator}) are given.  This is done by using a special
+ * iterator when using the {@link Span.DownsamplingIterator}.
+ */
+abstract class AbstractSpanGroup implements DataPoints {
+    /**
+     * Finds the {@code i}th data point of this group in {@code O(n)}.
+     * Where {@code n} is the number of data points in this group.
+     */
+    protected DataPoint getDataPoint(int i) {
+        if (i < 0) {
+            throw new IndexOutOfBoundsException("negative index: " + i);
+        }
+        final int saved_i = i;
+        final SeekableView it = iterator();
+        DataPoint dp = null;
+        while (it.hasNext() && i >= 0) {
+            dp = it.next();
+            i--;
+        }
+        if (i != -1 || dp == null) {
+            throw new IndexOutOfBoundsException("index " + saved_i
+                    + " too large (it's >= " + size() + ") for " + this);
+        }
+        return dp;
+    }
+}

--- a/src/core/GroupCallback.java
+++ b/src/core/GroupCallback.java
@@ -1,0 +1,30 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2012  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import com.stumbleupon.async.Callback;
+
+import java.util.ArrayList;
+
+class GroupCallback implements Callback<Object, ArrayList<Object>> {
+    /**
+     * We're only waiting for all callbacks to complete, ignoring their return values.
+     *
+     * @param ignored The return values of the individual callbacks - ignored
+     * @return null
+     */
+    @Override
+    public Object call(ArrayList<Object> ignored) {
+        return null;
+    }
+}

--- a/src/core/Query.java
+++ b/src/core/Query.java
@@ -171,7 +171,23 @@ public interface Query {
    */
   public Deferred<Object> configureFromQuery(final TSQuery query, 
       final int index);
-  
+
+  /**
+   * Prepares a query against HBase by setting up group bys and resolving
+   * strings to UIDs asynchronously. This replaces calls to all of the setters
+   * like the {@link setTimeSeries}, {@link setStartTime}, etc.
+   * Make sure to wait on the deferred return before calling {@link runAsync}.
+   * @param query The main query to fetch the start and end time from
+   * @param index The index of which sub query we're executing
+   * @param force_raw If true, always get the data from the raw table; disables rollups
+   * @throws IllegalArgumentException if the query was missing sub queries or
+   * the index was out of bounds.
+   * @throws NoSuchUniqueName if the name of a metric, or a tag name/value
+   * does not exist. (Bubbles up through the deferred)
+   * @since 2.4
+   */
+  Deferred<Object> configureFromQuery(final TSQuery query, final int index, boolean force_raw);
+
   /**
    * Downsamples the results by specifying a fixed interval between points.
    * <p>
@@ -262,7 +278,19 @@ public interface Query {
    * @return
    */
   public boolean isHistogramQuery();
-  
+
+  /**
+   * @return Whether or not this is a rollup query
+   * @since 2.4
+   */
+  public boolean isRollupQuery();
+
+  /**
+   * @return whether this query needs to be split.
+   * @since 2.4
+   */
+  public boolean needsSplitting();
+
   /**
    * Set the percentile calculation parameters for this query if this is 
    * a histogram query

--- a/src/core/SeekableViewChain.java
+++ b/src/core/SeekableViewChain.java
@@ -1,0 +1,97 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2014  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public class SeekableViewChain implements SeekableView {
+
+    private final List<SeekableView> iterators;
+    private int currentIterator;
+
+    SeekableViewChain(List<SeekableView> iterators) {
+        this.iterators = iterators;
+    }
+
+    /**
+     * Returns {@code true} if this view has more elements.
+     */
+    @Override
+    public boolean hasNext() {
+        SeekableView iterator = getCurrentIterator();
+        return iterator != null && iterator.hasNext();
+    }
+
+    /**
+     * Returns a <em>view</em> on the next data point.
+     * No new object gets created, the referenced returned is always the same
+     * and must not be stored since its internal data structure will change the
+     * next time {@code next()} is called.
+     *
+     * @throws NoSuchElementException if there were no more elements to iterate
+     *                                on (in which case {@link #hasNext} would have returned {@code false}.
+     */
+    @Override
+    public DataPoint next() {
+        SeekableView iterator = getCurrentIterator();
+        if (iterator == null || !iterator.hasNext()) {
+            throw new NoSuchElementException("No elements left in iterator");
+        }
+
+        DataPoint next = iterator.next();
+
+        if (!iterator.hasNext()) {
+            currentIterator++;
+        }
+
+        return next;
+    }
+
+    /**
+     * Unsupported operation.
+     *
+     * @throws UnsupportedOperationException always.
+     */
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("Removing items is not supported");
+    }
+
+    /**
+     * Advances the iterator to the given point in time.
+     * <p>
+     * This allows the iterator to skip all the data points that are strictly
+     * before the given timestamp.
+     *
+     * @param timestamp A strictly positive 32 bit UNIX timestamp (in seconds).
+     * @throws IllegalArgumentException if the timestamp is zero, or negative,
+     *                                  or doesn't fit on 32 bits (think "unsigned int" -- yay Java!).
+     */
+    @Override
+    public void seek(long timestamp) {
+        for (final SeekableView it : iterators) {
+            it.seek(timestamp);
+        }
+    }
+
+    private SeekableView getCurrentIterator() {
+        while (currentIterator < iterators.size()) {
+            if (iterators.get(currentIterator).hasNext()) {
+                return iterators.get(currentIterator);
+            }
+            currentIterator++;
+        }
+        return null;
+    }
+}

--- a/src/core/SpanGroup.java
+++ b/src/core/SpanGroup.java
@@ -12,14 +12,7 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.core;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.hbase.async.Bytes;
 import org.hbase.async.Bytes.ByteMap;
@@ -109,7 +102,10 @@ final class SpanGroup implements DataPoints {
   
   /** The TSDB to which we belong, used for resolution */
   private final TSDB tsdb;
-  
+
+  /** The group we belong to */
+  private byte[] group;
+
   /**
    * Ctor.
    * @param tsdb The TSDB we belong to.
@@ -231,7 +227,7 @@ final class SpanGroup implements DataPoints {
             final long query_end,
             final int query_index) {
      this(tsdb, start_time, end_time, spans, rate, rate_options, aggregator, 
-         downsampler, query_start, query_end, query_index, null);
+         downsampler, query_start, query_end, query_index, null, new byte[0]);
   }
   
   /**
@@ -265,7 +261,8 @@ final class SpanGroup implements DataPoints {
             final long query_start,
             final long query_end,
             final int query_index,
-            final RollupQuery rollup_query) {
+            final RollupQuery rollup_query,
+            byte[] group) {
      annotations = new ArrayList<Annotation>();
      this.start_time = (start_time & Const.SECOND_MASK) == 0 ? 
          start_time * 1000 : start_time;
@@ -285,6 +282,7 @@ final class SpanGroup implements DataPoints {
      this.query_index = query_index;
      this.rollup_query = rollup_query;
      this.tsdb = tsdb;
+     this.group = group;
   }
   
   /**
@@ -557,6 +555,18 @@ final class SpanGroup implements DataPoints {
     return getDataPoint(i).timestamp();
   }
 
+  /**
+   * Returns the group the spans in here belong to.
+   *
+   * Returns null if the NONE aggregator was requested in the query
+   * Returns an empty array if there were no group bys and they're all in the same group
+   * Returns the group otherwise
+   * @return The group
+   */
+  public byte[] group() {
+    return group;
+  }
+
   public boolean isInteger(final int i) {
     return getDataPoint(i).isInteger();
   }
@@ -585,7 +595,8 @@ final class SpanGroup implements DataPoints {
       + ", aggregator=" + aggregator
       + ", downsampler=" + downsampler
       + ", query_start=" + query_start
-      + ", query_end" + query_end
+      + ", query_end=" + query_end
+      + ", group=" + Arrays.toString(group)
       + ')';
   }
 
@@ -601,6 +612,10 @@ final class SpanGroup implements DataPoints {
   @Override
   public float getPercentile() {
     throw new UnsupportedOperationException("getPercentile not supported");
+  }
+
+  public List<Span> getSpans() {
+    return spans;
   }
   
   /**

--- a/src/core/SpanGroup.java
+++ b/src/core/SpanGroup.java
@@ -45,7 +45,7 @@ import net.opentsdb.rollup.RollupQuery;
  * {@link Aggregator}) are given.  This is done by using a special
  * iterator when using the {@link Span.DownsamplingIterator}.
  */
-final class SpanGroup implements DataPoints {
+final class SpanGroup extends AbstractSpanGroup {
   /** Annotations */
   private final ArrayList<Annotation> annotations;
 
@@ -527,28 +527,6 @@ final class SpanGroup implements DataPoints {
                                   aggregator.interpolationMethod(),
                                   downsampler, query_start, query_end,
                                   rate, rate_options, rollup_query);
-  }
-
-  /**
-   * Finds the {@code i}th data point of this group in {@code O(n)}.
-   * Where {@code n} is the number of data points in this group.
-   */
-  private DataPoint getDataPoint(int i) {
-    if (i < 0) {
-      throw new IndexOutOfBoundsException("negative index: " + i);
-    }
-    final int saved_i = i;
-    final SeekableView it = iterator();
-    DataPoint dp = null;
-    while (it.hasNext() && i >= 0) {
-      dp = it.next();
-      i--;
-    }
-    if (i != -1 || dp == null) {
-      throw new IndexOutOfBoundsException("index " + saved_i
-          + " too large (it's >= " + size() + ") for " + this);
-    }
-    return dp;
   }
 
   public long timestamp(final int i) {

--- a/src/core/SplitRollupQuery.java
+++ b/src/core/SplitRollupQuery.java
@@ -71,6 +71,11 @@ public class SplitRollupQuery extends AbstractQuery {
      */
     @Override
     public void setStartTime(long timestamp) {
+        if (rollupQuery == null) {
+            rawQuery.setStartTime(timestamp);
+            return;
+        }
+
         if (rollupQuery.getEndTime() <= timestamp) {
             rollupQuery = null;
             rawQuery.setStartTime(timestamp);

--- a/src/core/SplitRollupQuery.java
+++ b/src/core/SplitRollupQuery.java
@@ -60,7 +60,7 @@ public class SplitRollupQuery extends AbstractQuery {
     }
 
     /**
-     * Sets the start time of the graph.
+     * Sets the start time of the graph. Converts the timestamp to milliseconds if necessary.
      *
      * @param timestamp The start time, all the data points returned will have a
      *                  timestamp greater than or equal to this one.
@@ -71,6 +71,8 @@ public class SplitRollupQuery extends AbstractQuery {
      */
     @Override
     public void setStartTime(long timestamp) {
+        if ((timestamp & Const.SECOND_MASK) == 0) { timestamp *= 1000L; }
+
         if (rollupQuery == null) {
             rawQuery.setStartTime(timestamp);
             return;
@@ -101,7 +103,7 @@ public class SplitRollupQuery extends AbstractQuery {
     }
 
     /**
-     * Sets the end time of the graph.
+     * Sets the end time of the graph. Converts the timestamp to milliseconds if necessary.
      *
      * @param timestamp The end time, all the data points returned will have a
      *                  timestamp less than or equal to this one.
@@ -112,6 +114,8 @@ public class SplitRollupQuery extends AbstractQuery {
      */
     @Override
     public void setEndTime(long timestamp) {
+        if ((timestamp & Const.SECOND_MASK) == 0) { timestamp *= 1000L; }
+
         rawQuery.setEndTime(timestamp);
     }
 

--- a/src/core/SplitRollupQuery.java
+++ b/src/core/SplitRollupQuery.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
-public class SplitRollupQuery implements Query {
+public class SplitRollupQuery extends AbstractQuery {
 
     private TSDB tsdb;
 
@@ -317,57 +317,6 @@ public class SplitRollupQuery implements Query {
             rollupQuery.downsample(interval, downsampler, fill_policy);
         }
         rawQuery.downsample(interval, downsampler, fill_policy);
-    }
-
-    /**
-     * Runs this query.
-     *
-     * @return The data points matched by this query.
-     * <p>
-     * Each element in the non-{@code null} but possibly empty array returned
-     * corresponds to one time series for which some data points have been
-     * matched by the query.
-     * @throws HBaseException if there was a problem communicating with HBase to
-     *                        perform the search.
-     */
-    @Override
-    public DataPoints[] run() throws HBaseException {
-        // TODO: Avoid duplication
-        try {
-            return runAsync().joinUninterruptibly();
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new RuntimeException("Should never be here", e);
-        }
-    }
-
-    /**
-     * Runs this query.
-     *
-     * @return The data points matched by this query and applied with percentile calculation
-     * <p>
-     * Each element in the non-{@code null} but possibly empty array returned
-     * corresponds to one time series for which some data points have been
-     * matched by the query.
-     * @throws HBaseException        if there was a problem communicating with HBase to
-     *                               perform the search.
-     * @throws IllegalStateException if the query is not a histogram query
-     */
-    @Override
-    public DataPoints[] runHistogram() throws HBaseException {
-        // TODO: Avoid duplication
-        if (!isHistogramQuery()) {
-            throw new RuntimeException("Should never be here");
-        }
-
-        try {
-            return runHistogramAsync().joinUninterruptibly();
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new RuntimeException("Should never be here", e);
-        }
     }
 
     /**

--- a/src/core/SplitRollupQuery.java
+++ b/src/core/SplitRollupQuery.java
@@ -1,0 +1,522 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2010-2012  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+import net.opentsdb.rollup.RollupQuery;
+import net.opentsdb.uid.NoSuchUniqueName;
+import org.hbase.async.Bytes;
+import org.hbase.async.Bytes.ByteMap;
+import org.hbase.async.HBaseException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+public class SplitRollupQuery implements Query {
+
+    private TSDB tsdb;
+
+    private TsdbQuery rollupQuery;
+    private TsdbQuery rawQuery;
+
+    private Deferred<Object> rollupResolution;
+    private Deferred<Object> rawResolution;
+
+    SplitRollupQuery(final TSDB tsdb, TsdbQuery rollupQuery, Deferred<Object> rollupResolution) {
+        if (rollupQuery == null) {
+            throw new IllegalArgumentException("Rollup query cannot be null");
+        }
+
+        this.tsdb = tsdb;
+
+        this.rollupQuery = rollupQuery;
+        this.rollupResolution = rollupResolution;
+    }
+
+    /**
+     * Returns the start time of the graph.
+     *
+     * @return A strictly positive integer.
+     * @throws IllegalStateException if {@link #setStartTime(long)} was never
+     *                               called on this instance before.
+     */
+    @Override
+    public long getStartTime() {
+        return rollupQuery != null ? rollupQuery.getStartTime() : rawQuery.getStartTime();
+    }
+
+    /**
+     * Sets the start time of the graph.
+     *
+     * @param timestamp The start time, all the data points returned will have a
+     *                  timestamp greater than or equal to this one.
+     * @throws IllegalArgumentException if timestamp is less than or equal to 0,
+     *                                  or if it can't fit on 32 bits.
+     * @throws IllegalArgumentException if
+     *                                  {@code timestamp >= }{@link #getEndTime getEndTime}.
+     */
+    @Override
+    public void setStartTime(long timestamp) {
+        if (rollupQuery.getEndTime() <= timestamp) {
+            rollupQuery = null;
+            rawQuery.setStartTime(timestamp);
+            return;
+        }
+
+        rollupQuery.setStartTime(timestamp);
+    }
+
+    /**
+     * Returns the end time of the graph.
+     * <p>
+     * If {@link #setEndTime} was never called before, this method will
+     * automatically execute
+     * {@link #setEndTime setEndTime}{@code (System.currentTimeMillis() / 1000)}
+     * to set the end time.
+     *
+     * @return A strictly positive integer.
+     */
+    @Override
+    public long getEndTime() {
+        return rawQuery != null ? rawQuery.getEndTime() : rollupQuery.getEndTime();
+    }
+
+    /**
+     * Sets the end time of the graph.
+     *
+     * @param timestamp The end time, all the data points returned will have a
+     *                  timestamp less than or equal to this one.
+     * @throws IllegalArgumentException if timestamp is less than or equal to 0,
+     *                                  or if it can't fit on 32 bits.
+     * @throws IllegalArgumentException if
+     *                                  {@code timestamp <= }{@link #getStartTime getStartTime}.
+     */
+    @Override
+    public void setEndTime(long timestamp) {
+        rawQuery.setEndTime(timestamp);
+    }
+
+    /**
+     * Returns whether or not the data queried will be deleted.
+     *
+     * @return A boolean
+     * @since 2.4
+     */
+    @Override
+    public boolean getDelete() {
+        return rawQuery.getDelete();
+    }
+
+    /**
+     * Sets whether or not the data queried will be deleted.
+     *
+     * @param delete True if data should be deleted, false otherwise.
+     * @since 2.4
+     */
+    @Override
+    public void setDelete(boolean delete) {
+        if (rollupQuery != null) {
+            rollupQuery.setDelete(delete);
+        }
+        rawQuery.setDelete(delete);
+    }
+
+    /**
+     * Sets the time series to the query.
+     *
+     * @param metric       The metric to retrieve from the TSDB.
+     * @param tags         The set of tags of interest.
+     * @param function     The aggregation function to use.
+     * @param rate         If true, the rate of the series will be used instead of the
+     *                     actual values.
+     * @param rate_options If included specifies additional options that are used
+     *                     when calculating and graph rate values
+     * @throws NoSuchUniqueName if the name of a metric, or a tag name/value
+     *                          does not exist.
+     * @since 2.4
+     */
+    @Override
+    public void setTimeSeries(String metric,
+                              Map<String, String> tags,
+                              Aggregator function,
+                              boolean rate,
+                              RateOptions rate_options) throws NoSuchUniqueName {
+        if (rollupQuery != null) {
+            rollupQuery.setTimeSeries(metric, tags, function, rate, rate_options);
+        }
+        rawQuery.setTimeSeries(metric, tags, function, rate, rate_options);
+    }
+
+    /**
+     * Sets the time series to the query.
+     *
+     * @param metric   The metric to retrieve from the TSDB.
+     * @param tags     The set of tags of interest.
+     * @param function The aggregation function to use.
+     * @param rate     If true, the rate of the series will be used instead of the
+     *                 actual values.
+     * @throws NoSuchUniqueName if the name of a metric, or a tag name/value
+     *                          does not exist.
+     */
+    @Override
+    public void setTimeSeries(String metric, Map<String, String> tags, Aggregator function, boolean rate) throws NoSuchUniqueName {
+        if (rollupQuery != null) {
+            rollupQuery.setTimeSeries(metric, tags, function, rate);
+        }
+        rawQuery.setTimeSeries(metric, tags, function, rate);
+    }
+
+    /**
+     * Sets up a query for the given timeseries UIDs. For now, all TSUIDs in the
+     * group must share a common metric. This is to avoid issues where the scanner
+     * may have to traverse the entire data table if one TSUID has a metric of
+     * 000001 and another has a metric of FFFFFF. After modifying the query code
+     * to run asynchronously and use different scanners, we can allow different
+     * TSUIDs.
+     * <b>Note:</b> This method will not check to determine if the TSUIDs are
+     * valid, since that wastes time and we *assume* that the user provides TSUIDs
+     * that are up to date.
+     *
+     * @param tsuids   A list of one or more TSUIDs to scan for
+     * @param function The aggregation function to use on results
+     * @param rate     Whether or not the results should be converted to a rate
+     * @throws IllegalArgumentException if the tsuid list is null, empty or the
+     *                                  TSUIDs do not share a common metric
+     * @since 2.4
+     */
+    @Override
+    public void setTimeSeries(List<String> tsuids, Aggregator function, boolean rate) {
+        if (rollupQuery != null) {
+            rollupQuery.setTimeSeries(tsuids, function, rate);
+        }
+        rawQuery.setTimeSeries(tsuids, function, rate);
+    }
+
+    /**
+     * Sets up a query for the given timeseries UIDs. For now, all TSUIDs in the
+     * group must share a common metric. This is to avoid issues where the scanner
+     * may have to traverse the entire data table if one TSUID has a metric of
+     * 000001 and another has a metric of FFFFFF. After modifying the query code
+     * to run asynchronously and use different scanners, we can allow different
+     * TSUIDs.
+     * <b>Note:</b> This method will not check to determine if the TSUIDs are
+     * valid, since that wastes time and we *assume* that the user provides TSUIDs
+     * that are up to date.
+     *
+     * @param tsuids       A list of one or more TSUIDs to scan for
+     * @param function     The aggregation function to use on results
+     * @param rate         Whether or not the results should be converted to a rate
+     * @param rate_options If included specifies additional options that are used
+     *                     when calculating and graph rate values
+     * @throws IllegalArgumentException if the tsuid list is null, empty or the
+     *                                  TSUIDs do not share a common metric
+     * @since 2.4
+     */
+    @Override
+    public void setTimeSeries(List<String> tsuids, Aggregator function, boolean rate, RateOptions rate_options) {
+        if (rollupQuery != null) {
+            rollupQuery.setTimeSeries(tsuids, function, rate, rate_options);
+        }
+        rawQuery.setTimeSeries(tsuids, function, rate, rate_options);
+    }
+
+    /**
+     * Prepares a query against HBase by setting up group bys and resolving
+     * strings to UIDs asynchronously. This replaces calls to all of the setters
+     * like the {@link setTimeSeries}, {@link setStartTime}, etc.
+     * Make sure to wait on the deferred return before calling {@link runAsync}.
+     *
+     * @param query The main query to fetch the start and end time from
+     * @param index The index of which sub query we're executing
+     * @return A deferred to wait on for UID resolution. The result doesn't have
+     * any meaning and can be discarded.
+     * @throws IllegalArgumentException if the query was missing sub queries or
+     *                                  the index was out of bounds.
+     * @throws NoSuchUniqueName         if the name of a metric, or a tag name/value
+     *                                  does not exist. (Bubbles up through the deferred)
+     * @since 2.4
+     */
+    @Override
+    public Deferred<Object> configureFromQuery(TSQuery query, int index) {
+        return configureFromQuery(query, index, false);
+    }
+
+    @Override
+    public Deferred<Object> configureFromQuery(TSQuery query, int index, boolean force_raw) {
+        if (force_raw) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        if (!rollupQuery.needsSplitting()) {
+            return rollupResolution;
+        }
+
+        rawQuery = new TsdbQuery(tsdb);
+        rawResolution = rollupQuery.split(query, index, rawQuery);
+
+        if (rollupQuery.getRollupQuery().getLastRollupTimestampSeconds() * 1000L < rollupQuery.getStartTime()) {
+            // We're looking at a query that would normally hit a rollup table, but the table doesn't
+            // have data guaranteed to be available for the requested time period or any part of it
+            // (i.e. the last guaranteed rollup point is before the query actually starts)
+            // So we won't bother running it.
+            rollupQuery = null;
+        }
+
+        return Deferred.group(rollupResolution, rawResolution).addCallback(new GroupCallback());
+    }
+
+    /**
+     * Downsamples the results by specifying a fixed interval between points.
+     * <p>
+     * Technically, downsampling means reducing the sampling interval.  Here
+     * the idea is similar.  Instead of returning every single data point that
+     * matched the query, we want one data point per fixed time interval.  The
+     * way we get this one data point is by aggregating all the data points of
+     * that interval together using an {@link Aggregator}.  This enables you
+     * to compute things like the 5-minute average or 10 minute 99th percentile.
+     *
+     * @param interval    Number of seconds wanted between each data point.
+     * @param downsampler Aggregation function to use to group data points
+     */
+    @Override
+    public void downsample(long interval, Aggregator downsampler) {
+        if (rollupQuery != null) {
+            rollupQuery.downsample(interval, downsampler);
+        }
+        rawQuery.downsample(interval, downsampler);
+    }
+
+    /**
+     * Sets an optional downsampling function on this query
+     *
+     * @param interval    The interval, in milliseconds to rollup data points
+     * @param downsampler An aggregation function to use when rolling up data points
+     * @param fill_policy Policy specifying whether to interpolate or to fill
+     *                    missing intervals with special values.
+     * @throws NullPointerException     if the aggregation function is null
+     * @throws IllegalArgumentException if the interval is not greater than 0
+     * @since 2.4
+     */
+    @Override
+    public void downsample(long interval, Aggregator downsampler, FillPolicy fill_policy) {
+        if (rollupQuery != null) {
+            rollupQuery.downsample(interval, downsampler, fill_policy);
+        }
+        rawQuery.downsample(interval, downsampler, fill_policy);
+    }
+
+    /**
+     * Runs this query.
+     *
+     * @return The data points matched by this query.
+     * <p>
+     * Each element in the non-{@code null} but possibly empty array returned
+     * corresponds to one time series for which some data points have been
+     * matched by the query.
+     * @throws HBaseException if there was a problem communicating with HBase to
+     *                        perform the search.
+     */
+    @Override
+    public DataPoints[] run() throws HBaseException {
+        // TODO: Avoid duplication
+        try {
+            return runAsync().joinUninterruptibly();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Should never be here", e);
+        }
+    }
+
+    /**
+     * Runs this query.
+     *
+     * @return The data points matched by this query and applied with percentile calculation
+     * <p>
+     * Each element in the non-{@code null} but possibly empty array returned
+     * corresponds to one time series for which some data points have been
+     * matched by the query.
+     * @throws HBaseException        if there was a problem communicating with HBase to
+     *                               perform the search.
+     * @throws IllegalStateException if the query is not a histogram query
+     */
+    @Override
+    public DataPoints[] runHistogram() throws HBaseException {
+        // TODO: Avoid duplication
+        if (!isHistogramQuery()) {
+            throw new RuntimeException("Should never be here");
+        }
+
+        try {
+            return runHistogramAsync().joinUninterruptibly();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Should never be here", e);
+        }
+    }
+
+    /**
+     * Executes the query asynchronously
+     *
+     * @return The data points matched by this query.
+     * <p>
+     * Each element in the non-{@code null} but possibly empty array returned
+     * corresponds to one time series for which some data points have been
+     * matched by the query.
+     * @throws HBaseException if there was a problem communicating with HBase to
+     *                        perform the search.
+     * @since 1.2
+     */
+    @Override
+    public Deferred<DataPoints[]> runAsync() throws HBaseException {
+        Deferred<DataPoints[]> rollupResults = Deferred.fromResult(new DataPoints[0]);
+        if (rollupQuery != null) {
+            rollupResults = rollupQuery.runAsync();
+        }
+        Deferred<DataPoints[]> rawResults = rawQuery.runAsync();
+
+        return Deferred.groupInOrder(Arrays.asList(rollupResults, rawResults)).addCallback(new RunCB());
+    }
+
+    /**
+     * Runs this query asynchronously.
+     *
+     * @return The data points matched by this query and applied with percentile calculation
+     * <p>
+     * Each element in the non-{@code null} but possibly empty array returned
+     * corresponds to one time series for which some data points have been
+     * matched by the query.
+     * @throws HBaseException        if there was a problem communicating with HBase to
+     *                               perform the search.
+     * @throws IllegalStateException if the query is not a histogram query
+     */
+    @Override
+    public Deferred<DataPoints[]> runHistogramAsync() throws HBaseException {
+        Deferred<DataPoints[]> rollupResults = Deferred.fromResult(new DataPoints[0]);
+        if (rollupQuery != null) {
+            rollupResults = rollupQuery.runHistogramAsync();
+        }        Deferred<DataPoints[]> rawResults = rawQuery.runHistogramAsync();
+
+        return Deferred.groupInOrder(Arrays.asList(rollupResults, rawResults)).addCallback(new RunCB());
+    }
+
+    /**
+     * Returns an index for this sub-query in the original set of queries.
+     *
+     * @return A zero based index.
+     * @since 2.4
+     */
+    @Override
+    public int getQueryIdx() {
+        return rawQuery.getQueryIdx();
+    }
+
+    /**
+     * Check this is a histogram query or not
+     *
+     * @return
+     */
+    @Override
+    public boolean isHistogramQuery() {
+        return rawQuery.isHistogramQuery();
+    }
+
+    /**
+     * Check this is a rollup query or not
+     *
+     * @return Whether or not this is a rollup query
+     * @since 2.4
+     */
+    @Override
+    public boolean isRollupQuery() {
+        return rollupQuery != null && RollupQuery.isValidQuery(rollupQuery.getRollupQuery());
+    }
+
+    /**
+     * @since 2.4
+     */
+    @Override
+    public boolean needsSplitting() {
+        // No further splitting supported
+        return false;
+    }
+
+    /**
+     * Set the percentile calculation parameters for this query if this is
+     * a histogram query
+     *
+     * @param percentiles
+     */
+    @Override
+    public void setPercentiles(List<Float> percentiles) {
+        if (rollupQuery != null) {
+            rollupQuery.setPercentiles(percentiles);
+        }
+        rawQuery.setPercentiles(percentiles);
+    }
+
+    private class RunCB implements Callback<DataPoints[], ArrayList<DataPoints[]>> {
+
+        private ByteMap<SpanGroup> makeSpanGroupMap(DataPoints[] dataPointsArray) {
+            ByteMap<SpanGroup> map = new ByteMap<>();
+
+            for (DataPoints points : dataPointsArray) {
+                if (!(points instanceof SpanGroup)) {
+                    throw new IllegalArgumentException("Only SpanGroups implemented");
+                }
+                SpanGroup spanGroup = (SpanGroup) points;
+                map.put(spanGroup.group(), spanGroup);
+            }
+
+            return map;
+        }
+
+        private DataPoints[] merge(DataPoints[] rollup, DataPoints[] raw) {
+            ByteMap<SpanGroup> rollupResults = makeSpanGroupMap(rollup);
+            ByteMap<SpanGroup> rawResults = makeSpanGroupMap(raw);
+
+            TreeSet<byte[]> allGroups = new TreeSet<>(Bytes.MEMCMP);
+            allGroups.addAll(rollupResults.keySet());
+            allGroups.addAll(rawResults.keySet());
+
+            List<SplitRollupSpanGroup> results = new ArrayList<>(allGroups.size());
+
+            for (byte[] group : allGroups) {
+                SpanGroup rawGroup = rawResults.get(group);
+                SpanGroup rollupGroup = rollupResults.get(group);
+                results.add(new SplitRollupSpanGroup(rollupGroup, rawGroup));
+            }
+
+            return results.toArray(new DataPoints[0]);
+        }
+
+        /**
+         * After both queries have run, merge their results
+         *
+         * @param dataPointArrays The results from both queries
+         * @return The merged data points
+         */
+        @Override
+        public DataPoints[] call(ArrayList<DataPoints[]> dataPointArrays) {
+            DataPoints[] rollupResults = dataPointArrays.get(0);
+            DataPoints[] rawResults = dataPointArrays.get(1);
+
+            return merge(rollupResults, rawResults);
+        }
+    }
+}

--- a/src/core/SplitRollupSpanGroup.java
+++ b/src/core/SplitRollupSpanGroup.java
@@ -1,0 +1,439 @@
+package net.opentsdb.core;
+
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+import net.opentsdb.meta.Annotation;
+import org.hbase.async.Bytes;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SplitRollupSpanGroup implements DataPoints {
+    private final List<SpanGroup> spanGroups = new ArrayList<>();
+
+    public SplitRollupSpanGroup(SpanGroup... groups) {
+        for (SpanGroup group : groups) {
+            if (group != null) {
+                spanGroups.add(group);
+            }
+        }
+
+        if (spanGroups.isEmpty()) {
+            throw new IllegalArgumentException("At least one SpanGroup must be non-null");
+        }
+    }
+
+    /**
+     * Returns the name of the series.
+     */
+    @Override
+    public String metricName() {
+        return spanGroups.get(0).metricName();
+    }
+
+    /**
+     * Returns the name of the series.
+     *
+     * @since 1.2
+     */
+    @Override
+    public Deferred<String> metricNameAsync() {
+        return spanGroups.get(0).metricNameAsync();
+    }
+
+    /**
+     * @return the metric UID
+     * @since 2.3
+     */
+    @Override
+    public byte[] metricUID() {
+        return spanGroups.get(0).metricUID();
+    }
+
+    /**
+     * Returns the tags associated with these data points.
+     *
+     * @return A non-{@code null} map of tag names (keys), tag values (values).
+     */
+    @Override
+    public Map<String, String> getTags() {
+        Map<String, String> tags = new HashMap<>();
+
+        for (SpanGroup group : spanGroups) {
+            tags.putAll(group.getTags());
+        }
+
+        return tags;
+    }
+
+    /**
+     * Returns the tags associated with these data points.
+     *
+     * @return A non-{@code null} map of tag names (keys), tag values (values).
+     * @since 1.2
+     */
+    @Override
+    public Deferred<Map<String, String>> getTagsAsync() {
+        class GetTagsCB implements Callback<Map<String, String>, ArrayList<Map<String, String>>> {
+            @Override
+            public Map<String, String> call(ArrayList<Map<String, String>> resolvedTags) throws Exception {
+                Map<String, String> tags = new HashMap<>();
+                for (Map<String, String> groupTags : resolvedTags) {
+                    tags.putAll(groupTags);
+                }
+                return tags;
+            }
+        }
+
+        List<Deferred<Map<String, String>>> deferreds = new ArrayList<>(spanGroups.size());
+
+        for (SpanGroup group : spanGroups) {
+            deferreds.add(group.getTagsAsync());
+        }
+
+        return Deferred.groupInOrder(deferreds).addCallback(new GetTagsCB());
+    }
+
+    /**
+     * Returns a map of tag pairs as UIDs.
+     * When used on a span or row, it returns the tag set. When used on a span
+     * group it will return only the tag pairs that are common across all
+     * time series in the group.
+     *
+     * @return A potentially empty map of tagk to tagv pairs as UIDs
+     * @since 2.2
+     */
+    @Override
+    public Bytes.ByteMap<byte[]> getTagUids() {
+        Bytes.ByteMap<byte[]> tagUids = new Bytes.ByteMap<>();
+
+        for (SpanGroup group : spanGroups) {
+            tagUids.putAll(group.getTagUids());
+        }
+
+        return tagUids;
+    }
+
+    /**
+     * Returns the tags associated with some but not all of the data points.
+     * <p>
+     * When this instance represents the aggregation of multiple time series
+     * (same metric but different tags), {@link #getTags} returns the tags that
+     * are common to all data points (intersection set) whereas this method
+     * returns all the tags names that are not common to all data points (union
+     * set minus the intersection set, also called the symmetric difference).
+     * <p>
+     * If this instance does not represent an aggregation of multiple time
+     * series, the list returned is empty.
+     *
+     * @return A non-{@code null} list of tag names.
+     */
+    @Override
+    public List<String> getAggregatedTags() {
+        List<String> aggregatedTags = new ArrayList<>();
+
+        for (SpanGroup group : spanGroups) {
+            aggregatedTags.addAll(group.getAggregatedTags());
+        }
+
+        return aggregatedTags;
+    }
+
+    /**
+     * Returns the tags associated with some but not all of the data points.
+     * <p>
+     * When this instance represents the aggregation of multiple time series
+     * (same metric but different tags), {@link #getTags} returns the tags that
+     * are common to all data points (intersection set) whereas this method
+     * returns all the tags names that are not common to all data points (union
+     * set minus the intersection set, also called the symmetric difference).
+     * <p>
+     * If this instance does not represent an aggregation of multiple time
+     * series, the list returned is empty.
+     *
+     * @return A non-{@code null} list of tag names.
+     * @since 1.2
+     */
+    @Override
+    public Deferred<List<String>> getAggregatedTagsAsync() {
+        class GetAggregatedTagsCB implements Callback<List<String>, ArrayList<List<String>>> {
+            @Override
+            public List<String> call(ArrayList<List<String>> resolvedTags) throws Exception {
+                List<String> aggregatedTags = new ArrayList<>();
+                for (List<String> groupTags : resolvedTags) {
+                    aggregatedTags.addAll(groupTags);
+                }
+                return aggregatedTags;
+            }
+        }
+
+        List<Deferred<List<String>>> deferreds = new ArrayList<>(spanGroups.size());
+        for (SpanGroup group : spanGroups) {
+            deferreds.add(group.getAggregatedTagsAsync());
+        }
+
+        return Deferred.groupInOrder(deferreds).addCallback(new GetAggregatedTagsCB());
+    }
+
+    /**
+     * Returns the tagk UIDs associated with some but not all of the data points.
+     *
+     * @return a non-{@code null} list of tagk UIDs.
+     * @since 2.3
+     */
+    @Override
+    public List<byte[]> getAggregatedTagUids() {
+        List<byte[]> aggTagUids = new ArrayList<>();
+
+        for (SpanGroup group : spanGroups) {
+            aggTagUids.addAll(group.getAggregatedTagUids());
+        }
+
+        return aggTagUids;
+    }
+
+    /**
+     * Returns a list of unique TSUIDs contained in the results
+     *
+     * @return an empty list if there were no results, otherwise a list of TSUIDs
+     */
+    @Override
+    public List<String> getTSUIDs() {
+        List<String> tsuids = new ArrayList<>();
+
+        for (SpanGroup group : spanGroups) {
+            tsuids.addAll(group.getTSUIDs());
+        }
+
+        return tsuids;
+    }
+
+    /**
+     * Compiles the annotations for each span into a new array list
+     *
+     * @return Null if none of the spans had any annotations, a list if one or
+     * more were found
+     */
+    @Override
+    public List<Annotation> getAnnotations() {
+        List<Annotation> annotations = new ArrayList<>();
+
+        for (SpanGroup group : spanGroups) {
+            List<Annotation> groupAnnotations = group.getAnnotations();
+            if (groupAnnotations != null) {
+                annotations.addAll(group.getAnnotations());
+            }
+        }
+
+        return annotations;
+    }
+
+    /**
+     * Returns the number of data points.
+     * <p>
+     * This method must be implemented in {@code O(1)} or {@code O(n)}
+     * where <code>n = {@link #aggregatedSize} &gt; 0</code>.
+     *
+     * @return A positive integer.
+     */
+    @Override
+    public int size() {
+        int size = 0;
+        for (SpanGroup group : spanGroups) {
+            size += group.size();
+        }
+        return size;
+    }
+
+    /**
+     * Returns the number of data points aggregated in this instance.
+     * <p>
+     * When this instance represents the aggregation of multiple time series
+     * (same metric but different tags), {@link #size} returns the number of data
+     * points after aggregation, whereas this method returns the number of data
+     * points before aggregation.
+     * <p>
+     * If this instance does not represent an aggregation of multiple time
+     * series, then 0 is returned.
+     *
+     * @return A positive integer.
+     */
+    @Override
+    public int aggregatedSize() {
+        int aggregatedSize = 0;
+        for (SpanGroup group : spanGroups) {
+            aggregatedSize += group.aggregatedSize();
+        }
+        return aggregatedSize;
+    }
+
+    /**
+     * Returns a <em>zero-copy view</em> to go through {@code size()} data points.
+     * <p>
+     * The iterator returned must return each {@link DataPoint} in {@code O(1)}.
+     * <b>The {@link DataPoint} returned must not be stored</b> and gets
+     * invalidated as soon as {@code next} is called on the iterator.  If you
+     * want to store individual data points, you need to copy the timestamp
+     * and value out of each {@link DataPoint} into your own data structures.
+     */
+    @Override
+    public SeekableView iterator() {
+        List<SeekableView> iterators = new ArrayList<>();
+        for (SpanGroup group : spanGroups) {
+            iterators.add(group.iterator());
+        }
+        return new SeekableViewChain(iterators);
+    }
+
+    /**
+     * Returns the timestamp associated with the {@code i}th data point.
+     * The first data point has index 0.
+     * <p>
+     * This method must be implemented in
+     * <code>O({@link #aggregatedSize})</code> or better.
+     * <p>
+     * It is guaranteed that <pre>timestamp(i) &lt; timestamp(i+1)</pre>
+     *
+     * @param i
+     * @return A strictly positive integer.
+     * @throws IndexOutOfBoundsException if {@code i} is not in the range
+     *                                   <code>[0, {@link #size} - 1]</code>
+     */
+    @Override
+    public long timestamp(int i) {
+        return getDataPoint(i).timestamp();
+    }
+
+    /**
+     * Tells whether or not the {@code i}th value is of integer type.
+     * The first data point has index 0.
+     * <p>
+     * This method must be implemented in
+     * <code>O({@link #aggregatedSize})</code> or better.
+     *
+     * @param i
+     * @return {@code true} if the {@code i}th value is of integer type,
+     * {@code false} if it's of floating point type.
+     * @throws IndexOutOfBoundsException if {@code i} is not in the range
+     *                                   <code>[0, {@link #size} - 1]</code>
+     */
+    @Override
+    public boolean isInteger(int i) {
+        return getDataPoint(i).isInteger();
+    }
+
+    /**
+     * Returns the value of the {@code i}th data point as a long.
+     * The first data point has index 0.
+     * <p>
+     * This method must be implemented in
+     * <code>O({@link #aggregatedSize})</code> or better.
+     * Use {@link #iterator} to get successive {@code O(1)} accesses.
+     *
+     * @param i
+     * @throws IndexOutOfBoundsException if {@code i} is not in the range
+     *                                   <code>[0, {@link #size} - 1]</code>
+     * @throws ClassCastException        if the
+     *                                   <code>{@link #isInteger isInteger(i)} == false</code>.
+     * @see #iterator
+     */
+    @Override
+    public long longValue(int i) {
+        return getDataPoint(i).longValue();
+    }
+
+    /**
+     * Returns the value of the {@code i}th data point as a float.
+     * The first data point has index 0.
+     * <p>
+     * This method must be implemented in
+     * <code>O({@link #aggregatedSize})</code> or better.
+     * Use {@link #iterator} to get successive {@code O(1)} accesses.
+     *
+     * @param i
+     * @throws IndexOutOfBoundsException if {@code i} is not in the range
+     *                                   <code>[0, {@link #size} - 1]</code>
+     * @throws ClassCastException        if the
+     *                                   <code>{@link #isInteger isInteger(i)} == true</code>.
+     * @see #iterator
+     */
+    @Override
+    public double doubleValue(int i) {
+        return getDataPoint(i).doubleValue();
+    }
+
+    /**
+     * Return the query index that maps this datapoints to the original TSSubQuery.
+     *
+     * @return index of the query in the TSQuery class
+     * @throws UnsupportedOperationException if the implementing class can't map
+     *                                       to a sub query.
+     * @since 2.2
+     */
+    @Override
+    public int getQueryIndex() {
+        return spanGroups.get(0).getQueryIndex();
+    }
+
+    /**
+     * Return whether these data points are the result of the percentile calculation
+     * on the histogram data points. The client can call {@code getPercentile} to get
+     * the percentile calculation parameter.
+     *
+     * @return true or false
+     * @since 2.4
+     */
+    @Override
+    public boolean isPercentile() {
+        return spanGroups.get(0).isPercentile();
+    }
+
+    /**
+     * Return the percentile calculation parameter. This interface and {@code isPercentile} are used
+     * to convert {@code HistogramDataPoints} to {@code DataPoints}
+     *
+     * @return the percentile parameter
+     * @since 2.4
+     */
+    @Override
+    public float getPercentile() {
+        return spanGroups.get(0).getPercentile();
+    }
+
+    /**
+     * Returns the group the spans in here belong to.
+     * <p>
+     * Returns null if the NONE aggregator was requested in the query
+     * Returns an empty array if there were no group bys and they're all in the same group
+     * Returns the group otherwise
+     *
+     * @return The group
+     */
+    public byte[] group() {
+        return spanGroups.get(0).group();
+    }
+
+    /**
+     * Finds the {@code i}th data point of this group in {@code O(n)}.
+     * Where {@code n} is the number of data points in this group.
+     */
+    private DataPoint getDataPoint(int i) {
+        if (i < 0) {
+            throw new IndexOutOfBoundsException("negative index: " + i);
+        }
+        final int saved_i = i;
+        final SeekableView it = iterator();
+        DataPoint dp = null;
+        while (it.hasNext() && i >= 0) {
+            dp = it.next();
+            i--;
+        }
+        if (i != -1 || dp == null) {
+            throw new IndexOutOfBoundsException("index " + saved_i
+                    + " too large (it's >= " + size() + ") for " + this);
+        }
+        return dp;
+    }
+}

--- a/src/core/SplitRollupSpanGroup.java
+++ b/src/core/SplitRollupSpanGroup.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class SplitRollupSpanGroup implements DataPoints {
+public class SplitRollupSpanGroup extends AbstractSpanGroup {
     private final List<SpanGroup> spanGroups = new ArrayList<>();
 
     public SplitRollupSpanGroup(SpanGroup... groups) {
@@ -413,27 +413,5 @@ public class SplitRollupSpanGroup implements DataPoints {
      */
     public byte[] group() {
         return spanGroups.get(0).group();
-    }
-
-    /**
-     * Finds the {@code i}th data point of this group in {@code O(n)}.
-     * Where {@code n} is the number of data points in this group.
-     */
-    private DataPoint getDataPoint(int i) {
-        if (i < 0) {
-            throw new IndexOutOfBoundsException("negative index: " + i);
-        }
-        final int saved_i = i;
-        final SeekableView it = iterator();
-        DataPoint dp = null;
-        while (it.hasNext() && i >= 0) {
-            dp = it.next();
-            i--;
-        }
-        if (i != -1 || dp == null) {
-            throw new IndexOutOfBoundsException("index " + saved_i
-                    + " too large (it's >= " + size() + ") for " + this);
-        }
-        return dp;
     }
 }

--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -183,7 +183,13 @@ public final class TSDB {
   
   /** Whether or not to block writing of derived rollups/pre-ags */
   private final boolean rollups_block_derived;
-  
+
+  /**
+   * Whether or not to enable splitting rollup queries if the rollup table is lagging
+   * Global config setting: tsd.rollups.split_query.enable = true
+   */
+  private final boolean rollups_split_queries;
+
   /** An optional histogram manger used when the TSD will be dealing with
    * histograms and sketches. Instantiated ONLY if 
    * {@link #initializePlugins(boolean)} was called.*/
@@ -312,6 +318,7 @@ public final class TSDB {
       agg_tag_key = config.getString("tsd.rollups.agg_tag_key");
       raw_agg_tag_value = config.getString("tsd.rollups.raw_agg_tag_value");
       rollups_block_derived = config.getBoolean("tsd.rollups.block_derived");
+      rollups_split_queries = config.getBoolean("tsd.rollups.split_query.enable");
     } else {
       rollup_config = null;
       default_interval = null;
@@ -319,6 +326,7 @@ public final class TSDB {
       agg_tag_key = null;
       raw_agg_tag_value = null;
       rollups_block_derived = false;
+      rollups_split_queries = false;
     }
     
     QueryStats.setEnableDuplicates(
@@ -549,7 +557,7 @@ public final class TSDB {
           uid_filter.getClass().getCanonicalName() + "] version: "
           + uid_filter.version());
     }
-    
+
     // finally load the histo manager after plugins have been loaded.
     if (config.hasProperty("tsd.core.histograms.config")) {
       histogram_manager = new HistogramCodecManager(this);
@@ -566,7 +574,7 @@ public final class TSDB {
   public final Authentication getAuth() {
     return this.authentication;
   }
-
+  
   /** 
    * Returns the configured HBase client
    * @return The HBase client
@@ -2124,7 +2132,18 @@ public final class TSDB {
     return raw_agg_tag_value;
   }
 
-  /** @return The optional histogram manager registered to this TSD. 
+  /**
+   * Returns whether the global config setting allows splitting rollups queries
+   * if the rollups table to be hit is lagging.
+   *
+   * @return Whether or not splitting rollup queries is enabled
+   * @since 2.4
+   */
+  public boolean isRollupsSplittingEnabled() {
+    return rollups_split_queries;
+  }
+
+  /** @return The optional histogram manager registered to this TSD.
    * @since 2.4 */
   public HistogramCodecManager histogramManager() {
     return histogram_manager;

--- a/src/core/TSQuery.java
+++ b/src/core/TSQuery.java
@@ -240,8 +240,15 @@ public final class TSQuery {
     final List<Deferred<Object>> deferreds =
         new ArrayList<Deferred<Object>>(queries.size());
     for (int i = 0; i < queries.size(); i++) {
-      final Query query = tsdb.newQuery();
-      deferreds.add(query.configureFromQuery(this, i));
+      Query query = tsdb.newQuery();
+      Deferred<Object> resolution = query.configureFromQuery(this, i);
+
+      if (query.needsSplitting() && (query instanceof TsdbQuery)) {
+        query = new SplitRollupQuery(tsdb, (TsdbQuery) query, resolution);
+        resolution = query.configureFromQuery(this, i);
+      }
+      deferreds.add(resolution);
+
       tsdb_queries[i] = query;
     }
     

--- a/src/core/TsdbQuery.java
+++ b/src/core/TsdbQuery.java
@@ -450,8 +450,8 @@ final class TsdbQuery extends AbstractQuery {
 
     long lastRollupTimestampMillis = rollup_query.getLastRollupTimestampSeconds() * 1000L;
 
-    boolean isRawOnlyQuery = QueryUtil.isTimestampBefore(lastRollupTimestampMillis, getStartTime());
-    if (!isRawOnlyQuery) {
+    boolean needsRawAndRollupData = QueryUtil.isTimestampAfter(lastRollupTimestampMillis, getStartTime());
+    if (needsRawAndRollupData) {
       updateRollupSplitTimes(rawQuery, lastRollupTimestampMillis);
     }
 

--- a/src/core/TsdbQuery.java
+++ b/src/core/TsdbQuery.java
@@ -61,7 +61,7 @@ import net.opentsdb.utils.DateTime;
 /**
  * Non-synchronized implementation of {@link Query}.
  */
-final class TsdbQuery implements Query {
+final class TsdbQuery extends AbstractQuery {
 
   private static final Logger LOG = LoggerFactory.getLogger(TsdbQuery.class);
 
@@ -739,40 +739,7 @@ final class TsdbQuery implements Query {
       }
     }
   }
-  /**
-   * Executes the query.
-   * NOTE: Do not run the same query multiple times. Construct a new query with
-   * the same parameters again if needed
-   * TODO(cl) There are some strange occurrences when unit testing where the end
-   * time, if not set, can change between calls to run()
-   * @return An array of data points with one time series per array value
-   */
-  @Override
-  public DataPoints[] run() throws HBaseException {
-    try {
-      return runAsync().joinUninterruptibly();
-    } catch (RuntimeException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new RuntimeException("Should never be here", e);
-    }
-  }
-  
-  @Override
-  public DataPoints[] runHistogram() throws HBaseException {
-    if (!isHistogramQuery()) {
-      throw new RuntimeException("Should never be here");
-    }
-    
-    try {
-      return runHistogramAsync().joinUninterruptibly();
-    } catch (RuntimeException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new RuntimeException("Should never be here", e);
-    }
-  }
-  
+
   @Override
   public Deferred<DataPoints[]> runAsync() throws HBaseException {
     Deferred<DataPoints[]> result = null;

--- a/src/core/TsdbQuery.java
+++ b/src/core/TsdbQuery.java
@@ -229,7 +229,7 @@ final class TsdbQuery implements Query {
       return this == ROLLUP_FALLBACK || this == ROLLUP_FALLBACK_RAW;
     }
   }
-  
+
   /** Constructor. */
   public TsdbQuery(final TSDB tsdb) {
     this.tsdb = tsdb;
@@ -429,10 +429,45 @@ final class TsdbQuery implements Query {
   public void setExplicitTags(final boolean explicit_tags) {
     this.explicit_tags = explicit_tags;
   }
-  
+
+  /**
+   * Splits this query into one query for the part that is covered by the rollup
+   * table (as defined in its SLA) and one to get the data for the remaining time
+   * range from the raw table.
+   * @param query The original TSQuery as parsed
+   * @param index The index of the TSQuery
+   * @param rawQuery A new TsdbQuery instance that will be configured to hit the raw table
+   *                 for the correct time range
+   * @return the deferred analogous to {@link TsdbQuery#configureFromQuery(TSQuery, int)}
+   * @throws IllegalStateException if the query is not eligible or splitting is disabled
+   */
+  public Deferred<Object> split(final TSQuery query, final int index, final TsdbQuery rawQuery) {
+    if (!needsSplitting()) {
+      throw new IllegalStateException("Query is not eligible for splitting" + this.toString());
+    }
+
+    Deferred<Object> rawResolutionDeferred = rawQuery.configureFromQuery(query, index, true);
+
+    long lastAvailableMillis = rollup_query.getLastRollupTimestampSeconds() * 1000L;
+    boolean isRawOnlyQuery = lastAvailableMillis <= getStartTime();
+
+    if (!isRawOnlyQuery) {
+      setEndTime(lastAvailableMillis);
+      rawQuery.setStartTime(lastAvailableMillis);
+    }
+
+    return rawResolutionDeferred;
+  }
+
   @Override
-  public Deferred<Object> configureFromQuery(final TSQuery query, 
-      final int index) {
+  public Deferred<Object> configureFromQuery(final TSQuery query,
+                                             final int index) {
+    return configureFromQuery(query, index, false);
+  }
+
+
+  public Deferred<Object> configureFromQuery(final TSQuery query,
+      final int index, boolean force_raw) {
     if (query.getQueries() == null || query.getQueries().isEmpty()) {
       throw new IllegalArgumentException("Missing sub queries");
     }
@@ -477,7 +512,7 @@ final class TsdbQuery implements Query {
     percentiles = sub_query.getPercentiles();
     show_histogram_buckets = sub_query.getShowHistogramBuckets();
     
-    if (rollup_usage != ROLLUP_USAGE.ROLLUP_RAW) {
+    if (!force_raw && rollup_usage != ROLLUP_USAGE.ROLLUP_RAW) {
       //Check whether the down sampler is set and rollup is enabled
       transformDownSamplerToRollupQuery(aggregator, sub_query.getDownsample());
     }
@@ -576,7 +611,7 @@ final class TsdbQuery implements Query {
           return deferreds;
         }
       }
-      
+
       // fire off the callback chain by resolving the metric first
       return tsdb.metrics.getIdAsync(sub_query.getMetric())
           .addCallbackDeferring(new MetricCB());
@@ -587,7 +622,7 @@ final class TsdbQuery implements Query {
   public void downsample(final long interval, final Aggregator downsampler,
       final FillPolicy fill_policy) {
     this.downsampler = new DownsamplingSpecification(
-        interval, downsampler,fill_policy);
+        interval, downsampler, fill_policy);
   }
 
   /**
@@ -741,6 +776,7 @@ final class TsdbQuery implements Query {
   @Override
   public Deferred<DataPoints[]> runAsync() throws HBaseException {
     Deferred<DataPoints[]> result = null;
+
     if (use_multi_gets && override_multi_get) {
       result = this.findSpansWithMultiGetter().addCallback(new GroupByAndAggregateCB());
     } else {
@@ -777,10 +813,45 @@ final class TsdbQuery implements Query {
     if ((this.percentiles != null && this.percentiles.size() > 0) || show_histogram_buckets) {
       return true;
     }
-    
+
     return false;
   }
-  
+
+  @Override
+  public boolean isRollupQuery() {
+    return RollupQuery.isValidQuery(rollup_query);
+  }
+
+  /**
+   * Returns whether this query needs to be split. It does if
+   * - splitting of queries is enabled globally AND
+   * - it can be split (i.e. it's a valid rollups query) AND
+   * - the table it is hitting has an SLA configured that describes the blackout period AND
+   * - the query is actually looking at data from the time beyond the SLA
+   *
+   * @return whether this query needs to be split.
+   * @since 2.4
+   */
+  @Override
+  public boolean needsSplitting() {
+    if (!tsdb.isRollupsSplittingEnabled()) {
+      // Don't split if the global config doesn't allow it
+      return false;
+    }
+
+    if (!isRollupQuery()) {
+      // Don't split if it's hitting the raw table anyway
+      return false;
+    }
+
+    if (rollup_query.getRollupInterval().getMaximumLag() <= 0) {
+      // Don't split if the table doesn't have a maximum lag configured
+      return false;
+    }
+
+    return rollup_query.isInBlackoutPeriod(getEndTime());
+  }
+
   /**
    * Finds all the {@link Span}s that match this query.
    * This is what actually scans the HBase table and loads the data into
@@ -838,8 +909,8 @@ final class TsdbQuery implements Query {
     new TreeMap<byte[], Span>(new SpanCmp(metric_width));
 
     scan_start_time = System.nanoTime();
-    
-    return new MultiGetQuery(tsdb, this, metric, row_key_literals_list, 
+
+    return new MultiGetQuery(tsdb, this, metric, row_key_literals_list,
         getScanStartTimeSeconds(), getScanEndTimeSeconds(),
         tableToBeScanned(), spans, null, 0, rollup_query, query_stats, query_index, 0,
         false, search_query_failure).fetch();
@@ -954,7 +1025,8 @@ final class TsdbQuery implements Query {
               getStartTime(), 
               getEndTime(),
               query_index,
-              rollup_query);
+              rollup_query,
+              null);
           group.add(span);
           groups[i++] = group;
         }
@@ -974,7 +1046,8 @@ final class TsdbQuery implements Query {
                                               getStartTime(), 
                                               getEndTime(),
                                               query_index,
-                                              rollup_query);
+                                              rollup_query,
+                                              new byte[0]);
         if (query_stats != null) {
           query_stats.addStat(query_index, QueryStat.GROUP_BY_TIME, 0);
         }
@@ -1018,6 +1091,11 @@ final class TsdbQuery implements Query {
         //LOG.info("Span belongs to group " + Arrays.toString(group) + ": " + Arrays.toString(row));
         SpanGroup thegroup = groups.get(group);
         if (thegroup == null) {
+          // Copy the array because we're going to keep `group' and overwrite
+          // its contents. So we want the collection to have an immutable copy.
+          final byte[] group_copy = new byte[group.length];
+          System.arraycopy(group, 0, group_copy, 0, group.length);
+
           thegroup = new SpanGroup(tsdb, getScanStartTimeSeconds(),
                                    getScanEndTimeSeconds(),
                                    null, rate, rate_options, aggregator,
@@ -1025,11 +1103,8 @@ final class TsdbQuery implements Query {
                                    getStartTime(), 
                                    getEndTime(),
                                    query_index,
-                                   rollup_query);
-          // Copy the array because we're going to keep `group' and overwrite
-          // its contents. So we want the collection to have an immutable copy.
-          final byte[] group_copy = new byte[group.length];
-          System.arraycopy(group, 0, group_copy, 0, group.length);
+                                   rollup_query,
+                                   group_copy);
           groups.put(group_copy, thegroup);
         }
         thegroup.add(entry.getValue());
@@ -1503,7 +1578,7 @@ final class TsdbQuery implements Query {
   }
   
   /** Returns the UNIX timestamp from which we must start scanning.  */
-  private long getScanStartTimeSeconds() {
+  long getScanStartTimeSeconds() {
     // Begin with the raw query start time.
     long start = getStartTime();
 
@@ -1545,7 +1620,7 @@ final class TsdbQuery implements Query {
   }
 
   /** Returns the UNIX timestamp at which we must stop scanning.  */
-  private long getScanEndTimeSeconds() {
+  long getScanEndTimeSeconds() {
     // Begin with the raw query end time.
     long end = getEndTime();
 
@@ -1825,6 +1900,14 @@ final class TsdbQuery implements Query {
     }
 
   }
+
+  RateOptions getRateOptions() { return rate_options; }
+  boolean isRate() { return rate; }
+  Aggregator getAggregator() {return aggregator; }
+  DownsamplingSpecification getDownsampler() { return downsampler; }
+  RollupQuery getRollupQuery() { return rollup_query; }
+  int getQueryIndex() { return query_index; }
+
 
   /** Helps unit tests inspect private methods. */
   @VisibleForTesting

--- a/src/query/QueryUtil.java
+++ b/src/query/QueryUtil.java
@@ -403,4 +403,24 @@ public class QueryUtil {
     }
     return buf.toString();
   }
+
+  /**
+   * Compares two timestamps where either can be in seconds or milliseconds.
+   *
+   * @param ts1 The first timestamp in either seconds or milliseconds.
+   * @param ts2 The second timestamp in either seconds or milliseconds.
+   * @return Whether the first timestamp is before the second
+   */
+  public static boolean isTimestampBefore(long ts1, long ts2) {
+    boolean ts1InSeconds = (ts1 & Const.SECOND_MASK) == 0;
+    boolean ts2InSeconds = (ts2 & Const.SECOND_MASK) == 0;
+
+    if (ts1InSeconds && !ts2InSeconds) {
+      ts1 *= 1000L;
+    } else if (!ts1InSeconds && ts2InSeconds) {
+      ts2 *= 1000L;
+    }
+
+    return ts1 < ts2;
+  }
 }

--- a/src/query/QueryUtil.java
+++ b/src/query/QueryUtil.java
@@ -409,9 +409,9 @@ public class QueryUtil {
    *
    * @param ts1 The first timestamp in either seconds or milliseconds.
    * @param ts2 The second timestamp in either seconds or milliseconds.
-   * @return Whether the first timestamp is before the second
+   * @return Whether the first timestamp is after the second
    */
-  public static boolean isTimestampBefore(long ts1, long ts2) {
+  public static boolean isTimestampAfter(long ts1, long ts2) {
     boolean ts1InSeconds = (ts1 & Const.SECOND_MASK) == 0;
     boolean ts2InSeconds = (ts2 & Const.SECOND_MASK) == 0;
 
@@ -421,6 +421,6 @@ public class QueryUtil {
       ts2 *= 1000L;
     }
 
-    return ts1 < ts2;
+    return ts1 > ts2;
   }
 }

--- a/src/rollup/RollupQuery.java
+++ b/src/rollup/RollupQuery.java
@@ -17,6 +17,7 @@ import com.google.common.base.Objects;
 
 import net.opentsdb.core.Aggregator;
 import net.opentsdb.core.Aggregators;
+import net.opentsdb.utils.DateTime;
 
 /**
  * Holds information about a rollup interval and rollup aggregator.
@@ -184,5 +185,27 @@ public class RollupQuery {
    */
   public boolean isLowerSamplingRate() {
     return this.rollup_interval.getIntervalSeconds() * 1000 < sample_interval_ms;
+  }
+
+  /**
+   * Looks at the SLA configured for the table to be queried and determines the
+   * timestamp of the latest data point that is guaranteed to be covered by the
+   * table.
+   * @return last timestamp in seconds of the period guaranteed to be covered
+   */
+  public int getLastRollupTimestampSeconds() {
+    return (int) (DateTime.currentTimeMillis()/1000 - getRollupInterval().getMaximumLag());
+  }
+
+  /**
+   * Checks whether the passed timestamp is in the blackout period (between
+   * the latest guaranteed timestamp and now)
+   * @param timestampMillis The timestamp to check in milliseconds
+   * @return whether the timestamp is in the blackout period
+   */
+  public boolean isInBlackoutPeriod(long timestampMillis) {
+    long latestRollupPointTimestamp = DateTime.currentTimeMillis() - getRollupInterval().getMaximumLag()*1000L;
+
+    return timestampMillis > latestRollupPointTimestamp;
   }
 }

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -577,6 +577,7 @@ public class Config {
     default_map.put("tsd.rollups.agg_tag_key", "_aggregate");
     default_map.put("tsd.rollups.raw_agg_tag_value", "RAW");
     default_map.put("tsd.rollups.block_derived", "true");
+    default_map.put("tsd.rollups.split_query.enable", "false");
     default_map.put("tsd.rtpublisher.enable", "false");
     default_map.put("tsd.rtpublisher.plugin", "");
     default_map.put("tsd.search.enable", "false");

--- a/src/utils/DateTime.java
+++ b/src/utils/DateTime.java
@@ -18,6 +18,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.TimeZone;
 
+import com.google.common.base.Strings;
 import net.opentsdb.core.Tags;
 
 /**
@@ -184,6 +185,10 @@ public class DateTime {
    * @throws IllegalArgumentException if the interval was malformed.
    */
   public static final long parseDuration(final String duration) {
+    if (duration == null || duration.isEmpty()) {
+      throw new IllegalArgumentException("Cannot parse null or empty duration");
+    }
+
     long interval;
     long multiplier;
     double temp;
@@ -614,7 +619,7 @@ public class DateTime {
    * @since 2.3
    */
   public static int unitsToCalendarType(final String units) {
-    if (units == null || units.isEmpty()) {
+    if (Strings.isNullOrEmpty(units)) {
       throw new IllegalArgumentException("Units cannot be null or empty");
     }
     

--- a/test/core/BaseTsdbTest.java
+++ b/test/core/BaseTsdbTest.java
@@ -31,6 +31,8 @@ import net.opentsdb.auth.AuthState;
 import net.opentsdb.auth.Authentication;
 import net.opentsdb.auth.Authorization;
 import net.opentsdb.meta.Annotation;
+import net.opentsdb.rollup.RollupInterval;
+import net.opentsdb.rollup.RollupQuery;
 import net.opentsdb.storage.MockBase;
 import net.opentsdb.uid.NoSuchUniqueId;
 import net.opentsdb.uid.NoSuchUniqueName;
@@ -912,6 +914,23 @@ public class BaseTsdbTest {
     note.setDescription(NOTE_DESCRIPTION);
     note.setNotes(NOTE_NOTES);
     note.syncToStorage(tsdb, false).joinUninterruptibly();
+  }
+
+  RollupQuery makeRollupQuery() {
+    Whitebox.setInternalState(tsdb, "rollups_split_queries", true);
+    final RollupInterval oneHourWithDelay = RollupInterval.builder()
+            .setTable("fake-rollup-table")
+            .setPreAggregationTable("fake-preagg-table")
+            .setInterval("1h")
+            .setRowSpan("1d")
+            .setDelaySla("2d")
+            .build();
+    return new RollupQuery(
+            oneHourWithDelay,
+            Aggregators.SUM,
+            3600000,
+            Aggregators.SUM
+    );
   }
 
   /**

--- a/test/core/TestSeekableViewChain.java
+++ b/test/core/TestSeekableViewChain.java
@@ -1,0 +1,99 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2017  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(PowerMockRunner.class)
+public class TestSeekableViewChain {
+
+    private static final long BASE_TIME = 1356998400000L;
+    private static final DataPoint[] DATA_POINTS_1 = new DataPoint[]{
+            MutableDataPoint.ofLongValue(BASE_TIME, 40),
+            MutableDataPoint.ofLongValue(BASE_TIME + 10000, 50),
+            MutableDataPoint.ofLongValue(BASE_TIME + 30000, 70)
+    };
+
+    @Before
+    public void before() throws Exception {
+
+    }
+
+    @Test
+    public void testIteratorChain() {
+        List<SeekableView> iterators = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            iterators.add(SeekableViewsForTest.fromArray(DATA_POINTS_1));
+        }
+        SeekableViewChain chain = new SeekableViewChain(iterators);
+
+        int items = 0;
+        while (chain.hasNext()) {
+            chain.next();
+            items += 1;
+        }
+
+        assertEquals(9, items);
+    }
+
+    @Test
+    public void testSeek() {
+        List<SeekableView> iterators = new ArrayList<>();
+        iterators.add(SeekableViewsForTest.generator(
+                BASE_TIME, 10000, 5, true
+        ));
+        iterators.add(SeekableViewsForTest.generator(
+                BASE_TIME + 50000, 10000, 5, true
+        ));
+
+        SeekableViewChain chain = new SeekableViewChain(iterators);
+
+        chain.seek(BASE_TIME + 75000);
+
+        int items = 0;
+        while (chain.hasNext()) {
+            chain.next();
+            items += 1;
+        }
+
+        assertEquals(2, items);
+    }
+
+    @Test
+    public void testEmptyChain() {
+        SeekableViewChain chain = new SeekableViewChain(new ArrayList<>());
+        assertFalse(chain.hasNext());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRemoveUnsupported() {
+        makeChain(1).remove();
+    }
+
+    private SeekableViewChain makeChain(int numIterators) {
+        List<SeekableView> iterators = new ArrayList<>();
+        for (int i = 0; i < numIterators; i++) {
+            iterators.add(SeekableViewsForTest.fromArray(DATA_POINTS_1));
+        }
+        return new SeekableViewChain(iterators);
+    }
+}

--- a/test/core/TestSplitRollupQuery.java
+++ b/test/core/TestSplitRollupQuery.java
@@ -60,6 +60,17 @@ public class TestSplitRollupQuery extends BaseTsdbTest {
     }
 
     @Test
+    public void setStartTimeWithoutRollupQuery() {
+        TsdbQuery rawQuery = new TsdbQuery(tsdb);
+        Whitebox.setInternalState(queryUnderTest, "rollupQuery", (TsdbQuery)null);
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        queryUnderTest.setStartTime(42L);
+
+        assertEquals(42L, queryUnderTest.getStartTime());
+    }
+
+    @Test
     public void setEndTime() {
         TsdbQuery rawQuery = new TsdbQuery(tsdb);
         Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);

--- a/test/core/TestSplitRollupQuery.java
+++ b/test/core/TestSplitRollupQuery.java
@@ -44,8 +44,8 @@ public class TestSplitRollupQuery extends BaseTsdbTest {
     @Test
     public void setStartTime() {
         queryUnderTest.setStartTime(42L);
-        assertEquals(42L, queryUnderTest.getStartTime());
-        assertEquals(42L, rollupQuery.getStartTime());
+        assertEquals(42000L, queryUnderTest.getStartTime());
+        assertEquals(42000L, rollupQuery.getStartTime());
     }
 
     @Test
@@ -56,7 +56,7 @@ public class TestSplitRollupQuery extends BaseTsdbTest {
         rollupQuery.setEndTime(41L);
         queryUnderTest.setStartTime(42L);
 
-        assertEquals(42L, queryUnderTest.getStartTime());
+        assertEquals(42000L, queryUnderTest.getStartTime());
     }
 
     @Test
@@ -67,7 +67,7 @@ public class TestSplitRollupQuery extends BaseTsdbTest {
 
         queryUnderTest.setStartTime(42L);
 
-        assertEquals(42L, queryUnderTest.getStartTime());
+        assertEquals(42000L, queryUnderTest.getStartTime());
     }
 
     @Test
@@ -75,20 +75,21 @@ public class TestSplitRollupQuery extends BaseTsdbTest {
         TsdbQuery rawQuery = new TsdbQuery(tsdb);
         Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
 
-        rollupQuery.setEndTime(21L);
-        rawQuery.setStartTime(21L);
+        rollupQuery.setStartTime(0);
+        rollupQuery.setEndTime(21000L);
+        rawQuery.setStartTime(21000L);
 
         queryUnderTest.setEndTime(42L);
 
-        assertEquals(42L, queryUnderTest.getEndTime());
-        assertEquals(21L, rollupQuery.getEndTime());
-        assertEquals(42L, rawQuery.getEndTime());
+        assertEquals(42000L, queryUnderTest.getEndTime());
+        assertEquals(21000L, rollupQuery.getEndTime());
+        assertEquals(42000L, rawQuery.getEndTime());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void setEndTimeBeforeRawStartTime() {
         TsdbQuery rawQuery = new TsdbQuery(tsdb);
-        rawQuery.setStartTime(84L);
+        rawQuery.setStartTime(DateTime.currentTimeMillis());
 
         Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
 

--- a/test/core/TestSplitRollupQuery.java
+++ b/test/core/TestSplitRollupQuery.java
@@ -1,0 +1,317 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2015-2017  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import com.stumbleupon.async.Deferred;
+import net.opentsdb.utils.DateTime;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({DateTime.class, TsdbQuery.class})
+public class TestSplitRollupQuery extends BaseTsdbTest {
+    private SplitRollupQuery queryUnderTest;
+    private TsdbQuery rollupQuery;
+
+    @Before
+    public void beforeLocal() {
+        rollupQuery = spy(new TsdbQuery(tsdb));
+        queryUnderTest = new SplitRollupQuery(tsdb, rollupQuery, Deferred.fromResult(null));
+    }
+
+    @Test
+    public void setStartTime() {
+        queryUnderTest.setStartTime(42L);
+        assertEquals(42L, queryUnderTest.getStartTime());
+        assertEquals(42L, rollupQuery.getStartTime());
+    }
+
+    @Test
+    public void setStartTimeBeyondOriginalEnd() {
+        TsdbQuery rawQuery = new TsdbQuery(tsdb);
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        rollupQuery.setEndTime(41L);
+        queryUnderTest.setStartTime(42L);
+
+        assertEquals(42L, queryUnderTest.getStartTime());
+    }
+
+    @Test
+    public void setEndTime() {
+        TsdbQuery rawQuery = new TsdbQuery(tsdb);
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        rollupQuery.setEndTime(21L);
+        rawQuery.setStartTime(21L);
+
+        queryUnderTest.setEndTime(42L);
+
+        assertEquals(42L, queryUnderTest.getEndTime());
+        assertEquals(21L, rollupQuery.getEndTime());
+        assertEquals(42L, rawQuery.getEndTime());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setEndTimeBeforeRawStartTime() {
+        TsdbQuery rawQuery = new TsdbQuery(tsdb);
+        rawQuery.setStartTime(84L);
+
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        queryUnderTest.setEndTime(42L);
+    }
+
+    @Test
+    public void setDeletePassesThroughToBoth() {
+        TsdbQuery rawQuery = spy(new TsdbQuery(tsdb));
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        queryUnderTest.setDelete(true);
+
+        verify(rollupQuery).setDelete(true);
+        verify(rawQuery).setDelete(true);
+    }
+
+    @Test
+    public void setTimeSeriesPassesThroughToBoth() {
+        TsdbQuery rawQuery = spy(new TsdbQuery(tsdb));
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        RateOptions options = new RateOptions();
+
+        queryUnderTest.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false, options);
+
+        verify(rollupQuery).setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false, options);
+        verify(rawQuery).setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false, options);
+    }
+
+    @Test
+    public void setTimeSeriesWithoutRateOptionsPassesThroughToBoth() {
+        TsdbQuery rawQuery = spy(new TsdbQuery(tsdb));
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        queryUnderTest.setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
+
+        verify(rollupQuery).setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
+        verify(rawQuery).setTimeSeries(METRIC_STRING, tags, Aggregators.SUM, false);
+    }
+
+    @Test
+    public void setTimeSeriesWithTSUIDsPassesThroughToBoth() {
+        TsdbQuery rawQuery = spy(new TsdbQuery(tsdb));
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        List<String> tsuids = Arrays.asList("000001000001000001", "000001000001000002");
+        RateOptions options = new RateOptions();
+
+        queryUnderTest.setTimeSeries(tsuids, Aggregators.SUM, false, options);
+
+        verify(rollupQuery).setTimeSeries(tsuids, Aggregators.SUM, false, options);
+        verify(rawQuery).setTimeSeries(tsuids, Aggregators.SUM, false, options);
+    }
+
+    @Test
+    public void setTimeSeriesWithTSUIDsWithoutRateOptionsPassesThroughToBoth() {
+        TsdbQuery rawQuery = spy(new TsdbQuery(tsdb));
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        List<String> tsuids = Arrays.asList("000001000001000001", "000001000001000002");
+
+        queryUnderTest.setTimeSeries(tsuids, Aggregators.SUM, false);
+
+        verify(rollupQuery).setTimeSeries(tsuids, Aggregators.SUM, false);
+        verify(rawQuery).setTimeSeries(tsuids, Aggregators.SUM, false);
+    }
+
+    @Test
+    public void downsamplePassesThroughToBoth() {
+        TsdbQuery rawQuery = spy(new TsdbQuery(tsdb));
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        queryUnderTest.downsample(42L, Aggregators.SUM, FillPolicy.ZERO);
+
+        verify(rollupQuery).downsample(42L, Aggregators.SUM, FillPolicy.ZERO);
+        verify(rawQuery).downsample(42L, Aggregators.SUM, FillPolicy.ZERO);
+    }
+
+    @Test
+    public void downsampleWithoutFillPolicyPassesThroughToBoth() {
+        TsdbQuery rawQuery = spy(new TsdbQuery(tsdb));
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        queryUnderTest.downsample(42L, Aggregators.SUM);
+
+        verify(rollupQuery).downsample(42L, Aggregators.SUM);
+        verify(rawQuery).downsample(42L, Aggregators.SUM);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void configureFromQueryThrowsIfForcedRaw() {
+        queryUnderTest.configureFromQuery(null, 0, true);
+    }
+
+    @Test
+    public void configureFromQuerySplitsRollupQuery() {
+        mockEnableRollupQuerySplitting();
+        doReturn(Deferred.fromResult(null)).when(rollupQuery).split(any(), anyInt(), any());
+
+        assertNull(Whitebox.getInternalState(queryUnderTest, "rawQuery"));
+
+        rollupQuery.setStartTime(0);
+        queryUnderTest.configureFromQuery(null, 0, false);
+
+        verify(rollupQuery).split(eq(null), eq(0), anyObject());
+        assertNotNull(Whitebox.getInternalState(queryUnderTest, "rawQuery"));
+    }
+
+    @Test
+    public void configureFromQuerySplitsRollupQueryWithRawOnlyQuery() {
+        mockEnableRollupQuerySplitting();
+        doReturn(true).when(rollupQuery).needsSplitting();
+        doReturn(Deferred.fromResult(null)).when(rollupQuery).split(any(), anyInt(), any());
+
+        rollupQuery.setStartTime(DateTime.currentTimeMillis());
+
+        assertNull(Whitebox.getInternalState(queryUnderTest, "rawQuery"));
+
+        queryUnderTest.configureFromQuery(null, 0, false);
+
+        verify(rollupQuery).split(eq(null), eq(0), anyObject());
+        assertNotNull(Whitebox.getInternalState(queryUnderTest, "rawQuery"));
+        assertNull(Whitebox.getInternalState(queryUnderTest, "rollupQuery"));
+    }
+
+    @Test
+    public void setPercentiles() {
+        TsdbQuery rawQuery = spy(new TsdbQuery(tsdb));
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        List<Float> percentiles = Arrays.asList(50f, 75f, 99f, 99.9f);
+
+        queryUnderTest.setPercentiles(percentiles);
+
+        verify(rollupQuery).setPercentiles(percentiles);
+        verify(rawQuery).setPercentiles(percentiles);
+    }
+
+    @Test
+    public void run() {
+        TsdbQuery rawQuery = spy(new TsdbQuery(tsdb));
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        doReturn(Deferred.fromResult(new DataPoints[0])).when(rollupQuery).runAsync();
+        doReturn(Deferred.fromResult(new DataPoints[0])).when(rawQuery).runAsync();
+
+        DataPoints[] actualPoints = queryUnderTest.run();
+
+        verify(rollupQuery).runAsync();
+        verify(rawQuery).runAsync();
+
+        assertEquals(0, actualPoints.length);
+    }
+
+    @Test
+    public void runHistogram() {
+        TsdbQuery rawQuery = spy(new TsdbQuery(tsdb));
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        doReturn(true).when(rollupQuery).isHistogramQuery();
+        doReturn(Deferred.fromResult(new DataPoints[0])).when(rollupQuery).runHistogramAsync();
+        doReturn(true).when(rawQuery).isHistogramQuery();
+        doReturn(Deferred.fromResult(new DataPoints[0])).when(rawQuery).runHistogramAsync();
+
+        DataPoints[] actualPoints = queryUnderTest.runHistogram();
+
+        verify(rollupQuery).runHistogramAsync();
+        verify(rawQuery).runHistogramAsync();
+
+        assertEquals(0, actualPoints.length);
+    }
+
+    @Test
+    public void runAsyncMergesResults() {
+        TsdbQuery rawQuery = spy(new TsdbQuery(tsdb));
+        Whitebox.setInternalState(queryUnderTest, "rawQuery", rawQuery);
+
+        rollupQuery.setStartTime(0);
+        rollupQuery.setEndTime(21);
+        rawQuery.setStartTime(21);
+        rawQuery.setEndTime(42);
+
+        DataPoints[] rollupDataPoints = new DataPoints[] {
+                makeSpanGroup("group1"),
+                makeSpanGroup("group2"),
+                makeSpanGroup("group3"),
+        };
+
+        DataPoints[] rawDataPoints = new DataPoints[] {
+                makeSpanGroup("group2"),
+                makeSpanGroup("group3"),
+                makeSpanGroup("group4"),
+                makeSpanGroup("group5"),
+        };
+
+        doReturn(Deferred.fromResult(rollupDataPoints)).when(rollupQuery).runAsync();
+        doReturn(Deferred.fromResult(rawDataPoints)).when(rawQuery).runAsync();
+
+        DataPoints[] actualPoints = queryUnderTest.run();
+
+        verify(rollupQuery).runAsync();
+        verify(rawQuery).runAsync();
+
+        List<String> actualGroups = new ArrayList<>(actualPoints.length);
+        for (DataPoints dataPoints : actualPoints) {
+            actualGroups.add(new String(((SplitRollupSpanGroup) dataPoints).group()));
+        }
+        Collections.sort(actualGroups);
+
+        assertEquals(Arrays.asList("group1", "group2", "group3", "group4", "group5"), actualGroups);
+    }
+
+    private SpanGroup makeSpanGroup(String group) {
+
+        return new SpanGroup(
+                tsdb,
+                0,
+                42,
+                new ArrayList<>(),
+                false,
+                new RateOptions(),
+                Aggregators.SUM,
+                DownsamplingSpecification.NO_DOWNSAMPLER,
+                0,
+                42,
+                0,
+                null,
+                group.getBytes()
+        );
+    }
+
+    private void mockEnableRollupQuerySplitting() {
+        Whitebox.setInternalState(tsdb, "rollups_split_queries", true);
+        Whitebox.setInternalState(rollupQuery, "rollup_query", makeRollupQuery());
+    }
+}

--- a/test/core/TestSplitRollupSpanGroup.java
+++ b/test/core/TestSplitRollupSpanGroup.java
@@ -1,0 +1,194 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2015  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.core;
+
+import net.opentsdb.rollup.RollupSpan;
+import net.opentsdb.utils.Config;
+import org.hbase.async.Bytes;
+import org.hbase.async.HBaseClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({TSDB.class, HBaseClient.class, Config.class, SpanGroup.class,
+        Span.class, RollupSpan.class})
+public class TestSplitRollupSpanGroup {
+    private final static long START_TS = 1356998400L;
+    private final static long SPLIT_TS = 1356998500L;
+    private final static long END_TS = 1356998600L;
+
+    private TSDB tsdb;
+    private SpanGroup rollupSpanGroup;
+    private SpanGroup rawSpanGroup;
+
+    @Before
+    public void before() {
+        rawSpanGroup = PowerMockito.spy(new SpanGroup(tsdb, START_TS, SPLIT_TS, null, false, Aggregators.SUM, 0, null));
+        rollupSpanGroup = PowerMockito.spy(new SpanGroup(tsdb, SPLIT_TS, END_TS, null, false, Aggregators.SUM, 0, null));
+
+        doAnswer(new SeekableViewAnswer(START_TS, 100, 1, true)).when(rollupSpanGroup).iterator();
+        doAnswer(new SeekableViewAnswer(SPLIT_TS, 100, 2, true)).when(rawSpanGroup).iterator();
+
+        tsdb = PowerMockito.mock(TSDB.class);
+    }
+
+    @Test
+    public void testConstructorFiltersNullSpanGroups() {
+        SplitRollupSpanGroup group = new SplitRollupSpanGroup(null, rawSpanGroup);
+        final ArrayList<SpanGroup> actual = Whitebox.getInternalState(group, "spanGroups");
+        assertEquals(1, actual.size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorThrowsWhenAllNull() {
+        new SplitRollupSpanGroup(null, null);
+    }
+
+    @Test
+    public void testMetricName() {
+        when(rollupSpanGroup.metricName()).thenReturn("metric name");
+        assertEquals("metric name", (new SplitRollupSpanGroup(rollupSpanGroup, rawSpanGroup)).metricName());
+        verifyZeroInteractions(rawSpanGroup);
+    }
+
+    @Test
+    public void testMetricUID() {
+        when(rollupSpanGroup.metricUID()).thenReturn(new byte[]{0, 0, 1});
+        assertArrayEquals(new byte[]{0, 0, 1}, (new SplitRollupSpanGroup(rollupSpanGroup, rawSpanGroup)).metricUID());
+        verifyZeroInteractions(rawSpanGroup);
+    }
+
+    @Test
+    public void testSize() {
+        when(rollupSpanGroup.size()).thenReturn(5);
+        when(rawSpanGroup.size()).thenReturn(7);
+        assertEquals(12, (new SplitRollupSpanGroup(rollupSpanGroup, rawSpanGroup)).size());
+    }
+
+    @Test
+    public void testAggregatedSize() {
+        when(rollupSpanGroup.aggregatedSize()).thenReturn(5);
+        when(rawSpanGroup.aggregatedSize()).thenReturn(7);
+        assertEquals(12, (new SplitRollupSpanGroup(rollupSpanGroup, rawSpanGroup)).aggregatedSize());
+    }
+
+    @Test
+    public void testGetTagUids() {
+        final Bytes.ByteMap<byte[]> uids1 = new Bytes.ByteMap<>();
+        uids1.put(new byte[]{0, 0, 1}, new byte[]{0, 0, 2});
+        final Bytes.ByteMap<byte[]> uids2 = new Bytes.ByteMap<>();
+        uids2.put(new byte[]{0, 0, 3}, new byte[]{0, 0, 4});
+
+        when(rollupSpanGroup.getTagUids()).thenReturn(uids1);
+        when(rawSpanGroup.getTagUids()).thenReturn(uids2);
+
+        Bytes.ByteMap<byte[]> actual = (new SplitRollupSpanGroup(rollupSpanGroup, rawSpanGroup)).getTagUids();
+
+        assertEquals(2, actual.size());
+        assertArrayEquals(new byte[]{0, 0, 1}, actual.firstKey());
+        assertArrayEquals(new byte[]{0, 0, 2}, actual.firstEntry().getValue());
+        assertArrayEquals(new byte[]{0, 0, 3}, actual.lastKey());
+        assertArrayEquals(new byte[]{0, 0, 4}, actual.lastEntry().getValue());
+    }
+
+    @Test
+    public void testGetAggregatedTagUids() {
+        final List<byte[]> uids1 = new ArrayList<>();
+        uids1.add(new byte[]{0, 0, 1});
+        final List<byte[]> uids2 = new ArrayList<>();
+        uids2.add(new byte[]{0, 0, 2});
+
+        when(rollupSpanGroup.getAggregatedTagUids()).thenReturn(uids1);
+        when(rawSpanGroup.getAggregatedTagUids()).thenReturn(uids2);
+
+        List<byte[]> actual = (new SplitRollupSpanGroup(rollupSpanGroup, rawSpanGroup)).getAggregatedTagUids();
+
+        assertEquals(2, actual.size());
+        assertArrayEquals(new byte[]{0, 0, 1}, actual.get(0));
+        assertArrayEquals(new byte[]{0, 0, 2}, actual.get(1));
+    }
+
+    @Test
+    public void testIterator() {
+        SeekableView iterator = (new SplitRollupSpanGroup(rollupSpanGroup, rawSpanGroup)).iterator();
+        int size = 0;
+        while (iterator.hasNext()) {
+            size++;
+            iterator.next();
+        }
+        assertEquals(3, size);
+    }
+
+    @Test
+    public void testTimestamp() {
+        SplitRollupSpanGroup group = new SplitRollupSpanGroup(rollupSpanGroup, rawSpanGroup);
+        assertEquals(START_TS, group.timestamp(0));
+        assertEquals(SPLIT_TS, group.timestamp(1));
+        assertEquals(END_TS, group.timestamp(2));
+    }
+
+    @Test
+    public void testIsInteger() {
+        assertTrue(new SplitRollupSpanGroup(rollupSpanGroup).isInteger(0));
+    }
+
+    @Test
+    public void testLongValue() {
+        assertEquals(0L, new SplitRollupSpanGroup(rollupSpanGroup).longValue(0));
+    }
+
+    @Test
+    public void testDoubleValue() {
+        doAnswer(new SeekableViewAnswer(START_TS, 100, 1, false)).when(rollupSpanGroup).iterator();
+        assertEquals(0, new SplitRollupSpanGroup(rollupSpanGroup).doubleValue(0), 0.0);
+    }
+
+    @Test
+    public void testGroup() {
+        when(rollupSpanGroup.metricName()).thenReturn("group name");
+        assertEquals("group name", (new SplitRollupSpanGroup(rollupSpanGroup, rawSpanGroup)).metricName());
+        verifyZeroInteractions(rawSpanGroup);
+    }
+
+    static class SeekableViewAnswer implements Answer<SeekableView> {
+        private final long timestamp;
+        private final int samplePeriod;
+        private final int numPoints;
+        private final boolean isInteger;
+
+        SeekableViewAnswer(long startTimestamp, int samplePeriod, int numPoints, boolean isInteger) {
+            this.timestamp = startTimestamp;
+            this.samplePeriod = samplePeriod;
+            this.numPoints = numPoints;
+            this.isInteger = isInteger;
+        }
+
+        @Override
+        public SeekableView answer(InvocationOnMock ignored) {
+            return SeekableViewsForTest.generator(timestamp, samplePeriod, numPoints, isInteger);
+        }
+    }
+}

--- a/test/core/TestTSDBAddAggregatePoint.java
+++ b/test/core/TestTSDBAddAggregatePoint.java
@@ -84,6 +84,7 @@ public class TestTSDBAddAggregatePoint extends BaseTsdbTest {
     Whitebox.setInternalState(tsdb, "default_interval", 
         rollup_config.getRollupInterval("1m"));
     Whitebox.setInternalState(tsdb, "rollups_block_derived", true);
+    Whitebox.setInternalState(tsdb, "rollups_split_queries", false);
     Whitebox.setInternalState(tsdb, "agg_tag_key", 
         config.getString("tsd.rollups.agg_tag_key"));
     Whitebox.setInternalState(tsdb, "raw_agg_tag_value", 

--- a/test/core/TestTSDBAddAggregatePointSalted.java
+++ b/test/core/TestTSDBAddAggregatePointSalted.java
@@ -85,6 +85,7 @@ public class TestTSDBAddAggregatePointSalted extends TestTSDBAddAggregatePoint {
     Whitebox.setInternalState(tsdb, "default_interval", 
         rollup_config.getRollupInterval("1m"));
     Whitebox.setInternalState(tsdb, "rollups_block_derived", true);
+    Whitebox.setInternalState(tsdb, "rollups_split_queries", false);
     Whitebox.setInternalState(tsdb, "agg_tag_key", 
         config.getString("tsd.rollups.agg_tag_key"));
     Whitebox.setInternalState(tsdb, "raw_agg_tag_value", 

--- a/test/query/TestQueryUtil.java
+++ b/test/query/TestQueryUtil.java
@@ -12,6 +12,8 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.query;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -19,6 +21,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import net.opentsdb.core.Query;
+import net.opentsdb.utils.DateTime;
 import org.hbase.async.Bytes.ByteMap;
 import org.hbase.async.FilterList;
 import org.hbase.async.KeyRegexpFilter;
@@ -144,5 +148,21 @@ public class TestQueryUtil {
     verify(scanner, times(1)).setFilter(any(FilterList.class));
     verify(scanner, times(1)).setStartKey(any(byte[].class));
     verify(scanner, times(1)).setStopKey(any(byte[].class));
+  }
+
+  @Test
+  public void timestampComparison() {
+    long now = DateTime.currentTimeMillis() / 1000L;
+    assertTrue(QueryUtil.isTimestampBefore(now*1000, now+1));
+    assertTrue(QueryUtil.isTimestampBefore(now-1, now*1000L));
+    assertTrue(QueryUtil.isTimestampBefore(now-1, now));
+    assertTrue(QueryUtil.isTimestampBefore((now-1)*1000L, now*1000L));
+
+    assertFalse(QueryUtil.isTimestampBefore(now+1, now*1000L));
+    assertFalse(QueryUtil.isTimestampBefore(now*1000L, now-1));
+    assertFalse(QueryUtil.isTimestampBefore(now, now-1));
+    assertFalse(QueryUtil.isTimestampBefore(now*1000L, (now-1)*1000L));
+
+    assertFalse(QueryUtil.isTimestampBefore(now, now));
   }
 }

--- a/test/query/TestQueryUtil.java
+++ b/test/query/TestQueryUtil.java
@@ -153,16 +153,16 @@ public class TestQueryUtil {
   @Test
   public void timestampComparison() {
     long now = DateTime.currentTimeMillis() / 1000L;
-    assertTrue(QueryUtil.isTimestampBefore(now*1000, now+1));
-    assertTrue(QueryUtil.isTimestampBefore(now-1, now*1000L));
-    assertTrue(QueryUtil.isTimestampBefore(now-1, now));
-    assertTrue(QueryUtil.isTimestampBefore((now-1)*1000L, now*1000L));
+    assertFalse(QueryUtil.isTimestampAfter(now*1000, now+1));
+    assertFalse(QueryUtil.isTimestampAfter(now-1, now*1000L));
+    assertFalse(QueryUtil.isTimestampAfter(now-1, now));
+    assertFalse(QueryUtil.isTimestampAfter((now-1)*1000L, now*1000L));
 
-    assertFalse(QueryUtil.isTimestampBefore(now+1, now*1000L));
-    assertFalse(QueryUtil.isTimestampBefore(now*1000L, now-1));
-    assertFalse(QueryUtil.isTimestampBefore(now, now-1));
-    assertFalse(QueryUtil.isTimestampBefore(now*1000L, (now-1)*1000L));
+    assertTrue(QueryUtil.isTimestampAfter(now+1, now*1000L));
+    assertTrue(QueryUtil.isTimestampAfter(now*1000L, now-1));
+    assertTrue(QueryUtil.isTimestampAfter(now, now-1));
+    assertTrue(QueryUtil.isTimestampAfter(now*1000L, (now-1)*1000L));
 
-    assertFalse(QueryUtil.isTimestampBefore(now, now));
+    assertFalse(QueryUtil.isTimestampAfter(now, now));
   }
 }

--- a/test/rollup/TestRollupInterval.java
+++ b/test/rollup/TestRollupInterval.java
@@ -31,7 +31,7 @@ public class TestRollupInterval {
   private final static byte[] agg_table = preagg_table.getBytes(CHARSET);
   
   @Test
-  public void ctor1SecondHour() throws Exception {
+  public void ctor1SecondHourNoSla() throws Exception {
     final RollupInterval interval = RollupInterval.builder()
         .setTable(rollup_table)
         .setPreAggregationTable(preagg_table)
@@ -47,16 +47,18 @@ public class TestRollupInterval {
     assertEquals(preagg_table, interval.getPreAggregationTable());
     assertEquals(0, Bytes.memcmp(table, interval.getTemporalTable()));
     assertEquals(0, Bytes.memcmp(agg_table, interval.getGroupbyTable()));
+    assertEquals(0, interval.getMaximumLag());
   }
   
   // test odd boundaries
   @Test
-  public void ctor7SecondHour() throws Exception {
+  public void ctor7SecondHourTwoHoursDelay() throws Exception {
     final RollupInterval interval = RollupInterval.builder()
         .setTable(rollup_table)
         .setPreAggregationTable(preagg_table)
         .setInterval("7s")
         .setRowSpan("1h")
+        .setDelaySla("2h")
         .build();
     assertEquals('h', interval.getUnits());
     assertEquals("7s", interval.getInterval());
@@ -67,6 +69,7 @@ public class TestRollupInterval {
     assertEquals(preagg_table, interval.getPreAggregationTable());
     assertEquals(0, Bytes.memcmp(table, interval.getTemporalTable()));
     assertEquals(0, Bytes.memcmp(agg_table, interval.getGroupbyTable()));
+    assertEquals(7200, interval.getMaximumLag());
   }
   
   @Test
@@ -404,7 +407,7 @@ public class TestRollupInterval {
     .build();
   }
   
-  @Test (expected = NullPointerException.class)
+  @Test (expected = IllegalArgumentException.class)
   public void ctorNullInterval() throws Exception {
     RollupInterval.builder()
     .setTable(rollup_table)
@@ -414,7 +417,7 @@ public class TestRollupInterval {
     .build();
   }
   
-  @Test (expected = StringIndexOutOfBoundsException.class)
+  @Test (expected = IllegalArgumentException.class)
   public void ctorEmptyInterval() throws Exception {
     RollupInterval.builder()
     .setTable(rollup_table)

--- a/test/rollup/TestRollupQuery.java
+++ b/test/rollup/TestRollupQuery.java
@@ -1,0 +1,75 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2015-2017  The OpenTSDB Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.rollup;
+
+import net.opentsdb.core.Aggregators;
+import net.opentsdb.utils.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({
+        DateTime.class
+})
+public class TestRollupQuery {
+
+    private static final long MOCK_TIMESTAMP = 1554117071000L;
+    private static final int ONE_HOUR_SECONDS = 60 * 60;
+    private static final int ONE_DAY_SECONDS = 24 * ONE_HOUR_SECONDS;
+    private static final int TWO_DAYS_SECONDS = 2 * ONE_DAY_SECONDS;
+
+    private RollupQuery query;
+
+    @Before
+    public void before() {
+        final RollupInterval oneHourWithDelay = RollupInterval.builder()
+                .setTable("fake-rollup-table")
+                .setPreAggregationTable("fake-preagg-table")
+                .setInterval("1h")
+                .setRowSpan("1d")
+                .setDelaySla("2d")
+                .build();
+        query = new RollupQuery(
+                oneHourWithDelay,
+                Aggregators.SUM,
+                3600000,
+                Aggregators.SUM
+        );
+        PowerMockito.mockStatic(DateTime.class);
+        PowerMockito.when(DateTime.currentTimeMillis()).thenReturn(MOCK_TIMESTAMP);
+    }
+
+
+    @Test
+    public void testGetLastRollupTimestamp() {
+        long nowSeconds = MOCK_TIMESTAMP / 1000;
+        long twoDaysAgo = nowSeconds - TWO_DAYS_SECONDS;
+
+        assertEquals(twoDaysAgo, query.getLastRollupTimestampSeconds());
+    }
+
+    @Test
+    public void testIsInBlackoutPeriod() {
+        long oneHourAgo = MOCK_TIMESTAMP - ONE_HOUR_SECONDS * 1000;
+        assertTrue(query.isInBlackoutPeriod(oneHourAgo));
+
+        long threeDaysAgo = MOCK_TIMESTAMP - 3 * ONE_DAY_SECONDS * 1000;
+        assertFalse(query.isInBlackoutPeriod(threeDaysAgo));
+    }
+}

--- a/test/tsd/TestRollupRpc.java
+++ b/test/tsd/TestRollupRpc.java
@@ -100,7 +100,8 @@ public class TestRollupRpc extends BaseTestPutRpc {
     storage.addTable("tsdb-rollup-agg-1h".getBytes(), families);
     storage.addTable("tsdb-agg".getBytes(), families);
     Whitebox.setInternalState(tsdb, "rollups_block_derived", true);
-    Whitebox.setInternalState(tsdb, "agg_tag_key", 
+    Whitebox.setInternalState(tsdb, "rollups_split_queries", false);
+    Whitebox.setInternalState(tsdb, "agg_tag_key",
         config.getString("tsd.rollups.agg_tag_key"));
     Whitebox.setInternalState(tsdb, "raw_agg_tag_value", 
         config.getString("tsd.rollups.raw_agg_tag_value"));
@@ -850,5 +851,4 @@ public class TestRollupRpc extends BaseTestPutRpc {
     validateCounters(0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0);
     validateSEH(false);
   }
-
 }

--- a/test/utils/TestDateTime.java
+++ b/test/utils/TestDateTime.java
@@ -413,6 +413,11 @@ public final class TestDateTime {
   public void getDurationUnitsEmpty() {
     DateTime.getDurationUnits("");
   }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void getDurationIsNull() {
+    DateTime.getDurationUnits(null);
+  }
   
   @Test
   public void getDurationInterval() {


### PR DESCRIPTION
Adds a SplitRollupQuery class that suports splitting a rollup query into
two separate queries.
This is useful for when a rollup table is filled by e.g. a batch job
that processes the data from the previous day on a daily basis. Rollup
data for yesterday will then only be available some time today. This
delay SLA can be configured on a per-table basis. The delay would
specify by how much time the table can be behind real time.

If a query comes in that would query data from that blackout period
where data is only available in the raw table, but not yet guaranteed to
be in the rollup table, the incoming query can be split into two using
the SplitRollupQuery class. It wraps a query that queries the rollup
table until the last guaranteed to be available timestamp based on the
SLA; and one that gets the remaining data from the raw table.

Previously, without splitting and a lagging rollup table, the result was
something like this:
![image](https://user-images.githubusercontent.com/12208771/68773547-aaf49880-0623-11ea-8727-04f5b6b7c7fc.png)

With splitting and stitching the results, the data is complete:
![image](https://user-images.githubusercontent.com/12208771/68777006-e80f5980-0628-11ea-988f-ea279aa8a48a.png)


Query splitting needs to be enabled globally by 
- setting `tsd.rollups.split_query.enable = true` in the OpenTSDB config
- defining how far behind real time a rollup table can be in the worst case in the rollup table config, e.g. `"delaySla": "2d"` if, like in the following example, we know that the 1h rollup table is never going to be laging by more than two days:
```javascript
{
    "aggregationIds": {
        "sum": 0,
        "count": 1,
        "min": 2,
        "max": 3,
        "avg": 4
    },
    "intervals": [
        {
            "table": "tsdb",
            "preAggregationTable": "tsdb",
            "interval": "1m",
            "rowSpan": "1h",
            "defaultInterval": true
        },
        {
            "table": "tsdb-rollup-1h",
            "preAggregationTable": "tsdb-rollup-1h",
            "interval": "1h",
            "rowSpan": "1d",
            "delaySla": "2d",
            "defaultInterval": false
        }
    ]
}
```
Everything until now-2d will then be retrieved as raw data points from the table `tsdb` and all points before that from `tsdb-rollup-1h`. Results are combined into a single response so that users don't need to worry about how far rollup data is available. 

Resolves: #1686