### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleFactory.java
@@ -136,6 +136,11 @@ public class DownsampleFactory extends BaseQueryNodeFactory<DownsampleConfig, Do
       builder.setMinInterval(n.asText());
     }
     
+    n = node.get("reportingInterval");
+    if (n != null && !n.isNull()) {
+      builder.setReportingInterval(n.asText());
+    }
+    
     n = node.get("id");
     if (n != null) {
       builder.setId(n.asText());

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericToNumericArrayIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericToNumericArrayIterator.java
@@ -360,11 +360,18 @@ public class DownsampleNumericToNumericArrayIterator
       case avg:
 
         if (localDoubleAggs[5] == 0 && localLongAggs[5] == 0) {
-          v = (localDoubleAggs[0] + localLongAggs[0]) / (localDoubleAggs[1] + localLongAggs[1]);
+          v = (localDoubleAggs[0] + localLongAggs[0]) / 
+              (config.dpsInInterval() > 0 ?
+                  config.dpsInInterval() : 
+                    (localDoubleAggs[1] + localLongAggs[1]));
         } else if (localLongAggs[5] == 0) {
-          v = (double) localLongAggs[0] / (double) localLongAggs[1];
+          v = (double) localLongAggs[0] / (double) 
+              (config.dpsInInterval() > 0 ?
+                  config.dpsInInterval() : localLongAggs[1]);
         } else if (localDoubleAggs[5] == 0) {
-          v = localDoubleAggs[0] / localDoubleAggs[1];
+          v = localDoubleAggs[0] / 
+              (config.dpsInInterval() > 0 ?
+                  config.dpsInInterval() : localDoubleAggs[1]);
         }
 
         break;

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleConfig.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleConfig.java
@@ -68,6 +68,8 @@ public class TestDownsampleConfig {
         .setInterval("15s")
         .setStart("1514843302")
         .setEnd("1514846902")
+        .setMinInterval("5s")
+        .setReportingInterval("1s")
         .addInterpolatorConfig(numeric_config)
         .addInterpolatorConfig(summary_config)
         .build();
@@ -75,6 +77,8 @@ public class TestDownsampleConfig {
     assertEquals("foo", config.getId());
     assertEquals(Duration.of(15, ChronoUnit.SECONDS), config.interval());
     assertEquals(15, config.intervalPart());
+    assertEquals("5s", config.getMinInterval());
+    assertEquals(15, config.dpsInInterval());
     assertFalse(config.getFill());
     assertEquals(ZoneId.of("UTC"), config.timezone());
     assertEquals(ChronoUnit.SECONDS, config.units());
@@ -256,6 +260,8 @@ public class TestDownsampleConfig {
         .setAggregator("sum")
         .setId("foo")
         .setInterval("15s")
+        .setMinInterval("5s")
+        .setReportingInterval("1s")
         .setStart("1514843302")
         .setEnd("1514846902")
         .addInterpolatorConfig(numeric_config)
@@ -265,6 +271,8 @@ public class TestDownsampleConfig {
     final String json = JSON.serializeToString(config);
     assertTrue(json.contains("\"id\":\"foo\""));
     assertTrue(json.contains("\"interval\":\"15s\""));
+    assertTrue(json.contains("\"minInterval\":\"5s\""));
+    assertTrue(json.contains("\"reportingInterval\":\"1s\""));
     assertTrue(json.contains("\"timezone\":\"UTC\""));
     assertTrue(json.contains("\"aggregator\":\"sum\""));
     assertTrue(json.contains("\"fill\":false"));
@@ -284,9 +292,6 @@ public class TestDownsampleConfig {
     MockTSDB tsdb = MockTSDBDefault.getMockTSDB();
     
     JsonNode node = JSON.getMapper().readTree(json);
-//    System.out.println("JSON: " + json);
-//    System.out.println(node.get("start").asText());
-
     DownsampleFactory factory = new DownsampleFactory();
     config = (DownsampleConfig) factory.parseConfig(JSON.getMapper(), tsdb, node);
     
@@ -294,12 +299,13 @@ public class TestDownsampleConfig {
     assertEquals("foo", config.getId());
     assertEquals(Duration.of(15, ChronoUnit.SECONDS), config.interval());
     assertEquals(15, config.intervalPart());
+    assertEquals("5s", config.getMinInterval());
+    assertEquals(15, config.dpsInInterval());
     assertFalse(config.getFill());
     assertEquals(ZoneId.of("UTC"), config.timezone());
     assertEquals(ChronoUnit.SECONDS, config.units());
     assertFalse(config.getInfectiousNan());
     assertEquals(15, config.intervalPart());
-//    assertNull(config.startTime());
     assertEquals(1, config.getSources().size());
     assertEquals("m1", config.getSources().get(0));
     assertEquals(DownsampleFactory.TYPE, config.getType());


### PR DESCRIPTION
- Add a reporting interval config to the downsampler and if set, use it
  when computing averages as the "expected" base data point count. This is
  parcitularly useful for rolled up data when we have overlapping series
  and want an average as if the series would continue reporting for that
  interval instead of the mathematical average.