### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/AbstractQueryNode.java
+++ b/core/src/main/java/net/opentsdb/query/AbstractQueryNode.java
@@ -36,11 +36,6 @@ public abstract class AbstractQueryNode<T extends QueryNodeConfig> implements Qu
   private static final Logger LOG = 
       LoggerFactory.getLogger(AbstractQueryNode.class);
   
-  /** Return if nothing happens in the {@link #initialize(Span)} method
-   * asynchronously. */
-  protected static final Deferred<Void> INITIALIZED = 
-      Deferred.fromResult(null);
-  
   /** A reference to the query node factory that generated this node. */
   protected QueryNodeFactory factory;
   
@@ -85,7 +80,7 @@ public abstract class AbstractQueryNode<T extends QueryNodeConfig> implements Qu
     if (child != null) {
       child.setSuccessTags().finish();
     }
-    return INITIALIZED;
+    return Deferred.fromResult(null);
   }
   
   @Override

--- a/core/src/main/java/net/opentsdb/query/hacluster/HACluster.java
+++ b/core/src/main/java/net/opentsdb/query/hacluster/HACluster.java
@@ -236,7 +236,7 @@ public class HACluster extends AbstractQueryNode implements TimeSeriesDataSource
       return Deferred.fromError(new IllegalStateException(
           "Missing downstream sources."));
     }
-    return INITIALIZED;
+    return Deferred.fromResult(null);
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/merge/Merger.java
+++ b/core/src/main/java/net/opentsdb/query/processor/merge/Merger.java
@@ -71,7 +71,7 @@ public class Merger extends AbstractQueryNode {
     if (LOG.isTraceEnabled()) {
       LOG.trace("Expect to have results: " + results);
     }
-    return INITIALIZED;
+    return Deferred.fromResult(null);
   }
   
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/Summarizer.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/Summarizer.java
@@ -85,7 +85,7 @@ public class Summarizer extends AbstractQueryNode {
     if (child != null) {
       child.setSuccessTags().finish();
     }
-    return INITIALIZED;
+    return Deferred.fromResult(null);
   }
 
   @Override


### PR DESCRIPTION
- Don't rely on a static deferred in AbstractQueryNode. If a node uses this and
  calls it with an error, EVERY node that uses it will throw an error in the
  future. Sheesh.