### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/anomaly/BaseAnomalyConfig.java
+++ b/core/src/main/java/net/opentsdb/query/anomaly/BaseAnomalyConfig.java
@@ -17,6 +17,7 @@ package net.opentsdb.query.anomaly;
 import java.util.List;
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,6 +44,12 @@ public abstract class BaseAnomalyConfig
   protected final boolean serialize_observed;
   protected final boolean serialize_thresholds;
   protected final boolean serialize_deltas;
+  protected final double upper_threshold_bad;
+  protected final double upper_threshold_warn;
+  protected final boolean upper_is_scalar;
+  protected final double lower_threshold_bad;
+  protected final double lower_threshold_warn;
+  protected final boolean lower_is_scalar;
   
   protected BaseAnomalyConfig(final Builder builder) {
     super(builder);
@@ -50,6 +57,12 @@ public abstract class BaseAnomalyConfig
     serialize_observed = builder.serializeObserved;
     serialize_thresholds = builder.serializeThresholds;
     serialize_deltas = builder.serializeDeltas;
+    upper_threshold_bad = builder.upperThresholdBad;
+    upper_threshold_warn = builder.upperThresholdWarn;
+    upper_is_scalar = builder.upperIsScalar;
+    lower_threshold_bad = builder.lowerThresholdBad;
+    lower_threshold_warn = builder.lowerThresholdWarn;
+    lower_is_scalar = builder.lowerIsScalar;
   }
   
   @Override
@@ -71,6 +84,30 @@ public abstract class BaseAnomalyConfig
     return serialize_deltas;
   }
   
+  public double getUpperThresholdBad() {
+    return upper_threshold_bad;
+  }
+  
+  public double getUpperThresholdWarn() {
+    return upper_threshold_warn;
+  }
+
+  public boolean isUpperIsScalar() {
+    return upper_is_scalar;
+  }
+
+  public double getLowerThresholdBad() {
+    return lower_threshold_bad;
+  }
+  
+  public double getLowerThresholdWarn() {
+    return lower_threshold_warn;
+  }
+
+  public boolean isLowerIsScalar() {
+    return lower_is_scalar;
+  }
+  
   @Override
   public boolean equals(final Object o) {
     if (o == null) {
@@ -87,6 +124,12 @@ public abstract class BaseAnomalyConfig
     
     BaseAnomalyConfig other = (BaseAnomalyConfig) o;
     return Objects.equals(mode, other.mode) &&
+        Objects.equals(upper_threshold_bad, other.upper_threshold_bad) &&
+        Objects.equals(upper_threshold_warn, other.upper_threshold_warn) &&
+        Objects.equals(upper_is_scalar, other.upper_is_scalar) &&
+        Objects.equals(lower_threshold_bad, other.lower_threshold_bad) &&
+        Objects.equals(lower_threshold_warn, other.lower_threshold_warn) &&
+        Objects.equals(lower_is_scalar, other.lower_is_scalar) &&
         super.equals(other);
   }
   
@@ -102,16 +145,33 @@ public abstract class BaseAnomalyConfig
     final List<HashCode> hashes = Lists.newArrayListWithCapacity(2);
     hashes.add(hash);
     hashes.add(super.buildHashCode());
+    // NOTE: Purposely leaving out the thresholds.
     return Hashing.combineOrdered(hashes);
   }
   
   public static abstract class Builder<B extends Builder<B, C>, 
                                        C extends BaseQueryNodeConfigWithInterpolators> 
       extends BaseQueryNodeConfigWithInterpolators.Builder<B, C> {
+    @JsonProperty
     protected ExecutionMode mode;
+    @JsonProperty
     protected boolean serializeObserved;
+    @JsonProperty
     protected boolean serializeThresholds;
+    @JsonProperty
     protected boolean serializeDeltas;
+    @JsonProperty
+    private double upperThresholdBad;
+    @JsonProperty
+    private double upperThresholdWarn;
+    @JsonProperty
+    private boolean upperIsScalar;
+    @JsonProperty
+    private double lowerThresholdBad;
+    @JsonProperty
+    private double lowerThresholdWarn;
+    @JsonProperty
+    private boolean lowerIsScalar;
     
     public B setMode(final ExecutionMode mode) {
       this.mode = mode;
@@ -130,6 +190,36 @@ public abstract class BaseAnomalyConfig
     
     public B setSerializeDeltas(final boolean serialize_deltas) {
       this.serializeDeltas = serialize_deltas;
+      return self();
+    }
+
+    public B setUpperThresholdBad(final double upper_threshold) {
+      upperThresholdBad = upper_threshold;
+      return self();
+    }
+    
+    public B setUpperThresholdWarn(final double upper_threshold) {
+      upperThresholdWarn = upper_threshold;
+      return self();
+    }
+    
+    public B setUpperIsScalar(final boolean upper_is_scalar) {
+      upperIsScalar = upper_is_scalar;
+      return self();
+    }
+    
+    public B setLowerThresholdBad(final double lower_treshold) {
+      lowerThresholdBad = lower_treshold;
+      return self();
+    }
+    
+    public B setLowerThresholdWarn(final double lower_treshold) {
+      lowerThresholdWarn = lower_treshold;
+      return self();
+    }
+    
+    public B setLowerIsScalar(final boolean lower_is_scalar) {
+      lowerIsScalar = lower_is_scalar;
       return self();
     }
     
@@ -189,6 +279,37 @@ public abstract class BaseAnomalyConfig
       if (n != null && !n.isNull()) {
         builder.setSerializeDeltas(n.asBoolean());
       }
+      
+      n = node.get("upperThresholdBad");
+      if (n != null && !n.isNull()) {
+        builder.setUpperThresholdBad(n.asDouble());
+      }
+      
+      n = node.get("upperThresholdWarn");
+      if (n != null && !n.isNull()) {
+        builder.setUpperThresholdWarn(n.asDouble());
+      }
+      
+      n = node.get("upperIsScalar");
+      if (n != null && !n.isNull()) {
+        builder.setUpperIsScalar(n.asBoolean());
+      }
+      
+      n = node.get("lowerThresholdBad");
+      if (n != null && !n.isNull()) {
+        builder.setLowerThresholdBad(n.asDouble());
+      }
+      
+      n = node.get("lowerThresholdWarn");
+      if (n != null && !n.isNull()) {
+        builder.setLowerThresholdWarn(n.asDouble());
+      }
+      
+      n = node.get("lowerIsScalar");
+      if (n != null && !n.isNull()) {
+        builder.setLowerIsScalar(n.asBoolean());
+      }
+      
     }
   }
 }

--- a/core/src/test/java/net/opentsdb/data/types/numeric/MockNumericTimeSeries.java
+++ b/core/src/test/java/net/opentsdb/data/types/numeric/MockNumericTimeSeries.java
@@ -16,6 +16,8 @@ package net.opentsdb.data.types.numeric;
 
 import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.data.SecondTimeStamp;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesId;
@@ -65,6 +67,14 @@ public class MockNumericTimeSeries implements TimeSeries {
       throw new IllegalArgumentException("Value can't be null!");
     }
     data.add(value);
+  }
+  
+  public void add(final long second_timestamp, final long value) {
+    data.add(new MutableNumericValue(new SecondTimeStamp(second_timestamp), value));
+  }
+  
+  public void add(final long second_timestamp, final double value) {
+    data.add(new MutableNumericValue(new SecondTimeStamp(second_timestamp), value));
   }
   
   @Override

--- a/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/EgadsResult.java
+++ b/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/EgadsResult.java
@@ -70,9 +70,9 @@ public class EgadsResult implements QueryResult {
   }
 
   public void addPredictionsAndThresholds(final TimeSeries ts, 
-                                          final QueryResult result) {
+                                          final QueryResult[] results) {
     if (ts.types().contains(NumericArrayType.TYPE)) {
-      series.add(new AlignedArrayTimeSeries(ts, result));
+      series.add(new AlignedArrayTimeSeries(ts, results));
     } else {
       series.add(ts);
     }
@@ -140,11 +140,11 @@ public class EgadsResult implements QueryResult {
 
   class AlignedArrayTimeSeries implements TimeSeries {
     final TimeSeries source;
-    final QueryResult result;
+    final QueryResult[] results;
 
-    AlignedArrayTimeSeries(final TimeSeries source, final QueryResult result) {
+    AlignedArrayTimeSeries(final TimeSeries source, final QueryResult[] results) {
       this.source = source;
-      this.result = result;
+      this.results = results;
     }
 
     @Override
@@ -211,7 +211,7 @@ public class EgadsResult implements QueryResult {
         }
 
         value = (TimeSeriesValue<NumericArrayType>) iterator.next();
-        TimeStamp ts = result.timeSpecification().start().getCopy();
+        TimeStamp ts = results[0].timeSpecification().start().getCopy();
         int i = value.value().offset();
         int x = i;
         while (ts.compare(Op.LT, original_result.timeSpecification().start())) {

--- a/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/EgadsThresholdTimeSeries.java
+++ b/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/EgadsThresholdTimeSeries.java
@@ -14,6 +14,7 @@
 // limitations under the License.
 package net.opentsdb.query.anomaly.egads;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,7 @@ import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 
 import net.opentsdb.data.BaseTimeSeriesStringId;
+import net.opentsdb.data.SecondTimeStamp;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesId;
@@ -49,7 +51,7 @@ public class EgadsThresholdTimeSeries implements TimeSeries {
   
   public EgadsThresholdTimeSeries(final TimeSeriesId id, 
                                   final String suffix,
-                                  final TimeStamp timestamp,
+                                  final long prediction_start,
                                   final double[] values, 
                                   final int end_idx,
                                   final String model) {
@@ -68,7 +70,7 @@ public class EgadsThresholdTimeSeries implements TimeSeries {
     tags.put(EgadsTimeSeries.MODEL_TAG_KEY, model);
     builder.setTags(tags);
     this.id = builder.build();
-    this.timestamp = timestamp;
+    this.timestamp = new SecondTimeStamp(prediction_start);
     this.values = values;
     this.end_idx = end_idx;
   }

--- a/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/olympicscoring/OlympicScoringBaseline.java
+++ b/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/olympicscoring/OlympicScoringBaseline.java
@@ -100,7 +100,7 @@ public class OlympicScoringBaseline {
     }
   }
 
-  TimeSeries predict(final Properties properties) {
+  TimeSeries predict(final Properties properties, final long prediction_start) {
     if (baseline.size() < 2) {
       LOG.warn("Not enough data points to predict: " + baseline.size());
       return null;
@@ -111,7 +111,7 @@ public class OlympicScoringBaseline {
     final double[] results = new double[(int) node.predictionIntervals()];
     
     // fill the prediction with nans at the proper timestamps
-    long ts = node.predictionStart();
+    long ts = prediction_start;
     for (int i = 0; i < results.length; i++) {
       try {
         prediction.append(ts, Float.NaN);
@@ -134,7 +134,7 @@ public class OlympicScoringBaseline {
     final Iterator<com.yahoo.egads.data.TimeSeries.Entry> it = 
         prediction.data.iterator();
     int i = 0;
-    ts = node.predictionStart();
+    ts = prediction_start;
     while (it.hasNext()) {
       com.yahoo.egads.data.TimeSeries.Entry entry = it.next();
       if (entry.time != ts) {
@@ -147,7 +147,7 @@ public class OlympicScoringBaseline {
     }
     
     return new EgadsPredictionTimeSeries(id, results, 
-        new SecondTimeStamp(node.prediction_start));
+        new SecondTimeStamp(prediction_start));
   }
 
   void processNumeric(final TypedTimeSeriesIterator iterator) {

--- a/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/olympicscoring/OlympicScoringConfig.java
+++ b/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/olympicscoring/OlympicScoringConfig.java
@@ -39,12 +39,6 @@ public class OlympicScoringConfig extends BaseAnomalyConfig {
   private final String baseline_aggregator;
   private final int exclude_max;
   private final int exclude_min;
-  private final double upper_threshold_bad;
-  private final double upper_threshold_warn;
-  private final boolean upper_is_scalar;
-  private final double lower_threshold_bad;
-  private final double lower_threshold_warn;
-  private final boolean lower_is_scalar;
   
   protected OlympicScoringConfig(final Builder builder) {
     super(builder);
@@ -54,12 +48,6 @@ public class OlympicScoringConfig extends BaseAnomalyConfig {
     baseline_aggregator = builder.baselineAggregator;
     exclude_max = builder.excludeMax;
     exclude_min = builder.excludeMin;
-    upper_threshold_bad = builder.upperThresholdBad;
-    upper_threshold_warn = builder.upperThresholdWarn;
-    upper_is_scalar = builder.upperIsScalar;
-    lower_threshold_bad = builder.lowerThresholdBad;
-    lower_threshold_warn = builder.lowerThresholdWarn;
-    lower_is_scalar = builder.lowerIsScalar;
   }
   
   public SemanticQuery getBaselineQuery() {
@@ -84,30 +72,6 @@ public class OlympicScoringConfig extends BaseAnomalyConfig {
 
   public int getExcludeMin() {
     return exclude_min;
-  }
-
-  public double getUpperThresholdBad() {
-    return upper_threshold_bad;
-  }
-  
-  public double getUpperThresholdWarn() {
-    return upper_threshold_warn;
-  }
-
-  public boolean isUpperIsScalar() {
-    return upper_is_scalar;
-  }
-
-  public double getLowerThresholdBad() {
-    return lower_threshold_bad;
-  }
-  
-  public double getLowerThresholdWarn() {
-    return lower_threshold_warn;
-  }
-
-  public boolean isLowerIsScalar() {
-    return lower_is_scalar;
   }
 
   @Override
@@ -151,12 +115,6 @@ public class OlympicScoringConfig extends BaseAnomalyConfig {
         Objects.equals(baseline_aggregator, config.baseline_aggregator) &&
         Objects.equals(exclude_max, config.exclude_max) &&
         Objects.equals(exclude_min, config.exclude_min) &&
-        Objects.equals(upper_threshold_bad, config.upper_threshold_bad) &&
-        Objects.equals(upper_threshold_warn, config.upper_threshold_warn) &&
-        Objects.equals(upper_is_scalar, config.upper_is_scalar) &&
-        Objects.equals(lower_threshold_bad, config.lower_threshold_bad) &&
-        Objects.equals(lower_threshold_warn, config.lower_threshold_warn) &&
-        Objects.equals(lower_is_scalar, config.lower_is_scalar) &&
         baseline_query.equals(config.baseline_query) &&
         super.equals(config);
   }
@@ -174,7 +132,6 @@ public class OlympicScoringConfig extends BaseAnomalyConfig {
         .putString(baseline_aggregator, Const.UTF8_CHARSET)
         .putInt(exclude_max)
         .putInt(exclude_min)
-        // NOTE: Purposely leaving out the thresholds.
         .hash();
     final List<HashCode> hashes = Lists.newArrayListWithCapacity(3);
     hashes.add(hash);
@@ -202,18 +159,6 @@ public class OlympicScoringConfig extends BaseAnomalyConfig {
     private int excludeMax;
     @JsonProperty
     private int excludeMin;
-    @JsonProperty
-    private double upperThresholdBad;
-    @JsonProperty
-    private double upperThresholdWarn;
-    @JsonProperty
-    private boolean upperIsScalar;
-    @JsonProperty
-    private double lowerThresholdBad;
-    @JsonProperty
-    private double lowerThresholdWarn;
-    @JsonProperty
-    private boolean lowerIsScalar;
     
     Builder() {
       setType(OlympicScoringFactory.TYPE);
@@ -246,36 +191,6 @@ public class OlympicScoringConfig extends BaseAnomalyConfig {
     
     public Builder setExcludeMin(final int exclude_min) {
       excludeMin = exclude_min;
-      return this;
-    }
-    
-    public Builder setUpperThresholdBad(final double upper_threshold) {
-      upperThresholdBad = upper_threshold;
-      return this;
-    }
-    
-    public Builder setUpperThresholdWarn(final double upper_threshold) {
-      upperThresholdWarn = upper_threshold;
-      return this;
-    }
-    
-    public Builder setUpperIsScalar(final boolean upper_is_scalar) {
-      upperIsScalar = upper_is_scalar;
-      return this;
-    }
-    
-    public Builder setLowerThresholdBad(final double lower_treshold) {
-      lowerThresholdBad = lower_treshold;
-      return this;
-    }
-    
-    public Builder setLowerThresholdWarn(final double lower_treshold) {
-      lowerThresholdWarn = lower_treshold;
-      return this;
-    }
-    
-    public Builder setLowerIsScalar(final boolean lower_is_scalar) {
-      lowerIsScalar = lower_is_scalar;
       return this;
     }
     

--- a/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/olympicscoring/OlympicScoringFactory.java
+++ b/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/olympicscoring/OlympicScoringFactory.java
@@ -115,36 +115,6 @@ public class OlympicScoringFactory extends BaseQueryNodeFactory<
       builder.setExcludeMin(n.asInt());
     }
     
-    n = node.get("upperThresholdBad");
-    if (n != null && !n.isNull()) {
-      builder.setUpperThresholdBad(n.asDouble());
-    }
-    
-    n = node.get("upperThresholdWarn");
-    if (n != null && !n.isNull()) {
-      builder.setUpperThresholdWarn(n.asDouble());
-    }
-    
-    n = node.get("upperIsScalar");
-    if (n != null && !n.isNull()) {
-      builder.setUpperIsScalar(n.asBoolean());
-    }
-    
-    n = node.get("lowerThresholdBad");
-    if (n != null && !n.isNull()) {
-      builder.setLowerThresholdBad(n.asDouble());
-    }
-    
-    n = node.get("lowerThresholdWarn");
-    if (n != null && !n.isNull()) {
-      builder.setLowerThresholdWarn(n.asDouble());
-    }
-    
-    n = node.get("lowerIsScalar");
-    if (n != null && !n.isNull()) {
-      builder.setLowerIsScalar(n.asBoolean());
-    }
-    
     return builder.build();
   }
 

--- a/implementation/egads/src/test/java/net/opentsdb/query/anomaly/egads/TestEgadsThresholdEvaluator.java
+++ b/implementation/egads/src/test/java/net/opentsdb/query/anomaly/egads/TestEgadsThresholdEvaluator.java
@@ -1,0 +1,1306 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2019  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.anomaly.egads;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import net.opentsdb.data.BaseTimeSeriesStringId;
+import net.opentsdb.data.SecondTimeStamp;
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesId;
+import net.opentsdb.data.TimeSpecification;
+import net.opentsdb.data.types.numeric.MockNumericTimeSeries;
+import net.opentsdb.data.types.numeric.NumericArrayTimeSeries;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.SemanticQuery;
+import net.opentsdb.query.anomaly.AnomalyConfig.ExecutionMode;
+import net.opentsdb.query.anomaly.egads.olympicscoring.OlympicScoringConfig;
+import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
+import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
+import net.opentsdb.query.pojo.FillPolicy;
+
+public class TestEgadsThresholdEvaluator {
+  private static OlympicScoringConfig CONFIG;
+  private static NumericInterpolatorConfig INTERPOLATOR;
+  private static final int BASE_TIME = 1356998400;
+  private static final TimeSeriesId ID = BaseTimeSeriesStringId.newBuilder()
+      .setMetric("a")
+      .build();
+  
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    INTERPOLATOR = (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
+        .setFillPolicy(FillPolicy.NOT_A_NUMBER)
+        .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
+        .setDataType(NumericType.TYPE.toString())
+        .build();
+    CONFIG = OlympicScoringConfig.newBuilder()
+        .setBaselinePeriod("1h")
+        .setBaselineNumPeriods(3)
+        .setBaselineAggregator("avg")
+        .setBaselineQuery(mock(SemanticQuery.class))
+        .setSerializeObserved(true)
+        .setSerializeThresholds(true)
+        .setSerializeDeltas(true)
+        .setLowerThresholdBad(25)
+        .setUpperThresholdBad(25)
+        .setMode(ExecutionMode.EVALUATE)
+        .addInterpolatorConfig(INTERPOLATOR)
+        .addSource("ds")
+        .setId("egads")
+        .build();
+  }
+  
+  @Test
+  public void ctor() throws Exception {
+    OlympicScoringConfig config = OlympicScoringConfig.newBuilder()
+        .setBaselinePeriod("1h")
+        .setBaselineNumPeriods(3)
+        .setBaselineAggregator("avg")
+        .setBaselineQuery(mock(SemanticQuery.class))
+        .setSerializeObserved(true)
+        .setSerializeThresholds(true)
+        .setSerializeDeltas(true)
+        .setLowerThresholdBad(25)
+        .setUpperThresholdBad(25)
+        .setMode(ExecutionMode.EVALUATE)
+        .addInterpolatorConfig(INTERPOLATOR)
+        .addSource("ds")
+        .setId("egads")
+        .build();
+    
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(config, 42, 
+        mock(TimeSeries.class),
+        mock(QueryResult.class),
+        new TimeSeries[0],
+        new QueryResult[0]);
+    assertSame(config, eval.config);
+    assertEquals(42, eval.upper_bad_thresholds.length);
+    assertNull(eval.upper_warn_thresholds);
+    assertEquals(42, eval.lower_bad_thresholds.length);
+    assertNull(eval.lower_warn_thresholds);
+    assertEquals(42, eval.deltas.length);
+    assertNull(eval.alerts());
+    
+    config = OlympicScoringConfig.newBuilder()
+        .setBaselinePeriod("1h")
+        .setBaselineNumPeriods(3)
+        .setBaselineAggregator("avg")
+        .setBaselineQuery(mock(SemanticQuery.class))
+        .setLowerThresholdBad(25)
+        .setUpperThresholdBad(25)
+        .setMode(ExecutionMode.EVALUATE)
+        .addInterpolatorConfig(INTERPOLATOR)
+        .addSource("ds")
+        .setId("egads")
+        .build();
+    
+    eval = new EgadsThresholdEvaluator(config, 42, 
+        mock(TimeSeries.class),
+        mock(QueryResult.class),
+        new TimeSeries[0],
+        new QueryResult[0]);
+    assertSame(config, eval.config);
+    assertNull(eval.upper_bad_thresholds);
+    assertNull(eval.upper_warn_thresholds);
+    assertNull(eval.lower_bad_thresholds);
+    assertNull(eval.lower_warn_thresholds);
+    assertNull(eval.deltas);
+    assertNull(eval.alerts());
+  }
+
+  @Test
+  public void numericOneAligned() throws Exception {
+    TimeSeries source = new MockNumericTimeSeries(ID);
+    ((MockNumericTimeSeries) source).add(BASE_TIME, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 60, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 120, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 180, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 240, 25);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    QueryResult result = mockResult(BASE_TIME, BASE_TIME + 300);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 5, 
+        source,
+        result,
+        new TimeSeries[] { prediction },
+        new QueryResult[] { result });
+    eval.evaluate();
+    assertArrayEquals(new double[] { 31.25, 62.5, 93.75, 62.5, 31.25 }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { 18.75, 37.5, 56.25, 37.5, 18.75 }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[5], eval.deltas, 0.001);
+    assertNull(eval.alerts());
+    
+    source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(63);
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(99);
+    ((NumericArrayTimeSeries) source).add(25);
+    
+    eval = new EgadsThresholdEvaluator(CONFIG, 5, 
+        source,
+        result,
+        new TimeSeries[] { prediction },
+        new QueryResult[] { result });
+    eval.evaluate();
+    assertArrayEquals(new double[] { 31.25, 62.5, 93.75, 62.5, 31.25 }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { 18.75, 37.5, 56.25, 37.5, 18.75 }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { 0, 13, 0, 49, 0 }, eval.deltas, 0.001);
+    assertEquals(2, eval.alerts().size());
+  }
+  
+  @Test
+  public void numericOneUnAligned() throws Exception {
+    TimeSeries source = new MockNumericTimeSeries(ID);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 120, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 180, 50);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 300);
+    QueryResult prediction_result = mockResult(BASE_TIME, BASE_TIME + 300);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 5, 
+        source,
+        result,
+        new TimeSeries[] { prediction },
+        new QueryResult[] { prediction_result });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 0, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+    
+    source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(99);
+    
+    eval = new EgadsThresholdEvaluator(CONFIG, 5, 
+        source,
+        result,
+        new TimeSeries[] { prediction },
+        new QueryResult[] { prediction_result });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 49, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertEquals(1, eval.alerts().size());
+  }
+  
+  @Test
+  public void numericTwoUnAligned() throws Exception {
+    TimeSeries source = new MockNumericTimeSeries(ID);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 120, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 180, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 240, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 300, 1);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 360, 25);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    TimeSeries prediction2 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 300));
+    ((NumericArrayTimeSeries) prediction2).add(1);
+    ((NumericArrayTimeSeries) prediction2).add(25);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    ((NumericArrayTimeSeries) prediction2).add(75);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 480);
+    QueryResult prediction_result = mockResult(BASE_TIME, BASE_TIME + 300);
+    QueryResult prediction_result2 = mockResult(BASE_TIME + 300, BASE_TIME + 600);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 10, 
+        source,
+        result,
+        new TimeSeries[] { prediction, prediction2 },
+        new QueryResult[] { prediction_result, prediction_result2 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        1.25, 31.25, Double.NaN, Double.NaN, Double.NaN}, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        .75, 18.75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 0, 0, 
+        0, 0, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+    
+    source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(99);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    ((NumericArrayTimeSeries) source).add(83);
+    
+    eval = new EgadsThresholdEvaluator(CONFIG, 10, 
+        source,
+        result,
+        new TimeSeries[] { prediction, prediction2 },
+        new QueryResult[] { prediction_result, prediction_result2 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        1.25, 31.25, Double.NaN, Double.NaN, Double.NaN}, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        .75, 18.75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 49, 0, 
+        0, 58, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertEquals(2, eval.alerts().size());
+  }
+  
+  @Test
+  public void numericThreeUnAligned() throws Exception {
+    TimeSeries source = new MockNumericTimeSeries(ID);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 120, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 180, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 240, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 300, 1);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 360, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 420, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 480, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 540, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 600, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 660, 1);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    TimeSeries prediction2 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 300));
+    ((NumericArrayTimeSeries) prediction2).add(1);
+    ((NumericArrayTimeSeries) prediction2).add(25);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    ((NumericArrayTimeSeries) prediction2).add(75);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    
+    TimeSeries prediction3 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 600));
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(1);
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(50);
+    ((NumericArrayTimeSeries) prediction3).add(75);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 720);
+    QueryResult prediction_result = mockResult(BASE_TIME, BASE_TIME + 300);
+    QueryResult prediction_result2 = mockResult(BASE_TIME + 300, BASE_TIME + 600);
+    QueryResult prediction_result3 = mockResult(BASE_TIME + 600, BASE_TIME + 900);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { prediction, prediction2, prediction3 },
+        new QueryResult[] { prediction_result, prediction_result2, prediction_result3 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        1.25, 31.25, 62.5, 93.75, 62.5, 
+        31.25, 1.25, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        .75, 18.75, 37.5, 56.25, 37.5,
+        18.75, .75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 0, 0, 
+        0, 0, 0, 0, 0, 
+        0, 0, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+    
+    source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(99);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(0);
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(108);
+    ((NumericArrayTimeSeries) source).add(1);
+    
+    eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { prediction, prediction2, prediction3 },
+        new QueryResult[] { prediction_result, prediction_result2, prediction_result3 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        1.25, 31.25, 62.5, 93.75, 62.5, 
+        31.25, 1.25, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        .75, 18.75, 37.5, 56.25, 37.5,
+        18.75, .75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 49, 0, 
+        0, 0, -50, 0, 0, 
+        83, 0, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertEquals(3, eval.alerts().size());
+  }
+  
+  @Test
+  public void numericThreeUnAlignedFirstNull() throws Exception {
+    TimeSeries source = new MockNumericTimeSeries(ID);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 120, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 180, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 240, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 300, 1);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 360, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 420, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 480, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 540, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 600, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 660, 1);
+    
+    TimeSeries prediction2 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 300));
+    ((NumericArrayTimeSeries) prediction2).add(1);
+    ((NumericArrayTimeSeries) prediction2).add(25);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    ((NumericArrayTimeSeries) prediction2).add(75);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    
+    TimeSeries prediction3 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 600));
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(1);
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(50);
+    ((NumericArrayTimeSeries) prediction3).add(75);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 720);
+    QueryResult prediction_result2 = mockResult(BASE_TIME + 300, BASE_TIME + 600);
+    QueryResult prediction_result3 = mockResult(BASE_TIME + 600, BASE_TIME + 900);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { null, prediction2, prediction3 },
+        new QueryResult[] { null, prediction_result2, prediction_result3 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        1.25, 31.25, 62.5, 93.75, 62.5, 
+        31.25, 1.25, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        .75, 18.75, 37.5, 56.25, 37.5,
+        18.75, .75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        0, 0, 0, 0, 0, 
+        0, 0, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+  }
+  
+  @Test
+  public void numericThreeUnAlignedFirstTwoNull() throws Exception {
+    TimeSeries source = new MockNumericTimeSeries(ID);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 120, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 180, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 240, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 300, 1);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 360, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 420, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 480, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 540, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 600, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 660, 1);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    TimeSeries prediction3 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 600));
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(1);
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(50);
+    ((NumericArrayTimeSeries) prediction3).add(75);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 720);
+    QueryResult prediction_result3 = mockResult(BASE_TIME + 600, BASE_TIME + 900);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { null, null, prediction3 },
+        new QueryResult[] { null, null, prediction_result3 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        31.25, 1.25, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        18.75, .75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        0, 0, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+    
+    source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(99);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(0);
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(108);
+    ((NumericArrayTimeSeries) source).add(1);
+  }
+  
+  @Test
+  public void numericThreeUnAlignedMiddleNull() throws Exception {
+    TimeSeries source = new MockNumericTimeSeries(ID);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 120, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 180, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 240, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 300, 1);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 360, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 420, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 480, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 540, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 600, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 660, 1);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    TimeSeries prediction3 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 600));
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(1);
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(50);
+    ((NumericArrayTimeSeries) prediction3).add(75);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 720);
+    QueryResult prediction_result = mockResult(BASE_TIME, BASE_TIME + 300);
+    QueryResult prediction_result3 = mockResult(BASE_TIME + 600, BASE_TIME + 900);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { prediction, null, prediction3 },
+        new QueryResult[] { prediction_result, null, prediction_result3 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        31.25, 1.25, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        18.75, .75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 0, 0, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        0, 0, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+  }
+  
+  @Test
+  public void numericThreeUnAlignedMiddleAndEndNull() throws Exception {
+    TimeSeries source = new MockNumericTimeSeries(ID);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 120, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 180, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 240, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 300, 1);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 360, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 420, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 480, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 540, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 600, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 660, 1);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 720);
+    QueryResult prediction_result = mockResult(BASE_TIME, BASE_TIME + 300);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { prediction, null, null },
+        new QueryResult[] { prediction_result, null, null });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 0, 0, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+  }
+  
+  @Test
+  public void numericThreeUnAlignedEndNull() throws Exception {
+    TimeSeries source = new MockNumericTimeSeries(ID);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 120, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 180, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 240, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 300, 1);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 360, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 420, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 480, 75);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 540, 50);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 600, 25);
+    ((MockNumericTimeSeries) source).add(BASE_TIME + 660, 1);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    TimeSeries prediction2 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 300));
+    ((NumericArrayTimeSeries) prediction2).add(1);
+    ((NumericArrayTimeSeries) prediction2).add(25);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    ((NumericArrayTimeSeries) prediction2).add(75);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 720);
+    QueryResult prediction_result = mockResult(BASE_TIME, BASE_TIME + 300);
+    QueryResult prediction_result2 = mockResult(BASE_TIME + 300, BASE_TIME + 600);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { prediction, prediction2, null },
+        new QueryResult[] { prediction_result, prediction_result2, null });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        1.25, 31.25, 62.5, 93.75, 62.5, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        .75, 18.75, 37.5, 56.25, 37.5,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 0, 0, 
+        0, 0, 0, 0, 0, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+  }
+  
+  @Test
+  public void arrayOneAligned() throws Exception {
+    TimeSeries source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    QueryResult result = mockResult(BASE_TIME, BASE_TIME + 300);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 5, 
+        source,
+        result,
+        new TimeSeries[] { prediction },
+        new QueryResult[] { result });
+    eval.evaluate();
+    assertArrayEquals(new double[] { 31.25, 62.5, 93.75, 62.5, 31.25 }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { 18.75, 37.5, 56.25, 37.5, 18.75 }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[5], eval.deltas, 0.001);
+    assertNull(eval.alerts());
+    
+    source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(63);
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(99);
+    ((NumericArrayTimeSeries) source).add(25);
+    
+    eval = new EgadsThresholdEvaluator(CONFIG, 5, 
+        source,
+        result,
+        new TimeSeries[] { prediction },
+        new QueryResult[] { result });
+    eval.evaluate();
+    assertArrayEquals(new double[] { 31.25, 62.5, 93.75, 62.5, 31.25 }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { 18.75, 37.5, 56.25, 37.5, 18.75 }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { 0, 13, 0, 49, 0 }, eval.deltas, 0.001);
+    assertEquals(2, eval.alerts().size());
+  }
+  
+  @Test
+  public void arrayOneUnAligned() throws Exception {
+    TimeSeries source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 300);
+    QueryResult prediction_result = mockResult(BASE_TIME, BASE_TIME + 300);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 5, 
+        source,
+        result,
+        new TimeSeries[] { prediction },
+        new QueryResult[] { prediction_result });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 0, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+    
+    source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(99);
+    
+    eval = new EgadsThresholdEvaluator(CONFIG, 5, 
+        source,
+        result,
+        new TimeSeries[] { prediction },
+        new QueryResult[] { prediction_result });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 49, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertEquals(1, eval.alerts().size());
+  }
+  
+  @Test
+  public void arrayTwoUnAligned() throws Exception {
+    TimeSeries source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    ((NumericArrayTimeSeries) source).add(25);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    TimeSeries prediction2 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 300));
+    ((NumericArrayTimeSeries) prediction2).add(1);
+    ((NumericArrayTimeSeries) prediction2).add(25);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    ((NumericArrayTimeSeries) prediction2).add(75);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 480);
+    QueryResult prediction_result = mockResult(BASE_TIME, BASE_TIME + 300);
+    QueryResult prediction_result2 = mockResult(BASE_TIME + 300, BASE_TIME + 600);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 10, 
+        source,
+        result,
+        new TimeSeries[] { prediction, prediction2 },
+        new QueryResult[] { prediction_result, prediction_result2 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        1.25, 31.25, Double.NaN, Double.NaN, Double.NaN}, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        .75, 18.75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 0, 0, 
+        0, 0, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+    
+    source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(99);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    ((NumericArrayTimeSeries) source).add(83);
+    
+    eval = new EgadsThresholdEvaluator(CONFIG, 10, 
+        source,
+        result,
+        new TimeSeries[] { prediction, prediction2 },
+        new QueryResult[] { prediction_result, prediction_result2 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        1.25, 31.25, Double.NaN, Double.NaN, Double.NaN}, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        .75, 18.75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 49, 0, 
+        0, 58, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertEquals(2, eval.alerts().size());
+  }
+  
+  @Test
+  public void arrayThreeUnAligned() throws Exception {
+    TimeSeries source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    TimeSeries prediction2 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 300));
+    ((NumericArrayTimeSeries) prediction2).add(1);
+    ((NumericArrayTimeSeries) prediction2).add(25);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    ((NumericArrayTimeSeries) prediction2).add(75);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    
+    TimeSeries prediction3 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 600));
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(1);
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(50);
+    ((NumericArrayTimeSeries) prediction3).add(75);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 720);
+    QueryResult prediction_result = mockResult(BASE_TIME, BASE_TIME + 300);
+    QueryResult prediction_result2 = mockResult(BASE_TIME + 300, BASE_TIME + 600);
+    QueryResult prediction_result3 = mockResult(BASE_TIME + 600, BASE_TIME + 900);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { prediction, prediction2, prediction3 },
+        new QueryResult[] { prediction_result, prediction_result2, prediction_result3 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        1.25, 31.25, 62.5, 93.75, 62.5, 
+        31.25, 1.25, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        .75, 18.75, 37.5, 56.25, 37.5,
+        18.75, .75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 0, 0, 
+        0, 0, 0, 0, 0, 
+        0, 0, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+    
+    source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(99);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(0);
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(108);
+    ((NumericArrayTimeSeries) source).add(1);
+    
+    eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { prediction, prediction2, prediction3 },
+        new QueryResult[] { prediction_result, prediction_result2, prediction_result3 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        1.25, 31.25, 62.5, 93.75, 62.5, 
+        31.25, 1.25, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        .75, 18.75, 37.5, 56.25, 37.5,
+        18.75, .75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 49, 0, 
+        0, 0, -50, 0, 0, 
+        83, 0, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertEquals(3, eval.alerts().size());
+  }
+  
+  @Test
+  public void arrayThreeUnAlignedFirstNull() throws Exception {
+    TimeSeries source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    
+    TimeSeries prediction2 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 300));
+    ((NumericArrayTimeSeries) prediction2).add(1);
+    ((NumericArrayTimeSeries) prediction2).add(25);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    ((NumericArrayTimeSeries) prediction2).add(75);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    
+    TimeSeries prediction3 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 600));
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(1);
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(50);
+    ((NumericArrayTimeSeries) prediction3).add(75);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 720);
+    QueryResult prediction_result2 = mockResult(BASE_TIME + 300, BASE_TIME + 600);
+    QueryResult prediction_result3 = mockResult(BASE_TIME + 600, BASE_TIME + 900);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { null, prediction2, prediction3 },
+        new QueryResult[] { null, prediction_result2, prediction_result3 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        1.25, 31.25, 62.5, 93.75, 62.5, 
+        31.25, 1.25, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        .75, 18.75, 37.5, 56.25, 37.5,
+        18.75, .75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        0, 0, 0, 0, 0, 
+        0, 0, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+  }
+  
+  @Test
+  public void arrayThreeUnAlignedFirstTwoNull() throws Exception {
+    TimeSeries source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    TimeSeries prediction3 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 600));
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(1);
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(50);
+    ((NumericArrayTimeSeries) prediction3).add(75);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 720);
+    QueryResult prediction_result3 = mockResult(BASE_TIME + 600, BASE_TIME + 900);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { null, null, prediction3 },
+        new QueryResult[] { null, null, prediction_result3 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        31.25, 1.25, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        18.75, .75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        0, 0, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+    
+    source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(99);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(0);
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(108);
+    ((NumericArrayTimeSeries) source).add(1);
+  }
+  
+  @Test
+  public void arrayThreeUnAlignedMiddleNull() throws Exception {
+    TimeSeries source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    TimeSeries prediction3 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 600));
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(1);
+    ((NumericArrayTimeSeries) prediction3).add(25);
+    ((NumericArrayTimeSeries) prediction3).add(50);
+    ((NumericArrayTimeSeries) prediction3).add(75);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 720);
+    QueryResult prediction_result = mockResult(BASE_TIME, BASE_TIME + 300);
+    QueryResult prediction_result3 = mockResult(BASE_TIME + 600, BASE_TIME + 900);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { prediction, null, prediction3 },
+        new QueryResult[] { prediction_result, null, prediction_result3 });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        31.25, 1.25, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        18.75, .75, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 0, 0, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        0, 0, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+  }
+  
+  @Test
+  public void arrayThreeUnAlignedMiddleAndEndNull() throws Exception {
+    TimeSeries source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 720);
+    QueryResult prediction_result = mockResult(BASE_TIME, BASE_TIME + 300);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { prediction, null, null },
+        new QueryResult[] { prediction_result, null, null });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 0, 0, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+  }
+  
+  @Test
+  public void arrayThreeUnAlignedEndNull() throws Exception {
+    TimeSeries source = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 120));
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(75);
+    ((NumericArrayTimeSeries) source).add(50);
+    ((NumericArrayTimeSeries) source).add(25);
+    ((NumericArrayTimeSeries) source).add(1);
+    
+    TimeSeries prediction = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME));
+    ((NumericArrayTimeSeries) prediction).add(25);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(75);
+    ((NumericArrayTimeSeries) prediction).add(50);
+    ((NumericArrayTimeSeries) prediction).add(25);
+    
+    TimeSeries prediction2 = new NumericArrayTimeSeries(ID, 
+        new SecondTimeStamp(BASE_TIME + 300));
+    ((NumericArrayTimeSeries) prediction2).add(1);
+    ((NumericArrayTimeSeries) prediction2).add(25);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    ((NumericArrayTimeSeries) prediction2).add(75);
+    ((NumericArrayTimeSeries) prediction2).add(50);
+    
+    QueryResult result = mockResult(BASE_TIME + 120, BASE_TIME + 720);
+    QueryResult prediction_result = mockResult(BASE_TIME, BASE_TIME + 300);
+    QueryResult prediction_result2 = mockResult(BASE_TIME + 300, BASE_TIME + 600);
+    EgadsThresholdEvaluator eval = new EgadsThresholdEvaluator(CONFIG, 15, 
+        source,
+        result,
+        new TimeSeries[] { prediction, prediction2, null },
+        new QueryResult[] { prediction_result, prediction_result2, null });
+    eval.evaluate();
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 93.75, 62.5, 31.25, 
+        1.25, 31.25, 62.5, 93.75, 62.5, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.upper_bad_thresholds, 0.001);
+    assertNull(eval.upper_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 56.25, 37.5, 18.75,
+        .75, 18.75, 37.5, 56.25, 37.5,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.lower_bad_thresholds, 0.001);
+    assertNull(eval.lower_warn_thresholds);
+    assertArrayEquals(new double[] { Double.NaN, Double.NaN, 0, 0, 0, 
+        0, 0, 0, 0, 0, 
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN }, 
+        eval.deltas, 0.001);
+    assertNull(eval.alerts());
+  }
+  
+  // TODO - summary tests
+  // TODO - eval specific tests
+  
+  QueryResult mockResult(final int start, final int end) {
+    TimeSpecification spec = mock(TimeSpecification.class);
+    when(spec.start()).thenReturn(new SecondTimeStamp(start));
+    when(spec.end()).thenReturn(new SecondTimeStamp(end));
+    when(spec.interval()).thenReturn(Duration.ofMinutes(1));
+    QueryResult result = mock(QueryResult.class);
+    when(result.timeSpecification()).thenReturn(spec);
+    return result;
+  }
+}

--- a/implementation/egads/src/test/java/net/opentsdb/query/anomaly/egads/olympicscoring/TestOlympicScoringBaseline.java
+++ b/implementation/egads/src/test/java/net/opentsdb/query/anomaly/egads/olympicscoring/TestOlympicScoringBaseline.java
@@ -279,7 +279,6 @@ public class TestOlympicScoringBaseline {
   public void predict() throws Exception {
     when(node.predictionIntervals()).thenReturn(60L);
     when(node.predictionInterval()).thenReturn(60L);
-    when(node.predictionStart()).thenReturn(BASE_TIME + (3600 * 3));
     
     TimeSpecification time_spec = mock(TimeSpecification.class);
     when(time_spec.start()).thenReturn(new SecondTimeStamp(BASE_TIME));
@@ -320,7 +319,7 @@ public class TestOlympicScoringBaseline {
     properties.setProperty("NUM_TO_DROP_HIGHEST","0");
     properties.setProperty("PERIOD", "3600");
     
-    TimeSeries result = baseline.predict(properties);
+    TimeSeries result = baseline.predict(properties, BASE_TIME + (3600 * 3));
     
     TypedTimeSeriesIterator iterator = result.iterator(NumericArrayType.TYPE).get();
     assertTrue(iterator.hasNext());
@@ -340,7 +339,6 @@ public class TestOlympicScoringBaseline {
   public void predictNoBaseline() throws Exception {
     when(node.predictionIntervals()).thenReturn(60L);
     when(node.predictionInterval()).thenReturn(60L);
-    when(node.predictionStart()).thenReturn(BASE_TIME + (3600 * 3));
     
     TimeSpecification time_spec = mock(TimeSpecification.class);
     when(time_spec.start()).thenReturn(new SecondTimeStamp(BASE_TIME));
@@ -371,7 +369,7 @@ public class TestOlympicScoringBaseline {
     properties.setProperty("NUM_TO_DROP_HIGHEST","0");
     properties.setProperty("PERIOD", "3600");
     
-    assertNull(baseline.predict(properties));
+    assertNull(baseline.predict(properties, BASE_TIME + (3600 * 3)));
   }
   
 }


### PR DESCRIPTION
- Move thresholds from Olympic Scoring config to BaseAnomalyConfig.

EGADS:
- Fix the OlympicScoringNode so that it will request multiple predictions if
  we have a time overlap in evaluate mode. Before it would just keep truncating
  the evaluations at the end of the interval.