### PR TITLE
Fix: Rollup queries with count aggregator produce unexpected results

### DIFF
--- a/src/core/Downsampler.java
+++ b/src/core/Downsampler.java
@@ -213,10 +213,7 @@ public class Downsampler implements SeekableView, DataPoint {
           specification.getFunction() == Aggregators.COUNT) {
         double count = 0;
         while (values_in_interval.hasNextValue()) {
-          count += values_in_interval.nextValueCount();
-          // WARNING: consume and move next or we'll be stuck in an infinite
-          // loop here.
-          values_in_interval.nextDoubleValue(); 
+          count += values_in_interval.nextDoubleValue();
         }
         value = count;
       } else {

--- a/src/core/FillingDownsampler.java
+++ b/src/core/FillingDownsampler.java
@@ -244,10 +244,7 @@ public class FillingDownsampler extends Downsampler {
             specification.getFunction() == Aggregators.COUNT) {
           double count = 0;
           while (values_in_interval.hasNextValue()) {
-            count += values_in_interval.nextValueCount();
-            // WARNING: consume and move next or we'll be stuck in an infinite
-            // loop here.
-            values_in_interval.nextDoubleValue(); 
+            count += values_in_interval.nextDoubleValue();
           }
           value = count;
         } else {

--- a/src/core/TsdbQuery.java
+++ b/src/core/TsdbQuery.java
@@ -1678,9 +1678,6 @@ final class TsdbQuery implements Query {
           rollup_query = new RollupQuery(best_match_rollups.remove(0), 
                   downsampler.getFunction(), downsampler.getInterval(),
                   group_by);
-          if (group_by == Aggregators.COUNT) {
-            aggregator = Aggregators.SUM;
-          }
         }
         catch (NoSuchRollupForIntervalException nre) {
           LOG.error("There is no such rollup for the downsample interval "

--- a/test/core/TestDownsampler.java
+++ b/test/core/TestDownsampler.java
@@ -1269,14 +1269,23 @@ public class TestDownsampler {
         .setInterval("1h")
         .setRowSpan("1d")
         .build();
+
+    // This query, in combination with the configuration/interval above, is asking for rolled up COUNTs (i.e. already
+    // downsampled).  These COUNTs should then be SUMmed over some interval we'll define later in a DownsamplingSpecification
     final RollupQuery rollup_query = new RollupQuery(interval, Aggregators.COUNT,
         3600000, Aggregators.SUM);
+
+    // These points represent rolled up COUNTs that would be stored in the rollup table (e.g. tsdb-rollup-1h) and as
+    // such we don't expect these to be COUNTed again on retrieval.  These points are at 5s intervals
     source = spy(SeekableViewsForTest.fromArray(new DataPoint[] {
         MutableDataPoint.ofDoubleValue(BASE_TIME + 5000L * 0, 1),
         MutableDataPoint.ofDoubleValue(BASE_TIME + 5000L * 1, 2),
         MutableDataPoint.ofDoubleValue(BASE_TIME + 5000L * 2, 4),
         MutableDataPoint.ofDoubleValue(BASE_TIME + 5000L * 3, 8)
     }));
+
+    // The rolled up points above are at 5s intervals but we want to downsample these further so that we only get
+    // points at 10s intervals
     specification = new DownsamplingSpecification("10s-count");
     downsampler = new Downsampler(source, specification, 0, 0, rollup_query);
     verify(source, never()).next();
@@ -1289,10 +1298,16 @@ public class TestDownsampler {
       timestamps_in_millis.add(dp.timestamp());
     }
 
+    // Asserts here different to upstream as there is a bug upstream and the original test was written to pass with the bug.
+    // 2 points are expected because the 4 points at 5s intervals will be downsampled to 2 points at 10s intervals
     assertEquals(2, values.size());
-    assertEquals(2, values.get(0), 0.0000001);
+
+    // Expect the SUM of points 1 and 2
+    assertEquals(3, values.get(0), 0.0000001);
     assertEquals(BASE_TIME + 00000L, timestamps_in_millis.get(0).longValue());
-    assertEquals(2, values.get(1), 0.0000001);
+
+    // Expect the SUM of points 3 and 4
+    assertEquals(12, values.get(1), 0.0000001);
     assertEquals(BASE_TIME + 10000L, timestamps_in_millis.get(1).longValue());
   }
   


### PR DESCRIPTION
Resolves #1683

The reason for updating the unit tests is that they previously passed with what I believe to be incorrect results.  