### PR TITLE
Improve ExplicitTags queries with FuzzyFilters

### DIFF
--- a/test/core/TestTsdbQueryQueries.java
+++ b/test/core/TestTsdbQueryQueries.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import net.opentsdb.rollup.RollupInterval;
 import org.hbase.async.Bytes;
 import org.hbase.async.FilterList;
+import org.hbase.async.FuzzyRowFilter;
 import org.hbase.async.Scanner;
 import org.junit.Before;
 import org.junit.Test;
@@ -1632,7 +1633,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     assertEquals(300, dps[0].aggregatedSize());
     // assert fuzzy
     for (final MockScanner scanner : storage.getScanners()) {
-      assertTrue(scanner.getFilter() instanceof FilterList);
+      assertTrue(scanner.getFilter() instanceof FuzzyRowFilter);
     }
   }
 
@@ -1663,7 +1664,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     assertEquals(300, dps[0].aggregatedSize());
     // assert fuzzy
     for (final MockScanner scanner : storage.getScanners()) {
-      assertTrue(scanner.getFilter() instanceof FilterList);
+      assertTrue(scanner.getFilter() instanceof FuzzyRowFilter);
     }
   }
 
@@ -1689,7 +1690,7 @@ public class TestTsdbQueryQueries extends BaseTsdbTest {
     assertEquals(0, dps.length);
     // assert fuzzy
     for (final MockScanner scanner : storage.getScanners()) {
-      assertTrue(scanner.getFilter() instanceof FilterList);
+      assertTrue(scanner.getFilter() instanceof FuzzyRowFilter);
     }
   }
 

--- a/test/query/TestQueryUtil.java
+++ b/test/query/TestQueryUtil.java
@@ -129,7 +129,7 @@ public class TestQueryUtil {
   
   @Test
   public void setDataTableScanFilterEnableBoth() throws Exception {
-    when(scanner.getCurrentKey()).thenReturn(new byte[] { 0, 0, 0, 1 });
+    when(scanner.getCurrentKey()).thenReturn(new byte[] { 0, 0, 0, 0, 0, 0, 1 });
     final ByteMap<byte[][]> tags = new ByteMap<byte[][]>();
     tags.put(new byte[] { 0, 0, 1 }, new byte[][] { new byte[] {0, 0, 1} });
     QueryUtil.setDataTableScanFilter(


### PR DESCRIPTION
This patch reworks how FuzzyFilters are used in the case of ExplicitTags queries:

* Use a list of FuzzyFilters on tag key and value instead of a single FuzzyFilter over tag keys
* No more need for a Rowkey Regex filter (All filtering done by FuzzyFilters + scanner start/stop keys)

It brings noticeable performance improvement when filtering on tag value for metrics with high cardinality (eg. a query for metric for a single host, with host tag cardinality of 20000 which took 9s is down to 250ms)

The list of fuzzy filters is constructed by a new method `QueryUtil.buildFuzzyFilters(row_key_literals)`.
It is used for filtering all combinations of tags provided by the caller.

So for 3 tags `cluster`, `service` and `vm`, with filtering values: `cluster=dev|qa|test`, `service=mysvc` and `vm=web|db`, a list of 8 (= 3 x 1 x 2) FuzzyFilters  covering all combinations will be returned.

A few remarks:

* New (private) version of `QueryUtil.getRowKeyUIDRegex(row_key_literals, explicit_tags)`: simplified variant stripped of everything related to FuzzyFilters
* `QueryUtil.getRowKeyUIDRegex(group_bys, row_key_literals)` and `QueryUtil.getRowKeyUIDRegex(group_bys, row_key_literals, explicit_tags, fuzzy_key, fuzzy_mask)` are left unchanged as these are public API (but not used anymore)

