### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/BaseQueryNodeConfig.java
+++ b/core/src/main/java/net/opentsdb/query/BaseQueryNodeConfig.java
@@ -39,7 +39,8 @@ import net.opentsdb.utils.Comparators;
  * @since 3.0
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public abstract class BaseQueryNodeConfig<B extends BaseQueryNodeConfig.Builder<B, C>, C extends BaseQueryNodeConfig> implements QueryNodeConfig<B, C> {
+public abstract class BaseQueryNodeConfig<B extends BaseQueryNodeConfig.Builder<B, C>, 
+    C extends BaseQueryNodeConfig> implements QueryNodeConfig<B, C> {
 
   /** A unique name for this config. */
   protected final String id;
@@ -52,6 +53,9 @@ public abstract class BaseQueryNodeConfig<B extends BaseQueryNodeConfig.Builder<
   
   /** The optional map of overrides. */
   protected final Map<String, String> overrides;
+  
+  /** The cached hash code. */
+  protected volatile HashCode cached_hash;
   
   /**
    * Protected ctor.
@@ -209,15 +213,15 @@ public abstract class BaseQueryNodeConfig<B extends BaseQueryNodeConfig.Builder<
     return true;
   }
 
-
-
   @Override
   public int hashCode() {
     return buildHashCode().asInt();
   }
-
-
-  /** @return A HashCode object for deterministic, non-secure hashing */
+  
+  /**
+   * <b>WARNING:</b> This method won't set the cached hash.
+   * @return A HashCode object for deterministic, non-secure hashing 
+   */
   public HashCode buildHashCode() {
     final Hasher hc = Const.HASH_FUNCTION().newHasher()
             .putString(Strings.nullToEmpty(id), Const.UTF8_CHARSET)

--- a/core/src/main/java/net/opentsdb/query/DefaultTimeSeriesDataSourceConfig.java
+++ b/core/src/main/java/net/opentsdb/query/DefaultTimeSeriesDataSourceConfig.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.Sets;
+import com.google.common.hash.HashCode;
+
 import net.opentsdb.core.TSDB;
 import net.opentsdb.query.plan.DefaultQueryPlanner;
 import net.opentsdb.query.plan.QueryPlanner;
@@ -62,11 +64,20 @@ public class DefaultTimeSeriesDataSourceConfig
   }
 
   @Override
-  public int compareTo(DefaultTimeSeriesDataSourceConfig o) {
+  public int compareTo(final DefaultTimeSeriesDataSourceConfig o) {
     // TODO Auto-generated method stub
     return 0;
   }
 
+  @Override
+  public HashCode buildHashCode() {
+    if (cached_hash != null) {
+      return cached_hash;
+    }
+    cached_hash = super.buildHashCode();
+    return cached_hash;
+  }
+  
   public static void setupTimeShift(
       final TimeSeriesDataSourceConfig<DefaultTimeSeriesDataSourceConfig.Builder, DefaultTimeSeriesDataSourceConfig> config,
       final QueryPlanner planner) {

--- a/core/src/main/java/net/opentsdb/query/WrappedTimeSeriesDataSourceConfig.java
+++ b/core/src/main/java/net/opentsdb/query/WrappedTimeSeriesDataSourceConfig.java
@@ -48,6 +48,9 @@ public class WrappedTimeSeriesDataSourceConfig implements TimeSeriesDataSourceCo
   /** Whether or not we've been setup. */
   public final boolean has_been_setup;
   
+  /** Cached hash code. */
+  public volatile HashCode cached_hash;
+  
   /**
    * Default ctor.
    * @param id A non-null and non-empty ID.
@@ -126,6 +129,10 @@ public class WrappedTimeSeriesDataSourceConfig implements TimeSeriesDataSourceCo
 
   @Override
   public HashCode buildHashCode() {
+    if (cached_hash != null) {
+      return cached_hash;
+    }
+    
     final HashCode hc = Const.HASH_FUNCTION().newHasher()
             .putString(Strings.nullToEmpty(id), Const.UTF8_CHARSET)
             .hash();
@@ -136,7 +143,8 @@ public class WrappedTimeSeriesDataSourceConfig implements TimeSeriesDataSourceCo
 
     hashes.add(config.buildHashCode());
 
-    return Hashing.combineOrdered(hashes);
+    cached_hash = Hashing.combineOrdered(hashes);
+    return cached_hash;
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/query/hacluster/HAClusterConfig.java
+++ b/core/src/main/java/net/opentsdb/query/hacluster/HAClusterConfig.java
@@ -191,6 +191,10 @@ public class HAClusterConfig extends BaseTimeSeriesDataSourceConfig<
   @Override
   /** @return A HashCode object for deterministic, non-secure hashing */
   public HashCode buildHashCode() {
+    if (cached_hash != null) {
+      return cached_hash;
+    }
+    
     final Hasher hc = Const.HASH_FUNCTION().newHasher()
             .putString(Strings.nullToEmpty(merge_aggregator), Const.UTF8_CHARSET)
             .putString(Strings.nullToEmpty(secondary_timeout), Const.UTF8_CHARSET)
@@ -216,7 +220,8 @@ public class HAClusterConfig extends BaseTimeSeriesDataSourceConfig<
       }
     }
 
-    return Hashing.combineOrdered(hashes);
+    cached_hash = Hashing.combineOrdered(hashes);
+    return cached_hash;
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverterConfig.java
+++ b/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverterConfig.java
@@ -110,11 +110,14 @@ public class ByteToStringIdConverterConfig extends BaseQueryNodeConfig<ByteToStr
   public int hashCode() {
     return buildHashCode().asInt();
   }
-
-
+  
   @Override
   /** @return A HashCode object for deterministic, non-secure hashing */
   public HashCode buildHashCode() {
+    if (cached_hash != null) {
+      return cached_hash;
+    }
+    
     final List<HashCode> hashes =
             Lists.newArrayListWithCapacity(2);
 
@@ -130,7 +133,8 @@ public class ByteToStringIdConverterConfig extends BaseQueryNodeConfig<ByteToStr
       hashes.add(hasher.hash());
     }
 
-    return Hashing.combineOrdered(hashes);
+    cached_hash = Hashing.combineOrdered(hashes);
+    return cached_hash;
   }
 
   public static Builder newBuilder() {

--- a/core/src/main/java/net/opentsdb/query/processor/dedup/DedupConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/dedup/DedupConfig.java
@@ -64,7 +64,11 @@ public class DedupConfig extends BaseQueryNodeConfig<DedupConfig.Builder, DedupC
 
   @Override
   public HashCode buildHashCode() {
-    return super.buildHashCode();
+    if (cached_hash != null) {
+      return cached_hash;
+    }
+    cached_hash = super.buildHashCode();
+    return cached_hash;
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/movingaverage/MovingAverageConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/movingaverage/MovingAverageConfig.java
@@ -162,6 +162,10 @@ public class MovingAverageConfig extends BaseQueryNodeConfig<MovingAverageConfig
 
   @Override
   public HashCode buildHashCode() {
+    if (cached_hash != null) {
+      return cached_hash;
+    }
+    
     final HashCode hc = Const.HASH_FUNCTION().newHasher()
             .putInt(samples)
             .putString(Strings.nullToEmpty(interval), net.opentsdb.core.Const.UTF8_CHARSET)
@@ -176,7 +180,8 @@ public class MovingAverageConfig extends BaseQueryNodeConfig<MovingAverageConfig
         Lists.newArrayListWithCapacity(2);
     hashes.add(super.buildHashCode());
     hashes.add(hc);
-    return Hashing.combineOrdered(hashes);
+    cached_hash = Hashing.combineOrdered(hashes);
+    return cached_hash;
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/rate/RateConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/rate/RateConfig.java
@@ -273,6 +273,10 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
 
   /** @return A HashCode object for deterministic, non-secure hashing */
   public HashCode buildHashCode() {
+    if (cached_hash != null) {
+      return cached_hash;
+    }
+    
     final List<HashCode> hashes =
             Lists.newArrayListWithCapacity(3);
 
@@ -294,7 +298,8 @@ public class RateConfig extends BaseQueryNodeConfig<RateConfig.Builder, RateConf
 
     hashes.add(hasher.hash());
 
-    return Hashing.combineOrdered(hashes);
+    cached_hash = Hashing.combineOrdered(hashes);
+    return cached_hash;
   }
   
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/slidingwindow/SlidingWindowConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/slidingwindow/SlidingWindowConfig.java
@@ -109,9 +109,12 @@ public class SlidingWindowConfig extends BaseQueryNodeConfig<SlidingWindowConfig
     return null;
   }
 
-
   @Override
   public HashCode buildHashCode() {
+    if (cached_hash != null) {
+      return cached_hash;
+    }
+    
     final HashCode hc = Const.HASH_FUNCTION().newHasher()
             .putString(Strings.nullToEmpty(window_size), net.opentsdb.core.Const.UTF8_CHARSET)
             .putString(Strings.nullToEmpty(aggregator), Const.UTF8_CHARSET)
@@ -125,7 +128,8 @@ public class SlidingWindowConfig extends BaseQueryNodeConfig<SlidingWindowConfig
 
     hashes.add(hc);
 
-    return Hashing.combineOrdered(hashes);
+    cached_hash = Hashing.combineOrdered(hashes);
+    return cached_hash;
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerConfig.java
@@ -113,6 +113,10 @@ public class SummarizerConfig extends BaseQueryNodeConfig<SummarizerConfig.Build
 
   @Override
   public HashCode buildHashCode() {
+    if (cached_hash != null) {
+      return cached_hash;
+    }
+    
     final Hasher hc = Const.HASH_FUNCTION().newHasher()
             .putBoolean(infectious_nan);
 
@@ -130,7 +134,8 @@ public class SummarizerConfig extends BaseQueryNodeConfig<SummarizerConfig.Build
       hashes.add(hc.hash());
     }
 
-    return Hashing.combineOrdered(hashes);
+    cached_hash = Hashing.combineOrdered(hashes);
+    return cached_hash;
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/timeshift/TimeShiftConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/timeshift/TimeShiftConfig.java
@@ -102,6 +102,10 @@ public class TimeShiftConfig extends BaseQueryNodeConfig<TimeShiftConfig.Builder
 
   @Override
   public HashCode buildHashCode() {
+    if (cached_hash != null) {
+      return cached_hash;
+    }
+    
     final HashCode hc = net.opentsdb.core.Const.HASH_FUNCTION().newHasher()
             .putString(Strings.nullToEmpty(timeShiftInterval), Const.UTF8_CHARSET)
             .hash();
@@ -112,7 +116,8 @@ public class TimeShiftConfig extends BaseQueryNodeConfig<TimeShiftConfig.Builder
 
     hashes.add(hc);
 
-    return Hashing.combineOrdered(hashes);
+    cached_hash = Hashing.combineOrdered(hashes);
+    return cached_hash;
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/topn/TopNConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/topn/TopNConfig.java
@@ -128,6 +128,9 @@ public class TopNConfig extends BaseQueryNodeConfig<TopNConfig.Builder, TopNConf
 
   @Override
   public HashCode buildHashCode() {
+    if (cached_hash != null) {
+      return cached_hash;
+    }
     final HashCode hc = Const.HASH_FUNCTION().newHasher()
             .putInt(count)
             .putBoolean(top)
@@ -142,7 +145,8 @@ public class TopNConfig extends BaseQueryNodeConfig<TopNConfig.Builder, TopNConf
 
     hashes.add(hc);
 
-    return Hashing.combineOrdered(hashes);
+    cached_hash = Hashing.combineOrdered(hashes);
+    return cached_hash;
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/NumericRowSeq.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/NumericRowSeq.java
@@ -16,15 +16,11 @@ package net.opentsdb.storage.schemas.tsdb1x;
 
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.Iterator;
-import java.util.Map.Entry;
 
 import com.google.common.reflect.TypeToken;
 
 import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.types.numeric.NumericType;
-
-import java.util.TreeMap;
 
 /**
  * Represents a read-only sequence of continuous numeric columns.
@@ -250,18 +246,17 @@ public class NumericRowSeq implements RowSeq {
       return resolution;
     }
     
-    dps = 0;
     // if we made it here we need to dedupe and sort. Normalize to longs
     // then flush.
-    // TODO - any primitive tree maps out there? Or maybe there's just an
-    // all around better way to do this. For now this should be fast enough.
     // The value is a concatenation of the offset and length into a long.
     // The first 32 bits are the offset, the last 32 the width to copy.
-    TreeMap<Long,Long> map = new TreeMap<Long, Long>();
+    final long[] array = new long[data.length];
+    int array_idx = 0;
     idx = 0;
     //byte[] buf;
     int vlen;
     long encoded_value = 0;
+    System.out.println("DPS: "+ dps);
     // TODO - there's a possible optimization here to get the offset. For
     // now we're only looking at the highest resolution amongst dupes.
     while (idx < data.length) {
@@ -289,34 +284,63 @@ public class NumericRowSeq implements RowSeq {
             (long) (NumericCodec.S_Q_WIDTH + vlen);
         idx += NumericCodec.S_Q_WIDTH + vlen;
       }
-      
-      // now copy the data into the buffer then store it
-      if (keep_earliest) {
-        map.putIfAbsent(current_offset, encoded_value);
-      } else {
-        map.put(current_offset, encoded_value);
+
+      // and now a little merge sort with overwrites.
+      int i = array_idx;
+      if (i == 0) {
+        array[i] = current_offset;
+        array[i + 1] = encoded_value;
+        array_idx += 2;
+        continue;
       }
+      
+      i -= 2;
+      while (i > 0 && array[i] > current_offset) {
+        i -= 2;
+      }
+      
+      if (array[i] < current_offset) {
+        i += 2;
+        if (i != array_idx) {
+          shift(array, i, array_idx);
+        }
+        array[i] = current_offset;
+        array[i + 1] = encoded_value;
+        array_idx += 2;
+        continue;
+      }
+      
+      if (array[i] == current_offset) {
+        if (!keep_earliest) {
+          array[i + 1] = encoded_value;
+        }
+        continue;
+      }
+      
+      shift(array, i, array_idx);
+      array[i] = current_offset;
+      array[i + 1] = encoded_value;
+      array_idx += 2;
     }
-    
-    final byte[] sorted = new byte[data.length];
-    final Iterator<Entry<Long, Long>> iterator;
-    if (reverse) {
-      iterator = map.descendingMap().entrySet().iterator();
-    } else {
-      iterator = map.entrySet().iterator();
-    }
-    idx = 0;
     
     int offset = 0;
     int width = 0;
-    
-    while (iterator.hasNext()) {
-      final long value = iterator.next().getValue();
-      offset = (int) (value >> 32);
-      width = (int) value;
-      System.arraycopy(data, offset, sorted, idx, width);
-      idx += width;
-      dps++;
+    final byte[] sorted = new byte[data.length];
+    idx = 0;
+    if (reverse) {
+      for (int i = array_idx - 1; i >= 0; i -= 2) {
+        offset = (int) (array[i] >> 32);
+        width = (int) array[i];
+        System.arraycopy(data, offset, sorted, idx, width);
+        idx += width;
+      }
+    } else {
+      for (int i = 1; i < array_idx; i += 2) {
+        offset = (int) (array[i] >> 32);
+        width = (int) array[i];
+        System.arraycopy(data, offset, sorted, idx, width);
+        idx += width;
+      }
     }
     
     // truncate if necessary
@@ -325,6 +349,7 @@ public class NumericRowSeq implements RowSeq {
     } else {
       data = sorted;
     }
+    dps = array_idx / 2;
     return resolution;
   }
   
@@ -395,4 +420,17 @@ public class NumericRowSeq implements RowSeq {
     }
     data = reversed;
   }
+
+  /**
+   * Simple little shift function.
+   * @param array The array to shift.
+   * @param idx The shift point.
+   * @param end The end of the array (to avoid some shifts)
+   */
+  static void shift(final long[] array, final int idx, final int end) {
+    for (int i = end - 1; i >= idx; i--) {
+      array[i + 2] = array[i];
+    }
+  }
+  
 }


### PR DESCRIPTION
- Cache the hashcode for the nodes as this winds up creating af fair bit
  of garbage from the Guava methods allocating byte arrays.