### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/data/TimeSeriesByteId.java
+++ b/common/src/main/java/net/opentsdb/data/TimeSeriesByteId.java
@@ -1,5 +1,5 @@
 //This file is part of OpenTSDB.
-//Copyright (C) 2018  The OpenTSDB Authors.
+//Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 //This program is free software: you can redistribute it and/or modify it
 //under the terms of the GNU Lesser General Public License as published by
@@ -13,12 +13,12 @@
 package net.opentsdb.data;
 
 import java.util.List;
+import java.util.Map;
 
 import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.stats.Span;
 import net.opentsdb.utils.ByteSet;
-import net.opentsdb.utils.Bytes.ByteMap;
 
 /**
  * An identifier for a time series. The identity can be as simple as the alias
@@ -74,7 +74,7 @@ public interface TimeSeriesByteId extends TimeSeriesId,
    * 
    * @return A non-null map of zero or more tag pairs.
    */
-  public ByteMap<byte[]> tags();
+  public Map<byte[], byte[]> tags();
   
   /**
    * A list of tag names (tagk) that were represented in every source series

--- a/common/src/main/java/net/opentsdb/utils/Bytes.java
+++ b/common/src/main/java/net/opentsdb/utils/Bytes.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2010-2018  The OpenTSDB Authors.
+// Copyright (C) 2010-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -660,12 +660,13 @@ public final class Bytes {
   }
   
   /**
-   * Evaluates two byte maps of byte arrays for equality. Either map may be null.
+   * Evaluates two maps of byte arrays for equality. Either map may be null.
    * @param a A byte map of byte arrays, possibly null.
    * @param b A byte map of byte arrays, possibly null.
    * @return True if the maps contain the same byte array contents, false if not.
    */
-  public static boolean equals(final ByteMap<byte[]> a, final ByteMap<byte[]> b) {
+  public static boolean equals(final Map<byte[], byte[]> a, 
+                               final Map<byte[], byte[]> b) {
     if (a == null && b == null) {
       return true;
     }
@@ -791,10 +792,10 @@ public final class Bytes {
   public static final ByteMapComparator BYTE_MAP_CMP = new ByteMapComparator();
   
   /** {@link Comparator} for ByteMap&lt;byte[]&gt;s .Support nulls.  */
-  public static class ByteMapComparator implements Comparator<ByteMap<byte[]>> {
+  public static class ByteMapComparator implements Comparator<Map<byte[], byte[]>> {
     private ByteMapComparator() { }
     @Override
-    public int compare(final ByteMap<byte[]> a, final ByteMap<byte[]> b) {
+    public int compare(final Map<byte[], byte[]> a, final Map<byte[], byte[]> b) {
       if (a == b || a == null && b == null) {
         return 0;
       }

--- a/core/src/main/java/net/opentsdb/query/joins/ByteIdOverride.java
+++ b/core/src/main/java/net/opentsdb/query/joins/ByteIdOverride.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import com.google.common.base.Strings;
@@ -193,7 +194,7 @@ public class ByteIdOverride implements TimeSeriesByteId {
   }
 
   @Override
-  public ByteMap<byte[]> tags() {
+  public Map<byte[], byte[]> tags() {
     return id.tags();
   }
 


### PR DESCRIPTION
- Change the TimeSeriesByteId tag interface to a generic map instead of
  a ByteMap. This lets us use map implementations with less garbage.