### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/pools/BlockingQueueArrayObjectPool.java
+++ b/core/src/main/java/net/opentsdb/pools/BlockingQueueArrayObjectPool.java
@@ -164,7 +164,7 @@ public class BlockingQueueArrayObjectPool implements ArrayObjectPool, TimerTask 
     public void release() {
       if (was_pooled) {
         if (!pool.offer(this)) {
-          LOG.warn("Failed to return a pooled object to the pool for " + config.id());
+          LOG.warn("Failed to return a pooled object to the pool for " + config.id() + "  Size: " + pool.size());
           tsdb.getStatsCollector().incrementCounter("objectpool.offer.failure", 
               "pool", config.id());
         }

--- a/core/src/main/java/net/opentsdb/query/BaseQueryContext.java
+++ b/core/src/main/java/net/opentsdb/query/BaseQueryContext.java
@@ -207,13 +207,10 @@ public abstract class BaseQueryContext implements QueryContext {
       @Override
       public Deferred<Void> call(final Void ignored) throws Exception {
         if (query.getCacheMode() == null || 
-            query.getCacheMode() == CacheMode.BYPASS ||
-            tsdb.getRegistry().getDefaultPlugin(
-                ReadCacheQueryPipelineContext.class) == null) {
+            query.getCacheMode() == CacheMode.BYPASS) {
           pipeline = new LocalPipeline(BaseQueryContext.this, builder_sinks);
           return pipeline.initialize(local_span);
         }
-        
         pipeline = new ReadCacheQueryPipelineContext(
             BaseQueryContext.this, builder_sinks);
         return pipeline.initialize(local_span)
@@ -227,9 +224,7 @@ public abstract class BaseQueryContext implements QueryContext {
           .addCallbackDeferring(new FilterCB());
     } else {
       if (query.getCacheMode() == null || 
-          query.getCacheMode() == CacheMode.BYPASS ||
-          tsdb.getRegistry().getDefaultPlugin(
-              ReadCacheQueryPipelineContext.class) == null) {
+          query.getCacheMode() == CacheMode.BYPASS) {
         pipeline = new LocalPipeline(BaseQueryContext.this, builder_sinks);
         return pipeline.initialize(local_span);
       } else {

--- a/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByNumericArrayIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByNumericArrayIterator.java
@@ -400,7 +400,7 @@ public class GroupByNumericArrayIterator
         }
       }
     }
-    if (aggregator.end() < 1) {
+    if (aggregator.end() <= aggregator.offset()) {
       has_next = false;
     }
   }


### PR DESCRIPTION
- Don't look for the read cache context in the plugins.
- Add a bounds check in GBNAI
- Print the pools ize in the blocking queue pool.