### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/configuration/Configuration.java
+++ b/common/src/main/java/net/opentsdb/configuration/Configuration.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -986,6 +986,28 @@ public class Configuration implements Closeable {
   public Map<String, String> asUnsecuredMap() {
     final Map<String, String> map = 
         Maps.newHashMapWithExpectedSize(merged_config.size());
+    for (final Entry<String, ConfigurationEntry> entry : 
+        merged_config.entrySet()) {
+      final Object value = entry.getValue().getValue();
+      if (value != null) {
+        map.put(entry.getKey(), value.toString());        
+      }
+    }
+    return Collections.unmodifiableMap(map);
+  }
+  
+  /**
+   * Returns the full config, including un-registered entries, as a non-obfuscated
+   * map.
+   * @return A non-null unmodifiable, possibly empty map.
+   */
+  public Map<String, String> asRawUnsecuredMap() {
+    final Map<String, String> map = Maps.newHashMap();
+    for (int i = 0; i < providers.size(); i++) {
+      providers.get(i).populateRawMap(map);
+    }
+    
+    // now for registered values with their defaults
     for (final Entry<String, ConfigurationEntry> entry : 
         merged_config.entrySet()) {
       final Object value = entry.getValue().getValue();

--- a/common/src/main/java/net/opentsdb/configuration/UnitTestConfiguration.java
+++ b/common/src/main/java/net/opentsdb/configuration/UnitTestConfiguration.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@ package net.opentsdb.configuration;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Set;
 
 import io.netty.util.HashedWheelTimer;
 import net.opentsdb.configuration.ConfigurationValueValidator.ValidationResult;
@@ -144,6 +143,11 @@ public class UnitTestConfiguration extends Configuration {
     @Override
     public void reload() {
       // no-op
+    }
+    
+    @Override
+    public void populateRawMap(final Map<String, String> map) {
+      
     }
     
   }

--- a/common/src/main/java/net/opentsdb/configuration/provider/CommandLineProvider.java
+++ b/common/src/main/java/net/opentsdb/configuration/provider/CommandLineProvider.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 package net.opentsdb.configuration.provider;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import com.google.common.base.Strings;
 
@@ -86,6 +88,25 @@ public class CommandLineProvider extends BaseProvider {
   @Override
   public void reload() {
     // no-op
+  }
+  
+  @Override
+  public void populateRawMap(final Map<String, String> map) {
+    if (args == null || args.length < 1) {
+      return;
+    }
+    
+    final ArgP args = new ArgP(false);
+    for (int i = 0; i < this.args.length; i++) {
+      if (this.args[i] != null && this.args[i].startsWith("--")) {
+        String[] split = this.args[i].split("=");
+        args.addOption(split[0], "Foo");
+      }
+    }
+    args.parse(this.args);
+    for (final Entry<String, String> entry : args.getParsed().entrySet()) {
+      map.put(entry.getKey().replace("--", ""), entry.getValue());
+    }
   }
   
   public static class CommandLine implements ProviderFactory {

--- a/common/src/main/java/net/opentsdb/configuration/provider/EnvironmentProvider.java
+++ b/common/src/main/java/net/opentsdb/configuration/provider/EnvironmentProvider.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package net.opentsdb.configuration.provider;
 
 import java.io.IOException;
+import java.util.Map;
 
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.TimerTask;
@@ -79,6 +80,11 @@ public class EnvironmentProvider extends BaseProvider implements TimerTask {
     }
   }
 
+  @Override
+  public void populateRawMap(final Map<String, String> map) {
+    map.putAll(System.getenv());
+  }
+  
   public static class Environment implements ProviderFactory {
   
     @Override

--- a/common/src/main/java/net/opentsdb/configuration/provider/MapProvider.java
+++ b/common/src/main/java/net/opentsdb/configuration/provider/MapProvider.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -104,6 +104,11 @@ public class MapProvider implements Provider, ProviderFactory {
     // no-op
   }
 
+  @Override
+  public void populateRawMap(final Map<String, String> map) {
+    map.putAll(properties);
+  }
+  
   @Override
   public long lastReload() {
     return 0;

--- a/common/src/main/java/net/opentsdb/configuration/provider/PlainTextSecretProvider.java
+++ b/common/src/main/java/net/opentsdb/configuration/provider/PlainTextSecretProvider.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package net.opentsdb.configuration.provider;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,4 +90,8 @@ public class PlainTextSecretProvider extends BaseSecretProvider  {
     // no-op
   }
 
+  @Override
+  public void populateRawMap(final Map<String, String> map) {
+    // no-op
+  }
 }

--- a/common/src/main/java/net/opentsdb/configuration/provider/PropertiesFileProvider.java
+++ b/common/src/main/java/net/opentsdb/configuration/provider/PropertiesFileProvider.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -219,6 +219,11 @@ public class PropertiesFileProvider extends BaseProvider {
     } catch (IOException e) {
       LOG.error("Failed to read file: " + file_name, e);
     }
+  }
+  
+  @Override
+  public void populateRawMap(final Map<String, String> map) {
+    map.putAll(cache);
   }
   
   /**

--- a/common/src/main/java/net/opentsdb/configuration/provider/Provider.java
+++ b/common/src/main/java/net/opentsdb/configuration/provider/Provider.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import net.opentsdb.configuration.Configuration;
 import net.opentsdb.configuration.ConfigurationOverride;
 
 import java.io.Closeable;
+import java.util.Map;
 
 import io.netty.util.TimerTask;
 
@@ -69,5 +70,11 @@ public interface Provider extends Closeable, TimerTask {
    * @return A non-null factory.
    */
   public ProviderFactory factory();
+  
+  /**
+   * Used to populate a raw, flat map of all registered and unregistered settings.
+   * @param map A non-null map to populate with values.
+   */
+  public void populateRawMap(final Map<String, String> map);
   
 }

--- a/common/src/main/java/net/opentsdb/configuration/provider/RuntimeOverrideProvider.java
+++ b/common/src/main/java/net/opentsdb/configuration/provider/RuntimeOverrideProvider.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package net.opentsdb.configuration.provider;
 
 import java.io.IOException;
+import java.util.Map;
 
 import io.netty.util.HashedWheelTimer;
 import net.opentsdb.configuration.Configuration;
@@ -61,6 +62,11 @@ public class RuntimeOverrideProvider extends BaseProvider {
 
   @Override
   public void reload() {
+    // no-op
+  }
+  
+  @Override
+  public void populateRawMap(final Map<String, String> map) {
     // no-op
   }
   

--- a/common/src/main/java/net/opentsdb/configuration/provider/SystemPropertiesProvider.java
+++ b/common/src/main/java/net/opentsdb/configuration/provider/SystemPropertiesProvider.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
 package net.opentsdb.configuration.provider;
 
 import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Properties;
 
 import io.netty.util.HashedWheelTimer;
 import net.opentsdb.configuration.Configuration;
@@ -66,6 +69,20 @@ public class SystemPropertiesProvider extends BaseProvider {
   @Override
   public void reload() {
     // no-op
+  }
+  
+  @Override
+  public void populateRawMap(final Map<String, String> map) {
+    final Properties properties = System.getProperties();
+    if (properties == null || properties.isEmpty()) {
+      return;
+    }
+    
+    final Enumeration<Object> enumeration = properties.keys();
+    while (enumeration.hasMoreElements()) {
+      final String key = (String) enumeration.nextElement();
+      map.put(key, (String) properties.getProperty(key));
+    }
   }
   
   public static class SystemProperties implements ProviderFactory {

--- a/common/src/test/java/net/opentsdb/configuration/provider/TestProvider.java
+++ b/common/src/test/java/net/opentsdb/configuration/provider/TestProvider.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
@@ -120,5 +121,7 @@ public class TestProvider {
       }
     }
     
+    @Override
+    public void populateRawMap(final Map<String, String> map) { }
   }
 }

--- a/implementation/aws-secrets/src/main/java/net/opentsdb/configuration/providers/AWSSecretsProvider.java
+++ b/implementation/aws-secrets/src/main/java/net/opentsdb/configuration/providers/AWSSecretsProvider.java
@@ -16,6 +16,7 @@ package net.opentsdb.configuration.providers;
 
 import java.io.IOException;
 import java.util.Base64;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -169,7 +170,13 @@ public class AWSSecretsProvider extends BaseSecretProvider {
   public void reload() {
     // no-op
   }
-
+  
+  @Override
+  public void populateRawMap(Map<String, String> map) {
+    // TODO Auto-generated method stub
+    
+  }
+  
   /**
    * Helper to register configuration parameters.
    * @param config The non-null config object.
@@ -197,5 +204,6 @@ public class AWSSecretsProvider extends BaseSecretProvider {
         (Strings.isNullOrEmpty(id) ? "" : id + ".") 
           + suffix;
   }
+
   
 }

--- a/implementation/http-config/src/main/java/net/opentsdb/configuration/provider/HttpProvider.java
+++ b/implementation/http-config/src/main/java/net/opentsdb/configuration/provider/HttpProvider.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -165,6 +166,11 @@ public class HttpProvider extends YamlJsonBaseProvider {
     }
   }
 
+  @Override
+  public void populateRawMap(Map<String, String> map) {
+    // no-op 
+  }
+  
   String getFileName() {
     return uri.replaceAll(CACHE_REPLACE, "_");
   }
@@ -198,4 +204,6 @@ public class HttpProvider extends YamlJsonBaseProvider {
       }
     }
   }
+
+  
 }

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseDataStore.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseDataStore.java
@@ -307,6 +307,12 @@ public class Tsdb1xHBaseDataStore implements Tsdb1xDataStore, TimerTask {
       }
     }
     
+    /** Copy all configs, then we'll override with node specific entries. */
+    final Map<String, String> flat = config.asRawUnsecuredMap();
+    for (final Entry<String, String> entry : flat.entrySet()) {
+      async_config.overrideConfig(entry.getKey(), entry.getValue());
+    }
+    
     async_config.overrideConfig("hbase.zookeeper.quorum", 
         config.getString(getConfigKey(ZK_QUORUM_KEY)));
     async_config.overrideConfig("hbase.zookeeper.znode.parent", 
@@ -319,6 +325,7 @@ public class Tsdb1xHBaseDataStore implements Tsdb1xDataStore, TimerTask {
       async_config.overrideConfig("hbase.security.authentication", 
           "kerberos");
     }
+    
     async_config.overrideConfig("hbase.sasl.clientconfig", 
         config.getString(getConfigKey(SASL_CLIENT_KEY)));
     async_config.overrideConfig("hbase.meta.split", 


### PR DESCRIPTION
- Add the asRawUnsecuredMap() to the Configuration class so we can get a
  flattened view of the config and pass unregistered values to libraries
  like AsyncHBase.

ASYNCHBASE:
- Pass the config map so we can use all the variables for HBase.