### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/interpolation/QueryInterpolator.java
+++ b/common/src/main/java/net/opentsdb/query/interpolation/QueryInterpolator.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.io.Closeable;
 import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.TimeStamp;
+import net.opentsdb.data.TypedTimeSeriesIterator;
 import net.opentsdb.query.QueryFillPolicy;
 
 /**
@@ -30,7 +31,8 @@ import net.opentsdb.query.QueryFillPolicy;
  * 
  * @since 3.0
  */
-public interface QueryInterpolator<T extends TimeSeriesDataType> extends Closeable {
+public interface QueryInterpolator<T extends TimeSeriesDataType> 
+    extends TypedTimeSeriesIterator, Closeable {
   
   /** @return Whether or not the underlying source has another real value. */
   public boolean hasNext();

--- a/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericInterpolator.java
+++ b/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericInterpolator.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
+import com.google.common.reflect.TypeToken;
+
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TimeSeriesValue;
@@ -232,6 +234,17 @@ public class NumericInterpolator implements QueryInterpolator<NumericType> {
       response.reset(timestamp, fill);
     }
     return response;
+  }
+
+  @Override
+  public TypeToken getType() {
+    return NumericType.TYPE;
+  }
+
+  @Override
+  public Object next() {
+    throw new UnsupportedOperationException("This is an interpolator. "
+        + "Please call next(TimeStamp timestamp)");
   }
   
 }

--- a/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericSummaryInterpolator.java
+++ b/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/NumericSummaryInterpolator.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
 
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesDataType;
@@ -286,5 +287,16 @@ public class NumericSummaryInterpolator implements
         advanceSynchronized();
       }
     }
+  }
+
+  @Override
+  public TypeToken getType() {
+    return NumericSummaryType.TYPE;
+  }
+
+  @Override
+  public Object next() {
+    throw new UnsupportedOperationException("This is an interpolator. "
+        + "Please call next(TimeStamp timestamp)");
   }
 }

--- a/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/ReadAheadNumericInterpolator.java
+++ b/core/src/main/java/net/opentsdb/query/interpolation/types/numeric/ReadAheadNumericInterpolator.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
 
 import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.TimeStamp;
@@ -218,5 +219,16 @@ public class ReadAheadNumericInterpolator implements
       response.reset(timestamp, fill);
     }
     return response;
+  }
+
+  @Override
+  public TypeToken getType() {
+    return NumericType.TYPE;
+  }
+
+  @Override
+  public Object next() {
+    throw new UnsupportedOperationException("This is an interpolator. "
+        + "Please call next(TimeStamp timestamp)");
   }
 }

--- a/core/src/main/java/net/opentsdb/query/pojo/TimeSeriesQuery.java
+++ b/core/src/main/java/net/opentsdb/query/pojo/TimeSeriesQuery.java
@@ -42,6 +42,7 @@ import net.opentsdb.query.QueryMode;
 import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.SemanticQuery;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
+import net.opentsdb.query.execution.serdes.JsonV2QuerySerdesOptions;
 import net.opentsdb.query.filter.ChainFilter;
 import net.opentsdb.query.filter.ExplicitTagsFilter;
 import net.opentsdb.query.filter.MetricLiteralFilter;
@@ -57,6 +58,7 @@ import net.opentsdb.query.processor.expressions.ExpressionConfig;
 import net.opentsdb.query.processor.expressions.ExpressionParser;
 import net.opentsdb.query.processor.groupby.GroupByConfig;
 import net.opentsdb.query.processor.rate.RateConfig;
+import net.opentsdb.query.serdes.SerdesOptions;
 import net.opentsdb.utils.JSON;
 
 import java.util.Collections;
@@ -730,6 +732,34 @@ public class TimeSeriesQuery extends Validatable
     }
     
     builder.setExecutionGraph(nodes);
+    
+    // Set the outputs properly
+    if (outputs != null && !outputs.isEmpty()) {
+      final List<String> outs = Lists.newArrayListWithExpectedSize(
+          outputs.size());
+      // TODO - alias
+      for (final Output output : outputs) {
+        outs.add(output.getId());
+      }
+      builder.addSerdesConfig(JsonV2QuerySerdesOptions.newBuilder()
+          .setId("JsonV2ExpQuerySerdes")
+          .setType("JsonV2ExpQuerySerdes")
+          .setFilter(outs)
+          .build());
+    } else if (expressions != null && !expressions.isEmpty()) {
+      // just take the expressions
+      final List<String> outs = Lists.newArrayListWithExpectedSize(
+          expressions.size());
+      for (final Expression expression : expressions) {
+        outs.add(expression.getId());
+      }
+      builder.addSerdesConfig(JsonV2QuerySerdesOptions.newBuilder()
+          .setId("JsonV2ExpQuerySerdes")
+          .setType("JsonV2ExpQuerySerdes")
+          .setFilter(outs)
+          .build());
+    }
+    
     return builder;
   }
   

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNode.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNode.java
@@ -326,7 +326,7 @@ public class BinaryExpressionNode extends AbstractQueryNode<ExpressionParseNode>
           result.set(results);
           result.join();
           if (LOG.isTraceEnabled()) {
-            LOG.trace("Sending expression upstream: " + config.getId());
+            LOG.trace("Sending expression upstream: " + expression_config.getId());
           }
           sendUpstream(result);
         } catch (Exception e) {
@@ -334,7 +334,7 @@ public class BinaryExpressionNode extends AbstractQueryNode<ExpressionParseNode>
         }
       }
     } else if (LOG.isTraceEnabled()) {
-      LOG.trace("Not all results are in for: " + config.getId());
+      LOG.trace("Not all results are in for: " + expression_config.getId());
     }
   }
   

--- a/core/src/main/java/net/opentsdb/query/readcache/JsonReadCacheSerdes.java
+++ b/core/src/main/java/net/opentsdb/query/readcache/JsonReadCacheSerdes.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1601,11 +1601,14 @@ public class JsonReadCacheSerdes implements ReadCacheSerdes,
         if (i + 1 >= timestamps.length && timestamps.length > 1) {
           long delta = (long) timestamps[i] - (long) timestamps[i - 1];
           end = (int) (start + delta);
-        } else {
+        } else if (timestamps.length > 1) {
           end = timestamps[i + 1];
         }
-        for (int x = 0; x < serializers.length; x++) {
-          serializers[x].serialize(json, start, end);
+        
+        if (end > 0) {
+          for (int x = 0; x < serializers.length; x++) {
+            serializers[x].serialize(json, start, end);
+          }
         }
         
         json.writeEndArray();
@@ -1768,8 +1771,9 @@ public class JsonReadCacheSerdes implements ReadCacheSerdes,
               if (v.timestamp().epoch() >= end) {
                 break;
               }
-              
-              if (v.value().isInteger()) {
+              if (v.value() == null) {
+                continue;
+              } else if (v.value().isInteger()) {
                 json.writeNumberField(Long.toString(v.timestamp().epoch()), 
                     v.value().longValue());
               } else {

--- a/core/src/test/java/net/opentsdb/query/interpolation/TestBaseQueryIntperolatorFactory.java
+++ b/core/src/test/java/net/opentsdb/query/interpolation/TestBaseQueryIntperolatorFactory.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.reflect.TypeToken;
 import com.stumbleupon.async.Deferred;
 
 import net.opentsdb.core.TSDB;
@@ -181,6 +182,17 @@ public class TestBaseQueryIntperolatorFactory {
     
     @Override
     public void close() { }
+
+    @Override
+    public TypeToken getType() {
+      return NumericType.TYPE;
+    }
+
+    @Override
+    public Object next() {
+      throw new UnsupportedOperationException("This is an interpolator. "
+        + "Please call next(TimeStamp timestamp)");
+    }
     
   }
   
@@ -216,6 +228,17 @@ public class TestBaseQueryIntperolatorFactory {
     @Override
     public void close() { }
     
+    @Override
+    public TypeToken getType() {
+      return NumericType.TYPE;
+    }
+
+    @Override
+    public Object next() {
+      throw new UnsupportedOperationException("This is an interpolator. "
+        + "Please call next(TimeStamp timestamp)");
+    }
+    
   }
   
   static class MockInterpolatorMissTimeSeries implements 
@@ -245,6 +268,17 @@ public class TestBaseQueryIntperolatorFactory {
     @Override
     public void close() { }
     
+    @Override
+    public TypeToken getType() {
+      return NumericType.TYPE;
+    }
+
+    @Override
+    public Object next() {
+      throw new UnsupportedOperationException("This is an interpolator. "
+        + "Please call next(TimeStamp timestamp)");
+    }
+    
   }
   
   static class MockInterpolatorMissIterator implements 
@@ -272,5 +306,16 @@ public class TestBaseQueryIntperolatorFactory {
     
     @Override
     public void close() { }
+  
+    @Override
+    public TypeToken getType() {
+      return NumericType.TYPE;
+    }
+
+    @Override
+    public Object next() {
+      throw new UnsupportedOperationException("This is an interpolator. "
+        + "Please call next(TimeStamp timestamp)");
+    }
   }
 }

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/ExpressionRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/ExpressionRpc.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2016-2018  The OpenTSDB Authors.
+// Copyright (C) 2016-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 import javax.servlet.AsyncContext;
@@ -49,7 +48,6 @@ import net.opentsdb.auth.Authentication;
 import net.opentsdb.auth.AuthState.AuthStatus;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.exceptions.QueryExecutionException;
-import net.opentsdb.query.QueryContext;
 import net.opentsdb.query.SemanticQuery;
 import net.opentsdb.query.SemanticQueryContext;
 import net.opentsdb.query.TimeSeriesQuery;
@@ -58,7 +56,6 @@ import net.opentsdb.query.serdes.SerdesOptions;
 import net.opentsdb.servlet.applications.OpenTSDBApplication;
 import net.opentsdb.servlet.exceptions.GenericExceptionMapper;
 import net.opentsdb.servlet.filter.AuthFilter;
-import net.opentsdb.servlet.resources.RawQueryRpc.RunTSDQuery;
 import net.opentsdb.servlet.sinks.ServletSinkConfig;
 import net.opentsdb.servlet.sinks.ServletSinkFactory;
 import net.opentsdb.stats.DefaultQueryStats;
@@ -278,6 +275,7 @@ public class ExpressionRpc {
     if (serdes == null) {
       serdes = JsonV2QuerySerdesOptions.newBuilder()
           .setId("JsonV2ExpQuerySerdes")
+          .setType("JsonV2ExpQuerySerdes")
           .build();
     }
     
@@ -309,8 +307,7 @@ public class ExpressionRpc {
     
     return null;
   }
-
-
+  
   private void asyncRun(final Trace trace, final Span query_span, final Span setup_span,
       final AsyncContext async, SemanticQueryContext context) {
     class AsyncTimeout implements AsyncListener {


### PR DESCRIPTION
- QueryInterpolator now implements a TypedTimeSeriesIterator

CORE:
- Fix up JsonV2ExpQuerySerdes with proper synchronization (TODO - improve),
  millisecond timestamps like in V2 and support for the NumericArrayType. More
  to do still.
- Fix a couple of bugs in the NumericType JsonReadCacheSerdes path.