### PR TITLE
ASYNCHBASE:

### DIFF
--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanner.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanner.java
@@ -1104,6 +1104,7 @@ public class Tsdb1xScanner implements CloseablePooledObject {
       if (owner != null) {
         owner.exception((ex instanceof DeferredGroupException ? 
             Exceptions.getCause((DeferredGroupException) ex) : ex));
+        owner.scannerDone();
       }
       if (scanner != null) {
         scanner.close();

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanners.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xScanners.java
@@ -186,6 +186,9 @@ public class Tsdb1xScanners implements HBaseExecutor, CloseablePooledObject, Tim
   /** A list of durations for each scanner set reflecting the interval between
    * rows. */
   protected List<Duration> durations;
+  
+  /** TEMP fudge to close a scanner.... */
+  protected int close_attempts;
       
   /**
    * Resets the cached scanners object.
@@ -462,6 +465,11 @@ public class Tsdb1xScanners implements HBaseExecutor, CloseablePooledObject, Tim
 
   @Override
   public void run(final Timeout timeout) {
+    if (close_attempts++ > 6000) {
+      LOG.warn("Whoops, bug returning scanners to the pool after " 
+          + close_attempts + ". Resetting scanners done.");
+      scanners_done = scanners.get(scanner_index).length;
+    }
     close();
   }
   

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xUniqueIdStore.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xUniqueIdStore.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2010-2018  The OpenTSDB Authors.
+// Copyright (C) 2010-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.LongAdder;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -49,6 +48,7 @@ import net.opentsdb.data.TimeSeriesDatumId;
 import net.opentsdb.stats.Span;
 import net.opentsdb.uid.IdOrError;
 import net.opentsdb.uid.RandomUniqueId;
+import net.opentsdb.uid.UniqueId;
 import net.opentsdb.uid.UniqueIdAssignmentAuthorizer;
 import net.opentsdb.uid.UniqueIdStore;
 import net.opentsdb.uid.UniqueIdType;
@@ -357,7 +357,7 @@ public class Tsdb1xUniqueIdStore implements UniqueIdStore {
                 .finish();
             }
             throw new StorageException("UID resolution failed for ID " 
-                + ids.get(i), results.get(i).getException());
+                + UniqueId.uidToString(ids.get(i)), results.get(i).getException());
           } else if (results.get(i).getCells() == null ||
                      results.get(i).getCells().isEmpty()) {
             names.add(null);

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xScanner.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xScanner.java
@@ -196,7 +196,7 @@ public class TestTsdb1xScanner extends UTBase {
     verify(hbase_scanner, times(1)).close();
     verify(results, never()).decode(
         any(ArrayList.class), any(RollupInterval.class));
-    verify(owner, never()).scannerDone();
+    verify(owner, times(1)).scannerDone();
     verify(owner, times(1)).exception(any(Throwable.class));
     assertEquals(0, scanner.keepers.size());
     assertEquals(0, scanner.skips.size());
@@ -254,7 +254,7 @@ public class TestTsdb1xScanner extends UTBase {
     verify(hbase_scanner, times(1)).close();
     verify(results, never()).decode(
         any(ArrayList.class), any(RollupInterval.class));
-    verify(owner, never()).scannerDone();
+    verify(owner, times(1)).scannerDone();
     verify(owner, times(1)).exception(any(Throwable.class));
     assertEquals(0, scanner.keepers.size());
     assertEquals(0, scanner.skips.size());
@@ -326,7 +326,7 @@ public class TestTsdb1xScanner extends UTBase {
     verify(hbase_scanner, times(1)).close();
     verify(results, times(4)).decode(
         any(ArrayList.class), any(RollupInterval.class));
-    verify(owner, never()).scannerDone();
+    verify(owner, times(1)).scannerDone();
     verify(owner, times(1)).exception(any(Throwable.class));
     assertEquals(0, scanner.keepers.size());
     assertEquals(0, scanner.skips.size());
@@ -1345,7 +1345,7 @@ public class TestTsdb1xScanner extends UTBase {
     verify(hbase_scanner, times(1)).close();
     verify(results, times(1)).decode(
         any(ArrayList.class), any(RollupInterval.class));
-    verify(owner, times(1)).scannerDone();
+    verify(owner, times(2)).scannerDone();
     verify(owner, times(1)).exception(any(Throwable.class));
     assertEquals(State.EXCEPTION, scanner.state());
     verify(schema, times(2)).getName(UniqueIdType.METRIC, METRIC_BYTES, null);

--- a/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xScannerPush.java
+++ b/storage/asynchbase/src/test/java/net/opentsdb/storage/TestTsdb1xScannerPush.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -299,7 +299,7 @@ public class TestTsdb1xScannerPush extends UTBase {
     
     verify(hbase_scanner, times(1)).nextRows();
     verify(hbase_scanner, times(1)).close();
-    verify(owner, never()).scannerDone();
+    verify(owner, times(1)).scannerDone();
     verify(owner, times(1)).exception(any(Throwable.class));
     assertEquals(0, scanner.keepers.size());
     assertEquals(0, scanner.skips.size());
@@ -355,7 +355,7 @@ public class TestTsdb1xScannerPush extends UTBase {
     
     verify(hbase_scanner, times(1)).nextRows();
     verify(hbase_scanner, times(1)).close();
-    verify(owner, never()).scannerDone();
+    verify(owner, times(1)).scannerDone();
     verify(owner, times(1)).exception(any(Throwable.class));
     assertEquals(0, scanner.keepers.size());
     assertEquals(0, scanner.skips.size());
@@ -423,7 +423,7 @@ public class TestTsdb1xScannerPush extends UTBase {
     
     verify(hbase_scanner, times(1)).nextRows();
     verify(hbase_scanner, times(1)).close();
-    verify(owner, never()).scannerDone();
+    verify(owner, times(1)).scannerDone();
     verify(owner, times(1)).exception(any(Throwable.class));
     assertEquals(0, scanner.keepers.size());
     assertEquals(0, scanner.skips.size());
@@ -1469,7 +1469,7 @@ public class TestTsdb1xScannerPush extends UTBase {
     
     verify(hbase_scanner, times(1)).nextRows();
     verify(hbase_scanner, times(1)).close();
-    verify(owner, times(1)).scannerDone();
+    verify(owner, times(2)).scannerDone();
     verify(owner, times(1)).exception(any(Throwable.class));
     assertEquals(State.EXCEPTION, scanner.state());
     verify(schema, times(2)).getName(UniqueIdType.METRIC, METRIC_BYTES, null);


### PR DESCRIPTION
- Fix an edge case where scanners done wasn't incremented if the pending RPCs
  were full and resolution of an ID failed.
- Return the hex of the UID instead of the address in the UID store.