### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/DefaultQueryResultId.java
+++ b/common/src/main/java/net/opentsdb/query/DefaultQueryResultId.java
@@ -1,0 +1,87 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2020  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query;
+
+import com.google.common.base.Strings;
+
+/**
+ * A default implementation of the query result ID.
+ * 
+ * @since 3.0
+ */
+public class DefaultQueryResultId implements QueryResultId {
+  /** The node ID, part 1 of the colon delimited ID string. */
+  private final String node_id;
+  
+  /** The data source for the result, part 2 of the colon delimited ID String. */
+  private final String data_source;
+  
+  /**
+   * Default ctor.
+   * @param node_id The non-null and non-empty node ID.
+   * @param data_source The non-null and non-empty data source.
+   */
+  public DefaultQueryResultId(final String node_id, final String data_source) {
+    if (Strings.isNullOrEmpty(node_id)) {
+      throw new IllegalStateException("Node ID cannot be null or empty.");
+    }
+    if (Strings.isNullOrEmpty(data_source)) {
+      throw new IllegalStateException("Data source cannot be null or empty.");
+    }
+    this.node_id = node_id;
+    this.data_source = data_source;
+  }
+  
+  @Override
+  public String nodeID() {
+    return node_id;
+  }
+
+  @Override
+  public String dataSource() {
+    return data_source;
+  }
+
+  @Override
+  public String toString() {
+    return node_id + ":" + data_source;
+  }
+  
+  @Override
+  public boolean equals(final Object obj) {
+    if (obj == null || !(obj instanceof QueryResultId)) {
+      return false;
+    }
+    
+    final QueryResultId other = (QueryResultId) obj;
+    if (Strings.isNullOrEmpty(other.nodeID()) || 
+        Strings.isNullOrEmpty(other.dataSource())) {
+      throw new IllegalStateException("ID " + obj 
+          + " has a null or empty node or data source ID.");
+    }
+    
+    return other.nodeID().equals(node_id) &&
+           other.dataSource().equals(data_source);
+  }
+  
+  @Override
+  public int hashCode() {
+    // TODO - verify this is ok for ints. It should be as we'd have low
+    // cardinality within a given query. If we ever use this for multi-query
+    // then we need to revisit it.
+    return 2251 * node_id.hashCode() ^ 37 * data_source.hashCode();
+  }
+  
+}

--- a/common/src/main/java/net/opentsdb/query/QueryNodeConfig.java
+++ b/common/src/main/java/net/opentsdb/query/QueryNodeConfig.java
@@ -120,6 +120,17 @@ public interface QueryNodeConfig<B extends QueryNodeConfig.Builder<B, C>, C exte
    * @return
    */
   B toBuilder();
+  
+  /** @return The non-null data sources for this query node. Populated during
+   * node config initialization to denote the ID of data that will flow through
+   * the node for this configuration. Different than {@link #getSources()}. */
+  List<QueryResultId> resultIds();
+  
+  /** @return Whether or not this node in the graph is cacheable or not. May not
+   * match {@link #readCacheable()} */
+  boolean markedCacheable();
+  
+  void markCacheable(final boolean cacheable);
 
   /**
    * The interface for a QueryNodeConfig builder implementation.
@@ -165,6 +176,19 @@ public interface QueryNodeConfig<B extends QueryNodeConfig.Builder<B, C>, C exte
      */
     B addOverride(final String key, final String value);
 
+    /**
+     * @param result_id The list of result IDs. May be null to clear out the
+     * list and return an empty collection.
+     * @return The builder.
+     */
+    B setResultIds(final List<QueryResultId> result_id);
+    
+    /**
+     * @param result_id A non-null result ID for this node config. 
+     * @return The builder.
+     */
+    B addResultId(final QueryResultId result_id);
+    
     /** @return The non-null config instance. */
     C build();
 

--- a/common/src/main/java/net/opentsdb/query/QueryResult.java
+++ b/common/src/main/java/net/opentsdb/query/QueryResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2019  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,9 +41,6 @@ public interface QueryResult {
    */
   public TimeSpecification timeSpecification();
   
-  // TODO - I may need to reorg the time series by data source. That way
-  // we can link to the schema.
-  
   /**
    * The collection of time series results, potentially in order (e.g. if TopN
    * is used). May be empty but will not be null.
@@ -80,12 +77,12 @@ public interface QueryResult {
    */
   public QueryNode source();
   
-  /** @return The name of the data source that these results came from.
+  /** @return The identifier of the data source that these results came from.
    * E.g. can be a metric source (QuerySourceConfig) or it could be a 
    * node that generates a new result set such as an expression. If 
    * data is just passing through (e.g. a downsample node) this should
    * be the source metric or node. */
-  public String dataSource();
+  public QueryResultId dataSource();
   
   /**
    * The type of time series ID used to describe the time series in this

--- a/common/src/main/java/net/opentsdb/query/QueryResultId.java
+++ b/common/src/main/java/net/opentsdb/query/QueryResultId.java
@@ -1,0 +1,31 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2020  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query;
+
+/**
+ * A query result ID. This should be set during configuration node setup so that
+ * upstream nodes in the graph can find out how much data to expect.
+ * 
+ * @since 3.0
+ */
+public interface QueryResultId {
+
+  /** @return The non-null and non-empty ID of the node the result came from. */
+  public String nodeID();
+  
+  /** @return The non-null and non-empty data source ID for the result. */
+  public String dataSource();
+  
+}

--- a/common/src/main/java/net/opentsdb/query/TimeSeriesDataSourceConfig.java
+++ b/common/src/main/java/net/opentsdb/query/TimeSeriesDataSourceConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018-2019  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,10 +32,6 @@ public interface TimeSeriesDataSourceConfig<
     extends QueryNodeConfig<B, C> {
 
   public static final String DEFAULT = "TimeSeriesDataSource";
-  
-  /** @return The ID of the node as set by the user and populates the 
-   * {@link QueryResult#dataSource()} field. May be the same as the ID. */
-  public String getDataSourceId();
   
   /** @return The source ID. May be null in which case we use the default. */
   public String getSourceId();
@@ -103,8 +99,6 @@ public interface TimeSeriesDataSourceConfig<
    */
   interface Builder<B extends Builder<B, C>, 
       C extends TimeSeriesDataSourceConfig> extends QueryNodeConfig.Builder<B, C> {
-    
-    B setDataSourceId(final String data_source_id);
     
     B setSourceId(final String source_id);
     

--- a/common/src/main/java/net/opentsdb/query/plan/QueryPlanner.java
+++ b/common/src/main/java/net/opentsdb/query/plan/QueryPlanner.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018-2019  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
 package net.opentsdb.query.plan;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.Set;
 
 import com.google.common.graph.MutableGraph;
 import com.stumbleupon.async.Deferred;
@@ -118,27 +116,11 @@ public interface QueryPlanner {
   public Collection<QueryNodeConfig> terminalSourceNodes(final QueryNodeConfig config);
   
   /**
-   * Finds the set of data source IDs from the current node in the format
-   * config_id:datasource_id.
-   * @param node The non-null node to start from.
-   * @return A non-null list of source IDs.
-   */
-  public List<String> getDataSourceIds(final QueryNodeConfig node);
-  
-  /**
-   * Finds the name of metrics from the given node.
-   * TODO - won't work in the future if we have other filter types.
-   * @param node The non-null node to start from.
-   * @return A non-null set of metric names.
-   */
-  public Set<String> getMetrics(final QueryNodeConfig node);
-  
-  /**
    * A recursive look for the metric matching the given data source Id.
    * @param node The start node for the recursive search.
    * @param data_source_id The non-null data source to match.
    * @return The matched metric name in the format <metric>
    */
-  public String getMetricForDataSource(final QueryNodeConfig node, 
+  public String getMetricForDataSource(final QueryNodeConfig node,
                                        final String data_source_id);
 }

--- a/common/src/main/java/net/opentsdb/query/readcache/CachedQueryNode.java
+++ b/common/src/main/java/net/opentsdb/query/readcache/CachedQueryNode.java
@@ -27,6 +27,7 @@ import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.stats.Span;
 
 /**
@@ -136,6 +137,22 @@ public class CachedQueryNode implements QueryNode, QueryNodeConfig {
     return null;
   }
 
+  @Override
+  public List<QueryResultId> resultIds() {
+    // TODO - do we need to populate this?
+    return Collections.emptyList();
+  }
+  
+  @Override
+  public boolean markedCacheable() {
+    return false;
+  }
+  
+  @Override
+  public void markCacheable(final boolean cacheable) {
+    // no-op
+  }
+  
   @Override
   public QueryPipelineContext pipelineContext() {
     return original_node.pipelineContext();

--- a/common/src/main/java/net/opentsdb/query/readcache/ReadCacheQueryResultSet.java
+++ b/common/src/main/java/net/opentsdb/query/readcache/ReadCacheQueryResultSet.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package net.opentsdb.query.readcache;
 import java.util.Map;
 
 import net.opentsdb.data.TimeStamp;
+import net.opentsdb.query.QueryResultId;
 
 /**
  * All of the results from a cached segment including the index and key from
@@ -37,5 +38,5 @@ public interface ReadCacheQueryResultSet {
   public int index();
   
   /** @return The map of query result IDs to the results. */
-  public Map<String, ReadCacheQueryResult> results();
+  public Map<QueryResultId, ReadCacheQueryResult> results();
 }

--- a/common/src/main/java/net/opentsdb/query/readcache/ReadCacheSerdes.java
+++ b/common/src/main/java/net/opentsdb/query/readcache/ReadCacheSerdes.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ import java.util.Collection;
 import java.util.Map;
 
 import net.opentsdb.query.QueryNode;
-import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 
 /**
  * A serdes plugin for serializing and deserializing read cache data.
@@ -55,7 +55,7 @@ public interface ReadCacheSerdes {
    * @return The deserialized cache result map, may be empty, keyed on the
    * result ID.
    */
-  public Map<String, ReadCacheQueryResult> deserialize(
+  public Map<QueryResultId, ReadCacheQueryResult> deserialize(
       final QueryNode node, 
       final byte[] data);
 

--- a/core/src/main/java/net/opentsdb/pools/ByteArrayPool.java
+++ b/core/src/main/java/net/opentsdb/pools/ByteArrayPool.java
@@ -50,6 +50,7 @@ public class ByteArrayPool extends BaseArrayObjectPoolAllocator {
         .setAllocator(this)
         .setInitialCount(tsdb.getConfig().getInt(configKey(COUNT_KEY, TYPE)))
         .setMaxCount(tsdb.getConfig().getInt(configKey(COUNT_KEY, TYPE)))
+        .setArrayLength(tsdb.getConfig().getInt(configKey(LENGTH_KEY, TYPE)))
         .setId(this.id)
         .build();
     try {
@@ -77,10 +78,10 @@ public class ByteArrayPool extends BaseArrayObjectPoolAllocator {
   
   @Override
   protected void registerConfigs(final Configuration config, final String type) {
-    super.registerConfigs(config, type);
     if (!config.hasProperty(configKey(LENGTH_KEY, TYPE))) {
       config.register(configKey(LENGTH_KEY, TYPE), 8192, false, 
           "The length of each array to allocate");
     }
+    super.registerConfigs(config, type);
   }
 }

--- a/core/src/main/java/net/opentsdb/pools/DoubleArrayPool.java
+++ b/core/src/main/java/net/opentsdb/pools/DoubleArrayPool.java
@@ -78,12 +78,11 @@ public class DoubleArrayPool extends BaseArrayObjectPoolAllocator {
   
   @Override
   protected void registerConfigs(final Configuration config, final String type) {
-    super.registerConfigs(config, type);
     if (!config.hasProperty(configKey(LENGTH_KEY, TYPE))) {
       config.register(configKey(LENGTH_KEY, TYPE), 4096, false, 
           "The length of each array to allocate");
     }
+    super.registerConfigs(config, type);
   }
-
   
 }

--- a/core/src/main/java/net/opentsdb/query/BadQueryResult.java
+++ b/core/src/main/java/net/opentsdb/query/BadQueryResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public class BadQueryResult implements QueryResult {
   private final Throwable exception;
   private final String error;
   private final QueryNode node;
-  private final String data_source;
+  private final QueryResultId data_source;
   
   private BadQueryResult(final Builder builder) {
     exception = builder.exception;
@@ -76,7 +76,7 @@ public class BadQueryResult implements QueryResult {
   }
 
   @Override
-  public String dataSource() {
+  public QueryResultId dataSource() {
     return data_source;
   }
 
@@ -113,7 +113,7 @@ public class BadQueryResult implements QueryResult {
     private Throwable exception;
     private String error;
     private QueryNode node;
-    private String data_source;
+    private QueryResultId data_source;
     
     public Builder setException(final Throwable exception) {
       this.exception = exception;
@@ -130,7 +130,7 @@ public class BadQueryResult implements QueryResult {
       return this;
     }
     
-    public Builder setDataSource(final String data_source) {
+    public Builder setDataSource(final QueryResultId data_source) {
       this.data_source = data_source;
       return this;
     }
@@ -140,7 +140,9 @@ public class BadQueryResult implements QueryResult {
         throw new IllegalArgumentException("Must have an error string or "
             + "an exception.");
       }
-      if (Strings.isNullOrEmpty(data_source)) {
+      if (data_source == null || 
+          Strings.isNullOrEmpty(data_source.nodeID()) || 
+          Strings.isNullOrEmpty(data_source.dataSource())) {
         throw new IllegalArgumentException("Data source cannot be null or empty.");
       }
       if (node == null) {

--- a/core/src/main/java/net/opentsdb/query/BaseQueryNodeConfig.java
+++ b/core/src/main/java/net/opentsdb/query/BaseQueryNodeConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,6 +57,12 @@ public abstract class BaseQueryNodeConfig<B extends BaseQueryNodeConfig.Builder<
   /** The cached hash code. */
   protected volatile HashCode cached_hash;
   
+  /** Whether or not the node is cacheable in the config graph. */
+  protected boolean cacheable;
+  
+  /** The data sources from this node. */
+  protected List<QueryResultId> result_ids;
+  
   /**
    * Protected ctor.
    * @param builder A non-null builder.
@@ -71,6 +77,7 @@ public abstract class BaseQueryNodeConfig<B extends BaseQueryNodeConfig.Builder<
     sources = builder.sources == null ? Collections.emptyList() : 
       builder.sources;
     overrides = builder.overrides;
+    result_ids = builder.result_ids;
   }
   
   @Override
@@ -244,6 +251,35 @@ public abstract class BaseQueryNodeConfig<B extends BaseQueryNodeConfig.Builder<
     return hc.hash();
   }
   
+  @Override
+  public List<QueryResultId> resultIds() {
+    return result_ids == null ? Collections.emptyList() : result_ids;
+  }
+  
+  @Override
+  public boolean markedCacheable() {
+    return cacheable;
+  }
+  
+  @Override
+  public void markCacheable(final boolean cacheable) {
+    this.cacheable = cacheable;
+  }
+  
+  /**
+   * A method to set the common fields to the given builder so we avoid a little
+   * boilerplate.
+   * @param builder A non-null builder to set the fieldso n.
+   */
+  protected void toBuilder(final Builder builder) {
+    builder
+      .setSources(sources != null ? Lists.newArrayList(sources) : null)
+      .setResultIds(result_ids != null ? Lists.newArrayList(result_ids) : null)
+      .setOverrides(overrides != null ? Maps.newHashMap(overrides) : null)
+      .setType(type)
+      .setId(id);
+  }
+  
   /** Base builder for QueryNodeConfig. */
   @JsonIgnoreProperties(ignoreUnknown = true)
   public abstract static class Builder<B extends Builder<B, C>, C extends BaseQueryNodeConfig>
@@ -257,6 +293,7 @@ public abstract class BaseQueryNodeConfig<B extends BaseQueryNodeConfig.Builder<
     protected List<String> sources;
     @JsonProperty
     protected Map<String, String> overrides;
+    protected List<QueryResultId> result_ids;
 
     /**
      * @param id An ID for this builder.
@@ -320,5 +357,21 @@ public abstract class BaseQueryNodeConfig<B extends BaseQueryNodeConfig.Builder<
       return self();
     }
 
+    @Override
+    public B setResultIds(final List<QueryResultId> data_sources) {
+      this.result_ids = data_sources;
+      return self();
+    }
+    
+    @Override
+    public B addResultId(final QueryResultId source) {
+      if (result_ids == null) {
+        result_ids = Lists.newArrayList(source);
+      } else {
+        result_ids.add(source);
+      }
+      return self();
+    }
+    
   }
 }

--- a/core/src/main/java/net/opentsdb/query/BaseQueryNodeConfigWithInterpolators.java
+++ b/core/src/main/java/net/opentsdb/query/BaseQueryNodeConfigWithInterpolators.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import com.google.common.collect.Maps;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.common.reflect.TypeToken;
+
 import net.opentsdb.query.interpolation.QueryInterpolatorConfig;
 import net.opentsdb.utils.Comparators.MapComparator;
 
@@ -87,6 +88,12 @@ public abstract class BaseQueryNodeConfigWithInterpolators<B extends BaseQueryNo
       interpolator_configs.get(type);
   }
 
+  protected void toBuilder(final Builder builder) {
+    builder.setInterpolatorConfigs(
+        Lists.newArrayList(interpolator_configs.values()));
+    super.toBuilder(builder);
+  }
+  
   public static abstract class Builder<B extends Builder<B, C>, C extends BaseQueryNodeConfigWithInterpolators> extends BaseQueryNodeConfig.Builder<B, C> {
     @JsonProperty
     protected List<QueryInterpolatorConfig> interpolatorConfigs;
@@ -121,7 +128,6 @@ public abstract class BaseQueryNodeConfigWithInterpolators<B extends BaseQueryNo
     
   }
 
-
   @Override
   public boolean equals(final Object o) {
     if (this == o)
@@ -139,12 +145,10 @@ public abstract class BaseQueryNodeConfigWithInterpolators<B extends BaseQueryNo
 
   }
 
-
   @Override
   public int hashCode() {
     return buildHashCode().asInt();
   }
-
 
   /** @return A HashCode object for deterministic, non-secure hashing */
   public HashCode buildHashCode() {

--- a/core/src/main/java/net/opentsdb/query/ConvertedQueryResult.java
+++ b/core/src/main/java/net/opentsdb/query/ConvertedQueryResult.java
@@ -69,7 +69,7 @@ public class ConvertedQueryResult extends BaseWrappedQueryResult
   protected ConvertedQueryResult(final QueryResult result, 
                                  final QueryNode node,
                                  final Span span) {
-    super(result);
+    super(node, result);
     this.node = node;
     sink = null;
     this.span = span;
@@ -186,6 +186,11 @@ public class ConvertedQueryResult extends BaseWrappedQueryResult
     return result.source();
   }
 
+  @Override
+  public QueryResultId dataSource() {
+    return result.dataSource();
+  }
+  
   @Override
   public TypeToken<? extends TimeSeriesId> idType() {
     return Const.TS_STRING_ID;

--- a/core/src/main/java/net/opentsdb/query/DefaultTimeSeriesDataSourceConfig.java
+++ b/core/src/main/java/net/opentsdb/query/DefaultTimeSeriesDataSourceConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // This program is free software: you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License as published by
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.hash.HashCode;
 
@@ -239,5 +240,6 @@ public class DefaultTimeSeriesDataSourceConfig
     public Builder self() {
       return this;
     }
+
   }
 }

--- a/core/src/main/java/net/opentsdb/query/WrappedTimeSeriesDataSourceConfig.java
+++ b/core/src/main/java/net/opentsdb/query/WrappedTimeSeriesDataSourceConfig.java
@@ -16,6 +16,7 @@ package net.opentsdb.query;
 
 import java.time.temporal.TemporalAmount;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -78,11 +79,6 @@ public class WrappedTimeSeriesDataSourceConfig implements TimeSeriesDataSourceCo
     return config.getType();
   }
 
-  @Override
-  public String getDataSourceId() {
-    return config.getDataSourceId();
-  }
-  
   @Override
   public List<String> getSources() {
     return config.getSources();
@@ -300,5 +296,20 @@ public class WrappedTimeSeriesDataSourceConfig implements TimeSeriesDataSourceCo
   @Override
   public int compareTo(Object o) {
     throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  @Override
+  public List<QueryResultId> resultIds() {
+    return config.resultIds();
+  }
+  
+  @Override
+  public boolean markedCacheable() {
+    return config.markedCacheable();
+  }
+  
+  @Override
+  public void markCacheable(final boolean cacheable) {
+    config.markCacheable(cacheable);
   }
 }

--- a/core/src/main/java/net/opentsdb/query/anomaly/MemoryPredictionCache.java
+++ b/core/src/main/java/net/opentsdb/query/anomaly/MemoryPredictionCache.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import net.opentsdb.core.Const;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.query.readcache.ReadCacheQueryResult;
 import net.opentsdb.query.readcache.ReadCacheSerdes;
 import net.opentsdb.query.readcache.ReadCacheSerdesFactory;
@@ -92,9 +93,9 @@ public class MemoryPredictionCache extends BaseTSDBPlugin implements PredictionC
     if (value== null || value.expired()) {
       return Deferred.fromResult(null);
     } else {
-      Map<String, ReadCacheQueryResult> map = serdes.deserialize(context, value.value);
+      Map<QueryResultId, ReadCacheQueryResult> map = serdes.deserialize(context, value.value);
       ReadCacheQueryResult result = null;
-      for (final Entry<String, ReadCacheQueryResult> entry : map.entrySet()) {
+      for (final Entry<QueryResultId, ReadCacheQueryResult> entry : map.entrySet()) {
         if (entry.getValue() != null) {
           result = entry.getValue();
           break;

--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV2ExpQuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV2ExpQuerySerdes.java
@@ -191,7 +191,7 @@ public class JsonV2ExpQuerySerdes implements TimeSeriesSerdes {
           }
           
           json.writeStartObject();
-          json.writeStringField("id", result.dataSource());
+          json.writeStringField("id", result.dataSource().dataSource());
           json.writeArrayFieldStart("dps");
           
           final List<TypedTimeSeriesIterator<?>> iterators = Lists.newArrayList();

--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
@@ -186,8 +186,7 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes {
           throws Exception {
         try {
           json.writeStartObject();
-          json.writeStringField("source", result.source().config().getId()
-              + ":" + result.dataSource());
+          json.writeStringField("source", result.dataSource().toString());
           final TimeStamp spec_start;
           final TimeStamp spec_end;
 

--- a/core/src/main/java/net/opentsdb/query/hacluster/HACluster.java
+++ b/core/src/main/java/net/opentsdb/query/hacluster/HACluster.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018-2019  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.query.readcache.CachedQueryNode;
 import net.opentsdb.stats.Span;
 import net.opentsdb.utils.DateTime;
@@ -390,7 +391,7 @@ public class HACluster extends AbstractQueryNode implements TimeSeriesDataSource
     EmptyResult(final QueryResult result, 
                 final QueryNode node, 
                 final String missing_src) {
-      super(result);
+      super(node, result);
       this.node = new CachedQueryNode(missing_src, node);
       this.missing_src = missing_src;
     }
@@ -406,7 +407,7 @@ public class HACluster extends AbstractQueryNode implements TimeSeriesDataSource
     }
 
     @Override
-    public String dataSource() {
+    public QueryResultId dataSource() {
       return result.dataSource();
     }
 

--- a/core/src/main/java/net/opentsdb/query/hacluster/HAClusterFactory.java
+++ b/core/src/main/java/net/opentsdb/query/hacluster/HAClusterFactory.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -215,8 +215,6 @@ public class HAClusterFactory extends BaseQueryNodeFactory<
         builder.setDataSources(Lists.newArrayList(default_sources));
       }
     }
-    
-    builder.setDataSourceId(config.getDataSourceId());
 
     final String new_id = "ha_" + config.getId();
     if (context.query().isTraceEnabled()) {

--- a/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverter.java
+++ b/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverter.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018-2019  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 
 /**
  * Simply converts byte encoded IDs to their strings using the 
@@ -120,7 +121,8 @@ public class ByteToStringIdConverter extends AbstractQueryNode {
     }
     
     Deferred.groupInOrder(deferreds)
-      .addCallbacks(new ResolveCB(), new ErrorCB());
+      .addCallback(new ResolveCB())
+      .addErrback(new ErrorCB());
   }
 
   @Override
@@ -161,7 +163,7 @@ public class ByteToStringIdConverter extends AbstractQueryNode {
     
     public ConvertedResult(final QueryResult result, 
                            final List<TimeSeriesStringId> ids) {
-      super(result);
+      super(ByteToStringIdConverter.this, result);
       wrapped_series = Lists.newArrayListWithExpectedSize(result.timeSeries().size());
       int index = 0;
       // Invariate: the number of ids must match the time series AND the
@@ -184,6 +186,11 @@ public class ByteToStringIdConverter extends AbstractQueryNode {
     @Override
     public QueryNode source() {
       return ByteToStringIdConverter.this;
+    }
+    
+    @Override
+    public QueryResultId dataSource() {
+      return result.dataSource();
     }
     
   }

--- a/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverterConfig.java
+++ b/core/src/main/java/net/opentsdb/query/idconverter/ByteToStringIdConverterConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018-2019  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,8 @@ import java.util.Map;
  */
 @JsonInclude(Include.NON_NULL)
 @JsonDeserialize(builder = ByteToStringIdConverterConfig.Builder.class)
-public class ByteToStringIdConverterConfig extends BaseQueryNodeConfig<ByteToStringIdConverterConfig.Builder, ByteToStringIdConverterConfig> {
+public class ByteToStringIdConverterConfig extends BaseQueryNodeConfig<
+    ByteToStringIdConverterConfig.Builder, ByteToStringIdConverterConfig> {
   
   /** The map of data sources to factories. */
   private Map<String, TimeSeriesDataSourceFactory> data_sources;
@@ -62,8 +63,7 @@ public class ByteToStringIdConverterConfig extends BaseQueryNodeConfig<ByteToStr
     return data_sources.get(source);
   }
 
-
-  public Map<String, TimeSeriesDataSourceFactory> getDataSources() {
+  public Map<String, TimeSeriesDataSourceFactory> getDataSourceFactories() {
     return data_sources;
   }
 
@@ -79,7 +79,10 @@ public class ByteToStringIdConverterConfig extends BaseQueryNodeConfig<ByteToStr
 
   @Override
   public Builder toBuilder() {
-    return null;
+    final Builder builder = newBuilder()
+        .setDataSourcesFactories(getDataSourceFactories());
+    super.toBuilder(builder);
+    return builder;
   }
 
   @Override
@@ -103,7 +106,7 @@ public class ByteToStringIdConverterConfig extends BaseQueryNodeConfig<ByteToStr
     final ByteToStringIdConverterConfig byteconfig = (ByteToStringIdConverterConfig) o;
 
 
-    return Objects.equal(data_sources.keySet(), byteconfig.getDataSources().keySet());
+    return Objects.equal(data_sources.keySet(), byteconfig.getDataSourceFactories().keySet());
   }
 
   @Override
@@ -148,14 +151,14 @@ public class ByteToStringIdConverterConfig extends BaseQueryNodeConfig<ByteToStr
       setType(ByteToStringIdConverterFactory.TYPE);
     }
     
-    public Builder setDataSources(
+    public Builder setDataSourcesFactories(
         final Map<String, TimeSeriesDataSourceFactory> data_sources) {
       this.data_sources = data_sources;
       return this;
     }
     
-    public Builder addDataSource(final String source, 
-                                 final TimeSeriesDataSourceFactory factory) {
+    public Builder addDataSourceFactory(final String source, 
+                                        final TimeSeriesDataSourceFactory factory) {
       if (data_sources == null) {
         data_sources = Maps.newHashMap();
       }

--- a/core/src/main/java/net/opentsdb/query/processor/dedup/DedupNode.java
+++ b/core/src/main/java/net/opentsdb/query/processor/dedup/DedupNode.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -94,7 +95,7 @@ public class DedupNode extends AbstractQueryNode {
     private List<TimeSeries> results = new ArrayList<>();
 
     public DedupResult(final QueryResult next) {
-      super(next);
+      super(DedupNode.this, next);
     }
     
     @Override
@@ -105,6 +106,11 @@ public class DedupNode extends AbstractQueryNode {
     @Override
     public QueryNode source() {
       return DedupNode.this;
+    }
+    
+    @Override
+    public QueryResultId dataSource() {
+      return result.dataSource();
     }
     
   }

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/Downsample.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/Downsample.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,7 +128,7 @@ public class Downsample extends AbstractQueryNode {
      * @param results The non-null results set.
      */
     public DownsampleResult(final QueryResult results) {
-      super(results);
+      super(Downsample.this, results);
       latch = new CountDownLatch(Downsample.this.upstream.size());
       downsamplers = Lists.newArrayListWithCapacity(results.timeSeries().size());
       for (final TimeSeries series : results.timeSeries()) {
@@ -197,12 +197,7 @@ public class Downsample extends AbstractQueryNode {
     public List<TimeSeries> timeSeries() {
       return downsamplers;
     }
-    
-    @Override
-    public QueryNode source() {
-      return Downsample.this;
-    }
-    
+
     @Override
     public ChronoUnit resolution() {
       return resolution;

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2019  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -438,6 +438,7 @@ public class DownsampleConfig extends BaseQueryNodeConfigWithInterpolators<
         .setEnd(end)
         .setIntervals(intervals)
         .setInterpolatorConfigs(Lists.newArrayList(interpolator_configs.values()))
+        .setResultIds(result_ids != null ? Lists.newArrayList(result_ids) : null)
         .setId(id);
   }
 
@@ -458,6 +459,7 @@ public class DownsampleConfig extends BaseQueryNodeConfigWithInterpolators<
         .setOriginalInterval(config.original_interval)
         .setInterpolatorConfigs(Lists.newArrayList(config.interpolator_configs.values()))
         .setSources(Lists.newArrayList(config.getSources()))
+        .setResultIds(config.result_ids != null ? Lists.newArrayList(config.result_ids) : null)
         .setId(config.id);
   }
 

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNodeFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/BinaryExpressionNodeFactory.java
@@ -1,5 +1,5 @@
 //This file is part of OpenTSDB.
-//Copyright (C) 2018  The OpenTSDB Authors.
+//Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 //Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.
@@ -33,11 +33,8 @@ import net.opentsdb.data.types.numeric.NumericArrayType;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryIteratorFactory;
-import net.opentsdb.query.QueryNode;
-import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
-import net.opentsdb.query.plan.QueryPlanner;
 import net.opentsdb.query.processor.BaseQueryNodeFactory;
 import net.opentsdb.query.processor.expressions.ExpressionParseNode.ExpressionOp;
 import net.opentsdb.query.processor.expressions.ExpressionParseNode.OperandType;
@@ -175,16 +172,6 @@ public class BinaryExpressionNodeFactory extends BaseQueryNodeFactory<Expression
     n = node.get("as");
     if (n != null && !n.isNull()) {
       builder.setAs(n.asText());
-    }
-    
-    n = node.get("leftId");
-    if (n != null && !n.isNull()) {
-      builder.setLeftId(n.asText());
-    }
-    
-    n = node.get("rightId");
-    if (n != null && !n.isNull()) {
-      builder.setRightId(n.asText());
     }
     
     n = node.get("id");

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionConfig.java
@@ -175,8 +175,8 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
   @Override
   public Builder toBuilder() {
     Builder cloneBuilder = new Builder();
-    cloneBuilder(this,cloneBuilder);
-
+    cloneBuilder(this, cloneBuilder);
+    super.toBuilder(cloneBuilder);
     return cloneBuilder;
   }
 
@@ -381,7 +381,7 @@ public class ExpressionConfig extends BaseQueryNodeConfigWithInterpolators<Expre
            .setExpression(expressionConfig.getExpression())
            .setJoinConfig(join.toBuilder().build())
            .setInfectiousNan(expressionConfig.getInfectiousNan());
-
+    
   }
 
   public static Builder newBuilder(){

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParseNode.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParseNode.java
@@ -14,6 +14,7 @@
 // limitations under the License.
 package net.opentsdb.query.processor.expressions;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -24,7 +25,7 @@ import com.google.common.hash.HashCode;
 
 import net.opentsdb.common.Const;
 import net.opentsdb.query.BaseQueryNodeConfig;
-import net.opentsdb.query.QueryNodeConfig;
+import net.opentsdb.query.QueryResultId;
 
 /**
  * A node populated during parsing of a metric expression.
@@ -129,8 +130,8 @@ public class ExpressionParseNode extends BaseQueryNodeConfig<ExpressionParseNode
   private final ExpressionConfig expression_config;
   
   /** Node IDs for linking results. */
-  private String left_id;
-  private String right_id;
+  private QueryResultId left_id;
+  private QueryResultId right_id;
   
   /**
    * Protected ctor.
@@ -200,12 +201,14 @@ public class ExpressionParseNode extends BaseQueryNodeConfig<ExpressionParseNode
   }
   
   /** @return The left result source ID, may be null. */
-  public String getLeftId() {
+  @JsonIgnore
+  public QueryResultId getLeftId() {
     return left_id;
   }
   
   /** @return The right result source ID, may be null. */
-  public String getRightId() {
+  @JsonIgnore
+  public QueryResultId getRightId() {
     return right_id;
   }
   
@@ -285,7 +288,7 @@ public class ExpressionParseNode extends BaseQueryNodeConfig<ExpressionParseNode
 
   @Override
   public Builder toBuilder() {
-    return new Builder()
+    Builder builder = new Builder()
         .setExpressionConfig(expression_config)
         .setExpressionOp(op)
         .setLeft(left)
@@ -296,9 +299,9 @@ public class ExpressionParseNode extends BaseQueryNodeConfig<ExpressionParseNode
         .setNot(not)
         .setAs(as)
         .setLeftId(left_id)
-        .setRightId(right_id)
-        .setSources(Lists.newArrayList(sources))
-        .setId(id);
+        .setRightId(right_id);
+    super.toBuilder(builder);
+    return builder;
   }
 
   public static Builder newBuilder() {
@@ -325,9 +328,9 @@ public class ExpressionParseNode extends BaseQueryNodeConfig<ExpressionParseNode
     @JsonProperty
     protected String as;
     @JsonProperty
-    protected String leftId;
+    protected QueryResultId leftId;
     @JsonProperty
-    protected String rightId;
+    protected QueryResultId rightId;
     
     Builder() {
       setType(BinaryExpressionNodeFactory.TYPE);
@@ -400,12 +403,12 @@ public class ExpressionParseNode extends BaseQueryNodeConfig<ExpressionParseNode
       return id;
     }
     
-    public Builder setLeftId(final String left_id) {
+    public Builder setLeftId(final QueryResultId left_id) {
       this.leftId = left_id;
       return this;
     }
     
-    public Builder setRightId(final String right_id) {
+    public Builder setRightId(final QueryResultId right_id) {
       this.rightId = right_id;
       return this;
     }

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParser.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionParser.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import net.opentsdb.query.QueryNodeConfig;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.DefaultErrorStrategy;
@@ -375,23 +374,18 @@ public class ExpressionParser extends DefaultErrorStrategy
     } else if (obj instanceof ExpressionParseNode.Builder) {
       if (is_left) {
         builder.setLeft(((ExpressionParseNode.Builder) obj).id())
-               .setLeftType(OperandType.SUB_EXP)
-               .setLeftId(((ExpressionParseNode.Builder) obj).id());
+               .setLeftType(OperandType.SUB_EXP);
       } else {
         builder.setRight(((ExpressionParseNode.Builder) obj).id())
-               .setRightType(OperandType.SUB_EXP)
-               .setRightId(((ExpressionParseNode.Builder) obj).id());
+               .setRightType(OperandType.SUB_EXP);
       }
     } else if (obj instanceof String) {
-      // handle the funky "escape keywords" case. e.g. "sys.'if'.out"
       if (is_left) {
         builder.setLeft((String) obj)
-               .setLeftType(OperandType.VARIABLE)
-               .setLeftId((String) obj);
+               .setLeftType(OperandType.VARIABLE);
       } else {
         builder.setRight((String) obj)
-               .setRightType(OperandType.VARIABLE)
-               .setRightId((String) obj);
+               .setRightType(OperandType.VARIABLE);
       }
     } else {
       throw new RuntimeException("NEED TO HANDLE: " + obj.getClass());

--- a/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/expressions/ExpressionResult.java
@@ -1,5 +1,5 @@
 //This file is part of OpenTSDB.
-//Copyright (C) 2018  The OpenTSDB Authors.
+//Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 //Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.TimeSpecification;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.query.processor.expressions.ExpressionParseNode.OperandType;
 import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.utils.Pair;
@@ -146,8 +147,8 @@ public class ExpressionResult implements QueryResult {
   }
 
   @Override
-  public String dataSource() {
-    return node.config().getId();
+  public QueryResultId dataSource() {
+    return node.config().resultIds().get(0);
   }
   
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018  The OpenTSDB Authors.
+// Copyright (C) 2017-2020 The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,9 @@
 // limitations under the License.
 package net.opentsdb.query.processor.groupby;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -120,14 +122,14 @@ public class GroupByConfig extends BaseQueryNodeConfigWithInterpolators<GroupByC
 
   @Override
   public Builder toBuilder() {
-    return new Builder()
+    Builder builder = new Builder()
         .setTagKeys(Sets.newHashSet(tag_keys))
         .setAggregator(aggregator)
         .setInfectiousNan(infectious_nan)
         .setMergeIds(merge_ids)
-        .setFullMerge(full_merge)
-        .setInterpolatorConfigs(Lists.newArrayList(interpolator_configs.values()))
-        .setId(id);
+        .setFullMerge(full_merge);
+    super.toBuilder(builder);
+    return builder;
   }
 
   @Override
@@ -184,14 +186,10 @@ public class GroupByConfig extends BaseQueryNodeConfigWithInterpolators<GroupByC
             .putBoolean(full_merge)
             .hash();
 
-
     final List<HashCode> hashes =
             Lists.newArrayListWithCapacity(4);
-
     hashes.add(super.buildHashCode());
-
     hashes.add(hc);
-
 
     if (tag_keys != null) {
       final List<String> keys = Lists.newArrayList(tag_keys);

--- a/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,9 +34,7 @@ import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesByteId;
 import net.opentsdb.data.TimeSeriesStringId;
 import net.opentsdb.query.BaseWrappedQueryResult;
-import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
-import net.opentsdb.query.processor.downsample.Downsample.DownsampleResult;
 
 /**
  * A result from the {@link GroupBy} node for a segment. The grouping is 
@@ -68,7 +66,7 @@ public class GroupByResult extends BaseWrappedQueryResult {
    * @throws IllegalArgumentException if the node or result was null.
    */
   public GroupByResult(final GroupBy node, final QueryResult next) {
-    super(next);
+    super(node, next);
     if (node == null) {
       throw new IllegalArgumentException("Node cannot be null.");
     }
@@ -205,11 +203,6 @@ public class GroupByResult extends BaseWrappedQueryResult {
   @Override
   public List<TimeSeries> timeSeries() {
     return results;
-  }
-  
-  @Override
-  public QueryNode source() {
-    return node;
   }
 
   /** @return The downstream result. */

--- a/core/src/main/java/net/opentsdb/query/processor/merge/MergerConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/merge/MergerConfig.java
@@ -27,6 +27,7 @@ import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import net.opentsdb.core.Const;
 import net.opentsdb.query.BaseQueryNodeConfigWithInterpolators;
+import net.opentsdb.query.DefaultQueryResultId;
 
 import java.util.List;
 
@@ -54,6 +55,8 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
     data_source = builder.dataSource;
     aggregator = builder.aggregator;
     infectious_nan = builder.infectious_nan;
+    result_ids = Lists.newArrayList(
+        new DefaultQueryResultId(data_source, data_source));
   }
   
   public String getDataSource() {
@@ -73,12 +76,12 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
 
   @Override
   public Builder toBuilder() {
-    return new Builder()
+    final Builder builder = new Builder()
         .setDataSource(data_source)
         .setAggregator(aggregator)
-        .setInfectiousNan(infectious_nan)
-        .setInterpolatorConfigs(Lists.newArrayList(interpolator_configs.values()))
-        .setId(id);
+        .setInfectiousNan(infectious_nan);
+    super.toBuilder(builder);
+    return builder;
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/merge/MergerResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/merge/MergerResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.TimeSpecification;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.rollup.RollupConfig;
 
 /**
@@ -165,8 +166,8 @@ public class MergerResult implements QueryResult {
   }
 
   @Override
-  public String dataSource() {
-    return ((MergerConfig) node.config()).getDataSource();
+  public QueryResultId dataSource() {
+    return ((MergerConfig) node.config()).resultIds().get(0);
   }
   
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/movingaverage/MovingAverage.java
+++ b/core/src/main/java/net/opentsdb/query/processor/movingaverage/MovingAverage.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ import net.opentsdb.data.types.numeric.aggregators.NumericAggregatorFactory;
 import net.opentsdb.data.types.numeric.aggregators.WeightedMovingAverageFactory;
 import net.opentsdb.query.AbstractQueryNode;
 import net.opentsdb.query.BaseWrappedQueryResult;
-import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
@@ -151,7 +150,7 @@ public class MovingAverage extends AbstractQueryNode {
     private List<TimeSeries> series;
     
     MovingAverageResult(final QueryResult next) {
-      super(next);
+      super(MovingAverage.this, next);
       series = Lists.newArrayListWithExpectedSize(next.timeSeries().size());
       for (final TimeSeries ts : next.timeSeries()) {
         series.add(new MovingAverageTimeSeries(ts));
@@ -161,11 +160,6 @@ public class MovingAverage extends AbstractQueryNode {
     @Override
     public List<TimeSeries> timeSeries() {
       return series;
-    }
-    
-    @Override
-    public QueryNode source() {
-      return MovingAverage.this;
     }
     
     /**

--- a/core/src/main/java/net/opentsdb/query/processor/rate/Rate.java
+++ b/core/src/main/java/net/opentsdb/query/processor/rate/Rate.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ public class Rate extends AbstractQueryNode<RateConfig> {
      * @param results The non-null results set.
      */
     private RateResult(final QueryResult results) {
-      super(results);
+      super(Rate.this, results);
       latch = new CountDownLatch(Rate.this.upstream.size());
       downsamplers = Lists.newArrayListWithCapacity(results.timeSeries().size());
       for (final TimeSeries series : results.timeSeries()) {
@@ -111,11 +111,6 @@ public class Rate extends AbstractQueryNode<RateConfig> {
       return downsamplers;
     }
 
-    @Override
-    public QueryNode source() {
-      return Rate.this;
-    }
-    
     /**
      * The super simple wrapper around the time series source that generates 
      * iterators using the factory.

--- a/core/src/main/java/net/opentsdb/query/processor/slidingwindow/SlidingWindow.java
+++ b/core/src/main/java/net/opentsdb/query/processor/slidingwindow/SlidingWindow.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.TypedTimeSeriesIterator;
 import net.opentsdb.query.AbstractQueryNode;
 import net.opentsdb.query.BaseWrappedQueryResult;
-import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
@@ -94,7 +93,7 @@ public class SlidingWindow extends AbstractQueryNode {
     private List<TimeSeries> series;
     
     SlidingWindowResult(final QueryResult next) {
-      super(next);
+      super(SlidingWindow.this, next);
       series = Lists.newArrayListWithExpectedSize(next.timeSeries().size());
       for (final TimeSeries ts : next.timeSeries()) {
         series.add(new SlidingWindowTimeSeries(ts));
@@ -104,11 +103,6 @@ public class SlidingWindow extends AbstractQueryNode {
     @Override
     public List<TimeSeries> timeSeries() {
       return series;
-    }
-    
-    @Override
-    public QueryNode source() {
-      return SlidingWindow.this;
     }
     
     /**

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018-2019  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -150,10 +150,10 @@ public class SummarizerConfig extends BaseQueryNodeConfig<SummarizerConfig.Build
 
   @Override
   public Builder toBuilder() {
-    return newBuilder()
-        .setSummaries(Lists.newArrayList(summaries))
-        .setInfectiousNan(infectious_nan)
-        .setId(id);
+    final Builder builder = newBuilder()
+        .setSummaries(Lists.newArrayList(summaries));
+    super.toBuilder(builder);
+    return builder;
   }
 
   public static Builder newBuilder() {

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerNonPassThroughResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerNonPassThroughResult.java
@@ -51,7 +51,7 @@ public class SummarizerNonPassThroughResult extends BaseWrappedQueryResult {
    * @param results The non-null results to source from.
    */
   SummarizerNonPassThroughResult(final Summarizer node, final QueryResult results) {
-    super(results);
+    super(node, results);
     this.node = node;
     series = Lists.newArrayList();
     for (final TimeSeries ts : results.timeSeries()) {
@@ -68,11 +68,6 @@ public class SummarizerNonPassThroughResult extends BaseWrappedQueryResult {
   @Override
   public List<TimeSeries> timeSeries() {
     return series;
-  }
-  
-  @Override
-  public QueryNode source() {
-    return node;
   }
   
   /**

--- a/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/summarizer/SummarizerPassThroughResult.java
@@ -67,11 +67,6 @@ public class SummarizerPassThroughResult extends BaseWrappedQueryResult {
   }
   
   @Override
-  public QueryNode source() {
-    return results.source();
-  }
-  
-  @Override
   public void close() {
     results.close();
     node.onNext(new SummarizerSummarizedResult());
@@ -183,12 +178,7 @@ public class SummarizerPassThroughResult extends BaseWrappedQueryResult {
   public class SummarizerSummarizedResult extends BaseWrappedQueryResult {
     
     SummarizerSummarizedResult() {
-      super(results);
-    }
-
-    @Override
-    public QueryNode source() {
-      return node;
+      super(node, results);
     }
     
     @Override

--- a/core/src/main/java/net/opentsdb/query/processor/timeshift/TimeShiftResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/timeshift/TimeShiftResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import net.opentsdb.data.TimeSpecification;
 import net.opentsdb.data.TimeStamp;
 import net.opentsdb.data.TypedTimeSeriesIterator;
 import net.opentsdb.query.BaseWrappedQueryResult;
-import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
 
 /**
@@ -62,7 +61,7 @@ public class TimeShiftResult extends BaseWrappedQueryResult {
                          final QueryResult result,
                          final boolean is_previous,
                          final TemporalAmount amount) {
-    super(result);
+    super(node, result);
     this.node = node;
     this.is_previous = is_previous;
     this.amount = amount;
@@ -85,11 +84,6 @@ public class TimeShiftResult extends BaseWrappedQueryResult {
     }
   }
 
-  @Override
-  public QueryNode source() {
-    return node;
-  }
-  
   @Override
   public List<TimeSeries> timeSeries() {
     return time_series;

--- a/core/src/main/java/net/opentsdb/query/processor/topn/TopNConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/topn/TopNConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -98,7 +98,13 @@ public class TopNConfig extends BaseQueryNodeConfig<TopNConfig.Builder, TopNConf
 
   @Override
   public Builder toBuilder() {
-    return null;
+    final Builder builder = newBuilder()
+        .setAggregator(aggregator)
+        .setCount(count)
+        .setTop(top)
+        .setInfectiousNan(infectious_nan);
+    super.toBuilder(builder);
+    return builder;
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/query/processor/topn/TopNResult.java
+++ b/core/src/main/java/net/opentsdb/query/processor/topn/TopNResult.java
@@ -48,7 +48,7 @@ public class TopNResult extends BaseWrappedQueryResult implements Runnable {
    * @param next The non-null results to pull from.
    */
   public TopNResult(final TopN node, final QueryResult next) {
-    super(next);
+    super(node, next);
     if (node == null) {
       throw new IllegalArgumentException("Node cannot be null.");
     }
@@ -113,11 +113,6 @@ public class TopNResult extends BaseWrappedQueryResult implements Runnable {
   @Override
   public List<TimeSeries> timeSeries() {
     return results;
-  }
-  
-  @Override
-  public QueryNode source() {
-    return node;
   }
   
   class SortOnDouble implements Comparable<SortOnDouble> {

--- a/core/src/main/java/net/opentsdb/query/readcache/CombinedCachedResult.java
+++ b/core/src/main/java/net/opentsdb/query/readcache/CombinedCachedResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import net.opentsdb.data.TimeStamp.Op;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.query.QuerySink;
 import net.opentsdb.rollup.RollupConfig;
 import net.opentsdb.utils.DateTime;
@@ -67,7 +68,7 @@ public class CombinedCachedResult implements QueryResult, TimeSpecification {
   protected final QueryNode<?> node;
   
   /** The data source name. */
-  protected final String data_source;
+  protected final QueryResultId data_source;
   
   /** Whether or not the query is aligned on hour boundaries. */
   protected final boolean aligned;
@@ -106,7 +107,7 @@ public class CombinedCachedResult implements QueryResult, TimeSpecification {
   public CombinedCachedResult(final QueryPipelineContext context,
                               final QueryResult[] results,
                               final QueryNode<?> node,
-                              final String data_source,
+                              final QueryResultId data_source,
                               final List<QuerySink> sinks, 
                               final String result_interval) {
     this.context = context;
@@ -225,7 +226,7 @@ public class CombinedCachedResult implements QueryResult, TimeSpecification {
   }
 
   @Override
-  public String dataSource() {
+  public QueryResultId dataSource() {
     return data_source;
   }
 

--- a/core/src/main/java/net/opentsdb/query/readcache/GuavaLRUCache.java
+++ b/core/src/main/java/net/opentsdb/query/readcache/GuavaLRUCache.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2019  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,12 +41,7 @@ import net.opentsdb.core.TSDB;
 import net.opentsdb.data.TimeStamp;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
-import net.opentsdb.query.readcache.QueryReadCache;
-import net.opentsdb.query.readcache.ReadCacheCallback;
-import net.opentsdb.query.readcache.ReadCacheQueryResult;
-import net.opentsdb.query.readcache.ReadCacheQueryResultSet;
-import net.opentsdb.query.readcache.ReadCacheSerdes;
-import net.opentsdb.query.readcache.ReadCacheSerdesFactory;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.stats.Span;
 import net.opentsdb.utils.Bytes.ByteArrayKey;
 import net.opentsdb.utils.Bytes;
@@ -173,7 +168,7 @@ public class GuavaLRUCache extends BaseTSDBPlugin implements
       
       class CQR implements ReadCacheQueryResultSet {
         final byte[] key;
-        final Map<String, ReadCacheQueryResult> results;
+        final Map<QueryResultId, ReadCacheQueryResult> results;
         final int idx;
         
         CQR(final int idx) {
@@ -207,7 +202,7 @@ public class GuavaLRUCache extends BaseTSDBPlugin implements
         }
         
         @Override
-        public Map<String, ReadCacheQueryResult> results() {
+        public Map<QueryResultId, ReadCacheQueryResult> results() {
           return results;
         }
 

--- a/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xQueryResult.java
+++ b/core/src/main/java/net/opentsdb/storage/schemas/tsdb1x/Tsdb1xQueryResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.TimeSpecification;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
 import net.opentsdb.rollup.RollupConfig;
 
@@ -156,8 +157,9 @@ public class Tsdb1xQueryResult implements QueryResult {
   }
 
   @Override
-  public String dataSource() {
-    return ((TimeSeriesDataSourceConfig) node.config()).getDataSourceId();
+  public QueryResultId dataSource() {
+    // TODO - there should only be one, ever!
+    return (QueryResultId) ((TimeSeriesDataSourceConfig) node.config()).resultIds().get(0);
   }
   
   @Override

--- a/core/src/test/java/net/opentsdb/pools/TestByteArrayPool.java
+++ b/core/src/test/java/net/opentsdb/pools/TestByteArrayPool.java
@@ -49,14 +49,14 @@ public class TestByteArrayPool {
     verify(TSDB.getRegistry(), atLeast(1)).registerObjectPool(
         any(DummyObjectPool.class));
     verify(TSDB.getRegistry(), never()).registerObjectPool(pool);
-    assertEquals(1024, ((byte[]) allocator.allocate()).length);
+    assertEquals(8192, ((byte[]) allocator.allocate()).length);
     
     when(TSDB.getRegistry().getPlugin(ArrayObjectPoolFactory.class, null))
       .thenReturn(factory);
     assertNull(allocator.initialize(TSDB, null).join());
     verify(TSDB.getRegistry(), times(1)).registerObjectPool(pool);
     assertEquals(ByteArrayPool.TYPE, allocator.id());
-    assertEquals(1024, ((byte[]) allocator.allocate()).length);
+    assertEquals(8192, ((byte[]) allocator.allocate()).length);
     
     allocator.id = "foo";
     allocator.registerConfigs(TSDB.config, ByteArrayPool.TYPE);

--- a/core/src/test/java/net/opentsdb/pools/TestDoubleArrayPool.java
+++ b/core/src/test/java/net/opentsdb/pools/TestDoubleArrayPool.java
@@ -49,14 +49,14 @@ public class TestDoubleArrayPool {
     verify(TSDB.getRegistry(), atLeast(1)).registerObjectPool(
         any(DummyObjectPool.class));
     verify(TSDB.getRegistry(), never()).registerObjectPool(pool);
-    assertEquals(1024, ((double[]) allocator.allocate()).length);
+    assertEquals(4096, ((double[]) allocator.allocate()).length);
     
     when(TSDB.getRegistry().getPlugin(ArrayObjectPoolFactory.class, null))
       .thenReturn(factory);
     assertNull(allocator.initialize(TSDB, null).join());
     verify(TSDB.getRegistry(), times(1)).registerObjectPool(pool);
     assertEquals(DoubleArrayPool.TYPE, allocator.id());
-    assertEquals(1024, ((double[]) allocator.allocate()).length);
+    assertEquals(4096, ((double[]) allocator.allocate()).length);
     
     allocator.id = "foo";
     allocator.registerConfigs(TSDB.config, DoubleArrayPool.TYPE);

--- a/core/src/test/java/net/opentsdb/query/TestBaseQueryNodeConfig.java
+++ b/core/src/test/java/net/opentsdb/query/TestBaseQueryNodeConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,10 +14,6 @@
 // limitations under the License.
 package net.opentsdb.query;
 
-import net.opentsdb.data.types.numeric.NumericType;
-import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
-import net.opentsdb.query.interpolation.types.numeric.ScalarNumericInterpolatorConfig;
-import net.opentsdb.query.pojo.FillPolicy;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -25,8 +21,11 @@ import com.google.common.hash.HashCode;
 
 import net.opentsdb.utils.JSON;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TestBaseQueryNodeConfig {
 
@@ -36,19 +35,51 @@ public class TestBaseQueryNodeConfig {
         .setId("ut")
         .setSources(Lists.newArrayList("s1", "s2"))
         .setType("datasource")
+        .addResultId(new DefaultQueryResultId("s1", "s1"))
+        .addResultId(new DefaultQueryResultId("s2", "s2"))
+        .addOverride("key", "value")
         .build();
     assertEquals("ut", config.getId());
     assertEquals(2, config.getSources().size());
     assertTrue(config.getSources().contains("s1"));
     assertTrue(config.getSources().contains("s2"));
     assertEquals("datasource", config.getType());
+    assertEquals(2, config.resultIds().size());
+    assertEquals(new DefaultQueryResultId("s1", "s1"), config.resultIds().get(0));
+    assertEquals(new DefaultQueryResultId("s2", "s2"), config.resultIds().get(1));
+    assertEquals(1, config.getOverrides().size());
+    assertEquals("value", config.getOverrides().get("key"));
     
+    // bare minimum
     config = new TestConfig.Builder()
         .setId("ut")
         .build();
     assertEquals("ut", config.getId());
     assertTrue(config.getSources().isEmpty());
     assertNull(config.getType());
+    assertTrue(config.resultIds().isEmpty());
+    assertNull(config.getOverrides());
+    
+    // set resultIds
+    config = new TestConfig.Builder()
+        .setId("ut")
+        .setSources(Lists.newArrayList("s1", "s2"))
+        .setType("datasource")
+        .setResultIds(Lists.newArrayList(
+            new DefaultQueryResultId("s1", "s1"), 
+            new DefaultQueryResultId("s2", "s2")))
+        .addOverride("key", "value")
+        .build();
+    assertEquals("ut", config.getId());
+    assertEquals(2, config.getSources().size());
+    assertTrue(config.getSources().contains("s1"));
+    assertTrue(config.getSources().contains("s2"));
+    assertEquals("datasource", config.getType());
+    assertEquals(2, config.resultIds().size());
+    assertEquals(new DefaultQueryResultId("s1", "s1"), config.resultIds().get(0));
+    assertEquals(new DefaultQueryResultId("s2", "s2"), config.resultIds().get(1));
+    assertEquals(1, config.getOverrides().size());
+    assertEquals("value", config.getOverrides().get("key"));
     
     try {
       new TestConfig.Builder()
@@ -78,7 +109,6 @@ public class TestBaseQueryNodeConfig {
     assertTrue(json.contains("\"sources\":[\"s1\",\"s2\"]"));
   }
 
-
   @Test
   public void equality() throws Exception {
     QueryNodeConfig config = new TestConfig.Builder()
@@ -98,7 +128,6 @@ public class TestBaseQueryNodeConfig {
             .setSources(Lists.newArrayList("s1", "s2"))
             .setType("datasource")
             .build();
-
 
     assertTrue(config.equals(config2));
     assertTrue(!config.equals(config3));
@@ -123,6 +152,42 @@ public class TestBaseQueryNodeConfig {
     assertTrue(!config.equals(config3));
     assertNotEquals(config.hashCode(), config3.hashCode());
 
+  }
+  
+  @Test
+  public void toBuilder() throws Exception {
+    QueryNodeConfig original = new TestConfig.Builder()
+        .setId("ut")
+        .setSources(Lists.newArrayList("s1", "s2"))
+        .setType("datasource")
+        .addResultId(new DefaultQueryResultId("s1", "s1"))
+        .addResultId(new DefaultQueryResultId("s2", "s2"))
+        .addOverride("key", "value")
+        .build();
+    QueryNodeConfig rebuilt = original.toBuilder().build();
+    
+    assertEquals("ut", rebuilt.getId());
+    assertEquals(2, rebuilt.getSources().size());
+    assertTrue(rebuilt.getSources().contains("s1"));
+    assertTrue(rebuilt.getSources().contains("s2"));
+    assertEquals("datasource", rebuilt.getType());
+    assertEquals(2, rebuilt.resultIds().size());
+    assertEquals(new DefaultQueryResultId("s1", "s1"), rebuilt.resultIds().get(0));
+    assertEquals(new DefaultQueryResultId("s2", "s2"), rebuilt.resultIds().get(1));
+    assertEquals(1, rebuilt.getOverrides().size());
+    assertEquals("value", rebuilt.getOverrides().get("key"));
+    
+    // bare minimum
+    original = new TestConfig.Builder()
+        .setId("ut")
+        .build();
+    rebuilt = original.toBuilder().build();
+    
+    assertEquals("ut", rebuilt.getId());
+    assertTrue(rebuilt.getSources().isEmpty());
+    assertNull(rebuilt.getType());
+    assertTrue(rebuilt.resultIds().isEmpty());
+    assertNull(rebuilt.getOverrides());
   }
   
   static class TestConfig extends BaseQueryNodeConfig<TestConfig.Builder, TestConfig> {
@@ -152,7 +217,9 @@ public class TestBaseQueryNodeConfig {
 
     @Override
     public Builder toBuilder() {
-      return null;
+      TestConfig.Builder builder = new Builder();
+      super.toBuilder(builder);
+      return builder;
     }
 
     @Override

--- a/core/src/test/java/net/opentsdb/query/TestConvertedQueryResult.java
+++ b/core/src/test/java/net/opentsdb/query/TestConvertedQueryResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,6 +54,9 @@ public class TestConvertedQueryResult {
   @Test
   public void convertNode() throws Exception {
     QueryNode node = mock(QueryNode.class);
+    QueryNodeConfig config = mock(QueryNodeConfig.class);
+    when(config.getId()).thenReturn("id");
+    when(node.config()).thenReturn(config);
     
     try {
       ConvertedQueryResult.convert(null, node, null);
@@ -96,6 +99,7 @@ public class TestConvertedQueryResult {
     when(((TimeSeriesByteId) sources.get(0).id()).decode(false, null))
       .thenReturn(Deferred.fromError(new UnitTestException()));
     node = mock(QueryNode.class);
+    when(node.config()).thenReturn(config);
     ConvertedQueryResult.convert(result, node, null);
     verify(node, times(1)).onError(any(Throwable.class));
     
@@ -104,6 +108,7 @@ public class TestConvertedQueryResult {
     when(((TimeSeriesByteId) sources.get(0).id()).decode(false, null))
       .thenThrow(new UnitTestException());
     node = mock(QueryNode.class);
+    when(node.config()).thenReturn(config);
     ConvertedQueryResult.convert(result, node, null);
     verify(node, times(1)).onError(any(Throwable.class));
     
@@ -246,6 +251,7 @@ public class TestConvertedQueryResult {
     sources.add(ts2);
     
     result = mock(QueryResult.class);
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     when(result.timeSeries()).thenReturn(sources);
     when(result.idType()).thenAnswer(new Answer<TypeToken<?>>() {
       @Override
@@ -279,6 +285,7 @@ public class TestConvertedQueryResult {
     sources.add(ts2);
     
     result = mock(QueryResult.class);
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     when(result.timeSeries()).thenReturn(sources);
     when(result.idType()).thenAnswer(new Answer<TypeToken<?>>() {
       @Override

--- a/core/src/test/java/net/opentsdb/query/execution/serdes/TestJsonV3QuerySerdes.java
+++ b/core/src/test/java/net/opentsdb/query/execution/serdes/TestJsonV3QuerySerdes.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018 The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
-import java.time.Duration;
 import java.util.Collections;
 
 import org.junit.Before;
@@ -51,14 +50,13 @@ import net.opentsdb.data.TimeSeriesByteId;
 import net.opentsdb.data.TimeSeriesDataSourceFactory;
 import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.TimeSeriesStringId;
-import net.opentsdb.data.TimeSpecification;
 import net.opentsdb.data.BaseTimeSeriesByteId;
 import net.opentsdb.data.BaseTimeSeriesStringId;
 import net.opentsdb.data.types.numeric.MutableNumericSummaryValue;
-import net.opentsdb.data.types.numeric.NumericArrayTimeSeries;
 import net.opentsdb.data.types.numeric.NumericMillisecondShard;
 import net.opentsdb.data.types.numeric.aggregators.NumericAggregatorFactory;
 import net.opentsdb.data.types.numeric.aggregators.SumFactory;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryContext;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeConfig;
@@ -67,7 +65,6 @@ import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.TimeSeriesQuery;
 import net.opentsdb.query.pojo.Metric;
 import net.opentsdb.query.pojo.Timespan;
-import net.opentsdb.query.serdes.SerdesOptions;
 import net.opentsdb.utils.UnitTestException;
 
 public class TestJsonV3QuerySerdes {
@@ -94,6 +91,7 @@ public class TestJsonV3QuerySerdes {
 
     context = mock(QueryContext.class);
     result = mock(QueryResult.class);
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("s1", "s1"));
     store = mock(TimeSeriesDataSourceFactory.class);
     query = net.opentsdb.query.pojo.TimeSeriesQuery.newBuilder()
         .setTime(
@@ -193,7 +191,7 @@ public class TestJsonV3QuerySerdes {
     serdes.serializeComplete(null);
     output.close();
     final String json = new String(output.toByteArray(), Const.UTF8_CHARSET);
-    assertEquals(json, "{\"results\":[{\"source\":\"s1:null\",\"data\":[]}],\"log\":[]}");
+    assertEquals(json, "{\"results\":[{\"source\":\"s1:s1\",\"data\":[]}],\"log\":[]}");
   }
 
   @Test

--- a/core/src/test/java/net/opentsdb/query/hacluster/TestHACluster.java
+++ b/core/src/test/java/net/opentsdb/query/hacluster/TestHACluster.java
@@ -1,5 +1,5 @@
 //This file is part of OpenTSDB.
-//Copyright (C) 2018-2019  The OpenTSDB Authors.
+//Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 //This program is free software: you can redistribute it and/or modify it
 //under the terms of the GNU Lesser General Public License as published by
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import net.opentsdb.query.BaseTimeSeriesDataSourceConfig;
+import net.opentsdb.query.DefaultQueryResultId;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -82,7 +84,6 @@ public class TestHACluster {
         .setSecondaryTimeout("5s")
         .setMergeAggregator("max")
         .setDataSources(Lists.newArrayList("s1", "s2"))
-        .setDataSourceId("m1")
         .setId("m1");
     (builder).setMetric(MetricLiteralFilter.newBuilder().setMetric("sys.if.in").build());
     this.config = (HAClusterConfig) builder.build();
@@ -161,7 +162,7 @@ public class TestHACluster {
     QueryResult r1 = mock(QueryResult.class);
     QueryNode n1 = mock(TimeSeriesDataSource.class);
     when(r1.source()).thenReturn(n1);
-    when(r1.dataSource()).thenReturn("m1");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("s1");
     when(n1.config()).thenReturn(c1);
@@ -177,7 +178,7 @@ public class TestHACluster {
     QueryResult r2 = mock(QueryResult.class);
     QueryNode n2 = mock(TimeSeriesDataSource.class);
     when(r2.source()).thenReturn(n2);
-    when(r2.dataSource()).thenReturn("m1");
+    when(r2.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     QueryNodeConfig c2 = mock(QueryNodeConfig.class);
     when(c2.getId()).thenReturn("s2");
     when(n2.config()).thenReturn(c2);
@@ -188,10 +189,10 @@ public class TestHACluster {
     verify(upstream, times(2)).onNext(any(QueryResult.class));
     assertTrue(results.get(0).source().config().getId().equals("s1")
         || results.get(0).source().config().getId().equals("s2"));
-    assertEquals("m1", results.get(0).dataSource());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), results.get(0).dataSource());
     assertTrue(results.get(0).source().config().getId().equals("s1")
         || results.get(0).source().config().getId().equals("s2"));
-    assertEquals("m1", results.get(1).dataSource());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), results.get(1).dataSource());
     verify(tsdb.query_timer, times(1)).newTimeout(any(TimerTask.class), 
         eq(5000L), eq(TimeUnit.MILLISECONDS));
     verify(tsdb.query_timer.timeout, times(1)).cancel();
@@ -209,7 +210,7 @@ public class TestHACluster {
     QueryResult r2 = mock(QueryResult.class);
     QueryNode n2 = mock(TimeSeriesDataSource.class);
     when(r2.source()).thenReturn(n2);
-    when(r2.dataSource()).thenReturn("m1");
+    when(r2.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     QueryNodeConfig c2 = mock(QueryNodeConfig.class);
     when(c2.getId()).thenReturn("s2");
     when(n2.config()).thenReturn(c2);
@@ -226,7 +227,7 @@ public class TestHACluster {
     QueryResult r1 = mock(QueryResult.class);
     QueryNode n1 = mock(TimeSeriesDataSource.class);
     when(r1.source()).thenReturn(n1);
-    when(r1.dataSource()).thenReturn("m1");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("s1");
     when(n1.config()).thenReturn(c1);
@@ -237,10 +238,10 @@ public class TestHACluster {
     verify(upstream, times(2)).onNext(any(QueryResult.class));
     assertTrue(results.get(0).source().config().getId().equals("s1")
         || results.get(0).source().config().getId().equals("s2"));
-    assertEquals("m1", results.get(0).dataSource());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), results.get(0).dataSource());
     assertTrue(results.get(0).source().config().getId().equals("s1")
         || results.get(0).source().config().getId().equals("s2"));
-    assertEquals("m1", results.get(1).dataSource());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), results.get(1).dataSource());
     verify(tsdb.query_timer, times(1)).newTimeout(any(TimerTask.class), 
         eq(10000L), eq(TimeUnit.MILLISECONDS));
     verify(tsdb.query_timer.timeout, times(1)).cancel();
@@ -255,7 +256,7 @@ public class TestHACluster {
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("s1");
     when(n1.config()).thenReturn(c1);
-    when(r1.dataSource()).thenReturn("m1");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     when(r1.source()).thenReturn(n1);
     
     TimeSeriesDataSource n2 = mock(TimeSeriesDataSource.class);
@@ -290,10 +291,10 @@ public class TestHACluster {
     verify(upstream, times(2)).onNext(any(QueryResult.class));
     assertTrue(results.get(0).source().config().getId().equals("s1")
         || results.get(0).source().config().getId().equals("s2"));
-    assertEquals("m1", results.get(0).dataSource());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), results.get(0).dataSource());
     assertTrue(results.get(0).source().config().getId().equals("s1")
         || results.get(0).source().config().getId().equals("s2"));
-    assertEquals("m1", results.get(1).dataSource());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), results.get(1).dataSource());
     verify(tsdb.query_timer, times(1)).newTimeout(any(TimerTask.class), 
         eq(5000L), eq(TimeUnit.MILLISECONDS));
     verify(tsdb.query_timer.timeout, times(1)).cancel();
@@ -314,7 +315,7 @@ public class TestHACluster {
     when(c2.getId()).thenReturn("s2");
     when(n2.config()).thenReturn(c2);
     when(r2.source()).thenReturn(n2);
-    when(r2.dataSource()).thenReturn("m1");
+    when(r2.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     
     when(context.downstreamSources(any(QueryNode.class)))
       .thenReturn(Lists.newArrayList(n1, n2));
@@ -342,10 +343,10 @@ public class TestHACluster {
     verify(upstream, times(2)).onNext(any(QueryResult.class));
     assertTrue(results.get(0).source().config().getId().equals("s1")
         || results.get(0).source().config().getId().equals("s2"));
-    assertEquals("m1", results.get(0).dataSource());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), results.get(0).dataSource());
     assertTrue(results.get(0).source().config().getId().equals("s1")
         || results.get(0).source().config().getId().equals("s2"));
-    assertEquals("m1", results.get(1).dataSource());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), results.get(1).dataSource());
     verify(tsdb.query_timer, times(1)).newTimeout(any(TimerTask.class), 
         eq(10000L), eq(TimeUnit.MILLISECONDS));
     verify(tsdb.query_timer.timeout, times(1)).cancel();
@@ -360,7 +361,7 @@ public class TestHACluster {
     when(r1.error()).thenReturn("Whoops");
     QueryNode n1 = mock(TimeSeriesDataSource.class);
     when(r1.source()).thenReturn(n1);
-    when(r1.dataSource()).thenReturn("m1");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("s1");
     when(n1.config()).thenReturn(c1);
@@ -375,7 +376,7 @@ public class TestHACluster {
     QueryResult r2 = mock(QueryResult.class);
     QueryNode n2 = mock(TimeSeriesDataSource.class);
     when(r2.source()).thenReturn(n2);
-    when(r2.dataSource()).thenReturn("m1");
+    when(r2.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     QueryNodeConfig c2 = mock(QueryNodeConfig.class);
     when(c2.getId()).thenReturn("s2");
     when(n2.config()).thenReturn(c2);
@@ -386,10 +387,10 @@ public class TestHACluster {
     verify(upstream, times(2)).onNext(any(QueryResult.class));
     assertTrue(results.get(0).source().config().getId().equals("s1")
         || results.get(0).source().config().getId().equals("s2"));
-    assertEquals("m1", results.get(0).dataSource());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), results.get(0).dataSource());
     assertTrue(results.get(0).source().config().getId().equals("s1")
         || results.get(0).source().config().getId().equals("s2"));
-    assertEquals("m1", results.get(1).dataSource());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), results.get(1).dataSource());
     verify(tsdb.query_timer, never()).newTimeout(any(TimerTask.class), 
         eq(5000L), eq(TimeUnit.MILLISECONDS));
   }
@@ -407,7 +408,7 @@ public class TestHACluster {
     when(r2.error()).thenReturn("Whoops");
     QueryNode n2 = mock(TimeSeriesDataSource.class);
     when(r2.source()).thenReturn(n2);
-    when(r2.dataSource()).thenReturn("m1");
+    when(r2.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     QueryNodeConfig c2 = mock(QueryNodeConfig.class);
     when(c2.getId()).thenReturn("s2");
     when(n2.config()).thenReturn(c2);
@@ -423,7 +424,7 @@ public class TestHACluster {
     QueryResult r1 = mock(QueryResult.class);
     QueryNode n1 = mock(TimeSeriesDataSource.class);
     when(r1.source()).thenReturn(n1);
-    when(r1.dataSource()).thenReturn("m1");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("s1");
     when(n1.config()).thenReturn(c1);
@@ -434,10 +435,10 @@ public class TestHACluster {
     verify(upstream, times(2)).onNext(any(QueryResult.class));
     assertTrue(results.get(0).source().config().getId().equals("s1")
         || results.get(0).source().config().getId().equals("s2"));
-    assertEquals("m1", results.get(0).dataSource());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), results.get(0).dataSource());
     assertTrue(results.get(0).source().config().getId().equals("s1")
         || results.get(0).source().config().getId().equals("s2"));
-    assertEquals("m1", results.get(1).dataSource());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), results.get(1).dataSource());
     verify(tsdb.query_timer, never()).newTimeout(any(TimerTask.class), 
         eq(10000L), eq(TimeUnit.MILLISECONDS));
   }

--- a/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterConfig.java
+++ b/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterFactory.java
+++ b/core/src/test/java/net/opentsdb/query/hacluster/TestHAClusterFactory.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -993,7 +993,7 @@ public class TestHAClusterFactory {
     QueryNode ctx_node = mock(QueryNode.class);
     DefaultQueryPlanner planner = new DefaultQueryPlanner(context, ctx_node);
     planner.plan(null).join(250);
-System.out.println(planner.printConfigGraph());
+    
     assertEquals(7, planner.graph().nodes().size());
     assertFalse(planner.configGraph().nodes().contains(query.getExecutionGraph().get(0)));
     QueryNode node = planner.nodeForId("ha_m1_s2");

--- a/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverter.java
+++ b/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverter.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import net.opentsdb.data.TimeSeriesByteId;
 import net.opentsdb.data.TimeSeriesDataSourceFactory;
 import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.TimeSeriesStringId;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryContext;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeFactory;
@@ -156,6 +157,7 @@ public class TestByteToStringIdConverter {
         return Const.TS_BYTE_ID;
       }
     });
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     
     TimeSeries ts1 = mock(TimeSeries.class);
     TimeSeries ts2 = mock(TimeSeries.class);
@@ -183,6 +185,7 @@ public class TestByteToStringIdConverter {
     doAnswer(new Answer<Void>() {
       @Override
       public Void answer(InvocationOnMock invocation) throws Throwable {
+        System.out.println("***** HERE");
         from_upstream[0] = (QueryResult) invocation.getArguments()[0];
         return null;
       }
@@ -197,7 +200,9 @@ public class TestByteToStringIdConverter {
     verify(upstream, never()).onNext(result);
     verify(upstream, never()).onError(any(Throwable.class));
     
-    assertEquals(2, from_upstream[0].timeSeries().size());
+    assertEquals(2, from_upstream[0]
+        .timeSeries()
+        .size());
     assertEquals(Const.TS_STRING_ID, from_upstream[0].idType());
     Iterator<TimeSeries> iterator = from_upstream[0].timeSeries().iterator();
     TimeSeries series = iterator.next();
@@ -263,8 +268,8 @@ public class TestByteToStringIdConverter {
   public void onNextPTSEmptyTimeSeries() throws Exception {
     config = (ByteToStringIdConverterConfig)
         ByteToStringIdConverterConfig.newBuilder()
-          .addDataSource("m1", factory_a)
-          .addDataSource("m2", factory_b)
+          .addDataSourceFactory("m1", factory_a)
+          .addDataSourceFactory("m2", factory_b)
           .setId("cvtr")
           .build();
     
@@ -286,8 +291,8 @@ public class TestByteToStringIdConverter {
   public void onNextPTSNotListed() throws Exception {
     config = (ByteToStringIdConverterConfig)
         ByteToStringIdConverterConfig.newBuilder()
-          .addDataSource("m1", factory_a)
-          .addDataSource("m2", factory_b)
+          .addDataSourceFactory("m1", factory_a)
+          .addDataSourceFactory("m2", factory_b)
           .setId("cvtr")
           .build();
     
@@ -311,8 +316,8 @@ public class TestByteToStringIdConverter {
   public void onNextPTS() throws Exception {
     config = (ByteToStringIdConverterConfig)
         ByteToStringIdConverterConfig.newBuilder()
-          .addDataSource("m1", factory_a)
-          .addDataSource("m2", factory_b)
+          .addDataSourceFactory("m1", factory_a)
+          .addDataSourceFactory("m2", factory_b)
           .setId("cvtr")
           .build();
     

--- a/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverterConfig.java
+++ b/core/src/test/java/net/opentsdb/query/idconverter/TestByteToStringIdConverterConfig.java
@@ -38,8 +38,8 @@ public class TestByteToStringIdConverterConfig {
     TimeSeriesDataSourceFactory m2 = mock(TimeSeriesDataSourceFactory.class);
     ByteToStringIdConverterConfig config = 
         (ByteToStringIdConverterConfig) ByteToStringIdConverterConfig.newBuilder()
-        .addDataSource("m1", m1)
-        .addDataSource("m2", m2)
+        .addDataSourceFactory("m1", m1)
+        .addDataSourceFactory("m2", m2)
         .setId("cvtr")
         .build();
     
@@ -79,8 +79,8 @@ public class TestByteToStringIdConverterConfig {
     TimeSeriesDataSourceFactory m2 = mock(TimeSeriesDataSourceFactory.class);
     ByteToStringIdConverterConfig config =
             (ByteToStringIdConverterConfig) ByteToStringIdConverterConfig.newBuilder()
-                    .addDataSource("m1", m1)
-                    .addDataSource("m2", m2)
+                    .addDataSourceFactory("m1", m1)
+                    .addDataSourceFactory("m2", m2)
                     .setId("cvtr")
                     .build();
 
@@ -88,8 +88,8 @@ public class TestByteToStringIdConverterConfig {
     TimeSeriesDataSourceFactory m4 = mock(TimeSeriesDataSourceFactory.class);
     ByteToStringIdConverterConfig config2 =
             (ByteToStringIdConverterConfig) ByteToStringIdConverterConfig.newBuilder()
-                    .addDataSource("m2", m3)
-                    .addDataSource("m1", m4)
+                    .addDataSourceFactory("m2", m3)
+                    .addDataSourceFactory("m1", m4)
                     .setId("cvtr")
                     .build();
 
@@ -97,8 +97,8 @@ public class TestByteToStringIdConverterConfig {
     TimeSeriesDataSourceFactory m6 = mock(TimeSeriesDataSourceFactory.class);
     ByteToStringIdConverterConfig config3 =
             (ByteToStringIdConverterConfig) ByteToStringIdConverterConfig.newBuilder()
-                    .addDataSource("m1", m5)
-                    .addDataSource("m2", m6)
+                    .addDataSourceFactory("m1", m5)
+                    .addDataSourceFactory("m2", m6)
                     .setId("other")
                     .build();
 
@@ -110,8 +110,8 @@ public class TestByteToStringIdConverterConfig {
 
     config3 =
             (ByteToStringIdConverterConfig) ByteToStringIdConverterConfig.newBuilder()
-                    .addDataSource("m2", m5)
-                    .addDataSource("m3", m6)
+                    .addDataSourceFactory("m2", m5)
+                    .addDataSourceFactory("m3", m6)
                     .setId("cvtr")
                     .build();
 

--- a/core/src/test/java/net/opentsdb/query/joins/BaseJoinTest.java
+++ b/core/src/test/java/net/opentsdb/query/joins/BaseJoinTest.java
@@ -36,6 +36,7 @@ import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesByteId;
 import net.opentsdb.data.TimeSeriesDataSourceFactory;
 import net.opentsdb.data.TimeSeriesId;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.joins.JoinConfig.JoinType;
 import net.opentsdb.utils.Pair;
@@ -344,6 +345,7 @@ public class BaseJoinTest {
   protected static Pair<QueryResult, QueryResult> multiResults(final TypeToken<?> ts_type) {
     final Pair<QueryResult, QueryResult> results = new Pair<QueryResult, QueryResult>();
     QueryResult result = mock(QueryResult.class);
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     List<TimeSeries> ts = Lists.newArrayList(
         L_1,
         L_2,
@@ -361,6 +363,7 @@ public class BaseJoinTest {
     
     // right
     result = mock(QueryResult.class);
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("m2", "m2"));
     ts = Lists.newArrayList(
         R_1,
         R_3,

--- a/core/src/test/java/net/opentsdb/query/pojo/TestRateOptions.java
+++ b/core/src/test/java/net/opentsdb/query/pojo/TestRateOptions.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import net.opentsdb.core.MockTSDB;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.utils.JSON;
 
 public class TestRateOptions {
@@ -77,13 +78,15 @@ public class TestRateOptions {
         .setCounter(true)
         .setInterval("60s")
         .setCounterMax(Integer.MAX_VALUE)
+        .addResultId(new DefaultQueryResultId("rate", "m1"))
         .build();
-    final RateOptions clone = RateOptions.newBuilder(options).build();
+    final RateOptions clone = options.toBuilder().build();
     assertTrue(clone.isCounter());
     assertFalse(clone.getDropResets());
     assertEquals("60s", clone.getInterval());
     assertEquals(0, clone.getResetValue());
     assertEquals(Integer.MAX_VALUE, clone.getCounterMax());
+    assertEquals(new DefaultQueryResultId("rate", "m1"), clone.resultIds().get(0));
   }
   
   @Test

--- a/core/src/test/java/net/opentsdb/query/processor/dedup/TestDedupNode.java
+++ b/core/src/test/java/net/opentsdb/query/processor/dedup/TestDedupNode.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -35,11 +34,10 @@ import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.TypedTimeSeriesIterator;
 import net.opentsdb.data.types.numeric.MutableNumericValue;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
-import net.opentsdb.query.processor.dedup.DedupConfig;
-import net.opentsdb.query.processor.dedup.DedupNode;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -96,6 +94,7 @@ public class TestDedupNode {
     when(queryResult.timeSeries()).thenReturn(new ArrayList<TimeSeries>() {{
         add(series);
     }});
+    when(queryResult.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
 
     DedupNode dedupNode = new DedupNode(null, pipelineContext, 
         (DedupConfig) DedupConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsample.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsample.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.SemanticQuery;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
@@ -56,6 +57,7 @@ public class TestDownsample {
   private DownsampleConfig config;
   private QueryNode upstream;
   private SemanticQuery query;
+  private QueryResult result;
   
   @Before
   public void before() throws Exception {
@@ -64,6 +66,8 @@ public class TestDownsample {
     upstream = mock(QueryNode.class);
     when(context.upstream(any(QueryNode.class)))
       .thenReturn(Lists.newArrayList(upstream));
+    result = mock(QueryResult.class);
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     
     query = SemanticQuery.newBuilder()
         .setMode(QueryMode.SINGLE)
@@ -133,7 +137,7 @@ public class TestDownsample {
   public void onNext() throws Exception {
     Downsample ds = new Downsample(factory, context, config);
     final QueryResult results = mock(QueryResult.class);
-    
+    when(results.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     ds.initialize(null);
     
     ds.onNext(results);
@@ -163,7 +167,6 @@ public class TestDownsample {
 
   @Test
   public void downsampleResultResolution() throws Exception {
-    QueryResult result = mock(QueryResult.class);
     when(result.timeSeries()).thenReturn(Collections.emptyList());
     Downsample ds = new Downsample(factory, context, config);
     ds.initialize(null);
@@ -249,7 +252,6 @@ public class TestDownsample {
   
   @Test
   public void downsampleResultUpdateTimestamp() throws Exception {
-    QueryResult result = mock(QueryResult.class);
     when(result.timeSeries()).thenReturn(Collections.emptyList());
     Downsample ds = new Downsample(factory, context, config);
     ds.initialize(null);
@@ -280,7 +282,6 @@ public class TestDownsample {
   
   @Test
   public void downsampleResultNextTimestamp() throws Exception {
-    QueryResult result = mock(QueryResult.class);
     when(result.timeSeries()).thenReturn(Collections.emptyList());
     Downsample ds = new Downsample(factory, context, config);
     ds.initialize(null);

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleFactory.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.data.types.numeric.aggregators.NumericAggregatorFactory;
 import net.opentsdb.data.types.numeric.aggregators.SumFactory;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.QueryIteratorFactory;
@@ -50,6 +51,7 @@ import net.opentsdb.query.interpolation.DefaultInterpolatorFactory;
 import net.opentsdb.query.interpolation.QueryInterpolatorFactory;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
+import net.opentsdb.query.plan.DefaultQueryPlanner;
 import net.opentsdb.query.plan.QueryPlanner;
 import net.opentsdb.query.pojo.FillPolicy;
 import net.opentsdb.query.processor.downsample.Downsample.DownsampleResult;
@@ -145,6 +147,7 @@ public class TestDownsampleFactory {
         .build(), new MillisecondTimeStamp(1000), new MillisecondTimeStamp(60000));
     source.add(30000, 42);
     final QueryResult result = mock(Downsample.DownsampleResult.class);
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     
     final DefaultRollupConfig rollup_config = DefaultRollupConfig.newBuilder()
         .addAggregationId("sum", 0)
@@ -347,7 +350,7 @@ public class TestDownsampleFactory {
         .setExecutionGraph(graph)
         .build();
     
-    QueryPlanner planner = mock(QueryPlanner.class);
+    QueryPlanner planner = mock(DefaultQueryPlanner.class);
     when(planner.terminalSourceNodes(any(QueryNodeConfig.class)))
       .thenReturn(Lists.newArrayList(source));
     TimeSeriesDataSourceFactory source_factory = 
@@ -460,7 +463,7 @@ public class TestDownsampleFactory {
         .setExecutionGraph(graph)
         .build();
     
-    QueryPlanner planner = mock(QueryPlanner.class);
+    QueryPlanner planner = mock(DefaultQueryPlanner.class);
     when(planner.terminalSourceNodes(any(QueryNodeConfig.class)))
       .thenReturn(Lists.newArrayList(source));
     TimeSeriesDataSourceFactory source_factory = 
@@ -574,7 +577,7 @@ public class TestDownsampleFactory {
         .setExecutionGraph(graph)
         .build();
     
-    QueryPlanner planner = mock(QueryPlanner.class);
+    QueryPlanner planner = mock(DefaultQueryPlanner.class);
     when(planner.terminalSourceNodes(any(QueryNodeConfig.class)))
       .thenReturn(Lists.newArrayList(source));
     TimeSeriesDataSourceFactory source_factory = 

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericIterator.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2014  The OpenTSDB Authors.
+// Copyright (C) 2014-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import net.opentsdb.data.TimeStamp.Op;
 import net.opentsdb.data.types.numeric.MutableNumericValue;
 import net.opentsdb.data.types.numeric.NumericMillisecondShard;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryContext;
 import net.opentsdb.query.QueryMode;
 import net.opentsdb.query.QueryNode;
@@ -3136,6 +3137,7 @@ public class TestDownsampleNumericIterator {
     Downsample ds = new Downsample(null, pipeline_context, config);
     ds.initialize(null);
     final QueryResult result = mock(Downsample.DownsampleResult.class);
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("ds", "m1"));
     return ds.new DownsampleResult(result);
   }
 }

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericSummaryIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericSummaryIterator.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.types.numeric.MutableNumericSummaryValue;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryContext;
 import net.opentsdb.query.QueryMode;
 import net.opentsdb.query.QueryNode;
@@ -3477,6 +3478,7 @@ public class TestDownsampleNumericSummaryIterator {
     Downsample ds = new Downsample(null, pipeline_context, config);
     ds.initialize(null);
     final QueryResult result = mock(Downsample.DownsampleResult.class);
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     when(result.rollupConfig()).thenReturn(rollup_config);
     this.result = ds.new DownsampleResult(result);
   }

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericToNumericArrayIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericToNumericArrayIterator.java
@@ -48,6 +48,7 @@ import net.opentsdb.data.types.numeric.NumericMillisecondShard;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.data.types.numeric.aggregators.NumericArrayAggregator;
 import net.opentsdb.data.types.numeric.aggregators.NumericArrayAggregatorFactory;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryContext;
 import net.opentsdb.query.QueryMode;
 import net.opentsdb.query.QueryNode;
@@ -1629,6 +1630,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Downsample ds = new Downsample(null, pipeline_context, config);
     ds.initialize(null);
     final QueryResult result = mock(Downsample.DownsampleResult.class);
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("ds", "m1"));
     return ds.new DownsampleResult(result);
   }
 

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNode.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018-2019  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.joins.JoinConfig;
@@ -104,8 +105,10 @@ public class TestBinaryExpressionNode {
     
     expression_config = ExpressionParseNode.newBuilder()
         .setLeft("a")
+        .setLeftId(new DefaultQueryResultId("a", "a"))
         .setLeftType(OperandType.VARIABLE)
         .setRight("b")
+        .setRightId(new DefaultQueryResultId("b", "b"))
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
         .setExpressionConfig(config)
@@ -125,8 +128,10 @@ public class TestBinaryExpressionNode {
     // sub-exp
     expression_config = ExpressionParseNode.newBuilder()
         .setLeft("a")
+        .setLeftId(new DefaultQueryResultId("a", "a"))
         .setLeftType(OperandType.VARIABLE)
         .setRight("SubExp#1")
+        .setRightId(new DefaultQueryResultId("SubExp#1", "b"))
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
         .setExpressionConfig(config)
@@ -137,12 +142,13 @@ public class TestBinaryExpressionNode {
     assertSame(expression_config, node.expression_config);
     assertNotNull(node.result);
     assertNotNull(node.joiner());
-    assertEquals("a", node.left_source);
-    assertEquals("SubExp#1", node.right_source);
+    assertEquals(new DefaultQueryResultId("a", "a"), node.left_source);
+    assertEquals(new DefaultQueryResultId("SubExp#1", "b"), node.right_source);
     
     // one needed
     expression_config = ExpressionParseNode.newBuilder()
         .setLeft("a")
+        .setLeftId(new DefaultQueryResultId("a", "a"))
         .setLeftType(OperandType.VARIABLE)
         .setRight("42")
         .setRightType(OperandType.LITERAL_NUMERIC)
@@ -155,7 +161,7 @@ public class TestBinaryExpressionNode {
     assertSame(expression_config, node.expression_config);
     assertNotNull(node.result);
     assertNotNull(node.joiner());
-    assertEquals("a", node.left_source);
+    assertEquals(new DefaultQueryResultId("a", "a"), node.left_source);
     assertNull(node.right_source);
     
     try {
@@ -208,14 +214,14 @@ public class TestBinaryExpressionNode {
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
-    when(r1.dataSource()).thenReturn("a");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("a", "a"));
     QueryNode n1 = mock(QueryNode.class);
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("a");
     when(n1.config()).thenReturn(c1);
     when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
-    when(r2.dataSource()).thenReturn("b");
+    when(r2.dataSource()).thenReturn(new DefaultQueryResultId("b", "b"));
     QueryNodeConfig c2 = mock(QueryNodeConfig.class);
     when(c2.getId()).thenReturn("b");
     QueryNode n2 = mock(QueryNode.class);
@@ -237,6 +243,7 @@ public class TestBinaryExpressionNode {
   public void onNextStringSingle() throws Exception {
     expression_config = ExpressionParseNode.newBuilder()
         .setLeft("a")
+        .setLeftId(new DefaultQueryResultId("a", "a"))
         .setLeftType(OperandType.VARIABLE)
         .setRight("42")
         .setRightType(OperandType.LITERAL_NUMERIC)
@@ -250,7 +257,7 @@ public class TestBinaryExpressionNode {
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
-    when(r1.dataSource()).thenReturn("a");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("a", "a"));
     QueryNode n1 = mock(QueryNode.class);
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("a");
@@ -270,14 +277,14 @@ public class TestBinaryExpressionNode {
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
-    when(r1.dataSource()).thenReturn("a");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("a", "a"));
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("a");
     QueryNode n1 = mock(QueryNode.class);
     when(n1.config()).thenReturn(c1);
     when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
-    when(r2.dataSource()).thenReturn("b");
+    when(r2.dataSource()).thenReturn(new DefaultQueryResultId("b", "b"));
     QueryNodeConfig c2 = mock(QueryNodeConfig.class);
     when(c2.getId()).thenReturn("b");
     QueryNode n2 = mock(QueryNode.class);
@@ -363,9 +370,10 @@ public class TestBinaryExpressionNode {
   public void onNextByteDoubleOneSubExp() throws Exception {
     expression_config = ExpressionParseNode.newBuilder()
         .setLeft("a")
+        .setLeftId(new DefaultQueryResultId("a", "a"))
         .setLeftType(OperandType.VARIABLE)
         .setRight("sub")
-        .setRightId("sub:m1")
+        .setRightId(new DefaultQueryResultId("sub", "m1"))
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
         .setExpressionConfig(config)
@@ -382,14 +390,14 @@ public class TestBinaryExpressionNode {
     when(c2.getId()).thenReturn("sub");
     
     QueryResult r1 = mock(QueryResult.class);
-    when(r1.dataSource()).thenReturn("a");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("a", "a"));
     QueryNode n1 = mock(QueryNode.class);
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("a");
     when(n1.config()).thenReturn(c1);
     when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
-    when(r2.dataSource()).thenReturn("m1");
+    when(r2.dataSource()).thenReturn(new DefaultQueryResultId("sub", "m1"));
     when(r2.source()).thenReturn(n2);
     when(r1.idType()).thenAnswer(new Answer<TypeToken<?>>() {
       @Override
@@ -471,10 +479,10 @@ public class TestBinaryExpressionNode {
   public void onNextByteDoubleTwoSubExp() throws Exception {
     expression_config = ExpressionParseNode.newBuilder()
         .setLeft("sub1")
-        .setLeftId("sub1:m1")
+        .setLeftId(new DefaultQueryResultId("sub1", "m1"))
         .setLeftType(OperandType.SUB_EXP)
         .setRight("sub2")
-        .setRightId("sub2:m1")
+        .setRightId(new DefaultQueryResultId("sub2", "m1"))
         .setRightType(OperandType.SUB_EXP)
         .setExpressionOp(ExpressionOp.ADD)
         .setExpressionConfig(config)
@@ -496,10 +504,10 @@ public class TestBinaryExpressionNode {
     when(c2.getId()).thenReturn("sub2");
     
     QueryResult r1 = mock(QueryResult.class);
-    when(r1.dataSource()).thenReturn("m1");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("sub1", "m1"));
     when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
-    when(r2.dataSource()).thenReturn("m1");
+    when(r2.dataSource()).thenReturn(new DefaultQueryResultId("sub2", "m1"));
     when(r2.source()).thenReturn(n2);
     when(r1.idType()).thenAnswer(new Answer<TypeToken<?>>() {
       @Override
@@ -566,6 +574,7 @@ public class TestBinaryExpressionNode {
         .setLeft("42")
         .setLeftType(OperandType.LITERAL_NUMERIC)
         .setRight("b")
+        .setRightId(new DefaultQueryResultId("b", "b"))
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
         .setExpressionConfig(config)
@@ -577,7 +586,7 @@ public class TestBinaryExpressionNode {
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
-    when(r1.dataSource()).thenReturn("b");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("b", "b"));
     QueryNode n1 = mock(QueryNode.class);
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("a");
@@ -652,6 +661,7 @@ public class TestBinaryExpressionNode {
   public void onNextByteSingleRight() throws Exception {
     expression_config = ExpressionParseNode.newBuilder()
         .setLeft("a")
+        .setLeftId(new DefaultQueryResultId("a", "a"))
         .setLeftType(OperandType.VARIABLE)
         .setRight("42")
         .setRightType(OperandType.LITERAL_NUMERIC)
@@ -665,7 +675,7 @@ public class TestBinaryExpressionNode {
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
-    when(r1.dataSource()).thenReturn("a");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("a", "a"));
     QueryNode n1 = mock(QueryNode.class);
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("a");
@@ -740,8 +750,10 @@ public class TestBinaryExpressionNode {
   public void onNextByteSameOperand() throws Exception {
     expression_config = ExpressionParseNode.newBuilder()
             .setLeft("a")
+            .setLeftId(new DefaultQueryResultId("a", "a"))
             .setLeftType(OperandType.VARIABLE)
             .setRight("a")
+            .setRightId(new DefaultQueryResultId("a", "a"))
             .setRightType(OperandType.VARIABLE)
             .setExpressionOp(ExpressionOp.ADD)
             .setExpressionConfig(config)
@@ -753,7 +765,7 @@ public class TestBinaryExpressionNode {
     node.initialize(null);
 
     QueryResult r1 = mock(QueryResult.class);
-    when(r1.dataSource()).thenReturn("a");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("a", "a"));
     QueryNode n1 = mock(QueryNode.class);
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("a");
@@ -831,14 +843,14 @@ public class TestBinaryExpressionNode {
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
-    when(r1.dataSource()).thenReturn("a");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("a", "a"));
     QueryNode n1 = mock(QueryNode.class);
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("a");
     when(n1.config()).thenReturn(c1);
     when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
-    when(r2.dataSource()).thenReturn("b");
+    when(r2.dataSource()).thenReturn(new DefaultQueryResultId("b", "b"));
     QueryNode n2 = mock(QueryNode.class);
     QueryNodeConfig c2 = mock(QueryNodeConfig.class);
     when(c2.getId()).thenReturn("b");
@@ -911,14 +923,14 @@ public class TestBinaryExpressionNode {
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
-    when(r1.dataSource()).thenReturn("a");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("a", "a"));
     QueryNode n1 = mock(QueryNode.class);
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("a");
     when(n1.config()).thenReturn(c1);
     when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
-    when(r2.dataSource()).thenReturn("b");
+    when(r2.dataSource()).thenReturn(new DefaultQueryResultId("b", "b"));
     QueryNode n2 = mock(QueryNode.class);
     QueryNodeConfig c2 = mock(QueryNodeConfig.class);
     when(c2.getId()).thenReturn("a");
@@ -1001,14 +1013,14 @@ public class TestBinaryExpressionNode {
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
-    when(r1.dataSource()).thenReturn("a");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("a", "a"));
     QueryNode n1 = mock(QueryNode.class);
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("a");
     when(n1.config()).thenReturn(c1);
     when(r1.source()).thenReturn(n1);
     QueryResult r2 = mock(QueryResult.class);
-    when(r2.dataSource()).thenReturn("b");
+    when(r2.dataSource()).thenReturn(new DefaultQueryResultId("b", "b"));
     QueryNode n2 = mock(QueryNode.class);
     QueryNodeConfig c2 = mock(QueryNodeConfig.class);
     when(c2.getId()).thenReturn("a");
@@ -1091,7 +1103,7 @@ public class TestBinaryExpressionNode {
     node.initialize(null);
     
     QueryResult r1 = mock(QueryResult.class);
-    when(r1.dataSource()).thenReturn("a");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("a", "a"));
     QueryNode n1 = mock(QueryNode.class);
     QueryNodeConfig c1 = mock(QueryNodeConfig.class);
     when(c1.getId()).thenReturn("a");

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNodeFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestBinaryExpressionNodeFactory.java
@@ -1,5 +1,5 @@
 //This file is part of OpenTSDB.
-//Copyright (C) 2018  The OpenTSDB Authors.
+//Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 //Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.
@@ -25,9 +25,9 @@ import org.junit.Test;
 import net.opentsdb.data.types.numeric.NumericArrayType;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.QueryNode;
-import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.joins.JoinConfig;
@@ -82,8 +82,10 @@ public class TestBinaryExpressionNodeFactory {
     ExpressionParseNode expression_config = 
         (ExpressionParseNode) ExpressionParseNode.newBuilder()
         .setLeft("a")
+        .setLeftId(new DefaultQueryResultId("a", "a"))
         .setLeftType(OperandType.VARIABLE)
         .setRight("b")
+        .setRightId(new DefaultQueryResultId("b", "b"))
         .setRightType(OperandType.VARIABLE)
         .setExpressionOp(ExpressionOp.ADD)
         .setExpressionConfig(config)

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionConfig.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionConfig.java
@@ -30,6 +30,7 @@ import net.opentsdb.core.MockTSDB;
 import net.opentsdb.core.MockTSDBDefault;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.joins.JoinConfig;
@@ -155,7 +156,6 @@ public class TestExpressionConfig {
 
   @Test
   public void toBuilder() throws Exception {
-
     NumericInterpolatorConfig numeric_config =
             (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
                     .setFillPolicy(FillPolicy.NOT_A_NUMBER)
@@ -175,6 +175,7 @@ public class TestExpressionConfig {
                     .setAs("some.metric.name")
                     .addInterpolatorConfig(numeric_config)
                     .setSources(new ArrayList<String>(){{add("source1");}})
+                    .addResultId(new DefaultQueryResultId("e1", "e1"))
                     .setId("e1")
                     .build();
     assertEquals("e1", config.getId());
@@ -184,6 +185,7 @@ public class TestExpressionConfig {
     assertEquals("host", config.getJoin().getJoins().get("host"));
     assertSame(numeric_config, config.interpolatorConfig(NumericType.TYPE));
     assertSame(numeric_config, config.getVariableInterpolators().get("a").get(0));
+    assertEquals(new DefaultQueryResultId("e1", "e1"), config.resultIds().get(0));
 
     final ExpressionConfig fromBuilder = config.toBuilder().build();
 
@@ -204,7 +206,7 @@ public class TestExpressionConfig {
     assertFalse(fromBuilder.getVariableInterpolators() == config.getVariableInterpolators());
     assertSame(numeric_config, fromBuilder.getVariableInterpolators().get("a").get(0));
 
-
+    assertEquals(new DefaultQueryResultId("e1", "e1"), fromBuilder.resultIds().get(0));
   }
 
   @Test

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionFactory.java
@@ -1,5 +1,5 @@
 //This file is part of OpenTSDB.
-//Copyright (C) 2018  The OpenTSDB Authors.
+//Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 //Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.
@@ -15,40 +15,52 @@
 package net.opentsdb.query.processor.expressions;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import java.util.Set;
 
+import net.opentsdb.query.BaseTimeSeriesDataSourceConfig;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
+import net.opentsdb.query.QueryContext;
+import net.opentsdb.query.QueryMode;
+import net.opentsdb.query.QueryNode;
+
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import com.google.common.graph.GraphBuilder;
-import com.google.common.graph.MutableGraph;
+import com.google.common.reflect.TypeToken;
+import com.stumbleupon.async.Deferred;
 
+import net.opentsdb.common.Const;
+import net.opentsdb.core.DefaultRegistry;
+import net.opentsdb.core.MockTSDB;
+import net.opentsdb.core.TSDB;
+import net.opentsdb.core.TSDBPlugin;
+import net.opentsdb.data.TimeSeriesDataSource;
+import net.opentsdb.data.TimeSeriesDataSourceFactory;
+import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.SemanticQuery;
 import net.opentsdb.query.filter.MetricLiteralFilter;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.joins.JoinConfig;
 import net.opentsdb.query.joins.JoinConfig.JoinType;
 import net.opentsdb.query.plan.DefaultQueryPlanner;
-import net.opentsdb.query.plan.QueryPlanner;
 import net.opentsdb.query.pojo.FillPolicy;
 import net.opentsdb.query.processor.downsample.DownsampleConfig;
 import net.opentsdb.query.processor.expressions.ExpressionParseNode.ExpressionOp;
@@ -58,12 +70,21 @@ import net.opentsdb.query.processor.merge.MergerConfig;
 
 public class TestExpressionFactory {
 
+  private static MockTSDB TSDB;
+  private static TimeSeriesDataSourceFactory STORE_FACTORY;
   protected static NumericInterpolatorConfig NUMERIC_CONFIG;
   protected static JoinConfig JOIN_CONFIG;
-  protected static QueryNodeConfig SINK;
+  protected static QueryNode SINK;
+  private static List<TimeSeriesDataSource> STORE_NODES;
+  private static TimeSeriesDataSourceFactory S1;
+  private static TimeSeriesDataSourceFactory S2;
+  
+  private QueryPipelineContext context;
   
   @BeforeClass
   public static void beforeClass() throws Exception {
+    TSDB = new MockTSDB();
+    STORE_FACTORY = mock(TimeSeriesDataSourceFactory.class);
     NUMERIC_CONFIG = 
         (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
       .setFillPolicy(FillPolicy.NOT_A_NUMBER)
@@ -75,7 +96,110 @@ public class TestExpressionFactory {
         .setJoinType(JoinType.NATURAL)
         .build();
     
-    SINK = mock(QueryNodeConfig.class);
+    SINK = mock(QueryNode.class);
+    STORE_NODES = Lists.newArrayList();
+    S1 = mock(TimeSeriesDataSourceFactory.class);
+    S2 = mock(TimeSeriesDataSourceFactory.class);
+    
+    TSDB.registry = new DefaultRegistry(TSDB);
+    ((DefaultRegistry) TSDB.registry).initialize(true);
+    ((DefaultRegistry) TSDB.registry).registerPlugin(
+        TimeSeriesDataSourceFactory.class, null, (TSDBPlugin) STORE_FACTORY);
+    ((DefaultRegistry) TSDB.registry).registerPlugin(
+        TimeSeriesDataSourceFactory.class, "s1", (TSDBPlugin) S1);
+    ((DefaultRegistry) TSDB.registry).registerPlugin(
+        TimeSeriesDataSourceFactory.class, "s2", (TSDBPlugin) S2);
+    
+    when(S1.newNode(any(QueryPipelineContext.class), 
+        any(QueryNodeConfig.class)))
+      .thenAnswer(new Answer<QueryNode>() {
+        @Override
+        public QueryNode answer(InvocationOnMock invocation) throws Throwable {
+          final TimeSeriesDataSource node = mock(TimeSeriesDataSource.class);
+          when(node.initialize(null)).thenReturn(Deferred.fromResult(null));
+          when(node.config()).thenReturn((QueryNodeConfig) invocation.getArguments()[1]);
+          STORE_NODES.add(node);
+          return node;
+        }
+      });
+    when(S2.newNode(any(QueryPipelineContext.class), 
+        any(QueryNodeConfig.class)))
+      .thenAnswer(new Answer<QueryNode>() {
+        @Override
+        public QueryNode answer(InvocationOnMock invocation) throws Throwable {
+          final TimeSeriesDataSource node = mock(TimeSeriesDataSource.class);
+          when(node.initialize(null)).thenReturn(Deferred.fromResult(null));
+          when(node.config()).thenReturn((QueryNodeConfig) invocation.getArguments()[1]);
+          STORE_NODES.add(node);
+          return node;
+        }
+      });
+    when(STORE_FACTORY.newNode(any(QueryPipelineContext.class), 
+        any(QueryNodeConfig.class)))
+      .thenAnswer(new Answer<QueryNode>() {
+        @Override
+        public QueryNode answer(InvocationOnMock invocation) throws Throwable {
+          final TimeSeriesDataSource node = mock(TimeSeriesDataSource.class);
+          when(node.initialize(null)).thenReturn(Deferred.fromResult(null));
+          when(node.config()).thenReturn((QueryNodeConfig) invocation.getArguments()[1]);
+          STORE_NODES.add(node);
+          return node;
+        }
+      });
+    when(STORE_FACTORY.idType()).thenAnswer(new Answer<TypeToken<? extends TimeSeriesId>>() {
+      @Override
+      public TypeToken<? extends TimeSeriesId> answer(
+          InvocationOnMock invocation) throws Throwable {
+        return Const.TS_STRING_ID;
+      }
+    });
+    when(S1.idType()).thenAnswer(new Answer<TypeToken<? extends TimeSeriesId>>() {
+      @Override
+      public TypeToken<? extends TimeSeriesId> answer(
+          InvocationOnMock invocation) throws Throwable {
+        return Const.TS_BYTE_ID;
+      }
+    });
+    when(S2.idType()).thenAnswer(new Answer<TypeToken<? extends TimeSeriesId>>() {
+      @Override
+      public TypeToken<? extends TimeSeriesId> answer(
+          InvocationOnMock invocation) throws Throwable {
+        return Const.TS_BYTE_ID;
+      }
+    });
+    when(S1.id()).thenReturn("s1");
+    when(S2.id()).thenReturn("s2");
+    
+    when(STORE_FACTORY.parseConfig(any(ObjectMapper.class), any(TSDB.class), any(JsonNode.class)))
+    .thenAnswer(new Answer<QueryNodeConfig>() {
+      @Override
+      public QueryNodeConfig answer(InvocationOnMock invocation)
+          throws Throwable {
+        DefaultTimeSeriesDataSourceConfig.Builder builder = DefaultTimeSeriesDataSourceConfig.newBuilder();
+        
+        DefaultTimeSeriesDataSourceConfig.parseConfig
+            ((ObjectMapper) invocation.getArguments()[0], 
+                invocation.getArgumentAt(1, TSDB.class), 
+                (JsonNode) invocation.getArguments()[2],
+                (BaseTimeSeriesDataSourceConfig.Builder) builder);
+        return builder.build();
+      }
+    });
+    
+    QueryNodeConfig sink_config = mock(QueryNodeConfig.class);
+    when(sink_config.getId()).thenReturn("SINK");
+    when(SINK.config()).thenReturn(sink_config);
+  }
+  
+  @Before
+  public void before() throws Exception {
+    context = mock(QueryPipelineContext.class);
+    when(context.tsdb()).thenReturn(TSDB);
+    when(context.queryContext()).thenReturn(mock(QueryContext.class));
+    
+    STORE_NODES.clear();
+    when(STORE_FACTORY.supportsPushdown(any(Class.class)))
+      .thenReturn(false);
   }
   
   @Test
@@ -86,11 +210,7 @@ public class TestExpressionFactory {
   
   @Test
   public void setupGraph1MetricDirect() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    List<QueryNodeConfig> query = Lists.newArrayList(
+    List<QueryNodeConfig> graph = Lists.newArrayList(
         DefaultTimeSeriesDataSourceConfig.newBuilder()
           .setMetric(MetricLiteralFilter.newBuilder()
               .setMetric("sys.cpu.user")
@@ -107,690 +227,656 @@ public class TestExpressionFactory {
           .setId("expression")
           .addSource("m1")
           .build());
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
     
-    List<QueryNodeConfig> replacements = Lists.newArrayList();
-    QueryPlanner plan = mockPlanner(replacements, graph);
-    when(plan.configGraph()).thenReturn(graph);
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), anyString()))
-      .thenReturn("sys.cpu.user");
-    when(plan.getDataSourceIds(any(QueryNodeConfig.class)))
-      .thenReturn(Lists.newArrayList("m1:m1"));
+    when(context.query()).thenReturn(query);
     
-    graph.putEdge(query.get(1), query.get(0));
-    graph.putEdge(SINK, query.get(1));
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
     
-    factory.setupGraph(mock(QueryPipelineContext.class), 
-        (ExpressionConfig) query.get(1), plan);
-    assertEquals(3, graph.nodes().size());
-    assertTrue(graph.nodes().contains(query.get(0)));
-    assertFalse(graph.nodes().contains(query.get(1)));
-    assertTrue(graph.nodes().contains(SINK));
-    
-    QueryNodeConfig b1 = graph.predecessors(query.get(0)).iterator().next();
+    assertSame(STORE_NODES.get(0), planner.sources().get(0));
+    assertEquals(3, planner.graph().nodes().size());
+    assertEquals(1, planner.serializationSources().size());
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression"), 
+        planner.nodeForId("m1")));
+    assertTrue(planner.graph().hasEdgeConnecting(SINK, planner.nodeForId("expression")));
+
+    QueryNodeConfig b1 = planner.configNodeForId("expression");
     assertEquals("BinaryExpression", b1.getType());
-    assertTrue(graph.hasEdgeConnecting(b1, query.get(0)));
-    assertTrue(graph.hasEdgeConnecting(SINK, b1));
     
     ExpressionParseNode p1 = (ExpressionParseNode) b1;
     assertEquals("expression", p1.getId());
     assertEquals("sys.cpu.user", p1.getLeft());
-    assertEquals("m1:m1", p1.getLeftId());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), p1.getLeftId());
     assertEquals(OperandType.VARIABLE, p1.getLeftType());
     assertEquals(42, ((NumericLiteral) p1.getRight()).longValue());
     assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
     assertNull(p1.getRightId());
     assertEquals(ExpressionOp.ADD, p1.getOperator());
+    assertEquals(1, p1.resultIds().size());
+    assertEquals(new DefaultQueryResultId("expression", "expression"), 
+        p1.resultIds().get(0));
   }
   
   @Test
   public void setupGraph1MetricThroughNode() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
+    List<QueryNodeConfig> graph = Lists.newArrayList(
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.user")
+              .build())
+          .setFilterId("f1")
+          .setId("m1")
+          .build(),
+        DownsampleConfig.newBuilder()
+          .setAggregator("sum")
+          .setInterval("1m")
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .setId("downsample")
+          .addSource("m1")
+          .build(),
+        ExpressionConfig.newBuilder()
+          .setExpression("m1 + 42")
+          .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+              .setJoinType(JoinType.NATURAL)
+              .build())
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .setId("expression")
+          .addSource("downsample")
+          .build());
     
-    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.user")
-            .build())
-        .setFilterId("f1")
-        .setId("m1")
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
         .build();
-    QueryNodeConfig ds = DownsampleConfig.newBuilder()
-        .setAggregator("sum")
-        .setInterval("1m")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setId("downsample")
-        .build();
-    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
-    builder.setExpression("m1 + 42")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setJoinType(JoinType.NATURAL)
-            .build())
-        .addInterpolatorConfig(NUMERIC_CONFIG);
-    builder.setId("expression");
-    ExpressionConfig exp = builder.build();
-    List<QueryNodeConfig> replacements = Lists.newArrayList();
-    QueryPlanner plan = mockPlanner(replacements, graph);
-    when(plan.configGraph()).thenReturn(graph);
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), anyString()))
-      .thenReturn("sys.cpu.user");
-    when(plan.getDataSourceIds(any(QueryNodeConfig.class)))
-      .thenReturn(Lists.newArrayList("downsample:m1"));
     
-    graph.putEdge(ds, m1);
-    graph.putEdge(exp, ds);
-    graph.putEdge(SINK, exp);
+    when(context.query()).thenReturn(query);
     
-    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
-    assertEquals(4, graph.nodes().size());
-    assertTrue(graph.nodes().contains(m1));
-    assertTrue(graph.nodes().contains(ds));
-    assertFalse(graph.nodes().contains(exp));
-    assertTrue(graph.nodes().contains(SINK));
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
+
+    assertSame(STORE_NODES.get(0), planner.sources().get(0));
+    assertEquals(4, planner.graph().nodes().size());
+    assertEquals(1, planner.serializationSources().size());
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression"), 
+        planner.nodeForId("downsample")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("downsample"), 
+        planner.nodeForId("m1")));
+    assertTrue(planner.graph().hasEdgeConnecting(SINK, planner.nodeForId("expression")));
     
-    QueryNodeConfig b1 = graph.predecessors(ds).iterator().next();
+    QueryNodeConfig b1 = planner.configNodeForId("expression");
     assertEquals("BinaryExpression", b1.getType());
-    assertTrue(graph.hasEdgeConnecting(ds, m1));
-    assertTrue(graph.hasEdgeConnecting(b1, ds));
-    assertTrue(graph.hasEdgeConnecting(SINK, b1));
     
     ExpressionParseNode p1 = (ExpressionParseNode) b1;
     assertEquals("expression", p1.getId());
     assertEquals("sys.cpu.user", p1.getLeft());
-    assertEquals("downsample:m1", p1.getLeftId());
+    assertEquals(new DefaultQueryResultId("downsample", "m1"), p1.getLeftId());
     assertEquals(OperandType.VARIABLE, p1.getLeftType());
     assertEquals(42, ((NumericLiteral) p1.getRight()).longValue());
     assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
     assertNull(p1.getRightId());
     assertEquals(ExpressionOp.ADD, p1.getOperator());
+    assertEquals(1, p1.resultIds().size());
+    assertEquals(new DefaultQueryResultId("expression", "expression"), 
+        p1.resultIds().get(0));
   }
   
   @Test
   public void setupGraph2MetricsThroughNode() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.user")
-            .build())
-        .setFilterId("f1")
-        .setId("m1")
+    List<QueryNodeConfig> graph = Lists.newArrayList(
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.user")
+              .build())
+          .setFilterId("f1")
+          .setId("m1")
+          .build(),
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.sys")
+              .build())
+          .setFilterId("f1")
+          .setId("m2")
+          .build(),
+        DownsampleConfig.newBuilder()
+          .setAggregator("sum")
+          .setInterval("1m")
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .setId("downsample")
+          .addSource("m1")
+          .addSource("m2")
+          .build(),
+        ExpressionConfig.newBuilder()
+          .setExpression("m1 + m2")
+          .setJoinConfig(JoinConfig.newBuilder()
+              .setJoinType(JoinType.NATURAL)
+              .build())
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .addSource("downsample")
+          .setId("expression")
+          .build());
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
         .build();
-    QueryNodeConfig m2 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.sys")
-            .build())
-        .setFilterId("f1")
-        .setId("m2")
-        .build();
-    QueryNodeConfig ds = DownsampleConfig.newBuilder()
-        .setAggregator("sum")
-        .setInterval("1m")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setId("downsample")
-        .build();
-    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
-    builder.setExpression("m1 + m2")
-        .setJoinConfig(JoinConfig.newBuilder()
-            .setJoinType(JoinType.NATURAL)
-            .build())
-        .addInterpolatorConfig(NUMERIC_CONFIG);
-    builder.setId("expression");
-    ExpressionConfig exp = builder.build();
-    DefaultQueryPlanner plan = mock(DefaultQueryPlanner.class);
-    List<QueryNodeConfig> replacements = Lists.newArrayList();
-    doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        replacements.add((QueryNodeConfig) invocation.getArguments()[1]);
-        return null;
-      }
-    }).when(plan).replace(any(QueryNodeConfig.class), any(QueryNodeConfig.class));
-    when(plan.configGraph()).thenReturn(graph);
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), eq("m1")))
-      .thenReturn("sys.cpu.user");
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), eq("m2")))
-      .thenReturn("sys.cpu.sys");
-    when(plan.getDataSourceIds(any(QueryNodeConfig.class)))
-      .thenReturn(Lists.newArrayList("downsample:m1", "downsample:m2"));
     
-    graph.putEdge(ds, m1);
-    graph.putEdge(ds, m2);
-    graph.putEdge(exp, ds);
-    graph.putEdge(SINK, exp);
+    when(context.query()).thenReturn(query);
     
-    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
-    assertEquals(5, graph.nodes().size());
-    assertTrue(graph.nodes().contains(m1));
-    assertTrue(graph.nodes().contains(m2));
-    assertTrue(graph.nodes().contains(ds));
-    assertFalse(graph.nodes().contains(exp));
-    assertTrue(graph.nodes().contains(SINK));
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
     
-    QueryNodeConfig b1 = graph.predecessors(ds).iterator().next();
+    assertSame(STORE_NODES.get(0), planner.sources().get(0));
+    assertEquals(5, planner.graph().nodes().size());
+    assertEquals(1, planner.serializationSources().size());
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression"), 
+        planner.nodeForId("downsample")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("downsample"), 
+        planner.nodeForId("m1")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("downsample"), 
+        planner.nodeForId("m2")));
+    assertTrue(planner.graph().hasEdgeConnecting(SINK, planner.nodeForId("expression")));
+    
+    QueryNodeConfig b1 = planner.configNodeForId("expression");
     assertEquals("BinaryExpression", b1.getType());
-    assertTrue(graph.hasEdgeConnecting(ds, m1));
-    assertTrue(graph.hasEdgeConnecting(ds, m2));
-    assertTrue(graph.hasEdgeConnecting(b1, ds));
-    assertTrue(graph.hasEdgeConnecting(SINK, b1));
     
     ExpressionParseNode p1 = (ExpressionParseNode) b1;
     assertEquals("expression", p1.getId());
     assertEquals("sys.cpu.user", p1.getLeft());
-    assertEquals("downsample:m1", p1.getLeftId());
+    assertEquals(new DefaultQueryResultId("downsample", "m1"), p1.getLeftId());
     assertEquals(OperandType.VARIABLE, p1.getLeftType());
     assertEquals("sys.cpu.sys", p1.getRight());
-    assertEquals("downsample:m2", p1.getRightId());
+    assertEquals(new DefaultQueryResultId("downsample", "m2"), p1.getRightId());
     assertEquals(OperandType.VARIABLE, p1.getRightType());
     assertEquals(ExpressionOp.ADD, p1.getOperator());
-    assertTrue(replacements.isEmpty());
+    assertEquals(1, p1.resultIds().size());
+    assertEquals(new DefaultQueryResultId("expression", "expression"), 
+        p1.resultIds().get(0));
   }
   
   @Test
   public void setupGraph2Metrics1ThroughNode() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.user")
-            .build())
-        .setFilterId("f1")
-        .setId("m1")
+    List<QueryNodeConfig> graph = Lists.newArrayList(
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.user")
+              .build())
+          .setFilterId("f1")
+          .setId("m1")
+          .build(),
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.sys")
+              .build())
+          .setFilterId("f1")
+          .setId("m2")
+          .build(),
+        DownsampleConfig.newBuilder()
+          .setAggregator("sum")
+          .setInterval("1m")
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .setId("downsample")
+          .addSource("m1")
+          .build(),
+        ExpressionConfig.newBuilder()
+          .setExpression("m1 + m2")
+          .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+              .setJoinType(JoinType.NATURAL)
+              .build())
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .addSource("downsample")
+          .addSource("m2")
+          .setId("expression")
+          .build());
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
         .build();
-    QueryNodeConfig m2 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.sys")
-            .build())
-        .setFilterId("f1")
-        .setId("m2")
-        .build();
-    QueryNodeConfig ds = DownsampleConfig.newBuilder()
-        .setAggregator("sum")
-        .setInterval("1m")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setId("downsample")
-        .build();
-    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
-    builder.setExpression("m1 + m2")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setJoinType(JoinType.NATURAL)
-            .build())
-        .addInterpolatorConfig(NUMERIC_CONFIG);
-    builder.setId("expression");
-    ExpressionConfig exp = builder.build();
-    QueryPlanner plan = mock(QueryPlanner.class);
-    when(plan.configGraph()).thenReturn(graph);
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), eq("m1")))
-      .thenReturn("sys.cpu.user");
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), eq("m2")))
-      .thenReturn("sys.cpu.sys");
-    when(plan.getDataSourceIds(ds))
-      .thenReturn(Lists.newArrayList("downsample:m1"));
-    when(plan.getDataSourceIds(m2))
-      .thenReturn(Lists.newArrayList("m2:m2"));
     
-    graph.putEdge(ds, m1);
-    graph.putEdge(exp, m2);
-    graph.putEdge(exp, ds);
-    graph.putEdge(SINK, exp);
+    when(context.query()).thenReturn(query);
     
-    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
-    assertEquals(5, graph.nodes().size());
-    assertTrue(graph.nodes().contains(m1));
-    assertTrue(graph.nodes().contains(m2));
-    assertTrue(graph.nodes().contains(ds));
-    assertFalse(graph.nodes().contains(exp));
-    assertTrue(graph.nodes().contains(SINK));
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
     
-    QueryNodeConfig b1 = graph.predecessors(ds).iterator().next();
+    assertSame(STORE_NODES.get(0), planner.sources().get(0));
+    assertEquals(5, planner.graph().nodes().size());
+    assertEquals(1, planner.serializationSources().size());
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression"), 
+        planner.nodeForId("downsample")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("downsample"), 
+        planner.nodeForId("m1")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression"), 
+        planner.nodeForId("m2")));
+    assertTrue(planner.graph().hasEdgeConnecting(SINK, planner.nodeForId("expression")));
+    
+    QueryNodeConfig b1 = planner.configNodeForId("expression");
     assertEquals("BinaryExpression", b1.getType());
-    assertTrue(graph.hasEdgeConnecting(ds, m1));
-    assertTrue(graph.hasEdgeConnecting(b1, m2));
-    assertTrue(graph.hasEdgeConnecting(b1, ds));
-    assertTrue(graph.hasEdgeConnecting(SINK, b1));
     
     ExpressionParseNode p1 = (ExpressionParseNode) b1;
     assertEquals("expression", p1.getId());
     assertEquals("sys.cpu.user", p1.getLeft());
-    assertEquals("downsample:m1", p1.getLeftId());
+    assertEquals(new DefaultQueryResultId("downsample", "m1"), p1.getLeftId());
     assertEquals(OperandType.VARIABLE, p1.getLeftType());
     assertEquals("sys.cpu.sys", p1.getRight());
-    assertEquals("m2:m2", p1.getRightId());
+    assertEquals(new DefaultQueryResultId("m2", "m2"), p1.getRightId());
     assertEquals(OperandType.VARIABLE, p1.getRightType());
     assertEquals(ExpressionOp.ADD, p1.getOperator());
+    assertEquals(1, p1.resultIds().size());
+    assertEquals(new DefaultQueryResultId("expression", "expression"), 
+        p1.resultIds().get(0));
   }
   
   @Test
   public void setupGraph3MetricsThroughNode() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.user")
-            .build())
-        .setFilterId("f1")
-        .setId("m1")
+    List<QueryNodeConfig> graph = Lists.newArrayList(
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.user")
+              .build())
+          .setFilterId("f1")
+          .setId("m1")
+          .build(),
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.sys")
+              .build())
+          .setFilterId("f1")
+          .setId("m2")
+          .build(),
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.idle")
+              .build())
+          .setFilterId("f1")
+          .setId("m3")
+          .build(),
+        DownsampleConfig.newBuilder()
+          .setAggregator("sum")
+          .setInterval("1m")
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .setId("downsample")
+          .setSources(Lists.newArrayList("m1", "m2", "m3"))
+          .build(),
+        ExpressionConfig.newBuilder()
+          .setExpression("m1 + m2 + m3")
+          .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+              .setJoinType(JoinType.NATURAL)
+              .build())
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .setId("expression")
+          .addSource("downsample")
+          .build());
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
         .build();
-    QueryNodeConfig m2 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.sys")
-            .build())
-        .setFilterId("f1")
-        .setId("m2")
-        .build();
-    QueryNodeConfig m3 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.idle")
-            .build())
-        .setFilterId("f1")
-        .setId("m3")
-        .build();
-    QueryNodeConfig ds = DownsampleConfig.newBuilder()
-        .setAggregator("sum")
-        .setInterval("1m")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setId("downsample")
-        .build();
-    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
-    builder.setExpression("m1 + m2 + m3")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setJoinType(JoinType.NATURAL)
-            .build())
-        .addInterpolatorConfig(NUMERIC_CONFIG);
-    builder.setId("expression");
-    ExpressionConfig exp = builder.build();
-
-    QueryPlanner plan = mock(QueryPlanner.class);
-    when(plan.configGraph()).thenReturn(graph);
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), eq("m1")))
-      .thenReturn("sys.cpu.user");
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), eq("m2")))
-      .thenReturn("sys.cpu.sys");
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), eq("m3")))
-      .thenReturn("sys.cpu.idle");
-    when(plan.getDataSourceIds(ds))
-      .thenReturn(Lists.newArrayList("downsample:m1", "downsample:m2", "downsample:m3"));
     
-    graph.putEdge(ds, m1);
-    graph.putEdge(ds, m2);
-    graph.putEdge(ds, m3);
-    graph.putEdge(exp, ds);
-    graph.putEdge(SINK, exp);
+    when(context.query()).thenReturn(query);
     
-    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
-    assertEquals(7, graph.nodes().size());
-    assertTrue(graph.nodes().contains(m1));
-    assertTrue(graph.nodes().contains(m2));
-    assertTrue(graph.nodes().contains(m3));
-    assertTrue(graph.nodes().contains(ds));
-    assertFalse(graph.nodes().contains(exp));
-    assertTrue(graph.nodes().contains(SINK));
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
     
-    assertTrue(graph.hasEdgeConnecting(ds, m1));
-    assertTrue(graph.hasEdgeConnecting(ds, m2));
+    assertSame(STORE_NODES.get(0), planner.sources().get(0));
+    assertEquals(7, planner.graph().nodes().size());
+    assertEquals(1, planner.serializationSources().size());
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression"), 
+        planner.nodeForId("downsample")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("downsample"), 
+        planner.nodeForId("m1")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("downsample"), 
+        planner.nodeForId("m2")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("downsample"), 
+        planner.nodeForId("m3")));
+    assertTrue(planner.graph().hasEdgeConnecting(SINK, planner.nodeForId("expression")));
     
-    List<QueryNodeConfig> expressions = Lists.newArrayList(graph.predecessors(ds));
-    assertEquals(2, expressions.size());
-    for (final QueryNodeConfig binary : expressions) {
-      assertTrue(graph.hasEdgeConnecting(binary, ds));
-      assertEquals("BinaryExpression", binary.getType());
-      
-      if (binary.getId().equals("expression_SubExp#0")) {
-        ExpressionParseNode p1 = (ExpressionParseNode) binary;
-        assertEquals("expression_SubExp#0", p1.getId());
-        assertEquals("sys.cpu.user", p1.getLeft());
-        assertEquals("downsample:m1", p1.getLeftId());
-        assertEquals(OperandType.VARIABLE, p1.getLeftType());
-        assertEquals("sys.cpu.sys", p1.getRight());
-        assertEquals("downsample:m2", p1.getRightId());
-        assertEquals(OperandType.VARIABLE, p1.getRightType());
-        assertEquals(ExpressionOp.ADD, p1.getOperator());
-        
-        assertFalse(graph.hasEdgeConnecting(SINK, binary));
-      } else {
-        assertEquals("expression", binary.getId());
-        ExpressionParseNode p1 = (ExpressionParseNode) binary;
-        assertEquals("expression", p1.getId());
-        assertEquals("expression_SubExp#0", p1.getLeft());
-        assertEquals("expression_SubExp#0", p1.getLeftId());
-        assertEquals(OperandType.SUB_EXP, p1.getLeftType());
-        assertEquals("sys.cpu.idle", p1.getRight());
-        assertEquals("downsample:m3", p1.getRightId());
-        assertEquals(OperandType.VARIABLE, p1.getRightType());
-        assertEquals(ExpressionOp.ADD, p1.getOperator());
-        
-        assertTrue(graph.hasEdgeConnecting(SINK, binary));
-      }
-    }
+    QueryNodeConfig b1 = planner.configNodeForId("expression");
+    assertEquals("BinaryExpression", b1.getType());
+    ExpressionParseNode p1 = (ExpressionParseNode) b1;
+    assertEquals("expression", p1.getId());
+    assertEquals("expression_SubExp#0", p1.getLeft());
+    assertEquals(new DefaultQueryResultId(
+        "expression_SubExp#0", "expression_SubExp#0"), p1.getLeftId());
+    assertEquals(OperandType.SUB_EXP, p1.getLeftType());
+    assertEquals("sys.cpu.idle", p1.getRight());
+    assertEquals(new DefaultQueryResultId("downsample", "m3"), p1.getRightId());
+    assertEquals(OperandType.VARIABLE, p1.getRightType());
+    assertEquals(ExpressionOp.ADD, p1.getOperator());
+    assertEquals(new DefaultQueryResultId("expression", "expression"), 
+        p1.resultIds().get(0));
     
+    QueryNodeConfig b2 = planner.configNodeForId("expression_SubExp#0");
+    assertEquals("BinaryExpression", b2.getType());
+    
+    ExpressionParseNode p2 = (ExpressionParseNode) b2;
+    assertEquals("expression_SubExp#0", p2.getId());
+    assertEquals("sys.cpu.user", p2.getLeft());
+    assertEquals(new DefaultQueryResultId("downsample", "m1"), p2.getLeftId());
+    assertEquals(OperandType.VARIABLE, p2.getLeftType());
+    assertEquals("sys.cpu.sys", p2.getRight());
+    assertEquals(new DefaultQueryResultId("downsample", "m2"), p2.getRightId());
+    assertEquals(OperandType.VARIABLE, p2.getRightType());
+    assertEquals(ExpressionOp.ADD, p2.getOperator());
+    assertEquals(new DefaultQueryResultId("expression_SubExp#0", "expression_SubExp#0"), 
+        p2.resultIds().get(0));
   }
   
   @Test
   public void setupGraph3MetricsComplexThroughNode() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.user")
-            .build())
-        .setFilterId("f1")
-        .setId("m1")
+    List<QueryNodeConfig> graph = Lists.newArrayList(
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.user")
+              .build())
+          .setFilterId("f1")
+          .setId("m1")
+          .build(),
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.sys")
+              .build())
+          .setFilterId("f1")
+          .setId("m2")
+          .build(),
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.idle")
+              .build())
+          .setFilterId("f1")
+          .setId("m3")
+          .build(),
+        DownsampleConfig.newBuilder()
+          .setAggregator("sum")
+          .setInterval("1m")
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .setId("downsample")
+          .setSources(Lists.newArrayList("m1", "m3"))
+          .build(),
+        ExpressionConfig.newBuilder()
+          .setExpression("(m1 * 1024) + (m2 * 1024) + (m3 * 1024)")
+          .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+              .setJoinType(JoinType.NATURAL)
+              .build())
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .addSource("downsample")
+          .addSource("m2")
+          .setId("expression")
+          .build());
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
         .build();
-    QueryNodeConfig m2 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.sys")
-            .build())
-        .setFilterId("f1")
-        .setId("m2")
-        .build();
-    QueryNodeConfig m3 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.idle")
-            .build())
-        .setFilterId("f1")
-        .setId("m3")
-        .build();
-    QueryNodeConfig ds = DownsampleConfig.newBuilder()
-        .setAggregator("sum")
-        .setInterval("1m")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setId("downsample")
-        .build();
-    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
-    builder.setExpression("(m1 * 1024) + (m2 * 1024) + (m3 * 1024)")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setJoinType(JoinType.NATURAL)
-            .build())
-        .addInterpolatorConfig(NUMERIC_CONFIG);
-        builder.setId("expression");
-    ExpressionConfig exp = builder.build();
-
-    QueryPlanner plan = mock(QueryPlanner.class);
-    when(plan.configGraph()).thenReturn(graph);
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), eq("m1")))
-      .thenReturn("sys.cpu.user");
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), eq("m2")))
-      .thenReturn("sys.cpu.sys");
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), eq("m3")))
-      .thenReturn("sys.cpu.idle");
-    when(plan.getDataSourceIds(ds))
-      .thenReturn(Lists.newArrayList("downsample:m1", "downsample:m2", "downsample:m3"));
-  
-    graph.putEdge(ds, m1);
-    graph.putEdge(ds, m2);
-    graph.putEdge(ds, m3);
-    graph.putEdge(exp, ds);
-    graph.putEdge(SINK, exp);
     
-    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
-    assertEquals(10, graph.nodes().size());
-    assertTrue(graph.nodes().contains(m1));
-    assertTrue(graph.nodes().contains(m2));
-    assertTrue(graph.nodes().contains(m3));
-    assertTrue(graph.nodes().contains(ds));
-    assertFalse(graph.nodes().contains(exp));
-    assertTrue(graph.nodes().contains(SINK));
+    when(context.query()).thenReturn(query);
     
-    assertTrue(graph.hasEdgeConnecting(ds, m1));
-    assertTrue(graph.hasEdgeConnecting(ds, m2));
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
     
-    List<QueryNodeConfig> expressions = Lists.newArrayList(graph.predecessors(ds));
-    assertEquals(3, expressions.size());
-    for (final QueryNodeConfig binary : expressions) {
-      assertTrue(graph.hasEdgeConnecting(binary, ds));
-      assertEquals("BinaryExpression", binary.getType());
-      if (binary.getId().equals("expression_SubExp#0")) {
-        ExpressionParseNode p1 = (ExpressionParseNode) binary;
-        assertEquals("expression_SubExp#0", p1.getId());
-        assertEquals("sys.cpu.user", p1.getLeft());
-        assertEquals("downsample:m1", p1.getLeftId());
-        assertEquals(OperandType.VARIABLE, p1.getLeftType());
-        assertEquals(1024, ((NumericLiteral) p1.getRight()).longValue());
-        assertNull(p1.getRightId());
-        assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
-        assertEquals(ExpressionOp.MULTIPLY, p1.getOperator());
-        
-        assertFalse(graph.hasEdgeConnecting(SINK, binary));
-        assertEquals(1, graph.predecessors(binary).size());
-        assertEquals("expression_SubExp#2", 
-            graph.predecessors(binary).iterator().next().getId());
-      } else if (binary.getId().equals("expression_SubExp#1")) {
-        ExpressionParseNode p1 = (ExpressionParseNode) binary;
-        assertEquals("expression_SubExp#1", p1.getId());
-        assertEquals("sys.cpu.sys", p1.getLeft());
-        assertEquals("downsample:m2", p1.getLeftId());
-        assertEquals(OperandType.VARIABLE, p1.getLeftType());
-        assertEquals(1024, ((NumericLiteral) p1.getRight()).longValue());
-        assertNull(p1.getRightId());
-        assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
-        assertEquals(ExpressionOp.MULTIPLY, p1.getOperator());
-        
-        assertFalse(graph.hasEdgeConnecting(SINK, binary));
-        assertEquals(1, graph.predecessors(binary).size());
-        QueryNodeConfig b2 = graph.predecessors(binary).iterator().next();
-        assertEquals("expression_SubExp#2", b2.getId());
-        
-        // validate sub2 here
-        p1 = (ExpressionParseNode) b2;
-        assertEquals("expression_SubExp#2", p1.getId());
-        assertEquals("expression_SubExp#0", p1.getLeft());
-        assertEquals("expression_SubExp#0", p1.getLeftId());
-        assertEquals(OperandType.SUB_EXP, p1.getLeftType());
-        assertEquals("expression_SubExp#1", p1.getRight());
-        assertEquals("expression_SubExp#1", p1.getRightId());
-        assertEquals(OperandType.SUB_EXP, p1.getRightType());
-        assertEquals(ExpressionOp.ADD, p1.getOperator());
-        
-        assertFalse(graph.hasEdgeConnecting(SINK, b2));
-        
-      } else if (binary.getId().equals("expression_SubExp#3")) {
-        ExpressionParseNode p1 = (ExpressionParseNode) binary;
-        assertEquals("expression_SubExp#3", p1.getId());
-        assertEquals("sys.cpu.idle", p1.getLeft());
-        assertEquals("downsample:m3", p1.getLeftId());
-        assertEquals(OperandType.VARIABLE, p1.getLeftType());
-        assertEquals(1024, ((NumericLiteral) p1.getRight()).longValue());
-        assertNull(p1.getRightId());
-        assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
-        assertEquals(ExpressionOp.MULTIPLY, p1.getOperator());
-        
-        assertFalse(graph.hasEdgeConnecting(SINK, binary));
-        assertEquals(1, graph.predecessors(binary).size());
-        
-        // validate the expression here
-        QueryNodeConfig b2 = graph.predecessors(binary).iterator().next();
-        assertEquals("expression", b2.getId());
-        
-        // validate parent here
-        p1 = (ExpressionParseNode) b2;
-        assertEquals("expression", p1.getId());
-        assertEquals("expression_SubExp#2", p1.getLeft());
-        assertEquals("expression_SubExp#2", p1.getLeftId());
-        assertEquals(OperandType.SUB_EXP, p1.getLeftType());
-        assertEquals("expression_SubExp#3", p1.getRight());
-        assertEquals("expression_SubExp#3", p1.getRightId());
-        assertEquals(OperandType.SUB_EXP, p1.getRightType());
-        assertEquals(ExpressionOp.ADD, p1.getOperator());
-        
-        assertTrue(graph.hasEdgeConnecting(SINK, b2));
-      }
-    }
+    assertSame(STORE_NODES.get(0), planner.sources().get(0));
+    assertEquals(10, planner.graph().nodes().size());
+    assertEquals(1, planner.serializationSources().size());
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression_SubExp#0"), 
+        planner.nodeForId("downsample")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("downsample"), 
+        planner.nodeForId("m1")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression_SubExp#1"), 
+        planner.nodeForId("m2")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("downsample"), 
+        planner.nodeForId("m3")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression_SubExp#2"), 
+        planner.nodeForId("expression_SubExp#0")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression_SubExp#2"), 
+        planner.nodeForId("expression_SubExp#1")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression_SubExp#3"), 
+        planner.nodeForId("downsample")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression"), 
+        planner.nodeForId("expression_SubExp#2")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression"), 
+        planner.nodeForId("expression_SubExp#3")));
+    assertTrue(planner.graph().hasEdgeConnecting(SINK, planner.nodeForId("expression")));
     
+    ExpressionParseNode node = (ExpressionParseNode) planner.configNodeForId("expression_SubExp#0");
+    assertEquals("BinaryExpression", node.getType());
+    assertEquals("expression_SubExp#0", node.getId());
+    assertEquals("sys.cpu.user", node.getLeft());
+    assertEquals(new DefaultQueryResultId("downsample", "m1"), node.getLeftId());
+    assertEquals(OperandType.VARIABLE, node.getLeftType());
+    assertEquals(1024, ((NumericLiteral) node.getRight()).longValue());
+    assertNull(node.getRightId());
+    assertEquals(OperandType.LITERAL_NUMERIC, node.getRightType());
+    assertEquals(ExpressionOp.MULTIPLY, node.getOperator());
+    assertEquals(1, node.resultIds().size());
+    assertEquals(new DefaultQueryResultId("expression_SubExp#0", "expression_SubExp#0"), 
+        node.resultIds().get(0));
+    
+    node = (ExpressionParseNode) planner.configNodeForId("expression_SubExp#1");
+    assertEquals("BinaryExpression", node.getType());
+    assertEquals("expression_SubExp#1", node.getId());
+    assertEquals("sys.cpu.sys", node.getLeft());
+    assertEquals(new DefaultQueryResultId("m2", "m2"), node.getLeftId());
+    assertEquals(OperandType.VARIABLE, node.getLeftType());
+    assertEquals(1024, ((NumericLiteral) node.getRight()).longValue());
+    assertNull(node.getRightId());
+    assertEquals(OperandType.LITERAL_NUMERIC, node.getRightType());
+    assertEquals(ExpressionOp.MULTIPLY, node.getOperator());
+    assertEquals(1, node.resultIds().size());
+    assertEquals(new DefaultQueryResultId("expression_SubExp#1", "expression_SubExp#1"), 
+        node.resultIds().get(0));
+    
+    node = (ExpressionParseNode) planner.configNodeForId("expression_SubExp#3");
+    assertEquals("BinaryExpression", node.getType());
+    assertEquals("expression_SubExp#3", node.getId());
+    assertEquals("sys.cpu.idle", node.getLeft());
+    assertEquals(new DefaultQueryResultId("downsample", "m3"), node.getLeftId());
+    assertEquals(OperandType.VARIABLE, node.getLeftType());
+    assertEquals(1024, ((NumericLiteral) node.getRight()).longValue());
+    assertNull(node.getRightId());
+    assertEquals(OperandType.LITERAL_NUMERIC, node.getRightType());
+    assertEquals(ExpressionOp.MULTIPLY, node.getOperator());
+    assertEquals(1, node.resultIds().size());
+    assertEquals(new DefaultQueryResultId("expression_SubExp#3", "expression_SubExp#3"), 
+        node.resultIds().get(0));
+    
+    node = (ExpressionParseNode) planner.configNodeForId("expression");
+    assertEquals("BinaryExpression", node.getType());
+    assertEquals("expression", node.getId());
+    assertEquals("expression_SubExp#2", node.getLeft());
+    assertEquals(new DefaultQueryResultId("expression_SubExp#2", "expression_SubExp#2"), 
+        node.getLeftId());
+    assertEquals(OperandType.SUB_EXP, node.getLeftType());
+    assertEquals("expression_SubExp#3", node.getRight());
+    assertEquals(new DefaultQueryResultId("expression_SubExp#3", "expression_SubExp#3"), 
+        node.getRightId());
+    assertEquals(OperandType.SUB_EXP, node.getRightType());
+    assertEquals(ExpressionOp.ADD, node.getOperator());
+    assertEquals(1, node.resultIds().size());
+    assertEquals(new DefaultQueryResultId("expression", "expression"), 
+        node.resultIds().get(0));
   }
   
   @Test
   public void setupGraphThroughJoinNodeMetricName() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.user")
-            .build())
-        .setFilterId("f1")
-        .setId("ha_m1")
+    List<QueryNodeConfig> graph = Lists.newArrayList(
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.user")
+              .build())
+          .setFilterId("f1")
+          .setId("ha_m1")
+          .build(),
+        MergerConfig.newBuilder()
+          .setAggregator("sum")
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .setDataSource("m1")
+          .setId("m1")
+          .addSource("ha_m1")
+          .build(),
+        DownsampleConfig.newBuilder()
+          .setAggregator("sum")
+          .setInterval("1m")
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .setId("downsample")
+          .addSource("m1")
+          .build(),
+        ExpressionConfig.newBuilder()
+          .setExpression("(sys.cpu.user * 1024)")
+          .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+              .setJoinType(JoinType.NATURAL)
+              .build())
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .setId("expression")
+          .addSource("downsample")
+          .build());
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
         .build();
-    QueryNodeConfig merger = MergerConfig.newBuilder()
-        .setAggregator("sum")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setDataSource("m1")
-        .setId("m1")
-        .build();
-    QueryNodeConfig ds = DownsampleConfig.newBuilder()
-        .setAggregator("sum")
-        .setInterval("1m")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setId("downsample")
-        .build();
-    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
-    builder.setExpression("(sys.cpu.user * 1024)")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setJoinType(JoinType.NATURAL)
-            .build())
-        .addInterpolatorConfig(NUMERIC_CONFIG);
-    builder.setId("expression");
-    ExpressionConfig exp = builder.build();
     
-    List<QueryNodeConfig> replacements = Lists.newArrayList();
-    QueryPlanner plan = mockPlanner(replacements, graph);
-    when(plan.configGraph()).thenReturn(graph);
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), eq("m1")))
-      .thenReturn("sys.cpu.user");
-    when(plan.getDataSourceIds(ds))
-      .thenReturn(Lists.newArrayList("downsample:m1"));
-    when(plan.getMetrics(ds))
-      .thenReturn(Sets.newHashSet("downsample:sys.cpu.user"));
+    when(context.query()).thenReturn(query);
     
-    graph.putEdge(merger, m1);
-    graph.putEdge(ds, merger);
-    graph.putEdge(exp, ds);
-    graph.putEdge(SINK, exp);
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
     
-    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
-    assertEquals(5, graph.nodes().size());
-    assertTrue(graph.nodes().contains(m1));
-    assertTrue(graph.nodes().contains(merger));
-    assertTrue(graph.nodes().contains(ds));
-    assertFalse(graph.nodes().contains(exp));
-    assertTrue(graph.nodes().contains(SINK));
+    assertSame(STORE_NODES.get(0), planner.sources().get(0));
+    assertEquals(5, planner.graph().nodes().size());
+    assertEquals(1, planner.serializationSources().size());
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression"), 
+        planner.nodeForId("downsample")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("downsample"), 
+        planner.nodeForId("m1")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("m1"), 
+        planner.nodeForId("ha_m1")));
+    assertTrue(planner.graph().hasEdgeConnecting(SINK, planner.nodeForId("expression")));
     
-    assertTrue(graph.hasEdgeConnecting(merger, m1));
+    QueryNodeConfig b1 = planner.configNodeForId("expression");
+    assertEquals("BinaryExpression", b1.getType());
     
-    List<QueryNodeConfig> expressions = Lists.newArrayList(graph.predecessors(ds));
-    assertEquals(1, expressions.size());
-    ExpressionParseNode p1 = (ExpressionParseNode) expressions.get(0);
-    assertTrue(graph.hasEdgeConnecting(p1, ds));
+    ExpressionParseNode p1 = (ExpressionParseNode) b1;
     assertEquals("expression", p1.getId());
     assertEquals("sys.cpu.user", p1.getLeft());
-    assertEquals("downsample:m1", p1.getLeftId());
+    assertEquals(new DefaultQueryResultId("downsample", "m1"), p1.getLeftId());
     assertEquals(OperandType.VARIABLE, p1.getLeftType());
     assertEquals(1024, ((NumericLiteral) p1.getRight()).longValue());
     assertNull(p1.getRightId());
     assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
     assertEquals(ExpressionOp.MULTIPLY, p1.getOperator());
-    
-    assertTrue(graph.hasEdgeConnecting(SINK, p1));
-    assertEquals(1, graph.predecessors(p1).size());
+    assertEquals(1, p1.resultIds().size());
+    assertEquals(new DefaultQueryResultId("expression", "expression"), 
+        p1.resultIds().get(0));
   }
   
   @Test
   public void setupGraphNestedExpression() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    QueryNodeConfig m1 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.user")
-            .build())
-        .setFilterId("f1")
-        .setId("m1")
+    List<QueryNodeConfig> graph = Lists.newArrayList(
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.user")
+              .build())
+          .setFilterId("f1")
+          .setId("m1")
+          .build(),
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric("sys.cpu.busy")
+              .build())
+          .setFilterId("f1")
+          .setId("m2")
+          .build(),
+        DownsampleConfig.newBuilder()
+          .setAggregator("sum")
+          .setInterval("1m")
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .setId("ds1")
+          .addSource("m1")
+          .build(),
+        DownsampleConfig.newBuilder()
+          .setAggregator("sum")
+          .setInterval("1m")
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .setId("ds2")
+          .addSource("m2")
+          .build(),
+        ExpressionConfig.newBuilder()
+          .setExpression("m1 + m2 / 100")
+          .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
+              .setJoinType(JoinType.NATURAL)
+              .build())
+          .addInterpolatorConfig(NUMERIC_CONFIG)
+          .setId("expression")
+          .addSource("ds1")
+          .addSource("ds2")
+          .build());
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
         .build();
-    QueryNodeConfig m2 = DefaultTimeSeriesDataSourceConfig.newBuilder()
-        .setMetric(MetricLiteralFilter.newBuilder()
-            .setMetric("sys.cpu.busy")
-            .build())
-        .setFilterId("f1")
-        .setId("m2")
-        .build();
-    QueryNodeConfig ds1 = DownsampleConfig.newBuilder()
-        .setAggregator("sum")
-        .setInterval("1m")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setId("ds1")
-        .build();
-    QueryNodeConfig ds2 = DownsampleConfig.newBuilder()
-        .setAggregator("sum")
-        .setInterval("1m")
-        .addInterpolatorConfig(NUMERIC_CONFIG)
-        .setId("ds2")
-        .build();
-    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder();
-    builder.setExpression("m1 + m2 / 100")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setJoinType(JoinType.NATURAL)
-            .build())
-        .addInterpolatorConfig(NUMERIC_CONFIG);
-    builder.setId("expression");
-    ExpressionConfig exp = builder.build();
-
-    builder = ExpressionConfig.newBuilder();
-    builder.setExpression("m1 / expression")
-        .setJoinConfig((JoinConfig) JoinConfig.newBuilder()
-            .setJoinType(JoinType.NATURAL)
-            .build())
-        .addInterpolatorConfig(NUMERIC_CONFIG);
-    builder.setId("expression");
-    QueryNodeConfig exp2 = builder.build();
     
-    QueryPlanner plan = mock(QueryPlanner.class);
-    when(plan.configGraph()).thenReturn(graph);
-    when(plan.getMetrics(ds1))
-      .thenReturn(Sets.newHashSet("ds1:sys.cpu.user"));
-    when(plan.getMetrics(ds2))
-      .thenReturn(Sets.newHashSet("ds2:sys.cpu.busy"));
-    when(plan.getDataSourceIds(ds1))
-      .thenReturn(Lists.newArrayList("ds1:m1"));
-    when(plan.getDataSourceIds(ds2))
-      .thenReturn(Lists.newArrayList("ds2:m2"));
-    graph.putEdge(ds1, m1);
-    graph.putEdge(ds2, m2);
-    graph.putEdge(exp, ds1);
-    graph.putEdge(exp, ds2);
-    graph.putEdge(exp2, exp);
-    graph.putEdge(exp2, ds1);
-    graph.putEdge(SINK, exp);
+    when(context.query()).thenReturn(query);
     
-    factory.setupGraph(mock(QueryPipelineContext.class), exp, plan);
-    assertEquals(8, graph.nodes().size());
-    assertTrue(graph.nodes().contains(m1));
-    assertTrue(graph.nodes().contains(ds1));
-    assertFalse(graph.nodes().contains(exp));
-    assertTrue(graph.nodes().contains(SINK));
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
     
-    QueryNodeConfig b1 = graph.predecessors(ds1).iterator().next();
-    assertEquals("Expression", b1.getType());
-    assertTrue(graph.hasEdgeConnecting(ds1, m1));
-    assertTrue(graph.hasEdgeConnecting(b1, ds1));
-    assertFalse(graph.hasEdgeConnecting(SINK, b1));
+    assertSame(STORE_NODES.get(0), planner.sources().get(0));
+    assertEquals(7, planner.graph().nodes().size());
+    assertEquals(1, planner.serializationSources().size());
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression"), 
+        planner.nodeForId("expression_SubExp#0")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression"), 
+        planner.nodeForId("ds1")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ds1"), 
+        planner.nodeForId("m1")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("ds2"), 
+        planner.nodeForId("m2")));
+    assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("expression_SubExp#0"), 
+        planner.nodeForId("ds2")));
+    assertTrue(planner.graph().hasEdgeConnecting(SINK, planner.nodeForId("expression")));
+    
+    QueryNodeConfig b1 = planner.configNodeForId("expression");
+    assertEquals("BinaryExpression", b1.getType());
+    
+    ExpressionParseNode p1 = (ExpressionParseNode) b1;
+    assertEquals("expression", p1.getId());
+    assertEquals("sys.cpu.user", p1.getLeft());
+    assertEquals(new DefaultQueryResultId("ds1", "m1"), p1.getLeftId());
+    assertEquals(OperandType.VARIABLE, p1.getLeftType());
+    assertEquals("expression_SubExp#0", p1.getRight());
+    assertEquals(new DefaultQueryResultId("expression_SubExp#0", "expression_SubExp#0"), 
+        p1.getRightId());
+    assertEquals(OperandType.SUB_EXP, p1.getRightType());
+    assertEquals(ExpressionOp.ADD, p1.getOperator());
+    assertEquals(1, p1.resultIds().size());
+    assertEquals(new DefaultQueryResultId("expression", "expression"), 
+        p1.resultIds().get(0));
   }
   
   @Test
   public void setupGraph1MetricSetsInfectiousNan() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    List<QueryNodeConfig> query = Lists.newArrayList(
+    List<QueryNodeConfig> graph = Lists.newArrayList(
         DefaultTimeSeriesDataSourceConfig.newBuilder()
           .setMetric(MetricLiteralFilter.newBuilder()
               .setMetric("sys.cpu.user")
@@ -807,49 +893,38 @@ public class TestExpressionFactory {
           .setId("expression")
           .addSource("m1")
           .build());
+    SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
     
-    List<QueryNodeConfig> replacements = Lists.newArrayList();
-    QueryPlanner plan = mockPlanner(replacements, graph);
-    when(plan.configGraph()).thenReturn(graph);
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), anyString()))
-      .thenReturn("sys.cpu.user");
-    when(plan.getDataSourceIds(any(QueryNodeConfig.class)))
-      .thenReturn(Lists.newArrayList("m1:m1"));
+    when(context.query()).thenReturn(query);
     
-    graph.putEdge(query.get(1), query.get(0));
-    graph.putEdge(SINK, query.get(1));
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
     
-    factory.setupGraph(mock(QueryPipelineContext.class), 
-        (ExpressionConfig) query.get(1), plan);
-    assertEquals(3, graph.nodes().size());
-    assertTrue(graph.nodes().contains(query.get(0)));
-    assertFalse(graph.nodes().contains(query.get(1)));
-    assertTrue(graph.nodes().contains(SINK));
-    
-    QueryNodeConfig b1 = graph.predecessors(query.get(0)).iterator().next();
+    QueryNodeConfig b1 = planner.configNodeForId("expression");
     assertEquals("BinaryExpression", b1.getType());
-    assertTrue(graph.hasEdgeConnecting(b1, query.get(0)));
-    assertTrue(graph.hasEdgeConnecting(SINK, b1));
     
     ExpressionParseNode p1 = (ExpressionParseNode) b1;
     assertEquals("expression", p1.getId());
     assertEquals("sys.cpu.user", p1.getLeft());
-    assertEquals("m1:m1", p1.getLeftId());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), p1.getLeftId());
     assertEquals(OperandType.VARIABLE, p1.getLeftType());
     assertEquals(42, ((NumericLiteral) p1.getRight()).longValue());
     assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
     assertNull(p1.getRightId());
     assertEquals(ExpressionOp.ADD, p1.getOperator());
-    assertTrue(((ExpressionConfig) replacements.get(0)).getInfectiousNan());
+    // TODO - !!!!!!!! Figure this bit out
+    //assertTrue(p1.getExpressionConfig().getInfectiousNan());
   }
   
   @Test
   public void setupGraph1MetricAlreadyInfectious() throws Exception {
-    ExpressionFactory factory = new ExpressionFactory();
-    MutableGraph<QueryNodeConfig> graph = GraphBuilder.directed()
-        .allowsSelfLoops(false).build();
-    
-    List<QueryNodeConfig> query = Lists.newArrayList(
+    List<QueryNodeConfig> graph = Lists.newArrayList(
         DefaultTimeSeriesDataSourceConfig.newBuilder()
           .setMetric(MetricLiteralFilter.newBuilder()
               .setMetric("sys.cpu.user")
@@ -867,47 +942,31 @@ public class TestExpressionFactory {
           .setId("expression")
           .addSource("m1")
           .build());
+   SemanticQuery query = SemanticQuery.newBuilder()
+        .setMode(QueryMode.SINGLE)
+        .setStart("1514764800")
+        .setEnd("1514768400")
+        .setExecutionGraph(graph)
+        .build();
     
-    QueryPlanner plan = mock(QueryPlanner.class);
-    List<QueryNodeConfig> replacements = Lists.newArrayList();
-    doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        replacements.add((QueryNodeConfig) invocation.getArguments()[1]);
-        return null;
-      }
-    }).when(plan).replace(any(QueryNodeConfig.class), any(QueryNodeConfig.class));
-    when(plan.configGraph()).thenReturn(graph);
-    when(plan.getMetricForDataSource(any(QueryNodeConfig.class), anyString()))
-      .thenReturn("sys.cpu.user");
-    when(plan.getDataSourceIds(any(QueryNodeConfig.class)))
-      .thenReturn(Lists.newArrayList("m1:m1"));
+    when(context.query()).thenReturn(query);
     
-    graph.putEdge(query.get(1), query.get(0));
-    graph.putEdge(SINK, query.get(1));
+    DefaultQueryPlanner planner = 
+        new DefaultQueryPlanner(context, SINK);
+    planner.plan(null).join();
     
-    factory.setupGraph(mock(QueryPipelineContext.class), 
-        (ExpressionConfig) query.get(1), plan);
-    assertEquals(3, graph.nodes().size());
-    assertTrue(graph.nodes().contains(query.get(0)));
-    assertFalse(graph.nodes().contains(query.get(1)));
-    assertTrue(graph.nodes().contains(SINK));
-    
-    QueryNodeConfig b1 = graph.predecessors(query.get(0)).iterator().next();
+    QueryNodeConfig b1 = planner.configNodeForId("expression");
     assertEquals("BinaryExpression", b1.getType());
-    assertTrue(graph.hasEdgeConnecting(b1, query.get(0)));
-    assertTrue(graph.hasEdgeConnecting(SINK, b1));
     
     ExpressionParseNode p1 = (ExpressionParseNode) b1;
     assertEquals("expression", p1.getId());
     assertEquals("sys.cpu.user", p1.getLeft());
-    assertEquals("m1:m1", p1.getLeftId());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), p1.getLeftId());
     assertEquals(OperandType.VARIABLE, p1.getLeftType());
     assertEquals(42, ((NumericLiteral) p1.getRight()).longValue());
     assertEquals(OperandType.LITERAL_NUMERIC, p1.getRightType());
     assertNull(p1.getRightId());
     assertEquals(ExpressionOp.ADD, p1.getOperator());
-    assertTrue(replacements.isEmpty());
   }
   // TODO - this requires more work to function correctly. We need the expression
   // node to take ANY metric from `m1` instead of a single metric.
@@ -978,33 +1037,4 @@ public class TestExpressionFactory {
 //    assertTrue(graph.hasEdgeConnecting(SINK, p1));
 //    assertEquals(1, graph.predecessors(p1).size());
 //  }
- 
-  QueryPlanner mockPlanner(List<QueryNodeConfig> replacements,
-                           MutableGraph<QueryNodeConfig> graph) {
-    QueryPlanner plan = mock(QueryPlanner.class);
-    doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        QueryNodeConfig replacement = (QueryNodeConfig) invocation.getArguments()[1];
-        replacements.add(replacement);
-        QueryNodeConfig extant = (QueryNodeConfig) invocation.getArguments()[0];
-        Set<QueryNodeConfig> pred = Sets.newHashSet(graph.predecessors(extant));
-        Set<QueryNodeConfig> suc = Sets.newHashSet(graph.successors(extant));
-        
-        for (final QueryNodeConfig node : pred) {
-          graph.removeEdge(node, extant);
-          graph.putEdge(node, replacement);
-        }
-        
-        for (final QueryNodeConfig node : suc) {
-          graph.removeEdge(extant, node);
-          graph.putEdge(extant, node);
-        }
-        
-        graph.removeNode(extant);
-        return null;
-      }
-    }).when(plan).replace(any(QueryNodeConfig.class), any(QueryNodeConfig.class));
-    return plan;
-  }
 }

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionParseNode.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionParseNode.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import net.opentsdb.core.MockTSDB;
 import net.opentsdb.core.MockTSDBDefault;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.joins.JoinConfig;
@@ -148,7 +149,7 @@ public class TestExpressionParseNode {
     ExpressionParseNode node = (ExpressionParseNode) ExpressionParseNode.newBuilder()
         .setLeft("a")
         .setLeftType(OperandType.VARIABLE)
-        .setLeftId("m1")
+        .setLeftId(new DefaultQueryResultId("m1", "m1"))
         .setRight("42")
         .setRightType(OperandType.LITERAL_NUMERIC)
         .setExpressionOp(ExpressionOp.MOD)
@@ -159,7 +160,6 @@ public class TestExpressionParseNode {
         .build();
     
     final String json = JSON.serializeToString(node);
-    System.out.println(json);
     assertTrue(json.contains("\"left\":\"a\""));
     assertTrue(json.contains("\"right\":\"42\""));
     assertTrue(json.contains("\"negate\":false"));
@@ -169,8 +169,6 @@ public class TestExpressionParseNode {
     assertTrue(json.contains("\"operator\":\"MOD\""));
     assertTrue(json.contains("\"expressionConfig\":{"));
     assertTrue(json.contains("\"expression\":\"a + 42\""));
-    assertTrue(json.contains("\"leftId\":\"m1\""));
-    assertFalse(json.contains("\"rightId\":"));
     assertTrue(json.contains("\"as\":\"foo\""));
     
     MockTSDB tsdb = MockTSDBDefault.getMockTSDB();
@@ -180,7 +178,6 @@ public class TestExpressionParseNode {
     
     assertEquals("a", node.getLeft());
     assertEquals(OperandType.VARIABLE, node.getLeftType());
-    assertEquals("m1", node.getLeftId());
     assertEquals(42, ((NumericLiteral) node.getRight()).longValue());
     assertEquals(OperandType.LITERAL_NUMERIC, node.getRightType());
     assertNull(node.getRightId());

--- a/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionParser.java
+++ b/core/src/test/java/net/opentsdb/query/processor/expressions/TestExpressionParser.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,10 +65,8 @@ public class TestExpressionParser {
     assertEquals("e1", nodes.get(0).getId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getRightType());
     assertEquals("b.metric", nodes.get(0).getRight());
-    assertEquals("b.metric", nodes.get(0).getRightId());
     assertEquals(ExpressionOp.ADD, nodes.get(0).getOperator());
     
     parser = new ExpressionParser(config("a.metric - b.metric"));
@@ -78,10 +76,8 @@ public class TestExpressionParser {
     assertEquals("my.new.metric", nodes.get(0).getAs());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getRightType());
     assertEquals("b.metric", nodes.get(0).getRight());
-    assertEquals("b.metric", nodes.get(0).getRightId());
     assertEquals(ExpressionOp.SUBTRACT, nodes.get(0).getOperator());
     
     parser = new ExpressionParser(config("a.metric * b.metric"));
@@ -91,10 +87,8 @@ public class TestExpressionParser {
     assertEquals("my.new.metric", nodes.get(0).getAs());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getRightType());
     assertEquals("b.metric", nodes.get(0).getRight());
-    assertEquals("b.metric", nodes.get(0).getRightId());
     assertEquals(ExpressionOp.MULTIPLY, nodes.get(0).getOperator());
     
     parser = new ExpressionParser(config("a.metric / b.metric"));
@@ -104,10 +98,8 @@ public class TestExpressionParser {
     assertEquals("my.new.metric", nodes.get(0).getAs());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getRightType());
     assertEquals("b.metric", nodes.get(0).getRight());
-    assertEquals("b.metric", nodes.get(0).getRightId());
     assertEquals(ExpressionOp.DIVIDE, nodes.get(0).getOperator());
     
     parser = new ExpressionParser(config("a.metric % b.metric"));
@@ -117,10 +109,8 @@ public class TestExpressionParser {
     assertEquals("my.new.metric", nodes.get(0).getAs());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getRightType());
     assertEquals("b.metric", nodes.get(0).getRight());
-    assertEquals("b.metric", nodes.get(0).getRightId());
     assertEquals(ExpressionOp.MOD, nodes.get(0).getOperator());
     
     parser = new ExpressionParser(config("a.metric == b.metric"));
@@ -130,10 +120,8 @@ public class TestExpressionParser {
     assertEquals("my.new.metric", nodes.get(0).getAs());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getRightType());
     assertEquals("b.metric", nodes.get(0).getRight());
-    assertEquals("b.metric", nodes.get(0).getRightId());
     assertEquals(ExpressionOp.EQ, nodes.get(0).getOperator());
     
     parser = new ExpressionParser(config("a.metric != b.metric"));
@@ -143,10 +131,8 @@ public class TestExpressionParser {
     assertEquals("my.new.metric", nodes.get(0).getAs());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getRightType());
     assertEquals("b.metric", nodes.get(0).getRight());
-    assertEquals("b.metric", nodes.get(0).getRightId());
     assertEquals(ExpressionOp.NE, nodes.get(0).getOperator());
     
     parser = new ExpressionParser(config("a.metric > b.metric"));
@@ -156,10 +142,8 @@ public class TestExpressionParser {
     assertEquals("my.new.metric", nodes.get(0).getAs());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getRightType());
     assertEquals("b.metric", nodes.get(0).getRight());
-    assertEquals("b.metric", nodes.get(0).getRightId());
     assertEquals(ExpressionOp.GT, nodes.get(0).getOperator());
     
     parser = new ExpressionParser(config("a.metric < b.metric"));
@@ -169,10 +153,8 @@ public class TestExpressionParser {
     assertEquals("my.new.metric", nodes.get(0).getAs());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getRightType());
     assertEquals("b.metric", nodes.get(0).getRight());
-    assertEquals("b.metric", nodes.get(0).getRightId());
     assertEquals(ExpressionOp.LT, nodes.get(0).getOperator());
     
     parser = new ExpressionParser(config("a.metric >= b.metric"));
@@ -182,10 +164,8 @@ public class TestExpressionParser {
     assertEquals("my.new.metric", nodes.get(0).getAs());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getRightType());
     assertEquals("b.metric", nodes.get(0).getRight());
-    assertEquals("b.metric", nodes.get(0).getRightId());
     assertEquals(ExpressionOp.GE, nodes.get(0).getOperator());
     
     parser = new ExpressionParser(config("a.metric <= b.metric"));
@@ -195,10 +175,8 @@ public class TestExpressionParser {
     assertEquals("my.new.metric", nodes.get(0).getAs());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getRightType());
     assertEquals("b.metric", nodes.get(0).getRight());
-    assertEquals("b.metric", nodes.get(0).getRightId());
     assertEquals(ExpressionOp.LE, nodes.get(0).getOperator());
   }
 
@@ -213,20 +191,16 @@ public class TestExpressionParser {
     assertEquals("e1_SubExp#0", nodes.get(0).getAs());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getRightType());
     assertEquals("b.metric", nodes.get(0).getRight());
-    assertEquals("b.metric", nodes.get(0).getRightId());
     assertEquals(ExpressionOp.ADD, nodes.get(0).getOperator());
     
     assertEquals("e1", nodes.get(1).getId());
     assertEquals("my.new.metric", nodes.get(1).getAs());
     assertEquals(OperandType.SUB_EXP, nodes.get(1).getLeftType());
     assertEquals("e1_SubExp#0", nodes.get(1).getLeft());
-    assertEquals("e1_SubExp#0", nodes.get(1).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(1).getRightType());
     assertEquals("c.metric", nodes.get(1).getRight());
-    assertEquals("c.metric", nodes.get(1).getRightId());
     assertEquals(ExpressionOp.ADD, nodes.get(1).getOperator());
     
     // change order of precedence
@@ -238,20 +212,16 @@ public class TestExpressionParser {
     assertEquals("e1_SubExp#0", nodes.get(0).getAs());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("b.metric", nodes.get(0).getLeft());
-    assertEquals("b.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getRightType());
     assertEquals("c.metric", nodes.get(0).getRight());
-    assertEquals("c.metric", nodes.get(0).getRightId());
     assertEquals(ExpressionOp.ADD, nodes.get(0).getOperator());
     
     assertEquals("e1", nodes.get(1).getId());
     assertEquals("my.new.metric", nodes.get(1).getAs());
     assertEquals(OperandType.VARIABLE, nodes.get(1).getLeftType());
     assertEquals("a.metric", nodes.get(1).getLeft());
-    assertEquals("a.metric", nodes.get(1).getLeftId());
     assertEquals(OperandType.SUB_EXP, nodes.get(1).getRightType());
     assertEquals("e1_SubExp#0", nodes.get(1).getRight());
-    assertEquals("e1_SubExp#0", nodes.get(1).getRightId());
     assertEquals(ExpressionOp.ADD, nodes.get(1).getOperator());
     
     // numeric squashing, test all operators
@@ -259,28 +229,28 @@ public class TestExpressionParser {
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(44L, ((NumericLiteral) nodes.get(0).getRight()).longValue());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
+    assertEquals("a.metric", nodes.get(0).getLeft());
     assertNull(nodes.get(0).getRightId());
     
     parser = new ExpressionParser(config("a.metric + (42 - 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(40L, ((NumericLiteral) nodes.get(0).getRight()).longValue());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
+    assertEquals("a.metric", nodes.get(0).getLeft());
     assertNull(nodes.get(0).getRightId());
     
     parser = new ExpressionParser(config("a.metric + (42 * 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(84, ((NumericLiteral) nodes.get(0).getRight()).longValue());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
+    assertEquals("a.metric", nodes.get(0).getLeft());
     assertNull(nodes.get(0).getRightId());
     
     parser = new ExpressionParser(config("a.metric + (42 / 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(21, ((NumericLiteral) nodes.get(0).getRight()).longValue());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
+    assertEquals("a.metric", nodes.get(0).getLeft());
     assertNull(nodes.get(0).getRightId());
     
     // to double
@@ -288,14 +258,14 @@ public class TestExpressionParser {
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(8.4, ((NumericLiteral) nodes.get(0).getRight()).doubleValue(), 0.001);
-    assertEquals("a.metric", nodes.get(0).getLeftId());
+    assertEquals("a.metric", nodes.get(0).getLeft());
     assertNull(nodes.get(0).getRightId());
     
     parser = new ExpressionParser(config("a.metric + (42 % 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(0, ((NumericLiteral) nodes.get(0).getRight()).longValue());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
+    assertEquals("a.metric", nodes.get(0).getLeft());
     assertNull(nodes.get(0).getRightId());
     
     // doubles
@@ -303,35 +273,35 @@ public class TestExpressionParser {
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(44.5, ((NumericLiteral) nodes.get(0).getRight()).doubleValue(), 0.001);
-    assertEquals("a.metric", nodes.get(0).getLeftId());
+    assertEquals("a.metric", nodes.get(0).getLeft());
     assertNull(nodes.get(0).getRightId());
     
     parser = new ExpressionParser(config("a.metric + (42.5 - 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(40.5, ((NumericLiteral) nodes.get(0).getRight()).doubleValue(), 0.001);
-    assertEquals("a.metric", nodes.get(0).getLeftId());
+    assertEquals("a.metric", nodes.get(0).getLeft());
     assertNull(nodes.get(0).getRightId());
     
     parser = new ExpressionParser(config("a.metric + (42.5 * 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(85, ((NumericLiteral) nodes.get(0).getRight()).doubleValue(), 0.001);
-    assertEquals("a.metric", nodes.get(0).getLeftId());
+    assertEquals("a.metric", nodes.get(0).getLeft());
     assertNull(nodes.get(0).getRightId());
     
     parser = new ExpressionParser(config("a.metric + (42.5 / 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(21.25, ((NumericLiteral) nodes.get(0).getRight()).doubleValue(), 0.001);
-    assertEquals("a.metric", nodes.get(0).getLeftId());
+    assertEquals("a.metric", nodes.get(0).getLeft());
     assertNull(nodes.get(0).getRightId());
     
     parser = new ExpressionParser(config("a.metric + (42.5 % 2)"));
     nodes = parser.parse();
     assertEquals(1, nodes.size());
     assertEquals(0.0, ((NumericLiteral) nodes.get(0).getRight()).doubleValue(), 0.001);
-    assertEquals("a.metric", nodes.get(0).getLeftId());
+    assertEquals("a.metric", nodes.get(0).getLeft());
     assertNull(nodes.get(0).getRightId());
   }
   
@@ -344,7 +314,6 @@ public class TestExpressionParser {
     assertEquals("e1", nodes.get(0).getId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.LITERAL_NUMERIC, nodes.get(0).getRightType());
     assertEquals(42, ((NumericLiteral) nodes.get(0).getRight()).longValue());
     assertEquals(ExpressionOp.EQ, nodes.get(0).getOperator());
@@ -403,7 +372,6 @@ public class TestExpressionParser {
     assertEquals("e1_SubExp#0", nodes.get(0).getId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.LITERAL_NUMERIC, nodes.get(0).getRightType());
     assertEquals(0, ((NumericLiteral) nodes.get(0).getRight()).longValue());
     assertNull(nodes.get(0).getRightId());
@@ -480,7 +448,6 @@ public class TestExpressionParser {
     assertEquals("e1_SubExp#0", nodes.get(0).getId());
     assertEquals(OperandType.VARIABLE, nodes.get(0).getLeftType());
     assertEquals("a.metric", nodes.get(0).getLeft());
-    assertEquals("a.metric", nodes.get(0).getLeftId());
     assertEquals(OperandType.LITERAL_NUMERIC, nodes.get(0).getRightType());
     assertEquals(0, ((NumericLiteral) nodes.get(0).getRight()).longValue());
     assertNull(nodes.get(0).getRightId());
@@ -489,7 +456,6 @@ public class TestExpressionParser {
     assertEquals("e1_SubExp#1", nodes.get(1).getId());
     assertEquals(OperandType.VARIABLE, nodes.get(1).getLeftType());
     assertEquals("b.metric", nodes.get(1).getLeft());
-    assertEquals("b.metric", nodes.get(1).getLeftId());
     assertEquals(OperandType.LITERAL_NUMERIC, nodes.get(1).getRightType());
     assertEquals(0, ((NumericLiteral) nodes.get(1).getRight()).longValue());
     assertEquals(ExpressionOp.GT, nodes.get(1).getOperator());
@@ -499,10 +465,8 @@ public class TestExpressionParser {
     assertEquals("e1", nodes.get(2).getId());
     assertEquals(OperandType.SUB_EXP, nodes.get(2).getLeftType());
     assertEquals("e1_SubExp#0", nodes.get(2).getLeft());
-    assertEquals("e1_SubExp#0", nodes.get(2).getLeftId());
     assertEquals(OperandType.SUB_EXP, nodes.get(2).getRightType());
     assertEquals("e1_SubExp#1", nodes.get(2).getRight());
-    assertEquals("e1_SubExp#1", nodes.get(2).getRightId());
     assertEquals(ExpressionOp.AND, nodes.get(2).getOperator());
     
     // implicit

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupBy.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupBy.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,11 +51,11 @@ import net.opentsdb.data.TimeSeriesByteId;
 import net.opentsdb.data.TimeSeriesDataSourceFactory;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
-import net.opentsdb.exceptions.QueryUpstreamException;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
@@ -165,6 +165,7 @@ public class TestGroupBy {
     PowerMockito.whenNew(GroupByResult.class).withAnyArguments()
       .thenReturn(gb_results);
     final QueryResult results = mock(QueryResult.class);
+    when(results.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     when(results.idType()).thenAnswer(new Answer<TypeToken<?>>() {
       @Override
       public TypeToken<?> answer(InvocationOnMock invocation) throws Throwable {

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByConfig.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import net.opentsdb.core.MockTSDB;
 import net.opentsdb.core.MockTSDBDefault;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
@@ -191,6 +192,7 @@ public class TestGroupByConfig {
         .addTagKey("dc")
         .addInterpolatorConfig(numeric_config)
         .addInterpolatorConfig(summary_config)
+        .addResultId(new DefaultQueryResultId("m1", "m1"))
         .setId("GBy")
         .build();
     
@@ -200,6 +202,8 @@ public class TestGroupByConfig {
     assertTrue(config.getTagKeys().contains("host"));
     assertTrue(config.getTagKeys().contains("dc"));
     assertSame(numeric_config, config.interpolatorConfigs().get(NumericType.TYPE));
+    assertEquals(1, config.resultIds().size());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), config.resultIds().get(0));
   }
 
 }

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByNumericArrayIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByNumericArrayIterator.java
@@ -81,6 +81,7 @@ import net.opentsdb.data.types.numeric.aggregators.ArraySumFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.TimeSeriesQuery;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.pojo.FillPolicy;
@@ -564,7 +565,9 @@ public class TestGroupByNumericArrayIterator {
     factory.initialize(TSDB, null);
     Downsample ds = new Downsample(factory, context, dsConfig);
     ds.initialize(null);
-    Downsample.DownsampleResult dsResult = ds.new DownsampleResult(mock(QueryResult.class));
+    QueryResult r = mock(QueryResult.class);
+    when(r.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
+    Downsample.DownsampleResult dsResult = ds.new DownsampleResult(r);
 
     ts1 =
         new NumericMillisecondShard(
@@ -699,6 +702,7 @@ public class TestGroupByNumericArrayIterator {
     Downsample ds = new Downsample(factory, context, dsConfig);
     ds.initialize(null);
     QueryResult ds_of_ds_result = mock(QueryResult.class);
+    when(ds_of_ds_result.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     when(ds_of_ds_result.timeSpecification()).thenReturn(time_spec);
     Downsample.DownsampleResult dsResult = ds.new DownsampleResult(ds_of_ds_result);
     when(result.downstreamResult()).thenReturn(dsResult);

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import net.opentsdb.data.types.numeric.NumericMillisecondShard;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
@@ -129,6 +130,7 @@ public class TestGroupByResult {
     when(result.sequenceId()).thenReturn(42l);
     when(result.timeSpecification()).thenReturn(time_spec);
     when(result.idType()).thenReturn((TypeToken) Const.TS_STRING_ID);
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
   }
   
   @Test

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMerger.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMerger.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
@@ -132,7 +133,7 @@ public class TestMerger {
     QueryNode n1 = mock(QueryNode.class);
     when(n1.config()).thenReturn(c1);
     when(r1.source()).thenReturn(n1);
-    when(r1.dataSource()).thenReturn("m1");
+    when(r1.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     
     QueryResult r2 = mock(QueryResult.class);
     QueryNodeConfig c2 = mock(QueryNodeConfig.class);
@@ -140,7 +141,7 @@ public class TestMerger {
     QueryNode n2 = mock(QueryNode.class);
     when(n2.config()).thenReturn(c2);
     when(r2.source()).thenReturn(n2);
-    when(r2.dataSource()).thenReturn("m2");
+    when(r2.dataSource()).thenReturn(new DefaultQueryResultId("m2", "m2"));
     
     when(context.downstreamSourcesIds(any(QueryNode.class)))
       .thenReturn(Lists.newArrayList("m1", "m2"));

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerResult.java
@@ -34,6 +34,7 @@ import net.opentsdb.data.types.numeric.NumericMillisecondShard;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
 import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
 import net.opentsdb.query.interpolation.types.numeric.NumericSummaryInterpolatorConfig;
@@ -137,7 +138,8 @@ public class TestMergerResult {
     
     merger.add(result_a);
     assertSame(time_spec, merger.timeSpecification());
-    assertEquals("MyMetric", merger.dataSource());
+    assertEquals(new DefaultQueryResultId("MyMetric", "MyMetric"), 
+        merger.dataSource());
   }
   
   @Test

--- a/core/src/test/java/net/opentsdb/query/processor/movingaverage/TestMovingAverage.java
+++ b/core/src/test/java/net/opentsdb/query/processor/movingaverage/TestMovingAverage.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.junit.Test;
 import com.google.common.collect.Lists;
 
 import net.opentsdb.exceptions.QueryUpstreamException;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
@@ -91,6 +92,7 @@ public class TestMovingAverage {
   @Test
   public void onNext() throws Exception {
     final QueryResult results = mock(QueryResult.class);
+    when(results.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     
     MovingAverage sl = new MovingAverage(factory, context, config);
     sl.initialize(null);

--- a/core/src/test/java/net/opentsdb/query/processor/rate/TestRate.java
+++ b/core/src/test/java/net/opentsdb/query/processor/rate/TestRate.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import com.google.common.collect.Lists;
 
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
@@ -93,6 +94,7 @@ public class TestRate {
   public void onNext() throws Exception {
     Rate ds = new Rate(factory, context, config);
     final QueryResult results = mock(QueryResult.class);
+    when(results.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     
     ds.initialize(null);
     

--- a/core/src/test/java/net/opentsdb/query/processor/slidingwindow/TestSlidingWindow.java
+++ b/core/src/test/java/net/opentsdb/query/processor/slidingwindow/TestSlidingWindow.java
@@ -1,6 +1,6 @@
 
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.junit.Test;
 import com.google.common.collect.Lists;
 
 import net.opentsdb.exceptions.QueryUpstreamException;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
@@ -93,7 +94,7 @@ public class TestSlidingWindow {
   @Test
   public void onNext() throws Exception {
     final QueryResult results = mock(QueryResult.class);
-    
+    when(results.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     SlidingWindow sl = new SlidingWindow(factory, context, config);
     sl.initialize(null);
     

--- a/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizer.java
+++ b/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizer.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import com.google.common.collect.Lists;
 import net.opentsdb.core.MockTSDB;
 import net.opentsdb.core.MockTSDBDefault;
 import net.opentsdb.exceptions.QueryUpstreamException;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryMode;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeFactory;
@@ -140,6 +141,7 @@ public class TestSummarizer {
   public void onNext() throws Exception {
     Summarizer ds = new Summarizer(factory, context, config);
     final QueryResult results = mock(QueryResult.class);
+    when(results.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     
     ds.initialize(null);
     

--- a/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerFactory.java
+++ b/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerFactory.java
@@ -1,5 +1,5 @@
 //This file is part of OpenTSDB.
-//Copyright (C) 2018-2019  The OpenTSDB Authors.
+//Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 //Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import net.opentsdb.data.TimeSeriesDataSourceFactory;
 import net.opentsdb.data.types.numeric.NumericArrayType;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
 import net.opentsdb.query.QueryMode;
 import net.opentsdb.query.QueryNode;
@@ -49,6 +50,7 @@ import net.opentsdb.query.filter.MetricLiteralFilter;
 import net.opentsdb.query.plan.DefaultQueryPlanner;
 import net.opentsdb.query.serdes.SerdesOptions;
 import net.opentsdb.stats.Span;
+import net.opentsdb.utils.Pair;
 
 public class TestSummarizerFactory {
 
@@ -141,7 +143,8 @@ public class TestSummarizerFactory {
     QueryNode node = planner.nodeForId("summary");
     assertFalse(((SummarizerConfig) node.config()).passThrough());
     assertEquals(1, planner.serializationSources().size());
-    assertTrue(planner.serializationSources().contains("summary:m1"));
+    assertTrue(planner.serializationSources().contains(
+        new DefaultQueryResultId("summary", "m1")));
     assertTrue(planner.graph().hasEdgeConnecting(ctx_node,
         planner.nodeForId("summary")));
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("summary"),
@@ -172,13 +175,15 @@ public class TestSummarizerFactory {
     
     DefaultQueryPlanner planner = new DefaultQueryPlanner(context, ctx_node);
     planner.plan(null).join(250);
-    
+    System.out.println(planner.serializationSources());
     assertEquals(3, planner.graph().nodes().size());
     QueryNode node = planner.nodeForId("summary");
     assertTrue(((SummarizerConfig) node.config()).passThrough());
     assertEquals(2, planner.serializationSources().size());
-    assertTrue(planner.serializationSources().contains("summary:m1"));
-    assertTrue(planner.serializationSources().contains("m1:m1"));
+    assertTrue(planner.serializationSources().contains(
+        new DefaultQueryResultId("summary", "m1")));
+    assertTrue(planner.serializationSources().contains(
+        new DefaultQueryResultId("m1", "m1")));
     assertTrue(planner.graph().hasEdgeConnecting(ctx_node,
         planner.nodeForId("summary")));
     assertTrue(planner.graph().hasEdgeConnecting(planner.nodeForId("summary"),

--- a/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/summarizer/TestSummarizerResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import net.opentsdb.data.MockTimeSeries;
 import net.opentsdb.data.SecondTimeStamp;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.types.numeric.MutableNumericValue;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.processor.summarizer.SummarizerNonPassThroughResult.SummarizerTimeSeries;
 
@@ -59,6 +60,7 @@ public class TestSummarizerResult {
     node = mock(Summarizer.class);
     
     when(results.timeSeries()).thenReturn(Lists.newArrayList(SERIES));
+    when(results.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     
     config = (SummarizerConfig) 
         SummarizerConfig.newBuilder()

--- a/core/src/test/java/net/opentsdb/query/processor/timeshift/TestTimeShift.java
+++ b/core/src/test/java/net/opentsdb/query/processor/timeshift/TestTimeShift.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -94,7 +95,7 @@ public class TestTimeShift {
     shift.initialize(null).join();
     assertSame(config, shift.config());
     
-    when(result.dataSource()).thenReturn("m1-previous-P1D");
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     shift.onNext(result);
     verify(upstream, times(1)).onNext(any(TimeShiftResult.class));
   }
@@ -105,7 +106,7 @@ public class TestTimeShift {
     shift.initialize(null).join();
     assertSame(config, shift.config());
     
-    when(result.dataSource()).thenReturn("m1");
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     shift.onNext(result);
     verify(upstream, times(1)).onNext(any(TimeShiftResult.class));
   }

--- a/core/src/test/java/net/opentsdb/query/processor/timeshift/TestTimeShiftResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/timeshift/TestTimeShiftResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSpecification;
 import net.opentsdb.data.types.numeric.NumericArrayType;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultQueryResultId;
+import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.processor.timeshift.TimeShiftResult.TimeShiftTimeSeries;
 import net.opentsdb.utils.DateTime;
@@ -58,12 +60,17 @@ public class TestTimeShiftResult {
     when(FACTORY.newTypedIterator(eq(NumericType.TYPE), eq(NODE), 
         any(QueryResult.class), any(Collection.class)))
         .thenReturn(mock(TimeShiftNumericIterator.class));
+    QueryNodeConfig config = mock(QueryNodeConfig.class);
+    when(config.getId()).thenReturn("m1");
+    when(NODE.config()).thenReturn(config);
   }
   
   @Before
   public void before() throws Exception {
     result = mock(QueryResult.class);
+    when(result.source()).thenReturn(NODE);
     when(result.timeSeries()).thenReturn(Lists.newArrayList(SERIES));
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
   }
   
   @Test

--- a/core/src/test/java/net/opentsdb/query/processor/topn/TestTopNConfig.java
+++ b/core/src/test/java/net/opentsdb/query/processor/topn/TestTopNConfig.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,12 +18,12 @@ import static org.junit.Assert.*;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
 
-import net.opentsdb.query.processor.slidingwindow.SlidingWindowConfig;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
 import net.opentsdb.core.TSDB;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.utils.JSON;
 
 public class TestTopNConfig {
@@ -151,6 +151,26 @@ public class TestTopNConfig {
     assertTrue(!config.equals(config3));
     assertNotEquals(config.hashCode(), config3.hashCode());
 
+  }
+  
+  @Test
+  public void toBuilder() throws Exception {
+    TopNConfig original = (TopNConfig) TopNConfig.newBuilder()
+        .setTop(true)
+        .setCount(10)
+        .setInfectiousNan(true)
+        .setId("Toppy")
+        .addResultId(new DefaultQueryResultId("Toppy", "m1"))
+        .build();
+    
+    TopNConfig config = original.toBuilder().build();
+    
+    assertTrue(config.getTop());
+    assertEquals(10, config.getCount());
+    assertTrue(config.getInfectiousNan());
+    assertEquals("Toppy", config.getId());
+    assertEquals(1, config.resultIds().size());
+    assertEquals(new DefaultQueryResultId("Toppy", "m1"), config.resultIds().get(0));
   }
   
 }

--- a/core/src/test/java/net/opentsdb/query/processor/topn/TestTopNResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/topn/TestTopNResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2015-2018  The OpenTSDB Authors.
+// Copyright (C) 2015-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import net.opentsdb.data.MillisecondTimeStamp;
 import net.opentsdb.data.MockTimeSeries;
 import net.opentsdb.data.TimeSeriesStringId;
 import net.opentsdb.data.types.numeric.MutableNumericValue;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
@@ -58,6 +59,7 @@ public class TestTopNResult {
   public void before() throws Exception {
     node = mock(TopN.class);
     result = mock(QueryResult.class);
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("m1", "m1"));
     
     config = (TopNConfig) TopNConfig.newBuilder()
         .setAggregator("sum")

--- a/core/src/test/java/net/opentsdb/query/readcache/TestCombinedCachedResult.java
+++ b/core/src/test/java/net/opentsdb/query/readcache/TestCombinedCachedResult.java
@@ -37,9 +37,11 @@ import net.opentsdb.data.SecondTimeStamp;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesId;
 import net.opentsdb.data.TimeSpecification;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.query.QuerySink;
 import net.opentsdb.query.TimeSeriesQuery;
 import net.opentsdb.rollup.RollupConfig;
@@ -52,7 +54,7 @@ private static final int BASE_TIME = 1546300800;
   private TimeSeriesQuery query;
   private List<QuerySink> sinks;
   private QueryNode<?> node;
-  private String data_source;
+  private QueryResultId data_source;
   
   @Before
   public void before() throws Exception {
@@ -60,7 +62,7 @@ private static final int BASE_TIME = 1546300800;
     query = mock(TimeSeriesQuery.class);
     sinks = Lists.newArrayList(mock(QuerySink.class));
     node = mock(QueryNode.class);
-    data_source = "m1";
+    data_source = new DefaultQueryResultId("m1", "m1");
     when(context.query()).thenReturn(query);
     when(query.startTime()).thenReturn(new SecondTimeStamp(BASE_TIME));
     when(query.endTime()).thenReturn(new SecondTimeStamp(BASE_TIME + (3600 * 4)));

--- a/core/src/test/java/net/opentsdb/query/readcache/TestCombinedCachedTimeSeries.java
+++ b/core/src/test/java/net/opentsdb/query/readcache/TestCombinedCachedTimeSeries.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,9 +45,11 @@ import net.opentsdb.data.TypedTimeSeriesIterator;
 import net.opentsdb.data.types.numeric.NumericArrayType;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.query.QuerySink;
 import net.opentsdb.query.TimeSeriesQuery;
 
@@ -59,7 +61,7 @@ private static final int BASE_TIME = 1546300800;
   private List<QuerySink> sinks;
   private TimeSeriesId id;
   private QueryNode<?> node;
-  private String data_source;
+  private QueryResultId data_source;
   
   @Before
   public void before() throws Exception {
@@ -70,7 +72,7 @@ private static final int BASE_TIME = 1546300800;
     query = mock(TimeSeriesQuery.class);
     sinks = Lists.newArrayList(mock(QuerySink.class));
     node = mock(QueryNode.class);
-    data_source = "m1";
+    data_source = new DefaultQueryResultId("m1", "m1");
     when(context.query()).thenReturn(query);
     when(query.startTime()).thenReturn(new SecondTimeStamp(BASE_TIME));
     when(query.endTime()).thenReturn(new SecondTimeStamp(BASE_TIME + (3600 * 4)));

--- a/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Source.java
+++ b/executors/http/src/main/java/net/opentsdb/query/execution/HttpQueryV3Source.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -139,8 +139,8 @@ public class HttpQueryV3Source extends AbstractQueryNode implements SourceNode {
             .setPushDownNodes(null)
             .setSourceId(null) // TODO - we may want to make this configurable
             // TODO - flip flop shouldn't be required.
-            .setDataSourceId(config.getDataSourceId())
-            .setId(config.getDataSourceId())
+//            .setDataSourceId(config.getDataSourceId())
+//            .setId(config.getDataSourceId())
             .setType("TimeSeriesDataSource");
         
         builder.addExecutionGraphNode(source_builder.build());
@@ -164,25 +164,17 @@ public class HttpQueryV3Source extends AbstractQueryNode implements SourceNode {
           (Builder) config.toBuilder()
           .setPushDownNodes(null)
           .setSourceId(null) // TODO - we may want to make this configurable
-          // TODO - flip flop shouldn't be required.
-          .setDataSourceId(config.getId())
-          .setId(config.getDataSourceId())
           .setType("TimeSeriesDataSource");
       
       builder.addExecutionGraphNode(source_builder.build());
       for (QueryNodeConfig c : config.getPushDownNodes()) {
-        if (c.getSources() != null && c.getSources().contains(config.getId())) {
-          // TODO copy properly eventually.
-          if (c instanceof DownsampleConfig) {
-            DownsampleConfig downsampleConfig = (DownsampleConfig) c;
-            DownsampleConfig.Builder newBuilder = DownsampleConfig.newBuilder();
-            DownsampleConfig.cloneBuilder(downsampleConfig, newBuilder);
-            c = newBuilder.setStart(context.query().getStart())
-                .setEnd(context.query().getEnd())
-                .setId(c.getId()).build();
-          }
-          c.getSources().remove(config.getId());
-          c.getSources().add(config.getDataSourceId());
+        if (c instanceof DownsampleConfig) {
+          DownsampleConfig downsampleConfig = (DownsampleConfig) c;
+          DownsampleConfig.Builder newBuilder = DownsampleConfig.newBuilder();
+          DownsampleConfig.cloneBuilder(downsampleConfig, newBuilder);
+          c = newBuilder.setStart(context.query().getStart())
+              .setEnd(context.query().getEnd())
+              .setId(c.getId()).build();
         }
         builder.addExecutionGraphNode(c);
       }
@@ -288,7 +280,7 @@ public class HttpQueryV3Source extends AbstractQueryNode implements SourceNode {
                   sendUpstream(BadQueryResult.newBuilder()
                       .setNode(HttpQueryV3Source.this)
                       .setException(e)
-                      .setDataSource(config.getId())
+                      .setDataSource(config.resultIds().get(0))
                       .build());
                   return;
                 } else if (previous_ex != null && 
@@ -302,7 +294,7 @@ public class HttpQueryV3Source extends AbstractQueryNode implements SourceNode {
                   sendUpstream(BadQueryResult.newBuilder()
                       .setNode(HttpQueryV3Source.this)
                       .setException(e)
-                      .setDataSource(config.getId())
+                      .setDataSource(config.resultIds().get(0))
                       .build());
                   return;
                 }
@@ -339,7 +331,7 @@ public class HttpQueryV3Source extends AbstractQueryNode implements SourceNode {
                     sendUpstream(BadQueryResult.newBuilder()
                         .setNode(HttpQueryV3Source.this)
                         .setException(rqee)
-                        .setDataSource(config.getId())
+                        //.setDataSource(config.getId())
                         .build());
                     return;
                   }
@@ -352,7 +344,7 @@ public class HttpQueryV3Source extends AbstractQueryNode implements SourceNode {
                 .setException(new QueryExecutionException("Unexpected exception: " 
                     + EntityUtils.toString(response.getEntity()), 
                     response.getStatusLine().getStatusCode()))
-                .setDataSource(config.getId())
+                //.setDataSource(config.getId())
                 .build());
             return;
           }
@@ -370,7 +362,7 @@ public class HttpQueryV3Source extends AbstractQueryNode implements SourceNode {
                 .setNode(HttpQueryV3Source.this)
                 .setException(new QueryExecutionException(
                     "No JSON results from: " + json, 500))
-                .setDataSource(config.getId())
+                //.setDataSource(config.getId())
                 .build());
           } else {
             if (LOG.isDebugEnabled()) {
@@ -442,7 +434,7 @@ public class HttpQueryV3Source extends AbstractQueryNode implements SourceNode {
               sendUpstream(BadQueryResult.newBuilder()
                   .setNode(HttpQueryV3Source.this)
                   .setException(t)
-                  .setDataSource(config.getId())
+                  //.setDataSource(config.getId())
                   .build());
             } catch (Exception ex) {
               LOG.warn("Unexpected exception when handling exception: " 
@@ -463,7 +455,7 @@ public class HttpQueryV3Source extends AbstractQueryNode implements SourceNode {
               sendUpstream(BadQueryResult.newBuilder()
                   .setNode(HttpQueryV3Source.this)
                   .setException(ex)
-                  .setDataSource(config.getId())
+                  .setDataSource(config.resultIds().get(0))
                   .build());
             } catch (Exception ex) {
               LOG.warn("Unexpected exception when handling exception: " 
@@ -507,14 +499,14 @@ public class HttpQueryV3Source extends AbstractQueryNode implements SourceNode {
           sendUpstream(BadQueryResult.newBuilder()
               .setNode(HttpQueryV3Source.this)
               .setException(e)
-              .setDataSource(config.getId())
+              .setDataSource(config.resultIds().get(0))
               .build());
         } catch (Throwable t) {
           LOG.error("Unexpected exception processing query", t);
           sendUpstream(BadQueryResult.newBuilder()
               .setNode(HttpQueryV3Source.this)
               .setException(t)
-              .setDataSource(config.getId())
+              .setDataSource(config.resultIds().get(0))
               .build());
         }
       }

--- a/executors/http/src/test/java/net/opentsdb/query/execution/TestHttpQueryV3Result.java
+++ b/executors/http/src/test/java/net/opentsdb/query/execution/TestHttpQueryV3Result.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import java.time.ZoneId;
 import java.util.Iterator;
 
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +41,6 @@ import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.query.QueryMode;
 import net.opentsdb.query.QueryNode;
-import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.SemanticQuery;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
@@ -67,7 +67,7 @@ public class TestHttpQueryV3Result {
                 .setMetric("system.cpu.user")
                 .build())
             .setFilterId(null)
-            .setDataSourceId("otherMetric")
+            //.setDataSourceId("otherMetric")
             .setId("m1")
             .build();
 
@@ -101,7 +101,7 @@ public class TestHttpQueryV3Result {
     assertEquals(2, result.timeSeries().size());
     assertNull(result.error());
     assertNull(result.exception());
-    assertEquals("otherMetric", result.dataSource());
+    assertEquals(new DefaultQueryResultId("m0", "m0"), result.dataSource());
     assertEquals(Const.TS_STRING_ID, result.idType());
     
     Iterator<TimeSeries> ts_iterator = result.timeSeries().iterator();
@@ -181,7 +181,7 @@ public class TestHttpQueryV3Result {
     assertEquals(2, result.timeSeries().size());
     assertNull(result.error());
     assertNull(result.exception());
-    assertEquals("otherMetric", result.dataSource());
+    assertEquals(new DefaultQueryResultId("groupby", "m1"), result.dataSource());
     assertEquals(Const.TS_STRING_ID, result.idType());
     
     Iterator<TimeSeries> ts_iterator = result.timeSeries().iterator();
@@ -250,7 +250,7 @@ public class TestHttpQueryV3Result {
     assertNull(result.timeSpecification());
     assertNull(result.error());
     assertNull(result.exception());
-    assertEquals("otherMetric", result.dataSource());
+    assertEquals(new DefaultQueryResultId("summarizer", "m1"), result.dataSource());
     assertEquals(Const.TS_STRING_ID, result.idType());
     
     RollupConfig rollup_config = result.rollupConfig();
@@ -338,7 +338,7 @@ public class TestHttpQueryV3Result {
     assertNull(result.timeSpecification());
     assertNull(result.error());
     assertNull(result.exception());
-    assertEquals("otherMetric", result.dataSource());
+    assertEquals(new DefaultQueryResultId("summarizer", "m1"), result.dataSource());
     assertEquals(Const.TS_STRING_ID, result.idType());
     
     rollup_config = result.rollupConfig();
@@ -358,7 +358,7 @@ public class TestHttpQueryV3Result {
     assertTrue(result.timeSeries().isEmpty());
     assertEquals("Boo!", result.error());
     assertTrue(result.exception() instanceof RuntimeException);
-    assertEquals("m1", result.dataSource());
+    assertEquals(new DefaultQueryResultId("m1", "m1"), result.dataSource());
   }
   
   @Test
@@ -385,7 +385,7 @@ public class TestHttpQueryV3Result {
     assertEquals(2, result.timeSeries().size());
     assertNull(result.error());
     assertNull(result.exception());
-    assertEquals("otherMetric", result.dataSource());
+    assertEquals(new DefaultQueryResultId("groupby", "m1"), result.dataSource());
     assertEquals(Const.TS_STRING_ID, result.idType());
     
     Iterator<TimeSeries> ts_iterator = result.timeSeries().iterator();
@@ -466,7 +466,7 @@ public class TestHttpQueryV3Result {
     assertEquals(2, result.timeSeries().size());
     assertNull(result.error());
     assertNull(result.exception());
-    assertEquals("otherMetric", result.dataSource());
+    assertEquals(new DefaultQueryResultId("groupby", "m1"), result.dataSource());
     assertEquals(Const.TS_STRING_ID, result.idType());
     
     Iterator<TimeSeries> ts_iterator = result.timeSeries().iterator();

--- a/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/EgadsPredictionResult.java
+++ b/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/EgadsPredictionResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import net.opentsdb.data.TimeSpecification;
 import net.opentsdb.data.TimeStamp;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.rollup.RollupConfig;
 
 /**
@@ -37,14 +38,14 @@ import net.opentsdb.rollup.RollupConfig;
  */
 public class EgadsPredictionResult implements QueryResult, TimeSpecification {
   private final QueryNode node;
-  private final String data_source;
+  private final QueryResultId data_source;
   private final TimeStamp start;
   private final TimeStamp end;
   private final List<TimeSeries> series;
   private final TypeToken<? extends TimeSeriesId> id_type;
 
   public EgadsPredictionResult(final QueryNode node, 
-                               final String data_source,
+                               final QueryResultId data_source,
                                final TimeStamp start, 
                                final TimeStamp end, 
                                final List<TimeSeries> series,
@@ -89,7 +90,7 @@ public class EgadsPredictionResult implements QueryResult, TimeSpecification {
   }
 
   @Override
-  public String dataSource() {
+  public QueryResultId dataSource() {
     return data_source;
   }
 

--- a/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/EgadsResult.java
+++ b/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/EgadsResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import net.opentsdb.data.TimeStamp.Op;
 import net.opentsdb.data.types.numeric.NumericArrayType;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.rollup.RollupConfig;
 
 /**
@@ -109,7 +110,7 @@ public class EgadsResult implements QueryResult {
   }
 
   @Override
-  public String dataSource() {
+  public QueryResultId dataSource() {
     return original_result.dataSource();
   }
 

--- a/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/olympicscoring/OlympicScoringNode.java
+++ b/implementation/egads/src/main/java/net/opentsdb/query/anomaly/egads/olympicscoring/OlympicScoringNode.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import net.opentsdb.query.QueryNodeConfig;
 import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.query.QuerySink;
 import net.opentsdb.query.QuerySinkCallback;
 import net.opentsdb.query.SemanticQuery;
@@ -107,7 +108,7 @@ public class OlympicScoringNode extends AbstractQueryNode {
   protected final long prediction_interval;
   protected final int threshold_dps;
   protected String ds_interval;
-  protected volatile String data_source;
+  protected volatile QueryResultId data_source;
   
   public OlympicScoringNode(final QueryNodeFactory factory,
                             final QueryPipelineContext context,

--- a/implementation/protobuf/src/main/java/net/opentsdb/data/PBufQueryResult.java
+++ b/implementation/protobuf/src/main/java/net/opentsdb/data/PBufQueryResult.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018-2019  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,8 +26,10 @@ import net.opentsdb.common.Const;
 import net.opentsdb.data.pbuf.QueryResultPB;
 import net.opentsdb.data.pbuf.TimeSeriesPB;
 import net.opentsdb.exceptions.SerdesException;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.query.readcache.CachedQueryNode;
 import net.opentsdb.query.serdes.PBufSerdesFactory;
 import net.opentsdb.query.serdes.SerdesOptions;
@@ -143,8 +145,10 @@ public class PBufQueryResult implements QueryResult {
   }
 
   @Override
-  public String dataSource() {
-    return result.getDataSource();
+  public QueryResultId dataSource() {
+    int idx = result.getDataSource().indexOf(":");
+    return new DefaultQueryResultId(result.getDataSource().substring(0, idx), 
+        result.getDataSource().substring(idx + 1));
   }
   
   @Override

--- a/implementation/protobuf/src/main/java/net/opentsdb/query/serdes/PBufSerdes.java
+++ b/implementation/protobuf/src/main/java/net/opentsdb/query/serdes/PBufSerdes.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,8 +38,6 @@ import net.opentsdb.exceptions.SerdesException;
 import net.opentsdb.query.QueryContext;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
-import net.opentsdb.query.serdes.SerdesOptions;
-import net.opentsdb.query.serdes.TimeSeriesSerdes;
 import net.opentsdb.stats.Span;
 
 /**
@@ -225,7 +223,8 @@ public class PBufSerdes implements TimeSeriesSerdes {
   public QueryResultPB.QueryResult serializeResult(final QueryResult result) {
     final QueryResultPB.QueryResult.Builder result_builder = 
         QueryResultPB.QueryResult.newBuilder()
-          .setDataSource(result.dataSource())
+          .setDataSource(
+              result.dataSource().nodeID() + ":" + result.dataSource().dataSource())
           .setNodeId(result.source().config().getId());
     if (result.timeSpecification() != null) {
       result_builder.setTimeSpecification(TimeSpecification.newBuilder()

--- a/implementation/protobuf/src/test/java/net/opentsdb/grpc/TestQueryGRPCServer.java
+++ b/implementation/protobuf/src/test/java/net/opentsdb/grpc/TestQueryGRPCServer.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -250,7 +251,7 @@ public class TestQueryGRPCServer {
     verify(observer, never()).onError(any(UnitTestException.class));
     
     net.opentsdb.query.QueryResult result = mock(net.opentsdb.query.QueryResult.class);
-    when(result.dataSource()).thenReturn("UT");
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("UT", "UT"));
     verify(ctx, times(1)).fetchNext(null);
     verify(observer, never()).onNext(any(QueryResultPB.QueryResult.class));
     verify(observer, never()).onCompleted();

--- a/implementation/protobuf/src/test/java/net/opentsdb/query/serdes/TestPBufSerdes.java
+++ b/implementation/protobuf/src/test/java/net/opentsdb/query/serdes/TestPBufSerdes.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ import java.io.InputStream;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
-import java.util.Iterator;
 
 import net.opentsdb.data.TypedTimeSeriesIterator;
 import org.junit.Before;
@@ -61,6 +60,7 @@ import net.opentsdb.data.types.numeric.MutableNumericValue;
 import net.opentsdb.data.types.numeric.NumericSummaryType;
 import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.exceptions.SerdesException;
+import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryContext;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryNodeConfig;
@@ -176,7 +176,7 @@ public class TestPBufSerdes {
     when(config.getId()).thenReturn("ds");
     when(node.config()).thenReturn(config);
     when(result.source()).thenReturn(node);
-    when(result.dataSource()).thenReturn("UT");
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("UT", "UT"));
     when(result.resolution()).thenReturn(ChronoUnit.SECONDS);
     when(result.timeSeries()).thenReturn(Lists.newArrayList(ts, ts2));
     when(result.timeSpecification()).thenReturn(spec);
@@ -239,7 +239,7 @@ public class TestPBufSerdes {
     when(config.getId()).thenReturn("ds");
     when(node.config()).thenReturn(config);
     when(result.source()).thenReturn(node);
-    when(result.dataSource()).thenReturn("UT");
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("UT", "UT"));
     when(result.resolution()).thenReturn(ChronoUnit.SECONDS);
     when(result.timeSeries()).thenReturn(Collections.emptyList());
     
@@ -273,7 +273,7 @@ public class TestPBufSerdes {
   @Test
   public void serdesErrors() throws Exception {
     QueryResult result = mock(QueryResult.class);
-    when(result.dataSource()).thenReturn("UT");
+    when(result.dataSource()).thenReturn(new DefaultQueryResultId("UT", "UT"));
     when(result.resolution()).thenReturn(ChronoUnit.SECONDS);
     when(result.timeSeries()).thenReturn(Collections.emptyList());
     

--- a/implementation/redis/src/main/java/net/opentsdb/query/anomaly/RedisClusterPredictionCache.java
+++ b/implementation/redis/src/main/java/net/opentsdb/query/anomaly/RedisClusterPredictionCache.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,8 +31,7 @@ import net.opentsdb.core.Const;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
-import net.opentsdb.query.anomaly.AnomalyPredictionState;
-import net.opentsdb.query.anomaly.PredictionCache;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.query.execution.cache.RedisClusterQueryCache;
 import net.opentsdb.query.readcache.ReadCacheQueryResult;
 import net.opentsdb.query.readcache.ReadCacheSerdes;
@@ -177,10 +176,10 @@ public class RedisClusterPredictionCache extends BaseTSDBPlugin
     }
     
     try {
-      final Map<String, ReadCacheQueryResult> results = 
+      final Map<QueryResultId, ReadCacheQueryResult> results = 
           serdes.deserialize(context, raw);
       ReadCacheQueryResult result = null;
-      for (final Entry<String, ReadCacheQueryResult> entry : results.entrySet()) {
+      for (final Entry<QueryResultId, ReadCacheQueryResult> entry : results.entrySet()) {
         if (entry.getValue() != null) {
           result = entry.getValue();
           break;

--- a/implementation/redis/src/main/java/net/opentsdb/query/execution/cache/RedisClusterQueryCache.java
+++ b/implementation/redis/src/main/java/net/opentsdb/query/execution/cache/RedisClusterQueryCache.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018  The OpenTSDB Authors.
+// Copyright (C) 2017-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import net.opentsdb.core.TSDB;
 import net.opentsdb.data.TimeStamp;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.QueryResultId;
 import net.opentsdb.query.readcache.QueryReadCache;
 import net.opentsdb.query.readcache.ReadCacheCallback;
 import net.opentsdb.query.readcache.ReadCacheQueryResult;
@@ -325,7 +326,7 @@ public class RedisClusterQueryCache extends BaseTSDBPlugin
   
     class CQR implements ReadCacheQueryResultSet {
       final byte[] key;
-      final Map<String, ReadCacheQueryResult> results;
+      final Map<QueryResultId, ReadCacheQueryResult> results;
       final int idx;
       
       CQR(final int idx, final byte[] raw) {
@@ -349,7 +350,7 @@ public class RedisClusterQueryCache extends BaseTSDBPlugin
       }
       
       @Override
-      public Map<String, ReadCacheQueryResult> results() {
+      public Map<QueryResultId, ReadCacheQueryResult> results() {
         return results;
       }
 

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/sinks/ServletSink.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/sinks/ServletSink.java
@@ -158,7 +158,7 @@ public class ServletSink implements QuerySink, SerdesCallback {
               ImmutableMap.<String, Object>builder()
               // TODO - possible upstream headers
               .put("queryId", Bytes.byteArrayToString(context.query().buildHashCode().asBytes()))
-              .put("node", next.source().config().getId() + ":" + next.dataSource())
+              //.put("node", next.dataSource())
               .build()));
     }
     if (context.query().isTraceEnabled()) {

--- a/storage/asynchbase/pom.xml
+++ b/storage/asynchbase/pom.xml
@@ -77,6 +77,16 @@
       <dependency>
         <groupId>org.hbase</groupId>
         <artifactId>asynchbase</artifactId>
+        <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>netty</artifactId>
+                    <groupId>org.jboss.netty</groupId>
+                </exclusion>
+            </exclusions>
       </dependency>
       
       <dependency>

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseQueryNode.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseQueryNode.java
@@ -205,6 +205,8 @@ public class Tsdb1xHBaseQueryNode implements Tsdb1xQueryNode {
           .dynamicString(Tsdb1xHBaseDataStore.ROLLUP_USAGE_KEY));
     }
     push = parent.dynamicBoolean(Tsdb1xHBaseDataStore.ENABLE_PUSH_KEY);
+    
+    LOG.info("******NODE CTOR: " + ((TimeSeriesDataSourceConfig) config()).resultIds().get(0) + " of type " + ((TimeSeriesDataSourceConfig) config()).getClass());
   }
 
   @Override


### PR DESCRIPTION
- Add the QueryResultId and a default implementation. This allows for much cleaner
  and simpler result tracking through the query execution graph. It replaces the
  DataSourceId fields and lets the nodes set their own results so it is super
  easy for nodes (like the expression nodes) to find out what results are
  expected. Also add the appropriate builder methods and config getters.
- Also add a getter/setter, markedCacheable and markCacheable that will be used
  to replace the current read cache setup.

CORE:
- Implement the new QueryResultId everywhere.
- Change the DefaultQueryPlanner config node setup to properly walk the graph
  depth first so the upstream nodes have all of their downstream nodes setup.
  Also split up the plan() method into separate bits we can use in the read
  cache.
- Add a bit of logging to the Joiner.
- Fix up the toBuilder() calls for nodes that were missing implementations and
  add some helpers to the base classes.