### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/plan/DefaultQueryPlanner.java
+++ b/core/src/main/java/net/opentsdb/query/plan/DefaultQueryPlanner.java
@@ -971,7 +971,8 @@ public class DefaultQueryPlanner implements QueryPlanner {
       }
       
       final List<QueryNodeConfig> push_downs = Lists.newArrayList();
-      for (final QueryNodeConfig n : config_graph.predecessors(node)) {
+      final Set<QueryNodeConfig> nodes = Sets.newHashSet(config_graph.predecessors(node));
+      for (final QueryNodeConfig n : nodes) {
         pushDown(
             node, 
             node, 
@@ -1013,6 +1014,9 @@ public class DefaultQueryPlanner implements QueryPlanner {
     final Set<QueryNodeConfig> nodes = Sets.newHashSet(config_graph.nodes());
     for (final QueryNodeConfig config : nodes) {
       if (!linksToContext(config)) {
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Removing non-contributing node: " + config.getId());
+        }
         removeNode(config);
       }
     }
@@ -1210,7 +1214,8 @@ public class DefaultQueryPlanner implements QueryPlanner {
     for (final QueryNodeConfig node : config_graph.nodes()) {
       buffer.append("[V] " + node.getId() + " {" 
           + node.getClass().getSimpleName() + "} (" 
-          + System.identityHashCode(node) + ")\n");
+          + System.identityHashCode(node) + ") "
+          + node.resultIds() + "\n");
     }
     buffer.append("\n");
     for (final EndpointPair<QueryNodeConfig> pair : config_graph.edges()) {

--- a/core/src/main/java/net/opentsdb/query/processor/merge/MergerConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/merge/MergerConfig.java
@@ -56,7 +56,7 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
     aggregator = builder.aggregator;
     infectious_nan = builder.infectious_nan;
     result_ids = Lists.newArrayList(
-        new DefaultQueryResultId(data_source, data_source));
+        new DefaultQueryResultId(id, data_source));
   }
   
   public String getDataSource() {

--- a/core/src/test/java/net/opentsdb/query/plan/TestDefaultQueryPlanner.java
+++ b/core/src/test/java/net/opentsdb/query/plan/TestDefaultQueryPlanner.java
@@ -1869,7 +1869,7 @@ public class TestDefaultQueryPlanner {
     
     assertEquals(1, planner.serializationSources().size());
     QueryResultId source = planner.serializationSources().get(0);
-    assertEquals("m1", source.nodeID());
+    assertEquals("Merger", source.nodeID());
     assertEquals("m1", source.dataSource());
   }
   
@@ -1997,7 +1997,7 @@ public class TestDefaultQueryPlanner {
     
     assertEquals(1, planner.serializationSources().size());
     QueryResultId source = planner.serializationSources().get(0);
-    assertEquals("m1", source.nodeID());
+    assertEquals("Merger", source.nodeID());
     assertEquals("m1", source.dataSource());
   }
   
@@ -2128,7 +2128,7 @@ public class TestDefaultQueryPlanner {
     
     assertEquals(1, planner.serializationSources().size());
     QueryResultId source = planner.serializationSources().get(0);
-    assertEquals("m1", source.nodeID());
+    assertEquals("Merger", source.nodeID());
     assertEquals("m1", source.dataSource());
   }
   
@@ -2282,7 +2282,7 @@ public class TestDefaultQueryPlanner {
     
     assertEquals(1, planner.serializationSources().size());
     QueryResultId source = planner.serializationSources().get(0);
-    assertEquals("m3", source.nodeID());
+    assertEquals("Merger2", source.nodeID());
     assertEquals("m3", source.dataSource());
   }
   

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerResult.java
@@ -138,7 +138,7 @@ public class TestMergerResult {
     
     merger.add(result_a);
     assertSame(time_spec, merger.timeSpecification());
-    assertEquals(new DefaultQueryResultId("MyMetric", "MyMetric"), 
+    assertEquals(new DefaultQueryResultId("Testing", "MyMetric"), 
         merger.dataSource());
   }
   


### PR DESCRIPTION
- Fix an issue with summaries in the read cache pipeline
- Fix a CME in the query planner and add some result IDs to the debug log
- Yank the override for the Merger config result IDs as it actually broke
  the naming.