### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/SemanticQuery.java
+++ b/core/src/main/java/net/opentsdb/query/SemanticQuery.java
@@ -1,5 +1,5 @@
 //This file is part of OpenTSDB.
-//Copyright (C) 2018-2019  The OpenTSDB Authors.
+//Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 //This program is free software: you can redistribute it and/or modify it
 //under the terms of the GNU Lesser General Public License as published by
@@ -362,6 +362,10 @@ public class SemanticQuery implements TimeSeriesQuery {
     public Builder setExecutionGraph(final List<QueryNodeConfig> execution_graph) {
       this.execution_graph = execution_graph;
       return this;
+    }
+    
+    public List<QueryNodeConfig> executionGraph() {
+      return execution_graph;
     }
     
     public Builder addExecutionGraphNode(final QueryNodeConfig node) {

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseQueryNode.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseQueryNode.java
@@ -205,8 +205,6 @@ public class Tsdb1xHBaseQueryNode implements Tsdb1xQueryNode {
           .dynamicString(Tsdb1xHBaseDataStore.ROLLUP_USAGE_KEY));
     }
     push = parent.dynamicBoolean(Tsdb1xHBaseDataStore.ENABLE_PUSH_KEY);
-    
-    LOG.info("******NODE CTOR: " + ((TimeSeriesDataSourceConfig) config()).resultIds().get(0) + " of type " + ((TimeSeriesDataSourceConfig) config()).getClass());
   }
 
   @Override


### PR DESCRIPTION
- Add a metric override map to the DefaultQueryContextFilter. This allows
  for redirecting rollup queries to the raw HBase table and changing byte
  limits based on regex matches. I want to move it eventually and have
  filter chaining but for now we can stash it in here.