### PR TITLE
Jackson has a serious security problem in 2.9.5, which will cause RCE

### DIFF
--- a/third_party/jackson/include.mk
+++ b/third_party/jackson/include.mk
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-JACKSON_VERSION := 2.9.5
+JACKSON_VERSION := 2.9.10.3
 
 JACKSON_ANNOTATIONS_VERSION = $(JACKSON_VERSION)
 JACKSON_ANNOTATIONS := third_party/jackson/jackson-annotations-$(JACKSON_ANNOTATIONS_VERSION).jar


### PR DESCRIPTION
Adding the md5 needed for PR-1946.
Fixed #1946 