### PR TITLE
ALL:

### DIFF
--- a/common/src/main/java/net/opentsdb/meta/BatchMetaQuery.java
+++ b/common/src/main/java/net/opentsdb/meta/BatchMetaQuery.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2019  The OpenTSDB Authors.
+// Copyright (C) 2019-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,23 +36,23 @@ public interface BatchMetaQuery {
     DESCENDING
   }
 
-  public int from();
+  public int getFrom();
 
-  public int to();
+  public int getTo();
 
-  public String aggregationField();
+  public String getAggregationField();
 
-  public int aggregationSize();
+  public int getAggregationSize();
 
-  public QueryType type();
+  public QueryType getType();
 
-  public Order order();
+  public Order getOrder();
 
-  public TimeStamp start();
+  public TimeStamp getStart();
 
-  public TimeStamp end();
+  public TimeStamp getEnd();
 
-  public List<MetaQuery> metaQueries();
+  public List<MetaQuery> getQueries();
 
   public List<MetaQuery> meta_query = new ArrayList<>();
 

--- a/common/src/main/java/net/opentsdb/meta/MetaQuery.java
+++ b/common/src/main/java/net/opentsdb/meta/MetaQuery.java
@@ -23,11 +23,11 @@ import net.opentsdb.query.filter.QueryFilter;
  */
 public interface MetaQuery {
 
-  public String namespace();
+  public String getNamespace();
 
-  public QueryFilter filter();
+  public QueryFilter getFilter();
 
-  public String id();
+  public String getId();
   
   /**
    * Builder through which the query is parsed and parameters are set

--- a/common/src/main/java/net/opentsdb/query/filter/TagKeyFilter.java
+++ b/common/src/main/java/net/opentsdb/query/filter/TagKeyFilter.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/core/src/main/java/net/opentsdb/meta/DefaultBatchMetaQuery.java
+++ b/core/src/main/java/net/opentsdb/meta/DefaultBatchMetaQuery.java
@@ -105,11 +105,11 @@ public class DefaultBatchMetaQuery implements BatchMetaQuery {
     return namespace;
   }
 
-  public int from() {
+  public int getFrom() {
     return from;
   }
 
-  public int to() {
+  public int getTo() {
     return to;
   }
 
@@ -117,31 +117,31 @@ public class DefaultBatchMetaQuery implements BatchMetaQuery {
     return filters;
   }
 
-  public String aggregationField() {
+  public String getAggregationField() {
     return aggregation_field;
   }
 
-  public int aggregationSize() {
+  public int getAggregationSize() {
     return agg_size;
   }
 
-  public QueryType type() {
+  public QueryType getType() {
     return type;
   }
 
-  public Order order() {
+  public Order getOrder() {
     return order;
   }
 
-  public TimeStamp start() {
+  public TimeStamp getStart() {
     return start;
   }
 
-  public TimeStamp end() {
+  public TimeStamp getEnd() {
     return end;
   }
 
-  public List<MetaQuery> metaQueries() {
+  public List<MetaQuery> getQueries() {
     return meta_query;
   }
 

--- a/core/src/main/java/net/opentsdb/meta/DefaultMetaQuery.java
+++ b/core/src/main/java/net/opentsdb/meta/DefaultMetaQuery.java
@@ -60,15 +60,15 @@ public class DefaultMetaQuery implements MetaQuery {
     }
   }
 
-  public String namespace() {
+  public String getNamespace() {
     return namespace;
   }
 
-  public QueryFilter filter() {
+  public QueryFilter getFilter() {
     return filters;
   }
 
-  public String id() {
+  public String getId() {
     return id;
   }
 

--- a/core/src/main/java/net/opentsdb/query/filter/TagKeyRegexFilter.java
+++ b/core/src/main/java/net/opentsdb/query/filter/TagKeyRegexFilter.java
@@ -98,7 +98,7 @@ public class TagKeyRegexFilter implements TagKeyFilter {
 
   @Override
   public String getType() {
-    return TagValueRegexFactory.TYPE;
+    return TagKeyRegexFactory.TYPE;
   }
   
   /** Whether or not the regex would match all strings. */

--- a/core/src/main/java/net/opentsdb/storage/MockDataMeta.java
+++ b/core/src/main/java/net/opentsdb/storage/MockDataMeta.java
@@ -96,7 +96,7 @@ public class MockDataMeta extends BaseTSDBPlugin implements MetaDataStorageSchem
       }
     }
     Map<NamespacedKey, MetaDataStorageResult> results = Maps.newHashMap();
-    switch (query.type()) {
+    switch (query.getType()) {
     case NAMESPACES:
       // we'll iterate and pull out the metrics to the first dot.
       // TODO - no filter?
@@ -128,7 +128,7 @@ public class MockDataMeta extends BaseTSDBPlugin implements MetaDataStorageSchem
       break;
     default:
       return Deferred.fromError(
-          new IllegalArgumentException("Unsupported type: " + query.type()));
+          new IllegalArgumentException("Unsupported type: " + query.getType()));
     }
     return Deferred.fromResult(results);
   }
@@ -179,16 +179,16 @@ public class MockDataMeta extends BaseTSDBPlugin implements MetaDataStorageSchem
    */
   void handleSingleTypeMetaQuery(final BatchMetaQuery query,
                                  final Map<NamespacedKey, MetaDataStorageResult> results) {
-    for (final MetaQuery meta_query : query.metaQueries()) {
+    for (final MetaQuery meta_query : query.getQueries()) {
       NamespacedKey key = null;
       int hits = 0;
-      switch (query.type()) {
+      switch (query.getType()) {
       case METRICS:
         Map<String, UniqueKeyPair<String, Long>> metrics = null;
         for (final Entry<TimeSeriesDatumStringId, MockSpan> entry : 
               data_store.database().entrySet()) {
-          if (FilterUtils.matchesMetrics(meta_query.filter(), entry.getKey(), 
-              meta_query.namespace())) {
+          if (FilterUtils.matchesMetrics(meta_query.getFilter(), entry.getKey(), 
+              meta_query.getNamespace())) {
             if (metrics == null) {
               metrics = Maps.newHashMap();
             }
@@ -207,7 +207,7 @@ public class MockDataMeta extends BaseTSDBPlugin implements MetaDataStorageSchem
               extant.setValue(extant.getValue() + 1);
             }
             if (key == null) {
-              key = getNamespace(entry.getKey(), meta_query.id());
+              key = getNamespace(entry.getKey(), meta_query.getId());
             }
             hits++;
           }
@@ -223,11 +223,11 @@ public class MockDataMeta extends BaseTSDBPlugin implements MetaDataStorageSchem
         Set<String> matches = Sets.newHashSet();
         for (final Entry<TimeSeriesDatumStringId, MockSpan> entry : 
             data_store.database().entrySet()) {
-          if (FilterUtils.matchesTagKeysOrValues(meta_query.filter(), 
+          if (FilterUtils.matchesTagKeysOrValues(meta_query.getFilter(), 
                                                  entry.getKey(), 
-                                                 meta_query.namespace(), 
+                                                 meta_query.getNamespace(), 
                                                  matches, 
-                                                 query.type() == QueryType.TAG_KEYS)) {
+                                                 query.getType() == QueryType.TAG_KEYS)) {
             for (final String match : matches) {
               if (tag_keys_or_values == null) {
                 tag_keys_or_values = Maps.newHashMap();
@@ -240,7 +240,7 @@ public class MockDataMeta extends BaseTSDBPlugin implements MetaDataStorageSchem
                 extant.setValue(extant.getValue() + 1);
               }
               if (key == null) {
-                key = getNamespace(entry.getKey(), meta_query.id());
+                key = getNamespace(entry.getKey(), meta_query.getId());
               }
             }
             hits++;
@@ -257,8 +257,8 @@ public class MockDataMeta extends BaseTSDBPlugin implements MetaDataStorageSchem
         Map<String, String> tag_pairs = Maps.newHashMap(); 
         for (final Entry<TimeSeriesDatumStringId, MockSpan> entry : 
               data_store.database().entrySet()) {
-          if (FilterUtils.matchesTags(meta_query.filter(), entry.getKey(), 
-              meta_query.namespace(), tag_pairs)) {
+          if (FilterUtils.matchesTags(meta_query.getFilter(), entry.getKey(), 
+              meta_query.getNamespace(), tag_pairs)) {
             for (final Entry<String, String> tags : tag_pairs.entrySet()) {
               // blech
               UniqueKeyPair<String, Long> extant = keys.get(tags.getKey());
@@ -284,7 +284,7 @@ public class MockDataMeta extends BaseTSDBPlugin implements MetaDataStorageSchem
               }
               
               if (key == null) {
-                key = getNamespace(entry.getKey(), meta_query.id());
+                key = getNamespace(entry.getKey(), meta_query.getId());
               }
             }
           }
@@ -306,8 +306,8 @@ public class MockDataMeta extends BaseTSDBPlugin implements MetaDataStorageSchem
         Set<TimeSeriesId> ids = null;
         for (final Entry<TimeSeriesDatumStringId, MockSpan> entry : 
               data_store.database().entrySet()) {
-          if (FilterUtils.matches(meta_query.filter(), entry.getKey(), 
-                meta_query.namespace())) {
+          if (FilterUtils.matches(meta_query.getFilter(), entry.getKey(), 
+                meta_query.getNamespace())) {
             if (ids == null) {
               ids = Sets.newHashSet();
             }
@@ -316,7 +316,7 @@ public class MockDataMeta extends BaseTSDBPlugin implements MetaDataStorageSchem
                 .setTags(entry.getKey().tags())
                 .build());
             if (key == null) {
-              key = getNamespace(entry.getKey(), meta_query.id());
+              key = getNamespace(entry.getKey(), meta_query.getId());
             }
           }
         }

--- a/core/src/test/java/net/opentsdb/meta/TestDefaultMetaQuery.java
+++ b/core/src/test/java/net/opentsdb/meta/TestDefaultMetaQuery.java
@@ -45,8 +45,8 @@ public class TestDefaultMetaQuery {
       .build();
 
     assertNotNull(query);
-    assertEquals("Test-Namespace", query.namespace());
-    assertEquals("Chain" , query.filter().getType());
+    assertEquals("Test-Namespace", query.getNamespace());
+    assertEquals("Chain" , query.getFilter().getType());
   }
 
   @Test
@@ -61,8 +61,8 @@ public class TestDefaultMetaQuery {
       BatchMetaQuery.QueryType.METRICS).build();
 
     assertNotNull(query);
-    assertEquals("Test-Namespace", query.namespace());
-    assertEquals("Chain" , query.filter().getType());
+    assertEquals("Test-Namespace", query.getNamespace());
+    assertEquals("Chain" , query.getFilter().getType());
   }
 
   @Test
@@ -78,8 +78,8 @@ public class TestDefaultMetaQuery {
       .build();
 
     assertNotNull(query);
-    assertEquals("Test-Namespace", query.namespace());
-    assertEquals("Chain" , query.filter().getType());
+    assertEquals("Test-Namespace", query.getNamespace());
+    assertEquals("Chain" , query.getFilter().getType());
   }
 
   @Test
@@ -95,8 +95,8 @@ public class TestDefaultMetaQuery {
       .build();
 
     assertNotNull(query);
-    assertEquals("Test-Namespace", query.namespace());
-    assertEquals("Chain" , query.filter().getType());
+    assertEquals("Test-Namespace", query.getNamespace());
+    assertEquals("Chain" , query.getFilter().getType());
   }
 
   @Test
@@ -110,7 +110,7 @@ public class TestDefaultMetaQuery {
       .build();
 
     assertNotNull(query);
-    assertEquals("Test-Namespace", query.namespace());
+    assertEquals("Test-Namespace", query.getNamespace());
   }
 
 }

--- a/executors/http/src/main/java/net/opentsdb/meta/HttpMetaQueryExecutor.java
+++ b/executors/http/src/main/java/net/opentsdb/meta/HttpMetaQueryExecutor.java
@@ -1,0 +1,231 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2020  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.meta;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
+import java.util.concurrent.RejectedExecutionException;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.core.BaseTSDBPlugin;
+import net.opentsdb.core.TSDB;
+import net.opentsdb.exceptions.QueryExecutionCanceled;
+import net.opentsdb.exceptions.QueryExecutionException;
+import net.opentsdb.meta.BatchMetaQuery;
+import net.opentsdb.meta.BatchMetaQuery.QueryType;
+import net.opentsdb.meta.DefaultMetaQuery;
+import net.opentsdb.meta.MetaDataStorageResult;
+import net.opentsdb.meta.MetaDataStorageSchema;
+import net.opentsdb.meta.MetaQuery;
+import net.opentsdb.meta.NamespacedKey;
+import net.opentsdb.query.QueryPipelineContext;
+import net.opentsdb.query.TimeSeriesDataSourceConfig;
+import net.opentsdb.stats.Span;
+import net.opentsdb.utils.DateTime;
+import net.opentsdb.utils.DefaultSharedHttpClient;
+import net.opentsdb.utils.JSON;
+import net.opentsdb.utils.SharedHttpClient;
+
+/**
+ * Simple meta data query forwarder. For now it just sends to the endpoint given
+ * and in the future we'll add some smart routing to point different namespaces
+ * to different endpoints.
+ * 
+ * @since 3.0
+ */
+public class HttpMetaQueryExecutor extends BaseTSDBPlugin implements MetaDataStorageSchema {
+  private static final Logger LOG = LoggerFactory.getLogger(HttpMetaQueryExecutor.class);
+  
+  public static final String TYPE = "HttpMetaExecutor";
+  public static final String ENDPOINT = "http.meta.executor.endpoint";
+  public static final String CLIENT_KEY = "http.meta.executor.client.id";
+  
+  /** The client to query. */
+  private CloseableHttpAsyncClient client;
+  
+  @Override
+  public Deferred<Map<NamespacedKey, MetaDataStorageResult>> runQuery(
+      final BatchMetaQuery query, 
+      final Span span) {
+    final long start = DateTime.nanoTime();
+    final Deferred<Map<NamespacedKey, MetaDataStorageResult>> deferred = 
+        new Deferred<Map<NamespacedKey, MetaDataStorageResult>>();
+    final HttpPost post = new HttpPost(tsdb.getConfig().getString(ENDPOINT));
+    post.addHeader("Content-Type", "application/json");
+    final String json;
+    try {
+      json = JSON.serializeToString(query);
+      post.setEntity(new StringEntity(json));
+    } catch (UnsupportedEncodingException e) {
+      return Deferred.fromError(new RejectedExecutionException(
+          "Failed to generate request", e));
+    }
+    
+    class ResponseCallback implements FutureCallback<HttpResponse> {
+
+      @Override
+      public void completed(final HttpResponse response) {
+        try {
+          if (response.getStatusLine().getStatusCode() != 200) {
+            // bad. Try getting a useful exception to hand up.
+            final String parsed;
+            try {
+              parsed = DefaultSharedHttpClient.parseResponse(response, 0, 
+                  tsdb.getConfig().getString(ENDPOINT));
+              // TODO - no catch so just bubble up for now.
+              deferred.callback(new QueryExecutionException(parsed,
+                  response.getStatusLine().getStatusCode()));
+              return;
+            } catch (Exception e) {
+              LOG.warn("Exception from endpoint in response: " 
+                  + this, e);
+              deferred.callback(e);
+            }
+          } else {
+            // good
+            final String json = DefaultSharedHttpClient.parseResponse(response, 0, 
+                tsdb.getConfig().getString(ENDPOINT));
+            final JsonNode root = JSON.getMapper().readTree(json);
+            JsonNode results = root.get("results");
+            if (results == null) {
+              // could be an error, parse it.
+              LOG.error("No JSON results from: " + json);
+              deferred.callback(new QueryExecutionException("No JSON results from: " + json,
+                  500));
+            } else {
+              if (LOG.isDebugEnabled()) {
+                LOG.debug("Successful response from [" 
+                    + tsdb.getConfig().getString(ENDPOINT) + "] after " 
+                    + DateTime.msFromNanoDiff(DateTime.nanoTime(), start) + "ms");
+              }
+              
+              final Map<NamespacedKey, MetaDataStorageResult> map = Maps.newHashMap();
+              for (final JsonNode result : results) {
+                final NamespacedKey key;
+                JsonNode namespaces = result.get("namespaces");
+                if (namespaces == null || namespaces.size() < 1) {
+                  // TODO - throw an error most likely, for now use "null"
+                  key = new NamespacedKey("null", "null");
+                } else {
+                  key = new NamespacedKey(namespaces.get(0).asText(), 
+                      namespaces.get(0).asText());
+                }
+                
+                map.put(key, new HttpMetaResult(result));
+              }
+              deferred.callback(map);
+            }
+          }
+        } catch (Exception e) {
+          LOG.warn("Exception thrown when calling deferred on response: " 
+              + this, e);
+        }
+      }
+
+      @Override
+      public void failed(final Exception ex) {
+        // TODO - retries
+        try {
+          deferred.callback(ex);
+        } catch (Exception e) {
+          LOG.warn("Exception thrown when calling deferred on error handling: " 
+              + this, e);
+        }
+      }
+
+      @Override
+      public void cancelled() {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Http query was canceled: " + this);
+        }
+        try {
+          final Exception e = new QueryExecutionCanceled(
+              "Query was canceled: " + tsdb.getConfig().getString(ENDPOINT), 400, 0); 
+          deferred.callback(e);
+        } catch (Exception e) {
+          LOG.warn("Exception thrown when calling deferred on cancel: " 
+              + this, e);
+        }
+      }
+      
+    }
+    client.execute(post, new ResponseCallback());
+    return deferred;
+  }
+
+  @Override
+  public Deferred<MetaDataStorageResult> runQuery(final QueryPipelineContext context, 
+                                                  final TimeSeriesDataSourceConfig config,
+      Span span) {
+    return Deferred.fromError(new UnsupportedOperationException(
+        "Not forwarding data queries at this time."));
+  }
+
+  @Override
+  public MetaQuery parse(final TSDB tsdb, 
+                         final ObjectMapper mapper, 
+                         final JsonNode jsonNode, 
+                         final QueryType type) {
+    return DefaultMetaQuery.parse(tsdb, mapper, jsonNode, type).build();
+  }
+
+  @Override
+  public Deferred<Object> initialize(final TSDB tsdb, final String id) {
+    this.id = Strings.isNullOrEmpty(id) ? null : id;
+    this.tsdb = tsdb;
+    
+    if (!tsdb.getConfig().hasProperty(ENDPOINT)) {
+      tsdb.getConfig().register(ENDPOINT, null, true, 
+          "The HTTP(s) endpoint to forward queries to.");
+    }
+    if (!tsdb.getConfig().hasProperty(CLIENT_KEY)) {
+      tsdb.getConfig().register(CLIENT_KEY, 
+          null, false,
+          "The ID of the SharedHttpClient plugin to use. Defaults to `null`.");
+    }
+    
+    final String client_id = tsdb.getConfig().getString(CLIENT_KEY);
+    final SharedHttpClient shared_client = tsdb.getRegistry().getPlugin(
+        SharedHttpClient.class, client_id);
+    if (shared_client == null) {
+      throw new IllegalArgumentException("No shared HTTP client found "
+          + "for ID: " + (Strings.isNullOrEmpty(client_id) ? 
+              "Default" : client_id));
+    } else {
+      client = shared_client.getClient();
+    }
+    
+    return Deferred.fromResult(null);
+  }
+  
+  @Override
+  public String type() {
+    return TYPE;
+  }
+
+}

--- a/executors/http/src/main/java/net/opentsdb/meta/HttpMetaResult.java
+++ b/executors/http/src/main/java/net/opentsdb/meta/HttpMetaResult.java
@@ -1,0 +1,176 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2020  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.meta;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
+
+import net.opentsdb.common.Const;
+import net.opentsdb.data.BaseTimeSeriesStringId;
+import net.opentsdb.data.TimeSeriesId;
+import net.opentsdb.utils.UniqueKeyPair;
+
+/**
+ * Basic meta query result parser.
+ * TODO - improve this for memory performance.
+ * 
+ * @since 3.0
+ */
+public class HttpMetaResult implements MetaDataStorageResult {
+
+  private final JsonNode result;
+  private final long total_hits;
+  
+  HttpMetaResult(final JsonNode result) {
+    this.result = result;
+    total_hits = result.get("totalHits").asLong();
+    // TODO - some validation
+    
+  }
+  
+  @Override
+  public String id() {
+    return result.get("id").asText();
+  }
+
+  @Override
+  public long totalHits() {
+    return total_hits;
+  }
+
+  @Override
+  public MetaResult result() {
+    return total_hits > 0 ? MetaResult.DATA : MetaResult.NO_DATA;
+  }
+
+  @Override
+  public Throwable exception() {
+    return null;
+  }
+
+  @Override
+  public Collection<String> namespaces() {
+    List<String> namespaces = Lists.newArrayList();
+    JsonNode ns = result.get("namespaces");
+    for (final JsonNode namespace : ns) {
+      namespaces.add(namespace.asText());
+    }
+    return namespaces;
+  }
+
+  @Override
+  public Collection<TimeSeriesId> timeSeries() {
+    final JsonNode json_timeseries = result.get("timeseries");
+    if (json_timeseries == null || json_timeseries.size() <= 0) {
+      return Collections.emptyList();
+    }
+    
+    // TODO - view over JSON instead of loading a whole set.
+    List<TimeSeriesId> ids = Lists.newArrayList();
+    for (final JsonNode id : json_timeseries) {
+      final BaseTimeSeriesStringId.Builder builder = BaseTimeSeriesStringId.newBuilder()
+          .setMetric(id.get("metric").asText());
+      final Iterator<Entry<String, JsonNode>> iterator = id.get("tags").fields();
+      while (iterator.hasNext()) {
+        final Entry<String, JsonNode> pair = iterator.next();
+        builder.addTags(pair.getKey(), pair.getValue().asText());
+      }
+      ids.add(builder.build());
+    }
+    return ids;
+  }
+
+  @Override
+  public TypeToken<? extends TimeSeriesId> idType() {
+    return Const.TS_STRING_ID;
+  }
+
+  @Override
+  public Collection<UniqueKeyPair<String, Long>> metrics() {
+    final JsonNode json_metrics = result.get("metrics");
+    if (json_metrics == null || json_metrics.size() <= 0) {
+      return Collections.emptyList();
+    }
+    
+    // TODO - view over JSON instead of loading a whole set.
+    List<UniqueKeyPair<String, Long>> ids = Lists.newArrayList();
+    for (final JsonNode metric : json_metrics) {
+      ids.add(new UniqueKeyPair<String, Long>(
+          metric.get("name").asText(),
+          metric.get("count").asLong()));
+    }
+    return ids;
+  }
+
+  @Override
+  public Map<UniqueKeyPair<String, Long>, Collection<UniqueKeyPair<String, Long>>> tags() {
+    final JsonNode json_tkvs = result.get("tagKeysAndValues");
+    if (json_tkvs == null || json_tkvs.size() <= 0) {
+      return Collections.emptyMap();
+    }
+    
+    // TODO - view over JSON instead of loading a whole set. This is the ugliest
+    // of them
+    Map<UniqueKeyPair<String, Long>, Collection<UniqueKeyPair<String, Long>>> map
+      = Maps.newHashMap();
+    final Iterator<Entry<String, JsonNode>> iterator = json_tkvs.fields();
+    while (iterator.hasNext()) {
+      final Entry<String, JsonNode> pair = iterator.next();
+      UniqueKeyPair<String, Long> key = new UniqueKeyPair<String, Long>(
+          pair.getKey(),
+          pair.getValue().get("hits").asLong());
+      
+      List<UniqueKeyPair<String, Long>> values = Lists.newArrayList();
+      for (final JsonNode value : pair.getValue().get("values")) {
+        values.add(new UniqueKeyPair<String, Long>(
+            value.get("name").asText(),
+            value.get("count").asLong()));
+      }
+      map.put(key, values);
+    }
+    
+    return map;
+  }
+
+  @Override
+  public Collection<UniqueKeyPair<String, Long>> tagKeysOrValues() {
+    JsonNode json_tkvs = result.get("tagKeys");
+    if (json_tkvs == null || json_tkvs.size() <= 0) {
+      json_tkvs = result.get("tagValues");
+    }
+    if (json_tkvs == null || json_tkvs.size() <= 0) {
+      return Collections.emptyList();
+    }
+    
+    // TODO - view over JSON instead of loading a whole set.
+    List<UniqueKeyPair<String, Long>> ids = Lists.newArrayList();
+    for (final JsonNode korv : json_tkvs) {
+      ids.add(new UniqueKeyPair<String, Long>(
+          korv.get("name").asText(),
+          korv.get("count").asLong()));
+    }
+    return ids;
+  }
+  
+}

--- a/executors/http/src/main/resources/META-INF/services/net.opentsdb.meta.MetaDataStorageSchema
+++ b/executors/http/src/main/resources/META-INF/services/net.opentsdb.meta.MetaDataStorageSchema
@@ -1,0 +1,1 @@
+net.opentsdb.meta.HttpMetaQueryExecutor

--- a/implementation/elasticsearch/src/main/java/net/opentsdb/meta/NamespacedAggregatedDocumentResult.java
+++ b/implementation/elasticsearch/src/main/java/net/opentsdb/meta/NamespacedAggregatedDocumentResult.java
@@ -71,9 +71,9 @@ public class NamespacedAggregatedDocumentResult implements MetaDataStorageResult
                                             final MetaQuery meta_query) {
     this.result = result;
     this.query = query;
-    if (query != null && query.type() != null &&
-        query.type() != QueryType.NAMESPACES) {
-      namespaces = Sets.newHashSet(meta_query.namespace());
+    if (query != null && query.getType() != null &&
+        query.getType() != QueryType.NAMESPACES) {
+      namespaces = Sets.newHashSet(meta_query.getNamespace());
     }
     this.meta_query = meta_query;
   }
@@ -89,7 +89,7 @@ public class NamespacedAggregatedDocumentResult implements MetaDataStorageResult
 
   @Override
   public String id() {
-    return meta_query != null ? meta_query.id() : null;
+    return meta_query != null ? meta_query.getId() : null;
   }
 
   @Override
@@ -113,7 +113,7 @@ public class NamespacedAggregatedDocumentResult implements MetaDataStorageResult
       return Collections.emptyList();
     }
     final List<String> sorted = Lists.newArrayList(namespaces);
-    if (query.order() == Order.ASCENDING) {
+    if (query.getOrder() == Order.ASCENDING) {
       Collections.sort(sorted);
     } else {
       Collections.sort(sorted, Collections.reverseOrder());
@@ -138,7 +138,7 @@ public class NamespacedAggregatedDocumentResult implements MetaDataStorageResult
       return Collections.emptyList();
     }
     final List<UniqueKeyPair<String, Long>> sorted = Lists.newArrayList(metrics.values());
-    if (query.order() == Order.ASCENDING) {
+    if (query.getOrder() == Order.ASCENDING) {
       Collections.sort(sorted, UniqueKeyPair_CMP);
     } else {
       Collections.sort(sorted, REVERSE_UniqueKeyPair_CMP);
@@ -168,7 +168,7 @@ public class NamespacedAggregatedDocumentResult implements MetaDataStorageResult
     }
     final List<UniqueKeyPair<String, Long>> sorted = Lists.newArrayList
             (tag_keys_or_values.values());
-    if (query.order() == Order.ASCENDING) {
+    if (query.getOrder() == Order.ASCENDING) {
       Collections.sort(sorted, UniqueKeyPair_CMP);
     } else {
       Collections.sort(sorted, REVERSE_UniqueKeyPair_CMP);
@@ -213,7 +213,7 @@ public class NamespacedAggregatedDocumentResult implements MetaDataStorageResult
                             final boolean matchMetric) {
 
     if (matchMetric && meta_query != null &&
-          !matchMetric(metric_only, false, meta_query.filter())) {
+          !matchMetric(metric_only, false, meta_query.getFilter())) {
       return;
     }
 
@@ -251,7 +251,7 @@ public class NamespacedAggregatedDocumentResult implements MetaDataStorageResult
       tags = Maps.newHashMap();
     }
     if (tags.get(key) == null) {
-      Set<UniqueKeyPair<String, Long>> result = new TreeSet<>(query.order() == Order.ASCENDING ?
+      Set<UniqueKeyPair<String, Long>> result = new TreeSet<>(query.getOrder() == Order.ASCENDING ?
           UniqueKeyPair_CMP : REVERSE_UniqueKeyPair_CMP);
       result.addAll(values);
       tags.put(key, result);
@@ -265,10 +265,10 @@ public class NamespacedAggregatedDocumentResult implements MetaDataStorageResult
    * BatchMetaQuery}.
    *
    * @param values A non-null (possibly empty) list.
-   * @See {@link BatchMetaQuery#aggregationField()}
+   * @See {@link BatchMetaQuery#getAggregationField()}
    */
   public void addTags(final List<UniqueKeyPair<String, Long>> values) {
-    addTags(new UniqueKeyPair(query.aggregationField(), 1l), values);
+    addTags(new UniqueKeyPair(query.getAggregationField(), 1l), values);
   }
 
   /**
@@ -278,7 +278,7 @@ public class NamespacedAggregatedDocumentResult implements MetaDataStorageResult
    */
   public void addTag(final  UniqueKeyPair<String, Long> key, final UniqueKeyPair<String, Long> value) {
     if (tags == null) {
-      tags = Maps.newTreeMap(query.order() == Order.ASCENDING ? UniqueKeyPair_CMP : REVERSE_UniqueKeyPair_CMP);
+      tags = Maps.newTreeMap(query.getOrder() == Order.ASCENDING ? UniqueKeyPair_CMP : REVERSE_UniqueKeyPair_CMP);
     }
     Collection<UniqueKeyPair<String, Long>> values = tags.get(key);
     if (values == null) {

--- a/implementation/elasticsearch/src/main/java/net/opentsdb/meta/impl/es/ESMetaResponse.java
+++ b/implementation/elasticsearch/src/main/java/net/opentsdb/meta/impl/es/ESMetaResponse.java
@@ -88,9 +88,9 @@ public class ESMetaResponse implements MetaResponse {
       // NOTE: For multigets, case matters so we have to match with the original query.
       final NamespacedAggregatedDocumentResult result;
 
-      MetaQuery metaQuery = query.metaQueries().get(0);
-      String metric = findMetric(metaQuery.filter());
-      NamespacedKey namespacedKey = new NamespacedKey(metaQuery.namespace(), metaQuery.id());
+      MetaQuery metaQuery = query.getQueries().get(0);
+      String metric = findMetric(metaQuery.getFilter());
+      NamespacedKey namespacedKey = new NamespacedKey(metaQuery.getNamespace(), metaQuery.getId());
       // quick validation
       long max_hits = 0;
       for (final Map.Entry<String, MultiSearchResponse> response_entry : response.entrySet()) {
@@ -183,10 +183,10 @@ public class ESMetaResponse implements MetaResponse {
 
     } else {
       int i = 0;
-      for (MetaQuery meta_query : query.metaQueries()) {
+      for (MetaQuery meta_query : query.getQueries()) {
         long max_hits = 0;
 
-        int count = countMetricFilters(meta_query.filter(), 0);
+        int count = countMetricFilters(meta_query.getFilter(), 0);
 
         count = count == 0 ? 1 : count;
 
@@ -230,11 +230,11 @@ public class ESMetaResponse implements MetaResponse {
               tsdb.getStatsCollector()
                   .addTime("es.client.query.es.latency", response.getTookInMillis(), ChronoUnit.MILLIS,
                       "es_colo", search_response.getKey(),
-                      "namespace", query.type() == QueryType.NAMESPACES ? "all_namespaces": meta_query.namespace(),
-                      "type", query.type().toString());
+                      "namespace", query.getType() == QueryType.NAMESPACES ? "all_namespaces": meta_query.getNamespace(),
+                      "type", query.getType().toString());
 
               long startTime = System.currentTimeMillis();
-              switch (query.type()) {
+              switch (query.getType()) {
                 case NAMESPACES:
                   if (response.getAggregations() == null
                       || response
@@ -392,7 +392,7 @@ public class ESMetaResponse implements MetaResponse {
                   break;
                 default:
                   final_results.put(
-                      new NamespacedKey(meta_query.namespace(), meta_query.id()),
+                      new NamespacedKey(meta_query.getNamespace(), meta_query.getId()),
                       new NamespacedAggregatedDocumentResult(
                           MetaDataStorageResult.MetaResult.NO_DATA, query, meta_query));
                   return final_results;
@@ -420,7 +420,7 @@ public class ESMetaResponse implements MetaResponse {
         }
         if (null_results == response.size()) {
           final_results.put(
-              new NamespacedKey(meta_query.namespace(), meta_query.id()),
+              new NamespacedKey(meta_query.getNamespace(), meta_query.getId()),
               new NamespacedAggregatedDocumentResult(
                   MetaDataStorageResult.MetaResult.NO_DATA, query, meta_query));
         }
@@ -430,7 +430,7 @@ public class ESMetaResponse implements MetaResponse {
                   MetaDataStorageResult.MetaResult.NO_DATA, query, meta_query);
         }
         result.setTotalHits(max_hits);
-        final_results.put(new NamespacedKey(meta_query.namespace(), meta_query.id()), result);
+        final_results.put(new NamespacedKey(meta_query.getNamespace(), meta_query.getId()), result);
         i = i + count;
       }
     }
@@ -679,9 +679,9 @@ public class ESMetaResponse implements MetaResponse {
     }
 
     for (final Terms.Bucket bucket : ((StringTerms) tag_keys).getBuckets()) {
-      if (Strings.isNullOrEmpty(query.aggregationField()) ||
-              query.aggregationField().equalsIgnoreCase(".*") ||
-              bucket.getKey().equals(query.aggregationField())) {
+      if (Strings.isNullOrEmpty(query.getAggregationField()) ||
+              query.getAggregationField().equalsIgnoreCase(".*") ||
+              bucket.getKey().equals(query.getAggregationField())) {
         if (result == null) {
           result =
               new NamespacedAggregatedDocumentResult(
@@ -745,9 +745,9 @@ public class ESMetaResponse implements MetaResponse {
             }
             
             final TimeSeriesId id = buildTimeseries(
-                meta_query.namespace() + "." + m, tags);
+                meta_query.getNamespace() + "." + m, tags);
             if (isMultiGet) {
-              if (!FilterUtils.matchesTags(meta_query.filter(), 
+              if (!FilterUtils.matchesTags(meta_query.getFilter(), 
                   ((TimeSeriesStringId) id).tags(), Sets.newHashSet())) {
                 if (LOGGER.isTraceEnabled()) {
                   LOGGER.trace("Dropping ES meta response " + id 
@@ -766,9 +766,9 @@ public class ESMetaResponse implements MetaResponse {
                   MetaDataStorageResult.MetaResult.DATA, query, meta_query);
         }
         final TimeSeriesId id = buildTimeseries(
-            meta_query.namespace() + "." + metric, tags);
+            meta_query.getNamespace() + "." + metric, tags);
         if (isMultiGet) {
-          if (!FilterUtils.matchesTags(meta_query.filter(), 
+          if (!FilterUtils.matchesTags(meta_query.getFilter(), 
               ((TimeSeriesStringId) id).tags(), Sets.newHashSet())) {
             if (LOGGER.isTraceEnabled()) {
               LOGGER.trace("Dropping ES meta response " + id 

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/MetaRpc.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/resources/MetaRpc.java
@@ -262,7 +262,7 @@ public class MetaRpc {
 
             json.writeFieldName("tagKeys");
             json.writeStartArray();
-            if (query.type() == QueryType.TAG_KEYS &&
+            if (query.getType() == QueryType.TAG_KEYS &&
                     metadata_storage_result.tagKeysOrValues() != null) {
               for (final Pair<String, Long> key_or_value : metadata_storage_result.tagKeysOrValues()) {
                 json.writeStartObject();
@@ -275,7 +275,7 @@ public class MetaRpc {
 
             json.writeFieldName("tagValues");
             json.writeStartArray();
-            if (query.type() == QueryType.TAG_VALUES &&
+            if (query.getType() == QueryType.TAG_VALUES &&
                     metadata_storage_result.tagKeysOrValues() != null) {
               for (final Pair<String, Long> key_or_value : metadata_storage_result.tagKeysOrValues()) {
                 json.writeStartObject();


### PR DESCRIPTION
- Rename the BatchMetaQuery and MetaQuery fields to be jackson serializable.

HTTP:
- Add an HTTP meta query executor to pass queries on to another host.