### PR TITLE
COMMON:

### DIFF
--- a/common/src/main/java/net/opentsdb/data/AggregatingTypedTimeSeriesIterator.java
+++ b/common/src/main/java/net/opentsdb/data/AggregatingTypedTimeSeriesIterator.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018-2020  The OpenTSDB Authors.
+// Copyright (C) 2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,21 @@
 // limitations under the License.
 package net.opentsdb.data;
 
-import com.google.common.reflect.TypeToken;
-
-import java.io.Closeable;
-import java.util.Iterator;
-
 /**
- * An iterator for {@link TimeSeriesValue}s that lets us determine the
- * type of the underlying data without having to resolve the types.
+ * An interface that extends the iterator with a {@link #next(Aggregator)} method
+ * that will populate the given aggregator with the values at the proper 
+ * index. This can only be used for downsampled, normalized data.
  * 
  * @since 3.0
  */
-public interface TypedTimeSeriesIterator<T extends TimeSeriesDataType> 
-    extends Iterator<TimeSeriesValue<T>>, Closeable {
+public interface AggregatingTypedTimeSeriesIterator<T extends TimeSeriesDataType> 
+    extends TypedTimeSeriesIterator<T> {
 
   /**
-   * @return The non-null type of data returned in the iterator.
+   * Runs through the data and adds the results to the aggregator at the proper
+   * index.
+   * @param aggregator A non-null aggregator to populate.
    */
-  public TypeToken<T> getType();
+  public void next(final Aggregator aggregator);
   
 }

--- a/common/src/main/java/net/opentsdb/query/AggregatingQueryIterator.java
+++ b/common/src/main/java/net/opentsdb/query/AggregatingQueryIterator.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018-2020  The OpenTSDB Authors.
+// Copyright (C) 2020  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package net.opentsdb.data;
+package net.opentsdb.query;
 
-import com.google.common.reflect.TypeToken;
-
-import java.io.Closeable;
-import java.util.Iterator;
+import net.opentsdb.data.AggregatingTypedTimeSeriesIterator;
 
 /**
- * An iterator for {@link TimeSeriesValue}s that lets us determine the
- * type of the underlying data without having to resolve the types.
+ * An iterator generated at query time over time series values that can popluate
+ * an aggregator on calls to {@link #next(net.opentsdb.data.Aggregator)}.
  * 
  * @since 3.0
  */
-public interface TypedTimeSeriesIterator<T extends TimeSeriesDataType> 
-    extends Iterator<TimeSeriesValue<T>>, Closeable {
+public interface AggregatingQueryIterator extends AggregatingTypedTimeSeriesIterator {
 
-  /**
-   * @return The non-null type of data returned in the iterator.
-   */
-  public TypeToken<T> getType();
-  
 }

--- a/common/src/main/java/net/opentsdb/query/QueryIterator.java
+++ b/common/src/main/java/net/opentsdb/query/QueryIterator.java
@@ -14,7 +14,6 @@
 // limitations under the License.
 package net.opentsdb.query;
 
-import net.opentsdb.data.TimeSeriesDataType;
 import net.opentsdb.data.TypedTimeSeriesIterator;
 
 /**

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericArrayIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericArrayIterator.java
@@ -31,7 +31,7 @@ import net.opentsdb.data.types.numeric.NumericArrayType;
 import net.opentsdb.data.types.numeric.aggregators.NumericAggregator;
 import net.opentsdb.data.types.numeric.aggregators.NumericAggregatorFactory;
 import net.opentsdb.data.types.numeric.aggregators.NumericArrayAggregator;
-import net.opentsdb.query.QueryIterator;
+import net.opentsdb.query.AggregatingQueryIterator;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.processor.downsample.Downsample.DownsampleResult;
@@ -45,7 +45,7 @@ import net.opentsdb.query.processor.downsample.Downsample.DownsampleResult;
  * 
  * @since 3.0
  */
-public class DownsampleNumericArrayIterator implements QueryIterator, 
+public class DownsampleNumericArrayIterator implements AggregatingQueryIterator,
     TimeSeriesValue<NumericArrayType>, 
     NumericArrayType {
 
@@ -309,9 +309,9 @@ public class DownsampleNumericArrayIterator implements QueryIterator,
   }
 
   @Override
-  public TimeSeriesValue<NumericArrayType> nextPool(final Aggregator aggregator) {
+  public void next(final Aggregator aggregator) {
     if (iterator == null) {
-      return null;
+      return;
     }
 
     final NumericArrayAggregator agg = (NumericArrayAggregator) aggregator;
@@ -324,7 +324,7 @@ public class DownsampleNumericArrayIterator implements QueryIterator,
     } else {
       agg.accumulate(double_values, 0, intervals);
     }
-    return null;
+    return;
   }
   
   /**

--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericToNumericArrayIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericToNumericArrayIterator.java
@@ -28,7 +28,7 @@ import net.opentsdb.data.types.numeric.NumericType;
 import net.opentsdb.data.types.numeric.aggregators.ArrayCountFactory.ArrayCount;
 import net.opentsdb.data.types.numeric.aggregators.NumericArrayAggregator;
 import net.opentsdb.data.types.numeric.aggregators.NumericArrayAggregatorFactory;
-import net.opentsdb.query.QueryIterator;
+import net.opentsdb.query.AggregatingQueryIterator;
 import net.opentsdb.query.QueryNode;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.processor.downsample.Downsample.DownsampleResult;
@@ -81,7 +81,7 @@ import org.slf4j.LoggerFactory;
  * @since 3.0
  */
 public class DownsampleNumericToNumericArrayIterator 
-    implements QueryIterator, TimeSeriesValue<NumericArrayType> {
+    implements AggregatingQueryIterator, TimeSeriesValue<NumericArrayType> {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(DownsampleNumericToNumericArrayIterator.class);
@@ -235,10 +235,10 @@ public class DownsampleNumericToNumericArrayIterator
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
   @Override
-  public TimeSeriesValue<NumericArrayType> nextPool(Aggregator aggregator) {
+  public void next(Aggregator aggregator) {
     has_next = false;
     if (value == null) {
-      return null;
+      return;
     }
     
     NumericArrayAggregator numericArrayAggregator = (NumericArrayAggregator) aggregator; // group by
@@ -346,7 +346,7 @@ public class DownsampleNumericToNumericArrayIterator
       }
     }
 
-    return null;
+    return;
   }
 
   private double getAggValue(double[] localDoubleAggs, long[] localLongAggs) {
@@ -612,7 +612,7 @@ public class DownsampleNumericToNumericArrayIterator
     double[] nans = new double[config.intervals()];
     Arrays.fill(nans, Double.NaN);
     agg.accumulate(nans);
-    nextPool(agg);
+    next(agg);
     return this;
   }
   

--- a/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByNumericArrayIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/groupby/GroupByNumericArrayIterator.java
@@ -20,6 +20,7 @@ import com.google.common.reflect.TypeToken;
 import net.opentsdb.utils.BigSmallLinkedBlockingQueue;
 import net.opentsdb.utils.TSDBQueryQueue;
 import net.opentsdb.core.TSDB;
+import net.opentsdb.data.AggregatingTypedTimeSeriesIterator;
 import net.opentsdb.data.ArrayAggregatorConfig;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesDataType;
@@ -600,8 +601,8 @@ public class GroupByNumericArrayIterator
             optional.get()) {
           if (iterator.hasNext()) {
             has_next = true;
-            if (aggregator != null) {
-              iterator.nextPool(aggregator);
+            if (aggregator != null && iterator instanceof AggregatingTypedTimeSeriesIterator) {
+              ((AggregatingTypedTimeSeriesIterator) iterator).next(aggregator);
             } else {
               final TimeSeriesValue<NumericArrayType> array =
                   (TimeSeriesValue<NumericArrayType>) iterator.next();

--- a/core/src/main/java/net/opentsdb/query/processor/timeshift/TimeShiftNumericArrayIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/timeshift/TimeShiftNumericArrayIterator.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import com.google.common.reflect.TypeToken;
 
+import net.opentsdb.data.AggregatingTypedTimeSeriesIterator;
 import net.opentsdb.data.Aggregator;
 import net.opentsdb.data.TimeSeries;
 import net.opentsdb.data.TimeSeriesDataType;
@@ -26,6 +27,7 @@ import net.opentsdb.data.TimeSeriesValue;
 import net.opentsdb.data.TimeStamp;
 import net.opentsdb.data.TypedTimeSeriesIterator;
 import net.opentsdb.data.types.numeric.NumericArrayType;
+import net.opentsdb.query.AggregatingQueryIterator;
 import net.opentsdb.query.QueryIterator;
 import net.opentsdb.query.QueryResult;
 
@@ -35,7 +37,7 @@ import net.opentsdb.query.QueryResult;
  *
  * @since 3.0
  */
-public class TimeShiftNumericArrayIterator implements QueryIterator,
+public class TimeShiftNumericArrayIterator implements AggregatingQueryIterator,
     TimeSeriesValue<NumericArrayType> {
 
   /** The iterator. */
@@ -103,7 +105,10 @@ public class TimeShiftNumericArrayIterator implements QueryIterator,
   }
 
   @Override
-  public TimeSeriesValue<? extends TimeSeriesDataType> nextPool(Aggregator aggregator) {
-    return iterator.nextPool(aggregator);
+  public void next(final Aggregator aggregator) {
+    if (iterator instanceof AggregatingTypedTimeSeriesIterator) {
+      ((AggregatingTypedTimeSeriesIterator) iterator).next(aggregator);
+    }
+    throw new UnsupportedOperationException("TODO!");
   }
 }

--- a/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericToNumericArrayIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/downsample/TestDownsampleNumericToNumericArrayIterator.java
@@ -180,7 +180,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
 
@@ -229,7 +229,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
 
@@ -286,7 +286,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     NumericArrayAggregator numericArrayAggregator1 =
         factory.newAggregator(config.getInfectiousNan());
@@ -295,7 +295,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     numericArrayAggregator1.accumulate(nans);
     final DownsampleNumericToNumericArrayIterator it1 =
         new DownsampleNumericToNumericArrayIterator(node, result, source);
-    it1.nextPool(numericArrayAggregator1);
+    it1.next(numericArrayAggregator1);
     numericArrayAggregator.combine(numericArrayAggregator1);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
@@ -343,7 +343,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     long[] doubleArray = numericArrayAggregator.longArray();
 
@@ -390,7 +390,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     long[] doubleArray = numericArrayAggregator.longArray();
 
@@ -437,7 +437,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     NumericArrayAggregator numericArrayAggregator1 =
         factory.newAggregator(config.getInfectiousNan());
@@ -446,7 +446,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     numericArrayAggregator1.accumulate(nans);
     final DownsampleNumericToNumericArrayIterator it1 =
         new DownsampleNumericToNumericArrayIterator(node, result, source);
-    it1.nextPool(numericArrayAggregator1);
+    it1.next(numericArrayAggregator1);
     numericArrayAggregator.combine(numericArrayAggregator1);
 
     long[] doubleArray = numericArrayAggregator.longArray();
@@ -494,7 +494,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     NumericArrayAggregator numericArrayAggregator1 =
         factory.newAggregator(config.getInfectiousNan());
@@ -503,7 +503,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     numericArrayAggregator1.accumulate(nans);
     final DownsampleNumericToNumericArrayIterator it1 =
         new DownsampleNumericToNumericArrayIterator(node, result, source);
-    it1.nextPool(numericArrayAggregator1);
+    it1.next(numericArrayAggregator1);
     numericArrayAggregator.combine(numericArrayAggregator1);
 
     long[] doubleArray = numericArrayAggregator.longArray();
@@ -551,7 +551,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     NumericArrayAggregator numericArrayAggregator1 =
         factory.newAggregator(config.getInfectiousNan());
@@ -560,7 +560,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     numericArrayAggregator1.accumulate(nans);
     final DownsampleNumericToNumericArrayIterator it1 =
         new DownsampleNumericToNumericArrayIterator(node, result, source);
-    it1.nextPool(numericArrayAggregator1);
+    it1.next(numericArrayAggregator1);
     numericArrayAggregator.combine(numericArrayAggregator1);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
@@ -608,7 +608,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     NumericArrayAggregator numericArrayAggregator1 =
         factory.newAggregator(config.getInfectiousNan());
@@ -617,7 +617,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     numericArrayAggregator1.accumulate(nans);
     final DownsampleNumericToNumericArrayIterator it1 =
         new DownsampleNumericToNumericArrayIterator(node, result, source);
-    it1.nextPool(numericArrayAggregator1);
+    it1.next(numericArrayAggregator1);
     numericArrayAggregator.combine(numericArrayAggregator1);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
@@ -665,7 +665,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     NumericArrayAggregator numericArrayAggregator1 =
         factory.newAggregator(config.getInfectiousNan());
@@ -674,7 +674,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     numericArrayAggregator1.accumulate(nans);
     final DownsampleNumericToNumericArrayIterator it1 =
         new DownsampleNumericToNumericArrayIterator(node, result, source);
-    it1.nextPool(numericArrayAggregator1);
+    it1.next(numericArrayAggregator1);
     numericArrayAggregator.combine(numericArrayAggregator1);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
@@ -722,7 +722,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     NumericArrayAggregator numericArrayAggregator1 =
         factory.newAggregator(config.getInfectiousNan());
@@ -731,7 +731,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     numericArrayAggregator1.accumulate(nans);
     final DownsampleNumericToNumericArrayIterator it1 =
         new DownsampleNumericToNumericArrayIterator(node, result, source);
-    it1.nextPool(numericArrayAggregator1);
+    it1.next(numericArrayAggregator1);
     numericArrayAggregator.combine(numericArrayAggregator1);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
@@ -783,7 +783,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
 
@@ -913,7 +913,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
 
@@ -960,7 +960,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
 
@@ -1007,7 +1007,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     long[] longArray = numericArrayAggregator.longArray();
     for (long l : longArray) {
@@ -1057,7 +1057,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
 
@@ -1104,7 +1104,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
 
@@ -1151,7 +1151,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
 
@@ -1226,7 +1226,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
 
@@ -1282,7 +1282,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     long[] longArray = numericArrayAggregator.longArray();
 
@@ -1338,7 +1338,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
 
@@ -1396,7 +1396,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
 
@@ -1452,7 +1452,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
 
@@ -1507,7 +1507,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
     assertEquals(1, doubleArray.length);
@@ -1552,7 +1552,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
     assertEquals(1, doubleArray.length);
@@ -1597,7 +1597,7 @@ public class TestDownsampleNumericToNumericArrayIterator {
     Arrays.fill(nans, Double.NaN);
     numericArrayAggregator.accumulate(nans);
 
-    it.nextPool(numericArrayAggregator);
+    it.next(numericArrayAggregator);
 
     double[] doubleArray = numericArrayAggregator.doubleArray();
     assertEquals(1, doubleArray.length);


### PR DESCRIPTION
- Add the Aggregating iterators with the `next(Aggregator)` method and split
  it out from the TypedTimeSeriesIterator to make it cleaner and useful when
  only some nodes support it.

CORE:
- Implement the above.