### PR TITLE
Prometheus:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/filter/NotFilter.java
+++ b/common/src/main/java/net/opentsdb/query/filter/NotFilter.java
@@ -58,6 +58,17 @@ public class NotFilter implements NestedQueryFilter {
   }
   
   @Override
+  public String toString() {
+    return new StringBuilder()
+        .append("{type=")
+        .append(getClass().getSimpleName())
+        .append(", filter=")
+        .append(filter)
+        .append("}")
+        .toString();
+  }
+  
+  @Override
   public Deferred<Void> initialize(final Span span) {
     return filter.initialize(span);
   }

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -80,6 +80,11 @@
         </dependency>
         <dependency>
           <groupId>net.opentsdb</groupId>
+          <artifactId>opentsdb-prometheus</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>net.opentsdb</groupId>
           <artifactId>opentsdb-ultrabrew</artifactId>
           <version>${project.version}</version>
         </dependency>

--- a/distribution/src/main/assembly/default.xml
+++ b/distribution/src/main/assembly/default.xml
@@ -31,6 +31,7 @@
         <include>net.opentsdb:opentsdb-redis</include>
         <include>net.opentsdb:opentsdb-egads</include>
         <include>net.opentsdb:opentsdb-influx</include>
+        <include>net.opentsdb:opentsdb-prometheus</include>
         <include>net.opentsdb:opentsdb-ultrabrew</include>
       </includes>
       <outputDirectory>lib</outputDirectory>

--- a/implementation/prometheus/pom.xml
+++ b/implementation/prometheus/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+      <groupId>net.opentsdb</groupId>
+      <artifactId>opentsdb</artifactId>
+      <version>3.0.90-SNAPSHOT</version>
+      <relativePath>../../pom.xml</relativePath>
+    </parent>
+    
+    <artifactId>opentsdb-prometheus</artifactId>
+    <name>opentsdb-prometheus</name>
+    
+    <description>Prometheus related plugins.</description>
+    
+    <packaging>jar</packaging>
+    
+    <properties>
+
+    </properties>
+    
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>net.opentsdb</groupId>
+          <artifactId>opentsdb-common</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>net.opentsdb</groupId>
+          <artifactId>opentsdb-core</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>net.opentsdb</groupId>
+          <artifactId>opentsdb-servlet</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        
+        <dependency>
+          <groupId>org.antlr</groupId>
+          <artifactId>antlr4</artifactId>
+          <version>4.5</version>
+        </dependency>
+        
+      </dependencies>
+    </dependencyManagement>
+    
+    <dependencies>
+      <dependency>
+        <groupId>net.opentsdb</groupId>
+        <artifactId>opentsdb-common</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>net.opentsdb</groupId>
+        <artifactId>opentsdb-core</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>net.opentsdb</groupId>
+        <artifactId>opentsdb-servlet</artifactId>
+      </dependency>
+      
+      <dependency>
+        <groupId>org.antlr</groupId>
+        <artifactId>antlr4</artifactId>
+      </dependency>
+      
+      <!-- TESTING Deps. -->
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+      </dependency>
+      
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <scope>test</scope>
+      </dependency>
+
+    </dependencies>
+    
+    <build>
+      <plugins>
+      <plugin>
+          <groupId>org.antlr</groupId>
+          <artifactId>antlr4-maven-plugin</artifactId>
+          <version>4.5</version>
+          <configuration>
+            <arguments>
+              <argument>-package</argument>
+              <argument>net.opentsdb.prometheus.grammar</argument>
+              <argument>-no-listener</argument>
+              <argument>-visitor</argument>
+            </arguments>
+   
+            <outputDirectory>${project.build.directory}/generated-sources/antlr4/net/opentsdb/prometheus/grammar</outputDirectory>
+          </configuration>
+          <executions>
+            <execution>
+              <id>antlr</id>
+              <goals>
+                <goal>antlr4</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+</project>

--- a/implementation/prometheus/src/main/antlr4/PromQLLexer.g4
+++ b/implementation/prometheus/src/main/antlr4/PromQLLexer.g4
@@ -1,0 +1,165 @@
+/*
+ [The "BSD licence"]
+ Copyright (c) 2013 Terence Parr
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+lexer grammar PromQLLexer;
+
+NUMBER: [0-9]+ ('.' [0-9]+)?;
+
+STRING
+    : '\'' (~('\'' | '\\') | '\\' .)* '\''
+    | '"' (~('"' | '\\') | '\\' .)* '"'
+    ;
+
+// Binary operators
+
+ADD:  '+';
+SUB:  '-';
+MULT: '*';
+DIV:  '/';
+MOD:  '%';
+POW:  '^';
+
+AND:    'and';
+OR:     'or';
+UNLESS: 'unless';
+
+// Comparison operators
+
+EQ:  '=';
+DEQ: '==';
+NE:  '!=';
+GT:  '>';
+LT:  '<';
+GE:  '>=';
+LE:  '<=';
+RE:  '=~';
+NRE: '!~';
+
+// Aggregation modifiers
+
+BY:      'by';
+WITHOUT: 'without';
+
+// Join modifiers
+
+ON:          'on';
+IGNORING:    'ignoring';
+GROUP_LEFT:  'group_left';
+GROUP_RIGHT: 'group_right';
+
+OFFSET: 'offset';
+
+BOOL: 'bool';
+
+AGGREGATION_OPERATOR
+    : 'sum'
+    | 'min'
+    | 'max'
+    | 'avg'
+    | 'group'
+    | 'stddev'
+    | 'stdvar'
+    | 'count'
+    | 'count_values'
+    | 'bottomk'
+    | 'topk'
+    | 'quantile'
+    ;
+
+FUNCTION
+    : 'abs'
+    | 'absent'
+    | 'absent_over_time'
+    | 'ceil'
+    | 'changes'
+    | 'clamp_max'
+    | 'clamp_min'
+    | 'day_of_month'
+    | 'day_of_week'
+    | 'days_in_month'
+    | 'delta'
+    | 'deriv'
+    | 'exp'
+    | 'floor'
+    | 'histogram_quantile'
+    | 'holt_winters'
+    | 'hour'
+    | 'idelta'
+    | 'increase'
+    | 'irate'
+    | 'label_join'
+    | 'label_replace'
+    | 'ln'
+    | 'log2'
+    | 'log10'
+    | 'minute'
+    | 'month'
+    | 'predict_linear'
+    | 'rate'
+    | 'resets'
+    | 'round'
+    | 'scalar'
+    | 'sort'
+    | 'sort_desc'
+    | 'sqrt'
+    | 'time'
+    | 'timestamp'
+    | 'vector'
+    | 'year'
+    | 'avg_over_time'
+    | 'min_over_time'
+    | 'max_over_time'
+    | 'sum_over_time'
+    | 'count_over_time'
+    | 'quantile_over_time'
+    | 'stddev_over_time'
+    | 'stdvar_over_time'
+    ;
+
+LEFT_BRACE:  '{';
+RIGHT_BRACE: '}';
+
+LEFT_PAREN:  '(';
+RIGHT_PAREN: ')';
+
+LEFT_BRACKET:  '[';
+RIGHT_BRACKET: ']';
+
+COMMA: ',';
+
+TIME_RANGE
+    : LEFT_BRACKET DURATION RIGHT_BRACKET
+    | LEFT_BRACKET DURATION ':' DURATION? RIGHT_BRACKET ;
+
+DURATION: [0-9]+ ('s' | 'm' | 'h' | 'd' | 'w' | 'y');
+
+/* NOTE The addition of the period (and in the future other chars) */ 
+METRIC_NAME: [a-zA-Z_:\.] [a-zA-Z0-9_:\.]*;
+LABEL_NAME:  [a-zA-Z_\.] [a-zA-Z0-9_\.]*;
+
+WS: [\r\t\n ]+ -> skip;

--- a/implementation/prometheus/src/main/antlr4/PromQLParser.g4
+++ b/implementation/prometheus/src/main/antlr4/PromQLParser.g4
@@ -1,0 +1,136 @@
+/*
+ [The "BSD licence"]
+ Copyright (c) 2013 Terence Parr
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+parser grammar PromQLParser;
+
+options { tokenVocab = PromQLLexer; }
+
+expression: vectorOperation EOF;
+
+// Binary operations are ordered by precedence
+
+// Unary operations have the same precedence as multiplications
+
+vectorOperation
+    : <assoc=right> vectorOperation powOp vectorOperation
+    | unaryOp vectorOperation
+    | vectorOperation multOp vectorOperation
+    | vectorOperation addOp vectorOperation
+    | vectorOperation compareOp vectorOperation
+    | vectorOperation andUnlessOp vectorOperation
+    | vectorOperation orOp vectorOperation
+    | vector
+    ;
+
+// Operators
+
+unaryOp:     (ADD | SUB);
+powOp:       POW grouping?;
+multOp:      (MULT | DIV | MOD) grouping?;
+addOp:       (ADD | SUB) grouping?;
+compareOp:   (DEQ | NE | GT | LT | GE | LE) BOOL? grouping?;
+andUnlessOp: (AND | UNLESS) grouping?;
+orOp:        OR grouping?;
+
+vector
+    : function
+    | aggregation
+    | instantSelector
+    | matrixSelector
+    | offset
+    | literal
+    | parens
+    ;
+
+parens: LEFT_PAREN vectorOperation RIGHT_PAREN;
+
+// Selectors
+
+instantSelector
+    : METRIC_NAME (LEFT_BRACE labelMatcherList? RIGHT_BRACE)?
+    | LEFT_BRACE labelMatcherList RIGHT_BRACE
+    ;
+
+labelMatcher:         labelName labelMatcherOperator STRING;
+labelMatcherOperator: EQ | NE | RE | NRE;
+labelMatcherList:     labelMatcher (COMMA labelMatcher)*;
+
+matrixSelector: instantSelector TIME_RANGE;
+
+offset
+    : instantSelector OFFSET DURATION
+    | matrixSelector OFFSET DURATION
+    ;
+
+// Functions
+
+function: FUNCTION LEFT_PAREN parameter (COMMA parameter)* RIGHT_PAREN (TIME_RANGE)?;
+
+parameter:     literal | vector;
+parameterList: LEFT_PAREN (parameter (COMMA parameter)*)? RIGHT_PAREN;
+
+// Aggregations
+
+aggregation
+    : AGGREGATION_OPERATOR parameterList
+    | AGGREGATION_OPERATOR (by | without) parameterList
+    | AGGREGATION_OPERATOR parameterList ( by | without)
+    ;
+by:      BY labelNameList;
+without: WITHOUT labelNameList;
+
+// Vector one-to-one/one-to-many joins
+
+grouping:   (on | ignoring) (groupLeft | groupRight)?;
+on:         ON labelNameList;
+ignoring:   IGNORING labelNameList;
+groupLeft:  GROUP_LEFT labelNameList;
+groupRight: GROUP_RIGHT labelNameList;
+
+// Label names
+
+labelName:     keyword | METRIC_NAME | LABEL_NAME;
+labelNameList: LEFT_PAREN (labelName (COMMA labelName)*)? RIGHT_PAREN;
+
+keyword
+    : AND
+    | OR
+    | UNLESS
+    | BY
+    | WITHOUT
+    | ON
+    | IGNORING
+    | GROUP_LEFT
+    | GROUP_RIGHT
+    | OFFSET
+    | BOOL
+    | AGGREGATION_OPERATOR
+    | FUNCTION
+    ;
+
+literal: NUMBER | STRING;

--- a/implementation/prometheus/src/main/java/net/opentsdb/data/prometheus/PromQLParser.java
+++ b/implementation/prometheus/src/main/java/net/opentsdb/data/prometheus/PromQLParser.java
@@ -1,0 +1,1151 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2020  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data.prometheus;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.DefaultErrorStrategy;
+import org.antlr.v4.runtime.FailedPredicateException;
+import org.antlr.v4.runtime.InputMismatchException;
+import org.antlr.v4.runtime.NoViableAltException;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.antlr.v4.runtime.tree.ErrorNode;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.RuleNode;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+
+import jersey.repackaged.com.google.common.collect.Lists;
+import jersey.repackaged.com.google.common.collect.Maps;
+import jersey.repackaged.com.google.common.collect.Sets;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.prometheus.grammar.PromQLLexer;
+import net.opentsdb.prometheus.grammar.PromQLParser.AddOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.AggregationContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.AndUnlessOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.ByContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.CompareOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.ExpressionContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.FunctionContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.GroupLeftContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.GroupRightContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.GroupingContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.IgnoringContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.InstantSelectorContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.KeywordContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.LabelMatcherContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.LabelMatcherListContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.LabelMatcherOperatorContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.LabelNameContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.LabelNameListContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.LiteralContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.MatrixSelectorContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.MultOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.OffsetContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.OnContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.OrOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.ParameterContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.ParameterListContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.ParensContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.PowOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.UnaryOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.VectorContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.VectorOperationContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.WithoutContext;
+import net.opentsdb.query.DefaultTimeSeriesDataSourceConfig;
+import net.opentsdb.query.QueryMode;
+import net.opentsdb.query.QueryNodeConfig;
+import net.opentsdb.query.SemanticQuery;
+import net.opentsdb.query.TimeSeriesDataSourceConfig;
+import net.opentsdb.query.QueryFillPolicy.FillWithRealPolicy;
+import net.opentsdb.query.filter.ChainFilter;
+import net.opentsdb.query.filter.MetricLiteralFilter;
+import net.opentsdb.query.filter.NotFilter;
+import net.opentsdb.query.filter.QueryFilter;
+import net.opentsdb.query.filter.TagKeyLiteralOrFilter;
+import net.opentsdb.query.filter.TagValueLiteralOrFilter;
+import net.opentsdb.query.filter.TagValueRegexFilter;
+import net.opentsdb.query.interpolation.types.numeric.NumericInterpolatorConfig;
+import net.opentsdb.query.joins.JoinConfig;
+import net.opentsdb.query.joins.JoinConfig.JoinType;
+import net.opentsdb.query.pojo.FillPolicy;
+import net.opentsdb.query.processor.downsample.DownsampleConfig;
+import net.opentsdb.query.processor.expressions.ExpressionConfig;
+import net.opentsdb.query.processor.groupby.GroupByConfig;
+import net.opentsdb.query.processor.rate.RateConfig;
+import net.opentsdb.query.processor.topn.TopNConfig;
+import net.opentsdb.utils.DateTime;
+import net.opentsdb.prometheus.grammar.PromQLParserVisitor;
+
+/**
+ * The start of a PromQL query parsing visitor. Since TSDB doesn't do great with
+ * last values we're defaulting to a 1 hour query range and making everything a
+ * range. We _can_ support instants and will do so.
+ * 
+ * Notes:
+ * <b>RATE:</b>
+ * This one is odd. So from the docs, "rate(http_requests_total[5m])" will give 
+ * the per-second _average_ rate over 5 minutes. Sounds fine. But if we leave 
+ * out the range we should throw an exception cause a rate on an instant doesn't
+ * make sense?
+ * But then we have "rate(http_requests_total[5m])[30m:1m]" which supposedly is
+ * a sub-query that gives "the 5-minute rate" for the past 30m with a 1m resolution.
+ * So it looks like this may do a sliding window of 5m rate averages for 30m
+ * every minute. Blech.
+ * <p>
+ * <b>Downsample:</b>
+ * I think the downsample is always an average. Also, it is a bit confusing when
+ * it's applied in the docs so I'm supporting `[5m:1m]` as a downsample always.
+ * <p>
+ * <b>Misc:</b>
+ * TODO - support instants. We need a config to say how far back the TSD should 
+ * look and then we need to set the "last" flag on the data source.
+ * TODO - RE2 regex syntax to Java. Dunno how different it'd be.
+ * TODO - what's the range `[5m:]` mean??
+ * TODO - ranges at the end of all functions. How do we handle overrides?
+ * TODO - join ops
+ * TODO - power
+ * TODO - tons of functions
+ * TODO - what happens with different ranges in prom? If it's valid then we'd 
+ *        need a set of queries instead of a single query. *sigh*
+ * TODO - ranges on a ranged query. WWPD?
+ * 
+ * @since 3.0
+ */
+public class PromQLParser extends DefaultErrorStrategy implements PromQLParserVisitor {
+  private static final Logger LOG = LoggerFactory.getLogger(PromQLParser.class);
+  
+  private static final Pattern IS_EPOCH = Pattern.compile("^\\d+$");
+  private static final Pattern IS_FLOAT_STEP = Pattern.compile("^[0-9\\.]+$");
+  
+  /** The query we're working on. */
+  protected final String query;
+  protected final String start;
+  protected final String end;
+  
+  /** Can be a duration or a floating point value representing seconds. */
+  protected final String step;
+  
+  /** Naming counters. */
+  protected int metric_counter = 0;
+  protected int expression_counter = 0;
+  
+  /** Tracks counts in a query per node so if we have multiples we don't collide
+   * on the IDs. */
+  protected final Map<Class, Integer> id_counters;
+  
+  /** The last range applied to a metric. */
+  protected final Map<String, String> metric_ranges;
+  
+  /** Sub-queries keyed on the metric node ID. */
+  protected final Map<String, List<QueryNodeConfig>> sub_queries;
+  
+  /** The last node parsed from the visitor. */
+  protected QueryNodeConfig last_node;
+  
+  /** The ID of the last metric parsed. */
+  protected String last_metric_id;
+  
+  /** Default interpolator config. Doesn't look like Prometheus does much
+   * interpolation. TODO - figure it out. */
+  protected NumericInterpolatorConfig default_interperlator = 
+      (NumericInterpolatorConfig) NumericInterpolatorConfig.newBuilder()
+      .setFillPolicy(FillPolicy.NOT_A_NUMBER)
+      .setRealFillPolicy(FillWithRealPolicy.PREFER_NEXT)
+      .setDataType(NumericType.TYPE.toString())
+      .build();
+  
+  /** Default join config for now. */
+  protected JoinConfig join = JoinConfig.newBuilder()
+      .setJoinType(JoinType.NATURAL_OUTER)
+      .setId("default")
+      .build();
+  
+  /**
+   * Default ctor.
+   * @param query A non-null and non-empty query to parse.
+   * @param start The non-null and non-empty start timestamp to parse.
+   * @param end An optional end timestamp. If null or empt we use the current
+   * timestamp.
+   * @param step An optional downsample. 
+   */
+  public PromQLParser(final String query,
+                      final String start,
+                      final String end,
+                      final String step) {
+    this.query = query;
+    id_counters = Maps.newHashMap();
+    metric_ranges = Maps.newHashMap();
+    sub_queries = Maps.newHashMap();
+    
+    // validate and convert timestamps.
+    if (Strings.isNullOrEmpty(start)) {
+      throw new IllegalArgumentException("Missing the start timestamp.");
+    }
+    
+    if (IS_EPOCH.matcher(start).find()) {
+      this.start = start;
+    } else {
+      Instant temp = Instant.parse(start);
+      // TODO - ms
+      this.start = Long.toString(temp.getEpochSecond());
+    }
+    
+    if (!Strings.isNullOrEmpty(end)) {
+      if (IS_EPOCH.matcher(end).find()) {
+        this.end = end;
+      } else {
+        Instant temp = Instant.parse(end);
+        this.end = Long.toString(temp.getEpochSecond());
+      }
+    } else {
+      this.end = Long.toString(DateTime.currentTimeMillis() / 1000);
+    }
+    
+    if (!Strings.isNullOrEmpty(step) && IS_FLOAT_STEP.matcher(step).find()) {
+      final double float_step = Double.parseDouble(step);
+      // TODO - ignoring float values for now but we could assume that'd be in ms
+      this.step = ((int) float_step) + "s";
+    } else {
+      this.step = step;
+    }
+  }
+  
+  /**
+   * Parses the given query and turns it into a SemanticQuery builder.
+   * @return A non-null semantic query builder if successful. Throws an exception
+   * if not.
+   */
+  public SemanticQuery.Builder parse() {
+    final PromQLLexer lexer = new PromQLLexer(new ANTLRInputStream(query));
+    final CommonTokenStream tokens = new CommonTokenStream(lexer);
+    net.opentsdb.prometheus.grammar.PromQLParser parser = 
+        new net.opentsdb.prometheus.grammar.PromQLParser(tokens);
+    parser.removeErrorListeners(); // suppress logging to stderr.
+    parser.setErrorHandler(this);
+    
+    // parse.
+    parser.expression().accept(this);
+    
+    // TODO - add time shifts if ranges are different and appear in an expression
+    // otherwise if timeshifts differ we need to find a way to query just what
+    // we need. hmm.
+    final SemanticQuery.Builder builder = SemanticQuery.newBuilder()
+        .setStart(start)
+        .setEnd(end)
+        .setMode(QueryMode.SINGLE);
+    for (final Entry<String, List<QueryNodeConfig>> sub_query : sub_queries.entrySet()) {
+      List<QueryNodeConfig> list = sub_query.getValue();
+      for (int i = 0; i < list.size(); i++) {
+        builder.addExecutionGraphNode(list.get(i));
+      }
+    }
+    return builder;
+  }
+
+  @Override
+  public Object visit(ParseTree tree) {
+    return tree.accept(this);
+  }
+
+  @Override
+  public Object visitChildren(RuleNode node) {
+    // no idea what this is.
+    throw new UnsupportedOperationException("Unimplemented visitor: " + node);
+  }
+
+  @Override
+  public Object visitTerminal(TerminalNode node) {
+    return node.getText();
+  }
+
+  @Override
+  public Object visitErrorNode(ErrorNode node) {
+    throw new UnsupportedOperationException("Unimplemented visitor: " + node);
+  }
+
+  @Override
+  public Object visitExpression(ExpressionContext ctx) {
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      Object child = ctx.getChild(i).accept(this);
+      if (!child.equals("<EOF>")) {
+        last = child;
+      }
+    }
+    return last;
+  }
+
+  @Override
+  public Object visitVectorOperation(VectorOperationContext ctx) {
+    // Likely an expression but could be some other ops.
+    if (ctx.getChildCount() == 1) {
+      // simple
+      return ctx.getChild(0).accept(this);
+    }
+    
+    // an expression most definitly I think.
+    Object left_operand = ctx.getChild(0).accept(this);
+    String left_metric = last_metric_id;
+    
+    Object operand = ctx.getChild(1).accept(this);
+    
+    Object right_operand = ctx.getChild(2).accept(this);
+    int exp_cnt = expression_counter++;
+    String exp_id = "Expression_" + exp_cnt;
+    ExpressionConfig.Builder builder = ExpressionConfig.newBuilder()
+        .setAs(exp_id)
+        .setJoinConfig(join)
+        .addInterpolatorConfig(default_interperlator)
+        .setId(exp_id);
+    List<QueryNodeConfig> srcs = sub_queries.get(left_metric);
+    builder.addSource(srcs.get(srcs.size() - 1).getId());
+    
+    StringBuilder string_builder = new StringBuilder();
+    if (left_operand instanceof QueryNodeConfig || 
+        (left_operand instanceof String && ((String) left_operand).equals(")"))) {
+      string_builder.append(left_metric)
+                    .append(" ");
+    } else if (left_operand instanceof String) {
+      // could be literal
+      string_builder.append((String) left_operand)
+                    .append(" ");
+    } else {
+      throw new IllegalStateException("Unknown operand: " + left_operand);
+    }
+    string_builder.append(operand)
+                  .append(" ");
+    if (right_operand instanceof QueryNodeConfig) {
+      string_builder.append(last_metric_id);
+      builder.addSource(((QueryNodeConfig) right_operand).getId());
+    } else if (right_operand instanceof String) {
+      // could be literal
+      string_builder.append((String) right_operand);
+    }
+    builder.setExpression(string_builder.toString());
+    last_metric_id = exp_id;
+    ExpressionConfig config = builder.build();
+    last_node = config;
+    sub_queries.put(last_metric_id, Lists.newArrayList(config));
+    return config;
+  }
+
+  @Override
+  public Object visitUnaryOp(UnaryOpContext ctx) {
+    throw new UnsupportedOperationException("Unimplemented visitor: " + ctx);
+  }
+
+  @Override
+  public Object visitPowOp(PowOpContext ctx) {
+    throw new UnsupportedOperationException("Unimplemented visitor: " + ctx);
+  }
+
+  @Override
+  public Object visitMultOp(MultOpContext ctx) {
+    // can be * or / depending on text I believe.
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      last = ctx.getChild(i).accept(this);
+    }
+    return last;
+  }
+
+  @Override
+  public Object visitAddOp(AddOpContext ctx) {
+    // Add two values.
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      last = ctx.getChild(i).accept(this);
+    }
+    return last;
+  }
+
+  @Override
+  public Object visitCompareOp(CompareOpContext ctx) {
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      last = ctx.getChild(i).accept(this);
+    }
+    return last;
+  }
+
+  @Override
+  public Object visitAndUnlessOp(AndUnlessOpContext ctx) {
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      last = ctx.getChild(i).accept(this);
+    }
+    return last;
+  }
+
+  @Override
+  public Object visitOrOp(OrOpContext ctx) {
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      last = ctx.getChild(i).accept(this);
+    }
+    return last;
+  }
+
+  @Override
+  public Object visitVector(VectorContext ctx) {
+    // just a pass through.
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      last = ctx.getChild(i).accept(this);
+    }
+    return last;
+  }
+
+  @Override
+  public Object visitParens(ParensContext ctx) {
+    // skip through.
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      last = ctx.getChild(i).accept(this);
+    }
+    return last;
+  }
+
+  @Override
+  public Object visitInstantSelector(InstantSelectorContext ctx) {
+    // The metric we're fetching. May be nested in a vector and/or matrix.
+    int mc = metric_counter++;
+    final String metric_id = "m" + mc;
+    final String metric = (String) ctx.getChild(0).accept(this);
+    final TimeSeriesDataSourceConfig.Builder builder = 
+        DefaultTimeSeriesDataSourceConfig.newBuilder()
+          .setMetric(MetricLiteralFilter.newBuilder()
+              .setMetric(metric)
+              .build())
+          .setId(metric_id);
+    
+    DownsampleConfig ds = null;
+    if (!Strings.isNullOrEmpty(step)) {
+      ds = DownsampleConfig.newBuilder()
+          .setAggregator("avg")
+          .setInterval(step)
+          .addInterpolatorConfig(default_interperlator)
+          .setId(getNodeId(DownsampleConfig.class, last_metric_id))
+          .addSource(metric_id)
+          .build();
+    }
+    
+    if (ctx.getChildCount() == 1) {
+      final TimeSeriesDataSourceConfig config = (TimeSeriesDataSourceConfig) 
+          builder.build();
+      last_metric_id = config.getId();
+      final List<QueryNodeConfig> sub_queries = Lists.newArrayList(config);
+      this.sub_queries.put(config.getId(), sub_queries);
+      if (ds != null) {
+        sub_queries.add(ds);
+        last_node = ds;
+        return ds;
+      }
+      last_node = config;
+      return config;
+    }
+    
+    Object last = null;
+    // Next we can have a matrix selector (range via []) or filters (in curlies: {} )
+    for (int i = 1; i < ctx.getChildCount(); i++) {
+      String delimiter = (String) ctx.getChild(i).accept(this);
+      if (delimiter.equals("{")) {
+        i++;
+        Object filter = ctx.getChild(i).accept(this);
+        builder.setQueryFilter((QueryFilter) filter);
+        i++;
+        delimiter = (String) ctx.getChild(i).accept(this);
+        if (!delimiter.equals("}")) {
+          throw new IllegalStateException("Unexpected tag filter delimiter: " 
+              + delimiter);
+        }
+        // filter
+      }
+    }
+    
+    TimeSeriesDataSourceConfig config = (TimeSeriesDataSourceConfig) builder.build();
+    last_metric_id = config.getId();
+    final List<QueryNodeConfig> sub_queries = Lists.newArrayList(config);
+    this.sub_queries.put(config.getId(), Lists.newArrayList(config));
+    if (ds != null) {
+      sub_queries.add(ds);
+      last_node = ds;
+      return ds;
+    }
+    return config;
+  }
+
+  @Override
+  public Object visitLabelMatcher(LabelMatcherContext ctx) {
+    // A tag filter. 
+    // TODO - see if this is a VALUE matcher too! If so... meh
+    // otherwise it's a filter.
+    // TODO - de-escaping
+    String tag_key = (String) ctx.getChild(0).accept(this);
+    if (ctx.getChildCount() == 1) {
+      // just a tag key filter.
+      return TagKeyLiteralOrFilter.newBuilder()
+          .setFilter(tag_key)
+          .build();
+    }
+    // get the op next
+    String op = (String) ctx.getChild(1).accept(this);
+    
+    // get the value filter
+    // TODO - de-escape
+    String value_filter = (String) ctx.getChild(2).accept(this);
+    // strip the quotes at the top and end.
+    value_filter = value_filter.trim();
+    value_filter = value_filter.substring(1, value_filter.length() - 1);
+    
+    QueryFilter filter = null;
+    if (op.equals("=")) {
+      filter = TagValueLiteralOrFilter.newBuilder()
+          .setKey(tag_key)
+          .setFilter(value_filter)
+          .build();
+    } else if (op.equals("!=")) {
+      filter = NotFilter.newBuilder()
+          .setFilter(TagValueLiteralOrFilter.newBuilder()
+              .setKey(tag_key)
+              .setFilter(value_filter)
+              .build())
+          .build();
+    } else if (op.equals("=~")) {
+      filter = TagValueRegexFilter.newBuilder()
+          .setKey(tag_key)
+          .setFilter(anchorRegex(value_filter))
+          .build();
+    } else if (op.equals("!~")) {
+      filter = NotFilter.newBuilder()
+          .setFilter(TagValueRegexFilter.newBuilder()
+              .setKey(tag_key)
+              .setFilter(anchorRegex(value_filter))
+              .build())
+          .build();
+    }
+    return filter;
+  }
+
+  @Override
+  public Object visitLabelMatcherOperator(LabelMatcherOperatorContext ctx) {
+    // an op like `=` or `~` or `!~`
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      last = ctx.getChild(i).accept(this);
+    }
+    return last;
+  }
+
+  @Override
+  public Object visitLabelMatcherList(LabelMatcherListContext ctx) {
+    // chain filter!
+    if (ctx.getChildCount() == 1) {
+      return ctx.getChild(0).accept(this);
+    }
+    
+    ChainFilter.Builder builder = ChainFilter.newBuilder();
+    for (int i = 0; i < ctx.getChildCount(); i += 2) {
+      QueryFilter filter = (QueryFilter) ctx.getChild(i).accept(this);
+      builder.addFilter(filter);
+    }
+    return builder.build();
+  }
+
+  @Override
+  public Object visitMatrixSelector(MatrixSelectorContext ctx) {
+    // range selector. 
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      final Object temp = ctx.getChild(i).accept(this);
+      if (temp instanceof QueryNodeConfig) {
+        last = temp;
+      }
+      if (temp instanceof String) {
+        // assume a range!
+        String range = (String) temp;
+        metric_ranges.put(last_metric_id, range);
+        // check for a downsample
+        if (range.contains(":")) {
+          // add a DS node!
+          String[] splits = range.split(":");
+          if (splits.length == 1 || splits[1].equals("]")) {
+            // TODO - no-op, they did "1m:" for some reason. Why?
+          } else {
+            List<QueryNodeConfig> nodes = sub_queries.get(last_metric_id);
+            if (nodes.size() >= 2 && nodes.get(1) instanceof DownsampleConfig) {
+              final DownsampleConfig.Builder builder = 
+                  (DownsampleConfig.Builder) nodes.get(1).toBuilder();
+              builder.setInterval(splits[1].substring(0, splits[1].length() - 1));
+              if (last_node == nodes.get(1)) {
+                last_node = builder.build();
+                nodes.set(1, last_node);
+              } else {
+                nodes.set(1, builder.build());
+              }
+            } else {
+              DownsampleConfig ds = DownsampleConfig.newBuilder()
+                  .setAggregator("avg")
+                  .setInterval(splits[1].substring(0, splits[1].length() - 1))
+                  .addInterpolatorConfig(default_interperlator)
+                  .setId(getNodeId(DownsampleConfig.class, last_metric_id))
+                  .addSource(last_metric_id)
+                  .build();
+              nodes.add(ds);
+              last_node = ds;
+            }
+          }
+        }
+      }
+    }
+    
+    return last;
+  }
+
+  @Override
+  public Object visitOffset(OffsetContext ctx) {
+    // 0 is the metric
+    // 1 is the keyword offset.
+    // 2 is the duration.
+    ctx.getChild(0).accept(this);
+    String offset = (String) ctx.getChild(2).accept(this);
+    List<QueryNodeConfig> sub_query = sub_queries.get(last_metric_id);
+    TimeSeriesDataSourceConfig.Builder builder = 
+        (TimeSeriesDataSourceConfig.Builder) sub_query.get(0).toBuilder();
+    builder.setTimeShiftInterval(offset);
+    sub_query.set(0, builder.build());
+    
+    return offset;
+  }
+
+  @Override
+  public Object visitFunction(FunctionContext ctx) {
+    // function names, e.g. `rate`
+    // NOTE: topk/bottomk are aggregations, not functions. *sigh*
+    // function ID is the first child
+    final String function_id = (String) ctx.getChild(0).accept(this);
+    if (function_id.equalsIgnoreCase("rate")) {
+      return handleRate(ctx);
+    } else if (function_id.endsWith("_over_time")) {
+      return handleOverTime(function_id, ctx);
+    } else {
+      throw new UnsupportedOperationException("Unimplemented function: " + function_id);
+    }
+  }
+
+  @Override
+  public Object visitParameter(ParameterContext ctx) {
+    // function param.
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      last = ctx.getChild(i).accept(this);
+    }
+    return last;
+  }
+
+  @Override
+  public Object visitParameterList(ParameterListContext ctx) {
+    // list of function params.
+    List<Object> parameters = Lists.newArrayList();
+    // 0 and the last are the parens.
+    for (int i = 1; i < ctx.getChildCount(); i += 2) {
+      parameters.add(ctx.getChild(i).accept(this));
+    }
+    return parameters;
+  }
+
+  @Override
+  public Object visitAggregation(AggregationContext ctx) {
+    // Typically a group by but also the other agg operators from:
+    // https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
+    // looks like 0 is the aggregator
+    // and 1 or 2 can be the BY context or the Parameter context.
+
+    String aggregator = ((String) ctx.getChild(0).accept(this)).toLowerCase();
+    if (aggregator.equals("sum") ||
+        aggregator.equals("min") ||
+        aggregator.equals("max") ||
+        aggregator.equals("avg") ||
+        aggregator.equals("count")) {
+      Set<String> keys = null;
+      if (ctx.getChildCount() == 2) {
+        // group-all
+        ctx.getChild(1).accept(this);
+      } else {
+        if (ctx.getChild(1) instanceof ByContext) {
+          keys = (Set<String>) ctx.getChild(1).accept(this);
+          ctx.getChild(2).accept(this);  
+        } else {
+          ctx.getChild(1).accept(this);
+          keys = (Set<String>) ctx.getChild(2).accept(this);
+        }
+        
+      }
+      // check for other gb's in this sub graph. Could happen.
+      List<QueryNodeConfig> sub_graph = sub_queries.get(last_metric_id);
+      int gb_count = 0;
+      for (int i = 0; i < sub_graph.size(); i++) {
+        if (sub_graph.get(i) instanceof GroupByConfig) {
+          gb_count++;
+        }
+      }
+      GroupByConfig gb = GroupByConfig.newBuilder()
+          .setAggregator(aggregator)
+          .setTagKeys(keys)
+          .addInterpolatorConfig(default_interperlator)
+          .addSource(last_node.getId())
+          .setId("group_by_" + gb_count + "_" + last_metric_id)
+          .build();
+      last_node = gb;
+      if (sub_graph == null || sub_graph.isEmpty()) {
+        throw new IllegalStateException("Missing subgraph for " + last_metric_id);
+      }
+      sub_graph.add(gb);
+      return gb;
+    } else if (aggregator.equals("topk") ||
+               aggregator.equals("bottomk")) {
+      List<Object> parameters = (List<Object>) ctx.getChild(1).accept(this);
+      if (!(parameters.get(0) instanceof String)) {
+        throw new IllegalArgumentException("First parameter must be an integer.");
+      }
+      int count = Integer.parseInt((String) parameters.get(0));
+      
+      List<QueryNodeConfig> sub_query = sub_queries.get(last_metric_id);
+      TopNConfig.Builder builder = TopNConfig.newBuilder()
+          .setAggregator("avg") // TODO - not in the docs... look at the code
+          .setCount(count)
+          .setTop(true)
+          .addSource(sub_query.get(sub_query.size() - 1).getId())
+          .setId(getNodeId(TopNConfig.class, last_metric_id));
+      if (aggregator.equalsIgnoreCase("bottomk")) {
+        builder.setTop(false);
+      }
+      last_node = builder.build();
+      sub_query.add(last_node);
+      return last_node;
+    } else {
+      throw new IllegalStateException("Unimplemented aggregation operation " + aggregator);
+    }
+  }
+
+  @Override
+  public Object visitBy(ByContext ctx) {
+    // yup, the group by context:
+    // sum(rate(http_request_duration_seconds_bucket{le="0.3"}[5m])) by (job)
+    // 0 == 'by' keyword
+    // 1 == LabelNameListContext
+    return ctx.getChild(1).accept(this);
+  }
+
+  @Override
+  public Object visitWithout(WithoutContext ctx) {
+    throw new UnsupportedOperationException("Unimplemented visitor: " + ctx);
+  }
+
+  @Override
+  public Object visitGrouping(GroupingContext ctx) {
+    throw new UnsupportedOperationException("Unimplemented visitor: " + ctx);
+  }
+
+  @Override
+  public Object visitOn(OnContext ctx) {
+    throw new UnsupportedOperationException("Unimplemented visitor: " + ctx);
+  }
+
+  @Override
+  public Object visitIgnoring(IgnoringContext ctx) {
+    // THIS is a join operator wherein we're choosing the tags to match on.
+    // I need a way to handle this as the example is:
+    // method_code:http_errors:rate5m{code="500"} / ignoring(code) method:http_requests:rate5m
+    // wherein for the second instant we are ignoring the "code" tag so we can join across.
+    // We can grab the tag keys from the first metrics filters but how does this
+    // square with group bys?
+    // https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching
+    throw new UnsupportedOperationException("Unimplemented visitor: " + ctx);
+  }
+
+  @Override
+  public Object visitGroupLeft(GroupLeftContext ctx) {
+    // https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching
+    // also a join operator
+    throw new UnsupportedOperationException("Unimplemented visitor: " + ctx);
+  }
+
+  @Override
+  public Object visitGroupRight(GroupRightContext ctx) {
+    // https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching
+    // also a join operator
+    throw new UnsupportedOperationException("Unimplemented visitor: " + ctx);
+  }
+
+  @Override
+  public Object visitLabelName(LabelNameContext ctx) {
+    // The tag key.
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      last = ctx.getChild(i).accept(this);
+    }
+    return last;
+  }
+
+  @Override
+  public Object visitLabelNameList(LabelNameListContext ctx) {
+    // a list of tag keys used for a group by operation.
+    Set<String> tag_keys = Sets.newHashSet();
+    for (int i = 1; i < ctx.getChildCount() - 1; i++) {
+      final String param = (String) ctx.getChild(i).accept(this);
+      if (param.equals(",")) {
+        continue;
+      }
+      tag_keys.add(param);
+    }
+    return tag_keys;
+  }
+
+  @Override
+  public Object visitKeyword(KeywordContext ctx) {
+    // not sure yet....
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      last = ctx.getChild(i).accept(this);
+    }
+    return last;
+  }
+
+  @Override
+  public Object visitLiteral(LiteralContext ctx) {
+    // here's where we get something like `2` as a literal.
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      last = ctx.getChild(i).accept(this);
+    }
+    return last;
+  }
+
+  @Override
+  public void recover(final Parser recognizer, final RecognitionException e) {
+    final StringBuilder buf = new StringBuilder()
+        .append("Error at line (")
+        .append(e.getOffendingToken().getLine())
+        .append(":")
+        .append(e.getOffendingToken().getCharPositionInLine())
+        .append(") ");
+    if (e instanceof NoViableAltException) {
+      final TokenStream tokens = recognizer.getInputStream();
+      final NoViableAltException ex = (NoViableAltException) e;
+      buf.append("Expression may not be complete. '");
+      if (tokens != null) {
+        if (ex.getStartToken().getType() == Token.EOF) {
+          buf.append("<EOF>");
+        } else {
+          buf.append(tokens.getText(ex.getStartToken(), ex.getOffendingToken()));
+        }
+      } else {
+        buf.append(query);
+      }
+      buf.append("'");
+    } else if (e instanceof InputMismatchException) {
+      final InputMismatchException ex = (InputMismatchException) e;
+      buf.append("Missmatched input. Got '")
+         .append(getTokenErrorDisplay(ex.getOffendingToken()))
+         .append("' but expected '")
+         .append(ex.getExpectedTokens().toString(recognizer.getVocabulary()))
+         .append("'");
+    } else if (e instanceof FailedPredicateException) {
+      final FailedPredicateException ex = (FailedPredicateException) e;
+      final String rule_name = recognizer
+          .getRuleNames()[recognizer.getContext().getRuleIndex()];
+      buf.append(" Predicate error with rule '")
+         .append(rule_name)
+         .append("' ")
+         .append(ex.getMessage());
+    } else {
+      buf.append("Unexpected error at token '")
+         .append(getTokenErrorDisplay(e.getOffendingToken()))
+         .append("'");
+    }
+
+    for (ParserRuleContext context = recognizer.getContext();
+        context != null; context = context.getParent()) {
+      context.exception = e;
+    }
+    throw new ParseCancellationException(buf.toString(), e);
+  }
+
+  /** Make sure we don't attempt to recover inline; if the parser
+   *  successfully recovers, it won't throw an exception.
+   */
+  @Override
+  public Token recoverInline(final Parser recognizer)
+      throws RecognitionException {
+    final InputMismatchException e = new InputMismatchException(recognizer);
+    recover(recognizer, e);
+    return null;
+  }
+
+  /** Make sure we don't attempt to recover from problems in subrules. */
+  @Override
+  public void sync(final Parser recognizer) { }
+
+  /**
+   * Parses a duration, e.g. [5m] or [5m:1m].
+   * @param duration A non-null duration to parse.
+   * @return The duration in milliseconds.
+   */
+  static long parseDuration(final String duration) {
+    // can be concatenated.
+    long parsed = 0;
+    String temp = "";
+    for (int i = 1; i < 
+        (duration.charAt(duration.length() - 1) == ']' ? duration.length() - 1 : duration.length()); i++) {
+      final char c = duration.charAt(i);
+      if (c == ':') {
+        // resolution so break
+        break;
+      }
+      if (Character.isDigit(c)) {
+        temp += duration.charAt(i);
+      } else {
+        long digits = Long.parseLong(temp);
+        switch (c) {
+        case 'm':
+          if (i + 1 < duration.length() && duration.charAt(i + 1) == 's') {
+            // ms
+            parsed += digits;
+          } else {
+            // minutes
+            parsed += (digits * 60L * 1000L);
+          }
+          break;
+        case 's':
+          parsed += (digits * 1000L);
+          break;
+        case 'h':
+          parsed += (digits * 60L * 60L * 1000L);
+          break;
+        case 'd':
+          parsed += digits * 86400L * 1000L;
+          break;
+        case 'w':
+          parsed += digits * 7L * 86400L * 1000L;
+          break;
+        case 'y':
+          parsed += digits * 365L * 86400L * 1000L;
+          break;
+        default:
+          throw new IllegalArgumentException("Unhandled duration suffix [" + c 
+              + "] from " + duration);
+        }
+      }
+    }
+    return parsed;
+  }
+
+  /**
+   * Pulls out just the duration from a range in case it includes a downsample.
+   * @param range The non-null range to parse.
+   * @return The parsed duration.
+   */
+  static String durationFromRange(final String range) {
+    int index = range.indexOf(":");
+    if (index > -1) {
+      return range.substring(1, index);
+    }
+    return range.substring(1, range.length() - 1);
+  }
+  
+  /**
+   * Pulls out the resolution (downsample) for the query, i.e. the bit after the
+   * colon.
+   * @param range The non-null range to parse.
+   * @return The resolution if found.
+   */
+  static String resolutionFromRange(final String range) {
+    int index = range.indexOf(":");
+    if (index < 0) {
+      throw new IllegalStateException("Missing resolution from range: " + range);
+    }
+    return range.substring(index + 1, range.length() - 1);
+  }
+
+  /**
+   * Helper to check the regex for anchors and append them if needed.
+   * @param pattern The non-null pattern to validate.
+   * @return The updated pattern.
+   */
+  static String anchorRegex(final String pattern) {
+    if (pattern.startsWith("^")) {
+      if (pattern.endsWith("$")) {
+        return pattern;
+      }
+      return pattern + "$";
+    } else if (pattern.endsWith("$")) {
+      return "^" + pattern;
+    } else {
+      return "^" + pattern + "$";
+    }
+  }
+  
+  /**
+   * Handles setting up a rate and adjusts the range and downsample if required.
+   * @param ctx The non-null context to parse.
+   * @return the last node parsed.
+   */
+  Object handleRate(final FunctionContext ctx) {
+    // 1 == (
+    // 2 == instant
+    String range = null;
+    ctx.getChild(2).accept(this);
+    // 3 == )
+    if (ctx.getChildCount() >= 5) {
+      // 4 == a range and resolution
+      range = (String) ctx.getChild(4).accept(this);
+    }
+    
+    String resolution = null;
+    String interval = "1s";
+    if (!Strings.isNullOrEmpty(range)) {
+      // fun is... The resolution is the previous "ragne" (WTF?) and the new
+      // query range is THIS range with a downsample....
+      String existing_range = metric_ranges.get(last_metric_id);
+      if (Strings.isNullOrEmpty(existing_range)) {
+        throw new IllegalStateException("Missing the existing range for " + last_metric_id);
+      }
+      interval = durationFromRange(existing_range);
+      resolution = resolutionFromRange(range);
+      metric_ranges.put(last_metric_id, range);
+    }
+    
+    QueryNodeConfig return_value;
+    final String id = getNodeId(RateConfig.class, last_metric_id);
+    RateConfig.Builder rate_builder = RateConfig.newBuilder()
+        .setInterval("1s") // always 1s apparently.
+        .setCounter(true)  // and always a counter
+        .setDropResets(true)
+        .setId(id);
+    List<QueryNodeConfig> sub_query = sub_queries.get(last_metric_id);
+    if (sub_query.size() == 2 && 
+        sub_query.get(1) instanceof DownsampleConfig) {
+      rate_builder.addSource(sub_query.get(0).getId());
+      
+      // rebuild downsample as we have a new resolution
+      DownsampleConfig rebuilt = ((DownsampleConfig) sub_query.get(1)).toBuilder()
+          .setInterval(resolution)
+          .addSource(id)
+          .build();
+      sub_query.set(1, rebuilt);
+      
+      // insert between the metric and downsampler and note that we may change it
+      return_value = rate_builder.build();
+      sub_query.add(1, return_value);
+    } else {
+      // just appending
+      rate_builder.addSource(sub_query.get(sub_query.size() - 1).getId());
+      return_value = rate_builder.build();
+      sub_query.add(return_value);
+      last_node = return_value;
+      
+      if (range != null) {
+        DownsampleConfig ds = DownsampleConfig.newBuilder()
+            .setAggregator("avg")
+            .setInterval(resolution)
+            .addInterpolatorConfig(default_interperlator)
+            .setId(getNodeId(DownsampleConfig.class, last_metric_id))
+            .addSource(return_value.getId())
+            .build();
+        
+        return_value = ds;
+        sub_query.add(ds);
+        last_node = return_value;
+      }
+    }
+    
+    return return_value;
+  }
+  
+  /**
+   * Parses a downsample-all node from the *_over_time function.
+   * @param name The non-null name of the function (to pull out the aggregator)
+   * @param ctx The non-null context.
+   * @return The last node parsed.
+   */
+  Object handleOverTime(final String name, final FunctionContext ctx) {
+    String[] components = name.split("_");
+    // 0 == function
+    // 1 == open parens
+    // 2 == range vector
+    // 3 == close parens
+    ctx.getChild(2).accept(this);
+    
+    if (components[0].equals("stddev")) {
+      components[0] = "dev";
+    } else if (!components[0].equals("avg") && 
+               !components[0].equals("min") &&
+               !components[0].equals("max") &&
+               !components[0].equals("sum") &&
+               !components[0].equals("count")) {
+      throw new IllegalArgumentException("No implementation yet over_time for " 
+               + components[0]);
+    }
+    
+    List<QueryNodeConfig> sub_query = sub_queries.get(last_metric_id);
+    DownsampleConfig.Builder builder = DownsampleConfig.newBuilder()
+        .setAggregator(components[0])
+        .setRunAll(true)
+        .setInterval("0all")
+        .addSource(sub_query.get(sub_query.size() - 1).getId())
+        .addInterpolatorConfig(default_interperlator)
+        .setId(getNodeId(DownsampleConfig.class, last_metric_id));
+    last_node = builder.build();
+    sub_query.add(last_node);
+    return last_node;
+    
+  }
+  
+  /**
+   * Helper to increment the node type counter and generate a useful node ID. 
+   * @param clazz The non-null class we're building a node for.
+   * @param metric_id The non-null metric ID.
+   * @return The non-null node ID to use.
+   */
+  String getNodeId(final Class clazz, final String metric_id) {
+    Integer counter = id_counters.get(clazz);
+    if (counter == null) {
+      id_counters.put(clazz, 1);
+      return clazz.getSimpleName() + "_" + metric_id;
+    }
+    
+    String id = clazz.getSimpleName() + "_" + counter + "_" + metric_id;
+    id_counters.put(clazz, counter + 1);
+    return id;
+  }
+
+}

--- a/implementation/prometheus/src/main/java/net/opentsdb/query/execution/prometheus/PrometheusQuerySerdes.java
+++ b/implementation/prometheus/src/main/java/net/opentsdb/query/execution/prometheus/PrometheusQuerySerdes.java
@@ -1,0 +1,344 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2020  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.execution.prometheus;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.collect.Lists;
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+import com.stumbleupon.async.DeferredGroupException;
+
+import net.opentsdb.common.Const;
+import net.opentsdb.data.PartialTimeSeries;
+import net.opentsdb.data.TimeSeries;
+import net.opentsdb.data.TimeSeriesByteId;
+import net.opentsdb.data.TimeSeriesDataType;
+import net.opentsdb.data.TimeSeriesStringId;
+import net.opentsdb.data.TimeSeriesValue;
+import net.opentsdb.data.TimeStamp;
+import net.opentsdb.data.TimeStamp.Op;
+import net.opentsdb.data.TypedTimeSeriesIterator;
+import net.opentsdb.data.types.numeric.NumericArrayType;
+import net.opentsdb.data.types.numeric.NumericSummaryType;
+import net.opentsdb.data.types.numeric.NumericType;
+import net.opentsdb.exceptions.QueryExecutionException;
+import net.opentsdb.query.QueryContext;
+import net.opentsdb.query.QueryNode;
+import net.opentsdb.query.QueryResult;
+import net.opentsdb.query.serdes.SerdesCallback;
+import net.opentsdb.query.serdes.SerdesOptions;
+import net.opentsdb.query.serdes.TimeSeriesSerdes;
+import net.opentsdb.stats.Span;
+import net.opentsdb.utils.Exceptions;
+import net.opentsdb.utils.JSON;
+
+/**
+ * Super simple prometheus query range serialization implementation. It only 
+ * handles actual data, returning a status of "success" regardless of whether or
+ * not data has been found.
+ * 
+ * TODO - parallelization.
+ * 
+ * @since 3.0
+ */
+public class PrometheusQuerySerdes implements TimeSeriesSerdes {
+  private static final Logger LOG = LoggerFactory.getLogger(
+      PrometheusQuerySerdes.class);
+  
+  /** The query context. */
+  private final QueryContext context;
+  
+  /** The options for this serialization. */
+  private final SerdesOptions options;
+  
+  /** The query start and end timestamps. */
+  private final TimeStamp start;
+  private final TimeStamp end;
+  private final OutputStream stream;
+  
+  private List<byte[]> serialized_results = Lists.newArrayList();
+  
+  
+  public PrometheusQuerySerdes(final QueryContext context,
+                               final SerdesOptions options,
+                               final OutputStream stream) {
+    if (stream == null) {
+      throw new IllegalArgumentException("Stream cannot be null.");
+    }
+    this.context = context;
+    this.options = options;
+    this.stream = stream;
+
+    start = context.query().startTime();
+    end = context.query().endTime();
+  }
+  
+  @Override
+  public Deferred<Object> serialize(final QueryResult result, final Span span) {
+    if (result == null) {
+      throw new IllegalArgumentException("Data may not be null.");
+    }
+    
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    JsonGenerator json;
+    try {
+      json = JSON.getFactory().createGenerator(baos);
+    } catch (IOException e1) {
+      throw new RuntimeException("Failed to instantiate a JSON "
+          + "generator", e1);
+    }
+    
+    final List<TimeSeries> series;
+    final List<Deferred<TimeSeriesStringId>> deferreds;
+    if (result.idType() == Const.TS_BYTE_ID) {
+      series = result.timeSeries();
+      deferreds = Lists.newArrayListWithCapacity(series.size());
+      for (final TimeSeries ts : result.timeSeries()) {
+        deferreds.add(((TimeSeriesByteId) ts.id()).decode(false, span));
+      }
+    } else {
+      series = null;
+      deferreds = null;
+    }
+
+    /**
+     * Performs the serialization after determining if the serializations
+     * need to resolve series IDs.
+     */
+    class ResolveCB implements Callback<Object, ArrayList<TimeSeriesStringId>> {
+
+      @Override
+      public Object call(final ArrayList<TimeSeriesStringId> ids)
+          throws Exception {
+        try {
+          // assume array context here.
+          for (int i = 0; i < (series != null ? series.size() : result.timeSeries().size()); i++) {
+            final TimeSeries ts = series != null ? series.get(i) : result.timeSeries().get(i);
+            serializeSeries(ts, ids != null ? ids.get(i) : (TimeSeriesStringId) ts.id(), json, result);
+          }
+          
+          json.close();
+          final byte[] serialized = baos.toByteArray();
+          synchronized (serialized_results) {
+            serialized_results.add(serialized);
+          }
+          return Deferred.fromResult(null);
+        } catch (Exception e) {
+          LOG.error("Unexpected exception", e);
+          return Deferred.fromError(new QueryExecutionException(
+              "Unexpected exception "
+                  + "serializing: " + result, 500, e));
+        }
+      }
+
+    }
+
+    class ErrorCB implements Callback<Object, Exception> {
+      @Override
+      public Object call(final Exception ex) throws Exception {
+        if (ex instanceof DeferredGroupException) {
+          throw (Exception) Exceptions.getCause((DeferredGroupException) ex);
+        }
+        throw ex;
+      }
+    }
+
+    try {
+      if (deferreds != null) {
+        return Deferred.groupInOrder(deferreds)
+            .addCallback(new ResolveCB())
+            .addErrback(new ErrorCB());
+      } else {
+        return Deferred.fromResult(new ResolveCB().call(null));
+      }
+    } catch (InterruptedException e) {
+      throw new QueryExecutionException("Failed to resolve IDs", 500, e);
+    } catch (Exception e) {
+      LOG.error("Unexpected exception", e);
+      throw new QueryExecutionException("Failed to resolve IDs", 500, e);
+    }
+  }
+
+  @Override
+  public void serialize(final PartialTimeSeries series, 
+                        final SerdesCallback callback, 
+                        final Span span) {
+    throw new UnsupportedOperationException("Not implemented yet.");
+  }
+
+  @Override
+  public void serializeComplete(Span span) {
+    JsonGenerator json;
+    try {
+      json = JSON.getFactory().createGenerator(stream);
+    } catch (IOException e1) {
+      throw new RuntimeException("Failed to instantiate a JSON "
+          + "generator", e1);
+    }
+    try {
+      json.writeStartObject();
+      // TODO - errors!
+      json.writeStringField("status", "success");
+      json.writeObjectFieldStart("data");
+      // TODO - other types?
+      json.writeStringField("resultType", "matrix");
+      json.writeArrayFieldStart("result");
+      for (int i = 0; i < serialized_results.size(); i++) {
+        if (serialized_results.get(i) == null) {
+          continue;
+        }
+        if (i > 0) {
+          json.writeRaw(',');
+        }
+        json.writeRaw(new String(serialized_results.get(i), Const.UTF8_CHARSET));
+        serialized_results.set(i, null);
+      }
+      // end results.
+      json.writeEndArray();
+
+      // end data
+      json.writeEndObject();
+      
+      // end outer object
+      json.writeEndObject();
+      json.flush();
+    } catch (IOException e) {
+      throw new QueryExecutionException("Failure closing serializer", 500, e);
+    }
+  }
+
+  @Override
+  public void deserialize(final QueryNode node, final Span span) {
+    throw new UnsupportedOperationException("Not implemented yet.");
+  }
+
+  void serializeSeries(final TimeSeries series, final TimeSeriesStringId id,
+      final JsonGenerator json, final QueryResult result) throws IOException {
+    synchronized (this) {
+      json.writeStartObject();
+      
+      final Collection<TypedTimeSeriesIterator<? extends TimeSeriesDataType>> iterators = 
+          series.iterators();
+      if (iterators.isEmpty()) {
+        return;
+      }
+      
+      final TypedTimeSeriesIterator<? extends TimeSeriesDataType> iterator = 
+          iterators.iterator().next();
+      if (!iterator.hasNext()) {
+        return;
+      }
+      
+      // ID first
+      json.writeObjectFieldStart("metric");
+      json.writeStringField("__name__", id.metric());
+      for (final Entry<String, String> pair : id.tags().entrySet()) {
+        json.writeStringField(pair.getKey(), pair.getValue());
+      }
+      json.writeEndObject();
+      
+      json.writeArrayFieldStart("values");
+      
+      if (iterator.getType() == NumericType.TYPE) {
+        while (iterator.hasNext()) {
+          final TimeSeriesValue<NumericType> value = 
+              (TimeSeriesValue<NumericType>) iterator.next();
+          if (value.timestamp().compare(Op.LT, start)) {
+            continue;
+          }
+          if (value.timestamp().compare(Op.GTE, end)) {
+            break;
+          }
+          if (value.value() == null) {
+            continue;
+          }
+          
+          json.writeStartArray();
+          json.writeNumber(value.timestamp().epoch());
+          if (value.value().isInteger()) {
+            json.writeString(Long.toString(value.value().longValue()));
+          } else {
+            json.writeString(Double.toString(value.value().doubleValue()));
+          }
+          json.writeEndArray();
+        }
+      } else if (iterator.getType() == NumericSummaryType.TYPE) {
+        int summary = -1;
+        while (iterator.hasNext()) {
+          final TimeSeriesValue<NumericSummaryType> value = 
+              (TimeSeriesValue<NumericSummaryType>) iterator.next();
+          if (value.timestamp().compare(Op.LT, start)) {
+            continue;
+          }
+          if (value.timestamp().compare(Op.GTE, end)) {
+            break;
+          }
+          if (value.value() == null) {
+            continue;
+          }
+          
+          json.writeStartArray();
+          json.writeNumber(value.timestamp().epoch());
+          if (summary < 0) {
+            summary = value.value().summariesAvailable().iterator().next();
+          }
+          
+          final NumericType data = value.value().value(summary);
+          if (data.isInteger()) {
+            json.writeString(Long.toString(data.longValue()));
+          } else {
+            json.writeString(Double.toString(data.doubleValue()));
+          }
+          json.writeEndArray();
+        }
+      } else if (iterator.getType() == NumericArrayType.TYPE) {
+        final TimeStamp ts = result.timeSpecification().start().getCopy();
+        final TimeSeriesValue<NumericArrayType> value = 
+            (TimeSeriesValue<NumericArrayType>) iterator.next();
+        if (value.value().isInteger()) {
+          long[] values = value.value().longArray();
+          for (int i = value.value().offset(); i < value.value().end(); i++) {
+            json.writeStartArray();
+            json.writeNumber(ts.epoch());
+            ts.add(result.timeSpecification().interval());
+            json.writeString(Long.toString(values[i]));
+          }
+        } else {
+          double[] values = value.value().doubleArray();
+          for (int i = value.value().offset(); i < value.value().end(); i++) {
+            json.writeStartArray();
+            json.writeNumber(ts.epoch());
+            ts.add(result.timeSpecification().interval());
+            json.writeString(Double.toString(values[i]));
+          }
+        }
+      }
+      
+      json.writeEndArray();
+      json.writeEndObject();
+    }
+  }
+}

--- a/implementation/prometheus/src/main/java/net/opentsdb/query/execution/prometheus/PrometheusQuerySerdesFactory.java
+++ b/implementation/prometheus/src/main/java/net/opentsdb/query/execution/prometheus/PrometheusQuerySerdesFactory.java
@@ -1,0 +1,84 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2020  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.execution.prometheus;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
+import com.stumbleupon.async.Deferred;
+
+import net.opentsdb.core.BaseTSDBPlugin;
+import net.opentsdb.core.TSDB;
+import net.opentsdb.query.QueryContext;
+import net.opentsdb.query.serdes.SerdesFactory;
+import net.opentsdb.query.serdes.SerdesOptions;
+import net.opentsdb.query.serdes.TimeSeriesSerdes;
+
+/**
+ * A factory for the prometheus serialization format.
+ * 
+ * @since 3.0
+ */
+public class PrometheusQuerySerdesFactory extends BaseTSDBPlugin 
+    implements SerdesFactory {
+
+  public static final String TYPE = "PrometheusQuerySerdes";
+
+  @Override
+  public String type() {
+    return TYPE;
+  }
+
+  @Override
+  public TimeSeriesSerdes newInstance(final QueryContext context,
+                                      final SerdesOptions options,
+                                      final OutputStream stream) {
+    return new PrometheusQuerySerdes(context, options, stream);
+  }
+  
+  @Override
+  public TimeSeriesSerdes newInstance(final QueryContext context,
+                                      final SerdesOptions options, 
+                                      final InputStream stream) {
+    throw new UnsupportedOperationException();
+  }
+  
+  @Override
+  public String version() {
+    return "3.0.0";
+  }
+
+  @Override
+  public SerdesOptions parseConfig(final ObjectMapper mapper, 
+                                   final TSDB tsdb,
+                                   final JsonNode node) {
+    try {
+      return (SerdesOptions) mapper.treeToValue(node, 
+          PrometheusQuerySerdesOptions.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Unable to parse config.", e);
+    }
+  }
+  
+  @Override
+  public Deferred<Object> initialize(final TSDB tsdb, final String id) {
+    this.id = Strings.isNullOrEmpty(id) ? TYPE : id;
+    return Deferred.fromResult(null);
+  }
+}

--- a/implementation/prometheus/src/main/java/net/opentsdb/query/execution/prometheus/PrometheusQuerySerdesOptions.java
+++ b/implementation/prometheus/src/main/java/net/opentsdb/query/execution/prometheus/PrometheusQuerySerdesOptions.java
@@ -1,0 +1,30 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2020  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.query.execution.prometheus;
+
+import net.opentsdb.query.execution.serdes.BaseSerdesOptions;
+
+/**
+ * Pretty much doesn't do anything right now.
+ * 
+ * @since 3.0
+ */
+public class PrometheusQuerySerdesOptions extends BaseSerdesOptions {
+
+  protected PrometheusQuerySerdesOptions(Builder builder) {
+    super(builder);
+  }
+
+}

--- a/implementation/prometheus/src/main/java/net/opentsdb/servlet/resources/PromQLResource.java
+++ b/implementation/prometheus/src/main/java/net/opentsdb/servlet/resources/PromQLResource.java
@@ -1,0 +1,310 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2020  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.servlet.resources;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.temporal.ChronoUnit;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletConfig;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import net.opentsdb.auth.AuthState;
+import net.opentsdb.auth.Authentication;
+import net.opentsdb.auth.AuthState.AuthStatus;
+import net.opentsdb.core.BaseTSDBPlugin;
+import net.opentsdb.core.TSDB;
+import net.opentsdb.data.prometheus.PromQLParser;
+import net.opentsdb.exceptions.QueryExecutionException;
+import net.opentsdb.query.SemanticQuery;
+import net.opentsdb.query.SemanticQueryContext;
+import net.opentsdb.query.execution.prometheus.PrometheusQuerySerdesFactory;
+import net.opentsdb.query.execution.prometheus.PrometheusQuerySerdesOptions;
+import net.opentsdb.query.serdes.SerdesOptions;
+import net.opentsdb.servlet.applications.OpenTSDBApplication;
+import net.opentsdb.servlet.filter.AuthFilter;
+import net.opentsdb.servlet.sinks.ServletSinkConfig;
+import net.opentsdb.servlet.sinks.ServletSinkFactory;
+import net.opentsdb.stats.DefaultQueryStats;
+import net.opentsdb.stats.Span;
+import net.opentsdb.stats.Trace;
+import net.opentsdb.stats.Tracer;
+import net.opentsdb.stats.StatsCollector.StatsTimer;
+import net.opentsdb.threadpools.TSDTask;
+import net.opentsdb.utils.Bytes;
+import net.opentsdb.utils.DateTime;
+import net.opentsdb.utils.JSON;
+
+/**
+ * A resource to handle PromQL queries.
+ * 
+ * TODO - make sure we can pick different serializers.
+ * 
+ * TODO - support instants, have to parse out "time"
+ *
+ * @since 3.0
+ */
+@Path("query/promql")
+public class PromQLResource extends BaseTSDBPlugin implements ServletResource {
+  private static final Logger LOG = LoggerFactory.getLogger(PromQLResource.class);
+  
+  public static final String TYPE = PromQLResource.class.getSimpleName().toString();
+
+  @POST
+  @GET
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response post(final @Context ServletConfig servlet_config, 
+                       final @Context HttpServletRequest request) throws Exception {
+    final Object stream = request.getAttribute("DATA");
+    if (stream != null) {
+      return Response.ok()
+          .entity(((ByteArrayOutputStream) stream).toByteArray())
+          .header("Content-Type", "application/json")
+          .build();
+    }
+    
+    return handleQuery(servlet_config, request);
+  }
+  
+  private Response handleQuery(final ServletConfig servlet_config, 
+                               final HttpServletRequest request)
+      throws IOException, InterruptedException, ExecutionException {
+    
+    final String promql;
+    String temp = request.getHeader("query"); 
+    if (!Strings.isNullOrEmpty(temp)) {
+      promql = temp;
+    } else {
+      final StringBuilder buffer = new StringBuilder();
+      final char[] char_buf = new char[1024];
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream())) {
+        int read = 0;
+        while (read >= 0) {
+          read = reader.read(char_buf);
+          if (read < 0) {
+            break;
+          }
+          if (read == char_buf.length) {
+            buffer.append(char_buf);
+          } else {
+            for (int i = 0; i < read; i++) {
+              buffer.append(char_buf[i]);
+            }
+          }
+        }
+      }
+      promql = buffer.toString();
+    }
+      
+    Object obj = servlet_config.getServletContext()
+        .getAttribute(OpenTSDBApplication.TSD_ATTRIBUTE);
+    if (obj == null) {
+      throw new WebApplicationException("Unable to pull TSDB instance from "
+          + "servlet context.",
+          Response.Status.INTERNAL_SERVER_ERROR);
+    } else if (!(obj instanceof TSDB)) {
+      throw new WebApplicationException("Object stored for as the TSDB was "
+          + "of the wrong type: " + obj.getClass(),
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    final TSDB tsdb = (TSDB) obj;
+    
+    final StatsTimer timer;
+    if (tsdb.getStatsCollector() != null) {
+      tsdb.getStatsCollector().incrementCounter("query.new", "endpoint", "3x");
+      timer = tsdb.getStatsCollector().startTimer("query.user.latency", ChronoUnit.MILLIS);
+    } else {
+      timer = null;
+    }
+    
+    // check auth. 
+    final AuthState auth_state;
+    if (tsdb.getConfig().getBoolean(Authentication.AUTH_ENABLED_KEY)) {
+      if (request.getAttribute(AuthFilter.AUTH_STATE_KEY) == null || 
+          ((AuthState) request.getAttribute(AuthFilter.AUTH_STATE_KEY))
+            .getStatus() != AuthStatus.SUCCESS) {
+        throw new QueryExecutionException("Authentication failed.", 403);
+      }
+      auth_state = (AuthState) request.getAttribute(AuthFilter.AUTH_STATE_KEY);
+    } else {
+      auth_state = null; // TODO - add an "unknown" auth user.
+    }
+    
+    // initiate the tracer
+    final Trace trace;
+    final Span query_span;
+    final Tracer tracer = (Tracer) tsdb.getRegistry().getDefaultPlugin(Tracer.class);
+    if (tracer != null) {
+      trace = tracer.newTrace(true, true);
+      query_span = trace.newSpanWithThread(this.getClass().getSimpleName())
+          .withTag("endpoint", "/api/query/graph")
+          .withTag("user", auth_state != null ? auth_state.getUser() : "Unkown")
+          // TODO - more useful info
+          .start();
+    } else {
+      trace = null;
+      query_span = null;
+    }
+    Span parse_span = null;
+    if (query_span != null) {
+      parse_span = trace.newSpanWithThread("parseAndValidate")
+          .withTag("startThread", Thread.currentThread().getName())
+          .asChildOf(query_span)
+          .start();
+    }
+    
+    Map<String, String> log_headers = null;
+    Enumeration<String> keys = request.getHeaderNames();
+    while (keys.hasMoreElements()) {
+      final String name = keys.nextElement();
+      if (name.toLowerCase().startsWith("x-") &&
+          !Strings.isNullOrEmpty(request.getHeader(name))) {
+        if (log_headers == null) {
+          log_headers = Maps.newHashMap();
+        }
+        log_headers.put(name, request.getHeader(name));
+      }
+    }
+    
+    // extract query params
+    final String start = request.getHeader("start");
+    final String end = request.getHeader("end");
+    final String step = request.getHeader("step");
+    final String timeout = request.getHeader("timeout");
+
+    final SemanticQuery query = new PromQLParser(promql,
+                                                 start,
+                                                 end,
+                                                 step)
+                 .parse()
+                 .build();
+    LOG.info("Executing new PromQL query=" + JSON.serializeToString(
+        ImmutableMap.<String, Object>builder()
+        .put("headers", log_headers == null ? "null" : log_headers)
+        .put("queryId", Bytes.byteArrayToString(query.buildHashCode().asBytes()))
+        .put("traceId", trace != null ? trace.traceId() : "")
+        .put("user", auth_state != null ? auth_state.getUser() : "Unkown")
+        .put("remote", request.getRemoteAddr())
+        .put("promQL", promql)
+        .put("query", query)
+        .build()));
+    
+    SerdesOptions serdes = query.getSerdesConfigs().isEmpty() ? null :
+      query.getSerdesConfigs().get(0);
+    if (serdes == null) {
+      serdes = PrometheusQuerySerdesOptions.newBuilder()
+          .setId(PrometheusQuerySerdesFactory.TYPE)
+          .build();
+    }
+    
+    long query_timeout = (long) servlet_config.getServletContext()
+        .getAttribute(OpenTSDBApplication.ASYNC_TIMEOUT_ATTRIBUTE);
+    final AsyncContext async = request.startAsync();
+    if (!Strings.isNullOrEmpty(timeout)) {
+      try {
+        final long parsed = DateTime.parseDuration(timeout);
+        if (parsed > query_timeout) {
+          LOG.debug("Skipping given timeout of " + parsed + " as it's greater "
+              + "than the configured limit of " + query_timeout);
+        } else {
+          query_timeout = parsed;
+        }
+      } catch (Exception e) {
+        LOG.error("Failed to parse timeout [" + timeout + "] so using the "
+            + "default of " + query_timeout, e);
+      }
+    }
+    async.setTimeout(query_timeout);
+    
+    SemanticQueryContext context = (SemanticQueryContext) SemanticQueryContext.newBuilder()
+        .setTSDB(tsdb)
+        .setQuery(query)
+        .setStats(DefaultQueryStats.newBuilder()
+            .setTrace(trace)
+            .setQuerySpan(query_span)
+            .build())
+        .setAuthState(auth_state)
+        .setHeaders(log_headers)
+        .addSink(ServletSinkConfig.newBuilder()
+            .setId(ServletSinkFactory.TYPE)
+            .setSerdesOptions(serdes)
+            .setRequest(request)
+            .setAsync(async)
+            .setStatsTimer(timer)
+            .build())
+        .build();
+    tsdb.registerRunningQuery(Long.parseLong(request.getHeader(
+        OpenTSDBApplication.INTERNAL_HASH_HEADER)), context);
+    
+    if (trace != null && query.isDebugEnabled()) {
+      context.logDebug("Trace ID: " + trace.traceId());
+    }
+    
+    RunTSDQuery runTsdQuery = new RunTSDQuery(query_span, async, query, context);
+    
+    tsdb.getQueryThreadPool().submit(runTsdQuery, context, TSDTask.QUERY);
+    return null;
+  }
+  
+  class RunTSDQuery implements Runnable {
+
+    final Span query_span;
+    final AsyncContext async;
+    final SemanticQuery query;
+
+    final SemanticQueryContext context;
+
+    public RunTSDQuery(Span query_span, AsyncContext async, SemanticQuery query,
+        SemanticQueryContext context) {
+      this.query_span = query_span;
+      this.async = async;
+      this.query = query;
+      this.context = context;
+    }
+
+    @Override
+    public void run() {
+      AsyncRunner.asyncRun(null, null, query_span, async, context, PromQLResource.class);
+    }
+  }
+  
+  @Override
+  public String type() {
+    return TYPE;
+  }
+
+}

--- a/implementation/prometheus/src/main/resources/MANIFEST.MF
+++ b/implementation/prometheus/src/main/resources/MANIFEST.MF
@@ -1,0 +1,1 @@
+Manifest-Version: 1.0

--- a/implementation/prometheus/src/main/resources/META-INF/services/net.opentsdb.servlet.resources.ServletResource
+++ b/implementation/prometheus/src/main/resources/META-INF/services/net.opentsdb.servlet.resources.ServletResource
@@ -1,0 +1,1 @@
+net.opentsdb.servlet.resources.PromQLResource

--- a/implementation/prometheus/src/test/java/net/opentsdb/data/prometheus/PromQLParserDebug.java
+++ b/implementation/prometheus/src/test/java/net/opentsdb/data/prometheus/PromQLParserDebug.java
@@ -1,0 +1,623 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2020  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data.prometheus;
+
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.DefaultErrorStrategy;
+import org.antlr.v4.runtime.FailedPredicateException;
+import org.antlr.v4.runtime.InputMismatchException;
+import org.antlr.v4.runtime.NoViableAltException;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.antlr.v4.runtime.tree.ErrorNode;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.RuleNode;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+import net.opentsdb.prometheus.grammar.PromQLLexer;
+import net.opentsdb.prometheus.grammar.PromQLParserVisitor;
+import net.opentsdb.prometheus.grammar.PromQLParser.AddOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.AggregationContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.AndUnlessOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.ByContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.CompareOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.ExpressionContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.FunctionContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.GroupLeftContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.GroupRightContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.GroupingContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.IgnoringContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.InstantSelectorContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.KeywordContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.LabelMatcherContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.LabelMatcherListContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.LabelMatcherOperatorContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.LabelNameContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.LabelNameListContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.LiteralContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.MatrixSelectorContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.MultOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.OffsetContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.OnContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.OrOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.ParameterContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.ParameterListContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.ParensContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.PowOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.UnaryOpContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.VectorContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.VectorOperationContext;
+import net.opentsdb.prometheus.grammar.PromQLParser.WithoutContext;
+import net.opentsdb.query.SemanticQuery;
+
+/**
+ * Just a debugger.
+ * 
+ * @since 3.0
+ */
+public class PromQLParserDebug extends DefaultErrorStrategy  implements PromQLParserVisitor {
+
+
+  static public void main(final String[] args) {
+    
+  //String incoming = "http_request_duration_seconds_sum";
+  //String incoming = "http.request\\.duration.second.sum";
+//  String incoming = "http_requests_total{group!~\"canary\"}";
+//  String incoming = "http_requests_total{job=\"prometheus\",group!~\"canary\"}";
+//  String incoming = "rate(http_request_duration_seconds_sum)";
+//  String incoming = "http_request_duration_seconds_sum[5m]";
+//  String incoming = "http_requests_total{job=\"prometheus\",group!~\"canary\"}[5m]";
+//  String incoming = "rate(http_requests_total[5m])[30m:1m]";
+//  String incoming = "sum(http_request_duration_Seconds_sum)";
+//    String incoming = "topk(10, http_request_duration_Seconds_sum)";
+//    String incoming = "avg_over_time(mymetric)";
+    String incoming = "metric1 or metric2";
+//  String incoming = "(\n" + 
+//      "  sum(rate(http_request_duration_seconds_bucket{le=\"0.3\"}[5m])) by (job)\n" + 
+//      "+\n" + 
+//      "  sum(rate(http_request_duration_seconds_bucket{le=\"1.2\"}[5m])) by (job)\n" + 
+//      ") / 2 / sum(rate(http_request_duration_seconds_count[5m])) by (job)";
+//  String incoming = "http_requests_total{status!~\"4..\"}";
+  // WARNING* FRom examples page bug doesn't parse!
+//  String incoming = "max_over_time(deriv(rate(distance_covered_total[5s])[30s:5s])[10m:])";
+//  String incoming = "sum by (job) (\n" + 
+//      "  rate(http_requests_total[5m])\n" + 
+//      ")";
+//String incoming = "sum by (job) (http_requests_total[5m:5m])";
+//  String incoming = "sum by (job) (http_requests_total[5m:5m] offset 5m)";
+  
+  
+    new PromQLParserDebug().run(incoming);
+  }
+ 
+  int level = 0;
+  
+
+  public SemanticQuery run(final String incoming) {
+    PromQLLexer lexer = new PromQLLexer(new ANTLRInputStream(incoming));
+    final CommonTokenStream tokens = new CommonTokenStream(lexer);
+    net.opentsdb.prometheus.grammar.PromQLParser parser = 
+        new net.opentsdb.prometheus.grammar.PromQLParser(tokens);
+    parser.removeErrorListeners(); // suppress logging to stderr.
+    parser.setErrorHandler(this);
+    
+    Object obj = parser.expression().accept(this);
+    return null;
+  }
+
+  @Override
+  public Object visit(ParseTree tree) {
+    return tree.accept(this);
+  }
+
+  @Override
+  public Object visitChildren(RuleNode node) {
+    level += 2;
+    System.out.println(pad("RULE NODE: " + node));
+    level -= 2;
+    return null;
+  }
+
+  @Override
+  public Object visitTerminal(TerminalNode node) {
+    level += 2;
+    System.out.println(pad("TERMINAL: " + node));
+    level -= 2;
+    return node.getText();
+  }
+
+  @Override
+  public Object visitErrorNode(ErrorNode node) {
+    level += 2;
+    System.out.println(pad("ERROR NODE: " + node));
+    level -= 2;
+    return null;
+  }
+
+  @Override
+  public Object visitExpression(ExpressionContext ctx) {
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println("visitExpression[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i));
+      
+      Object child = ctx.getChild(i).accept(this);
+      if (!child.equals("<EOF>")) {
+        last = child;
+      }
+    }
+    return last;
+  }
+
+  @Override
+  public Object visitVectorOperation(VectorOperationContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitVectorOperation[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitUnaryOp(UnaryOpContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitUnaryOp[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitPowOp(PowOpContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitPowOp[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitMultOp(MultOpContext ctx) {
+    // can be * or / depending on text I believe.
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitMultOp[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitAddOp(AddOpContext ctx) {
+    // Add two values.
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitAddOp[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitCompareOp(CompareOpContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitCompareOp[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitAndUnlessOp(AndUnlessOpContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitAndUnlessOp[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitOrOp(OrOpContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitOrOp[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitVector(VectorContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitVector[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitParens(ParensContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitParens[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitInstantSelector(InstantSelectorContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitInstantSelector[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitLabelMatcher(LabelMatcherContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitLabelMatcher[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitLabelMatcherOperator(LabelMatcherOperatorContext ctx) {
+    // an op like `=` or `~` or `!~`
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitLabelMatcherOperator[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitLabelMatcherList(LabelMatcherListContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitLabelMatcherList[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitMatrixSelector(MatrixSelectorContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitMatrixSelector[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitOffset(OffsetContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitOffset[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitFunction(FunctionContext ctx) {
+    // function names, e.g. `rate`
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("FunctionContext[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitParameter(ParameterContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("ParameterContext[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitParameterList(ParameterListContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("ParameterListContext[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitAggregation(AggregationContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitAggregation[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitBy(ByContext ctx) {
+    // yup, the group by context:
+    // sum(rate(http_request_duration_seconds_bucket{le="0.3"}[5m])) by (job)
+    // 0 == 'by' keyword
+    // 1 == LabelNameListContext
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitBy[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitWithout(WithoutContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitWithout[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitGrouping(GroupingContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitGrouping[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitOn(OnContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitOn[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitIgnoring(IgnoringContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitIgnoring[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitGroupLeft(GroupLeftContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitGroupLeft[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitGroupRight(GroupRightContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitGroupRight[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitLabelName(LabelNameContext ctx) {
+    // came here after the group by for the tag key. Could be tag key?
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitLabelName[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitLabelNameList(LabelNameListContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitLabelNameList[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitKeyword(KeywordContext ctx) {
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitKeyword[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public Object visitLiteral(LiteralContext ctx) {
+    // here's where we get something like `2` as a literal.
+    level += 2;
+    Object last = null;
+    for (int i = 0; i < ctx.getChildCount(); i++) {
+      System.out.println(pad("visitLiteral[" + i + "] class: " + ctx.getChild(i).getClass() + " => " + ctx.getChild(i)));
+      last = ctx.getChild(i).accept(this);
+    }
+    level -= 2;
+    return last;
+  }
+
+  @Override
+  public void recover(final Parser recognizer, final RecognitionException e) {
+    final StringBuilder buf = new StringBuilder()
+        .append("Error at line (")
+        .append(e.getOffendingToken().getLine())
+        .append(":")
+        .append(e.getOffendingToken().getCharPositionInLine())
+        .append(") ");
+    if (e instanceof NoViableAltException) {
+      final TokenStream tokens = recognizer.getInputStream();
+      final NoViableAltException ex = (NoViableAltException) e;
+      buf.append("Expression may not be complete. '");
+      if (tokens != null) {
+        if (ex.getStartToken().getType() == Token.EOF) {
+          buf.append("<EOF>");
+        } else {
+          buf.append(tokens.getText(ex.getStartToken(), ex.getOffendingToken()));
+        }
+      } else {
+        buf.append("TODO");
+      }
+      buf.append("'");
+    } else if (e instanceof InputMismatchException) {
+      final InputMismatchException ex = (InputMismatchException) e;
+      buf.append("Missmatched input. Got '")
+         .append(getTokenErrorDisplay(ex.getOffendingToken()))
+         .append("' but expected '")
+         .append(ex.getExpectedTokens().toString(recognizer.getVocabulary()))
+         .append("'");
+    } else if (e instanceof FailedPredicateException) {
+      final FailedPredicateException ex = (FailedPredicateException) e;
+      final String rule_name = recognizer
+          .getRuleNames()[recognizer.getContext().getRuleIndex()];
+      buf.append(" Predicate error with rule '")
+         .append(rule_name)
+         .append("' ")
+         .append(ex.getMessage());
+    } else {
+      buf.append("Unexpected error at token '")
+         .append(getTokenErrorDisplay(e.getOffendingToken()))
+         .append("'");
+    }
+
+    for (ParserRuleContext context = recognizer.getContext();
+        context != null; context = context.getParent()) {
+      context.exception = e;
+    }
+    throw new ParseCancellationException(buf.toString(), e);
+  }
+
+  /** Make sure we don't attempt to recover inline; if the parser
+   *  successfully recovers, it won't throw an exception.
+   */
+  @Override
+  public Token recoverInline(final Parser recognizer)
+      throws RecognitionException {
+    final InputMismatchException e = new InputMismatchException(recognizer);
+    recover(recognizer, e);
+    return null;
+  }
+
+  /** Make sure we don't attempt to recover from problems in subrules. */
+  @Override
+  public void sync(final Parser recognizer) { }
+
+  String pad(String string) {
+    StringBuilder buf = new StringBuilder();
+    for (int i = 0; i < level; i++) {
+      buf.append(" ");
+    }
+    return buf.append(string).toString();
+  }
+
+}

--- a/implementation/prometheus/src/test/java/net/opentsdb/data/prometheus/TestPromQLParser.java
+++ b/implementation/prometheus/src/test/java/net/opentsdb/data/prometheus/TestPromQLParser.java
@@ -1,0 +1,739 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2020  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.data.prometheus;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.time.format.DateTimeParseException;
+
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.opentsdb.query.SemanticQuery;
+import net.opentsdb.query.TimeSeriesDataSourceConfig;
+import net.opentsdb.query.filter.ChainFilter;
+import net.opentsdb.query.filter.NotFilter;
+import net.opentsdb.query.filter.TagValueFilter;
+import net.opentsdb.query.joins.JoinConfig.JoinType;
+import net.opentsdb.query.processor.downsample.DownsampleConfig;
+import net.opentsdb.query.processor.expressions.ExpressionConfig;
+import net.opentsdb.query.processor.groupby.GroupByConfig;
+import net.opentsdb.query.processor.rate.RateConfig;
+import net.opentsdb.query.processor.topn.TopNConfig;
+
+public class TestPromQLParser {
+
+  private String start;
+  private String end;
+  private String step;
+  
+  @Before
+  public void before() throws Exception {
+    start = "1577836800";
+    end = "1577840400";
+  }
+  
+  @Test
+  public void ctor() throws Exception {
+    String promql = "http_request_duration_seconds_sum";
+    // only the start is required
+    end = null;
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    assertEquals(start, parser.start);
+    assertNotNull(parser.end);
+    
+    end = "1577840400";
+    parser = new PromQLParser(promql, start, end, step);
+    assertEquals(start, parser.start);
+    assertEquals(end, parser.end);
+    
+    step = "1m";
+    parser = new PromQLParser(promql, start, end, step);
+    assertEquals(start, parser.start);
+    assertEquals(end, parser.end);
+    assertEquals(step, parser.step);
+    
+    // internet date format
+    start = "1985-04-12T23:20:50.52Z";
+    end = "1985-04-12T23:30:50.52Z";
+    parser = new PromQLParser(promql, start, end, step);
+    assertEquals("482196050", parser.start);
+    assertEquals("482196650", parser.end);
+    
+    // float step
+    start = "1577836800";
+    end = "1577840400";
+    step = "60";
+    parser = new PromQLParser(promql, start, end, step);
+    assertEquals("60s", parser.step);
+    
+    step = "60.55";
+    parser = new PromQLParser(promql, start, end, step);
+    assertEquals("60s", parser.step);
+    
+    start = "1985-04-12T23:20:5whoops0.52Z";
+    try {
+      new PromQLParser(promql, start, end, step);
+      fail("Expected DateTimeParseException");
+    } catch (DateTimeParseException e) { }
+  }
+  
+  @Test
+  public void instant() throws Exception {
+    String promql = "http_request_duration_seconds_sum";
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    SemanticQuery query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(1, query.getExecutionGraph().size());
+    TimeSeriesDataSourceConfig source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    // hacked to support TSD style metrics.
+    promql = "http.request.duration.seconds.sum";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    // TODO This'll change
+    assertEquals(3600, query.endTime().epoch() - query.startTime().epoch());
+    assertEquals(1, query.getExecutionGraph().size());
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http.request.duration.seconds.sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    assertNull(source_config.getFilter());
+    assertNull(source_config.getFilterId());
+  }
+  
+  @Test
+  public void instantWithFilter() throws Exception {
+    String promql = "http_requests_total{job=\"prometheus\",group!~\"canary\",colo!=\"DEN\",group=~\"^prod\"}";
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    SemanticQuery query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(1, query.getExecutionGraph().size());
+    TimeSeriesDataSourceConfig source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_requests_total", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    ChainFilter chain = (ChainFilter) source_config.getFilter();
+    assertEquals(4, chain.getFilters().size());
+    TagValueFilter filter = (TagValueFilter) chain.getFilters().get(0);
+    assertEquals("job", filter.getTagKey());
+    assertEquals("prometheus", filter.getFilter());
+    assertEquals("TagValueLiteralOr", filter.getType());
+    
+    filter = (TagValueFilter) ((NotFilter) chain.getFilters().get(1)).getFilter();
+    assertEquals("group", filter.getTagKey());
+    assertEquals("^canary$", filter.getFilter());
+    assertEquals("TagValueRegex", filter.getType());
+    
+    filter = (TagValueFilter) ((NotFilter) chain.getFilters().get(2)).getFilter();
+    assertEquals("colo", filter.getTagKey());
+    assertEquals("DEN", filter.getFilter());
+    assertEquals("TagValueLiteralOr", filter.getType());
+    
+    filter = (TagValueFilter) chain.getFilters().get(3);
+    assertEquals("group", filter.getTagKey());
+    assertEquals("^prod$", filter.getFilter());
+    assertEquals("TagValueRegex", filter.getType());
+  }
+
+  @Test
+  public void range() throws Exception {
+    String promql = "http_request_duration_seconds_sum[5m]";
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    SemanticQuery query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(1, query.getExecutionGraph().size());
+    TimeSeriesDataSourceConfig source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    // step
+    step = "1m";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(2, query.getExecutionGraph().size());
+    source_config = (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    DownsampleConfig ds = (DownsampleConfig) query.getExecutionGraph().get(1);
+    assertEquals("avg", ds.getAggregator());
+    assertEquals("1m", ds.getInterval());
+    assertEquals("m0", ds.getSources().get(0));
+    
+    // TODO - what's this?
+    step = null;
+    promql = "http_request_duration_seconds_sum[5m:]";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(1, query.getExecutionGraph().size());
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+  }
+  
+  @Test
+  public void rangeDownsample() throws Exception {
+    String promql = "http_request_duration_seconds_sum[5m:1m]";
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    SemanticQuery query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(2, query.getExecutionGraph().size());
+    TimeSeriesDataSourceConfig source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    DownsampleConfig ds = (DownsampleConfig) query.getExecutionGraph().get(1);
+    assertEquals("avg", ds.getAggregator());
+    assertEquals("1m", ds.getInterval());
+    assertEquals("m0", ds.getSources().get(0));
+  }
+  
+  @Test
+  public void offset() throws Exception {
+    String promql = "http_request_duration_seconds_sum[5m] offset 5m";
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    SemanticQuery query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(1, query.getExecutionGraph().size());
+    TimeSeriesDataSourceConfig source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("5m", source_config.getTimeShiftInterval());
+    assertEquals("m0", source_config.getId());
+  }
+  
+  @Test
+  public void groupBy() throws Exception {
+    String promql = "sum by (job, host) (http_request_duration_seconds_sum)";
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    SemanticQuery query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(2, query.getExecutionGraph().size());
+    TimeSeriesDataSourceConfig source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    GroupByConfig gb = (GroupByConfig) query.getExecutionGraph().get(1);
+    assertEquals("sum", gb.getAggregator());
+    assertEquals(2, gb.getTagKeys().size());
+    assertTrue(gb.getTagKeys().contains("job"));
+    assertTrue(gb.getTagKeys().contains("host"));
+    assertEquals("m0", gb.getSources().get(0));
+    
+    // alternative way
+    promql = "sum(http_request_duration_seconds_sum) by (job, host)";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(2, query.getExecutionGraph().size());
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    gb = (GroupByConfig) query.getExecutionGraph().get(1);
+    assertEquals("sum", gb.getAggregator());
+    assertEquals(2, gb.getTagKeys().size());
+    assertTrue(gb.getTagKeys().contains("job"));
+    assertTrue(gb.getTagKeys().contains("host"));
+    assertEquals("m0", gb.getSources().get(0));
+    
+    // group-all
+    promql = "sum(http_request_duration_seconds_sum)";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(2, query.getExecutionGraph().size());
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    gb = (GroupByConfig) query.getExecutionGraph().get(1);
+    assertEquals("sum", gb.getAggregator());
+    assertEquals(0, gb.getTagKeys().size());
+    assertEquals("m0", gb.getSources().get(0));
+    
+    // rest of the functions
+    promql = "avg(http_request_duration_seconds_sum)";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    gb = (GroupByConfig) query.getExecutionGraph().get(1);
+    assertEquals("avg", gb.getAggregator());
+    
+    promql = "min(http_request_duration_seconds_sum)";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    gb = (GroupByConfig) query.getExecutionGraph().get(1);
+    assertEquals("min", gb.getAggregator());
+    
+    promql = "max(http_request_duration_seconds_sum)";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    gb = (GroupByConfig) query.getExecutionGraph().get(1);
+    assertEquals("max", gb.getAggregator());
+    
+    promql = "count(http_request_duration_seconds_sum)";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    gb = (GroupByConfig) query.getExecutionGraph().get(1);
+    assertEquals("count", gb.getAggregator());
+    
+    // nope
+    promql = "dev(http_request_duration_seconds_sum)";
+    parser = new PromQLParser(promql, start, end, step);
+    try {
+      parser.parse().build();
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException e) { }
+  }
+  
+  @Test
+  public void rate() throws Exception {
+    // TODO - this probably shouldn't be allowed when we handle instants properly.
+    String promql = "rate(http_request_duration_seconds_sum)";
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    SemanticQuery query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(2, query.getExecutionGraph().size());
+    TimeSeriesDataSourceConfig source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    RateConfig rate = (RateConfig) query.getExecutionGraph().get(1);
+    assertEquals("1s", rate.getInterval());
+    assertTrue(rate.isCounter());
+    assertTrue(rate.getDropResets());
+    
+    // with a range, should be the standard.
+    promql = "rate(http_request_duration_seconds_sum[5m])";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(2, query.getExecutionGraph().size());
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    rate = (RateConfig) query.getExecutionGraph().get(1);
+    assertEquals("1s", rate.getInterval());
+    assertTrue(rate.isCounter());
+    assertTrue(rate.getDropResets());
+    assertEquals("m0", rate.getSources().get(0));
+    
+    // this is the odd case where the previous range is now the rate!
+    promql = "rate(http_request_duration_seconds_sum[5m])[30m:1m]";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(3, query.getExecutionGraph().size());
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    rate = (RateConfig) query.getExecutionGraph().get(1);
+    assertEquals("1s", rate.getInterval());
+    assertTrue(rate.isCounter());
+    assertTrue(rate.getDropResets());
+    assertEquals("m0", rate.getSources().get(0));
+    
+    DownsampleConfig ds = (DownsampleConfig) query.getExecutionGraph().get(2);
+    assertEquals("DownsampleConfig_m0", ds.getId());
+    assertEquals("avg", ds.getAggregator());
+    assertEquals("1m", ds.getInterval());
+    assertEquals("RateConfig_m0", ds.getSources().get(0));
+    
+    // make sure we update the extant DS!
+    promql = "rate(http_request_duration_seconds_sum[5m:30s])[30m:1m]";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(3, query.getExecutionGraph().size());
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    rate = (RateConfig) query.getExecutionGraph().get(1);
+    assertEquals("1s", rate.getInterval());
+    assertTrue(rate.isCounter());
+    assertTrue(rate.getDropResets());
+    assertEquals("m0", rate.getSources().get(0));
+    
+    ds = (DownsampleConfig) query.getExecutionGraph().get(2);
+    assertEquals("DownsampleConfig_m0", ds.getId());
+    assertEquals("avg", ds.getAggregator());
+    assertEquals("1m", ds.getInterval());
+    assertEquals("RateConfig_m0", ds.getSources().get(0));
+  }
+
+  @Test
+  public void topk() throws Exception {
+    String promql = "topk(5, http_request_duration_seconds_sum[30m:1m])";
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    SemanticQuery query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(3, query.getExecutionGraph().size());
+    TimeSeriesDataSourceConfig source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    DownsampleConfig ds = (DownsampleConfig) query.getExecutionGraph().get(1);
+    assertEquals("DownsampleConfig_m0", ds.getId());
+    assertEquals("avg", ds.getAggregator());
+    assertEquals("1m", ds.getInterval());
+    assertEquals("m0", ds.getSources().get(0));
+    
+    TopNConfig top = (TopNConfig) query.getExecutionGraph().get(2);
+    assertEquals(5, top.getCount());
+    assertEquals("avg", top.getAggregator());
+    assertTrue(top.getTop());
+    assertEquals("DownsampleConfig_m0", top.getSources().get(0));
+    
+    promql = "bottomk(5, http_request_duration_seconds_sum[30m:1m])";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(3, query.getExecutionGraph().size());
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    top = (TopNConfig) query.getExecutionGraph().get(2);
+    assertEquals(5, top.getCount());
+    assertEquals("avg", top.getAggregator());
+    assertFalse(top.getTop());
+    assertEquals("DownsampleConfig_m0", top.getSources().get(0));
+  }
+
+  @Test
+  public void overTime() throws Exception {
+    String promql = "avg_over_time(http_request_duration_seconds_sum)";
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    SemanticQuery query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(2, query.getExecutionGraph().size());
+    TimeSeriesDataSourceConfig source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    DownsampleConfig ds = (DownsampleConfig) query.getExecutionGraph().get(1);
+    assertEquals("avg", ds.getAggregator());
+    assertTrue(ds.getRunAll());
+    assertEquals("0all", ds.getInterval());
+    assertEquals("m0", ds.getSources().get(0));
+    
+    // two downsamples
+    promql = "sum_over_time(http_request_duration_seconds_sum[30m:1m])";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(3, query.getExecutionGraph().size());
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_sum", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    ds = (DownsampleConfig) query.getExecutionGraph().get(1);
+    assertEquals("avg", ds.getAggregator());
+    assertFalse(ds.getRunAll());
+    assertEquals("1m", ds.getInterval());
+    assertEquals("m0", ds.getSources().get(0));
+    
+    ds = (DownsampleConfig) query.getExecutionGraph().get(2);
+    assertEquals("DownsampleConfig_1_m0", ds.getId());
+    assertEquals("sum", ds.getAggregator());
+    assertTrue(ds.getRunAll());
+    assertEquals("0all", ds.getInterval());
+    assertEquals("DownsampleConfig_m0", ds.getSources().get(0));
+  }
+
+  @Test
+  public void arithmeticExpression() throws Exception {
+    String promql = 
+        "  (http_request_duration_seconds_bucket_a\n" +
+        "+\n" + 
+        "  http_request_duration_seconds_bucket_b\n" + 
+        ") / 2 / http_request_duration_seconds_count";
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    SemanticQuery query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(6, query.getExecutionGraph().size());
+    TimeSeriesDataSourceConfig source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_bucket_a", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(1);
+    assertEquals("http_request_duration_seconds_bucket_b", 
+        source_config.getMetric().getMetric());
+    assertEquals("m1", source_config.getId());
+    
+    ExpressionConfig exp = (ExpressionConfig) query.getExecutionGraph().get(2);
+    assertEquals("Expression_0", exp.getId());
+    assertEquals("m0 + m1", exp.getExpression());
+    assertEquals("Expression_0", exp.getAs());
+    assertEquals(JoinType.NATURAL_OUTER, exp.getJoin().getJoinType());
+    assertEquals("m0", exp.getSources().get(0));
+    assertEquals("m1", exp.getSources().get(1));
+    
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(3);
+    assertEquals("http_request_duration_seconds_count", 
+        source_config.getMetric().getMetric());
+    assertEquals("m2", source_config.getId());
+    
+    exp = (ExpressionConfig) query.getExecutionGraph().get(4);
+    assertEquals("Expression_1", exp.getId());
+    assertEquals("Expression_0 / 2", exp.getExpression());
+    assertEquals("Expression_1", exp.getAs());
+    assertEquals(JoinType.NATURAL_OUTER, exp.getJoin().getJoinType());
+    assertEquals("Expression_0", exp.getSources().get(0));
+    
+    exp = (ExpressionConfig) query.getExecutionGraph().get(5);
+    assertEquals("Expression_2", exp.getId());
+    assertEquals("Expression_1 / m2", exp.getExpression());
+    assertEquals("Expression_2", exp.getAs());
+    assertEquals(JoinType.NATURAL_OUTER, exp.getJoin().getJoinType());
+    assertEquals("Expression_1", exp.getSources().get(0));
+    assertEquals("m2", exp.getSources().get(1));
+  }
+  
+  @Test
+  public void arithmeticExpressionWithRanges() throws Exception {
+    String promql = 
+        "  (http_request_duration_seconds_bucket_a[5m]\n" +
+        "+\n" + 
+        "  http_request_duration_seconds_bucket_b[5m]\n" + 
+        ") / 2 / http_request_duration_seconds_count[5m]";
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    SemanticQuery query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(6, query.getExecutionGraph().size());
+    TimeSeriesDataSourceConfig source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("http_request_duration_seconds_bucket_a", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(1);
+    assertEquals("http_request_duration_seconds_bucket_b", 
+        source_config.getMetric().getMetric());
+    assertEquals("m1", source_config.getId());
+    
+    ExpressionConfig exp = (ExpressionConfig) query.getExecutionGraph().get(2);
+    assertEquals("Expression_0", exp.getId());
+    assertEquals("m0 + m1", exp.getExpression());
+    assertEquals("Expression_0", exp.getAs());
+    assertEquals(JoinType.NATURAL_OUTER, exp.getJoin().getJoinType());
+    assertEquals("m0", exp.getSources().get(0));
+    assertEquals("m1", exp.getSources().get(1));
+    
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(3);
+    assertEquals("http_request_duration_seconds_count", 
+        source_config.getMetric().getMetric());
+    assertEquals("m2", source_config.getId());
+    
+    exp = (ExpressionConfig) query.getExecutionGraph().get(4);
+    assertEquals("Expression_1", exp.getId());
+    assertEquals("Expression_0 / 2", exp.getExpression());
+    assertEquals("Expression_1", exp.getAs());
+    assertEquals(JoinType.NATURAL_OUTER, exp.getJoin().getJoinType());
+    assertEquals("Expression_0", exp.getSources().get(0));
+    
+    exp = (ExpressionConfig) query.getExecutionGraph().get(5);
+    assertEquals("Expression_2", exp.getId());
+    assertEquals("Expression_1 / m2", exp.getExpression());
+    assertEquals("Expression_2", exp.getAs());
+    assertEquals(JoinType.NATURAL_OUTER, exp.getJoin().getJoinType());
+    assertEquals("Expression_1", exp.getSources().get(0));
+    assertEquals("m2", exp.getSources().get(1));
+  }
+
+  @Test
+  public void conditionalExpression() throws Exception {
+    String promql = "metric_a == metric_b";
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    SemanticQuery query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(3, query.getExecutionGraph().size());
+    TimeSeriesDataSourceConfig source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("metric_a", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(1);
+    assertEquals("metric_b", 
+        source_config.getMetric().getMetric());
+    assertEquals("m1", source_config.getId());
+    
+    ExpressionConfig exp = (ExpressionConfig) query.getExecutionGraph().get(2);
+    assertEquals("Expression_0", exp.getId());
+    assertEquals("m0 == m1", exp.getExpression());
+    assertEquals("Expression_0", exp.getAs());
+    assertEquals(JoinType.NATURAL_OUTER, exp.getJoin().getJoinType());
+    assertEquals("m0", exp.getSources().get(0));
+    assertEquals("m1", exp.getSources().get(1));
+    
+    // other conditional ops
+    promql = "metric_a != metric_b";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+
+    exp = (ExpressionConfig) query.getExecutionGraph().get(2);
+    assertEquals("m0 != m1", exp.getExpression());
+    
+    promql = "metric_a < metric_b";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+
+    exp = (ExpressionConfig) query.getExecutionGraph().get(2);
+    assertEquals("m0 < m1", exp.getExpression());
+    
+    promql = "metric_a > metric_b";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+
+    exp = (ExpressionConfig) query.getExecutionGraph().get(2);
+    assertEquals("m0 > m1", exp.getExpression());
+    
+    promql = "metric_a <= metric_b";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+
+    exp = (ExpressionConfig) query.getExecutionGraph().get(2);
+    assertEquals("m0 <= m1", exp.getExpression());
+    
+    promql = "metric_a >= metric_b";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+
+    exp = (ExpressionConfig) query.getExecutionGraph().get(2);
+    assertEquals("m0 >= m1", exp.getExpression());
+    
+    promql = "metric_a <> metric_b";
+    parser = new PromQLParser(promql, start, end, step);
+    try {
+      parser.parse();
+      fail("Expected ParseCancellationException");
+    } catch (ParseCancellationException e) { }
+  }
+  
+  @Test
+  public void relationalExpression() throws Exception {
+    String promql = "metric_a or metric_b";
+    PromQLParser parser = new PromQLParser(promql, start, end, step);
+    SemanticQuery query = parser.parse().build();
+    assertEquals(start, query.getStart());
+    assertEquals(end, query.getEnd());
+    assertEquals(3, query.getExecutionGraph().size());
+    TimeSeriesDataSourceConfig source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(0);
+    assertEquals("metric_a", 
+        source_config.getMetric().getMetric());
+    assertEquals("m0", source_config.getId());
+    
+    source_config = 
+        (TimeSeriesDataSourceConfig) query.getExecutionGraph().get(1);
+    assertEquals("metric_b", 
+        source_config.getMetric().getMetric());
+    assertEquals("m1", source_config.getId());
+    
+    ExpressionConfig exp = (ExpressionConfig) query.getExecutionGraph().get(2);
+    assertEquals("Expression_0", exp.getId());
+    assertEquals("m0 or m1", exp.getExpression());
+    assertEquals("Expression_0", exp.getAs());
+    assertEquals(JoinType.NATURAL_OUTER, exp.getJoin().getJoinType());
+    assertEquals("m0", exp.getSources().get(0));
+    assertEquals("m1", exp.getSources().get(1));
+    
+    // and
+    promql = "metric_a and metric_b";
+    parser = new PromQLParser(promql, start, end, step);
+    query = parser.parse().build();
+    
+    exp = (ExpressionConfig) query.getExecutionGraph().get(2);
+    assertEquals("m0 and m1", exp.getExpression());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <module>implementation/egads</module>
     <module>implementation/http-config</module>
     <module>implementation/elasticsearch</module>
+    <module>implementation/prometheus</module>
     <module>implementation/protobuf</module>
     <module>implementation/tracer-brave</module>
     <module>implementation/redis</module>


### PR DESCRIPTION
- Start PromQL compatibility by adding a query plugin and parsing the
  basic parts of the PromQL query language from the Antlrv4 grammar repo
  at https://github.com/antlr/grammars-v4/tree/master/promql.
  Right now it will take a PromQL query, munge it a bit (1hr query for
  now) and returns the results in a TSD v3 format. Next we need to
  implement joins, instants and more functions.
- Add a Prometheus range query output serializer.