### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
+++ b/core/src/main/java/net/opentsdb/query/execution/serdes/JsonV3QuerySerdes.java
@@ -206,7 +206,8 @@ public class JsonV3QuerySerdes implements TimeSeriesSerdes {
               spec_start = result.timeSpecification().start();
             }
 
-            if (result.timeSpecification().end().compare(Op.GT, end)) {
+            if (result.timeSpecification().end().compare(Op.GT, end) &&
+                result.timeSpecification().interval() != null) {
               spec_end = end.getCopy();
               int interval = DateTime.getDurationInterval(
                   result.timeSpecification().stringInterval());

--- a/core/src/test/java/net/opentsdb/query/processor/rate/TestRateNumericArrayIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/rate/TestRateNumericArrayIterator.java
@@ -501,7 +501,34 @@ public class TestRateNumericArrayIterator {
     
     assertFalse(it.hasNext());
   }
-  
+
+  @Test
+  public void runAll() {
+    setSource(new MutableNumericValue(new SecondTimeStamp(0L), 40));
+
+    config = (RateConfig) RateConfig.newBuilder()
+            .setInterval("1s")
+            .setId("foo")
+            .build();
+
+    setupMock();
+    when(time_spec.start()).thenReturn(new MillisecondTimeStamp(BASE_TIME));
+    when(time_spec.end()).thenReturn(new MillisecondTimeStamp(BASE_TIME + (60 * 5 * 1000)));
+    when(time_spec.interval()).thenReturn(null);
+    RateNumericArrayIterator it = new RateNumericArrayIterator(node, result,
+            Lists.newArrayList(source));
+
+    assertTrue(it.hasNext());
+    TimeSeriesValue<NumericArrayType> value =
+            (TimeSeriesValue<NumericArrayType>) it.next();
+
+    // TODO - fix it up to ask for the previous interval as well for runall.
+    assertArrayEquals(new double[] { Double.NaN },
+            value.value().doubleArray(), 0.001);
+
+    assertFalse(it.hasNext());
+  }
+
   private void setupMock() {
     node = mock(QueryNode.class);
     result = mock(QueryResult.class);


### PR DESCRIPTION
- Fix a bug in the v3 serdes for arrays with the runall flag.
- Hack around arrays in the RateNumericArrayIterator to prevent an NPE.
  TODO - need to return the previous interval as well.