### PR TITLE
Fix remote code execution #2051 by adding regex validators for the

### DIFF
--- a/src/graph/Plot.java
+++ b/src/graph/Plot.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2010-2012  The OpenTSDB Authors.
+// Copyright (C) 2010-2021  The OpenTSDB Authors.
 //
 // This program is free software: you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License as published by
@@ -15,7 +15,6 @@ package net.opentsdb.graph;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -139,7 +138,7 @@ public final class Plot {
     String[] y_format_keys = {"format y", "format y2"};
     for(String k : y_format_keys){
       if(params.containsKey(k)){
-        params.put(k, URLDecoder.decode(params.get(k)));
+        params.put(k, params.get(k));
       }
     }
     this.params = params;

--- a/test/tsd/TestGraphHandler.java
+++ b/test/tsd/TestGraphHandler.java
@@ -1,91 +1,118 @@
-//// This file is part of OpenTSDB.
-//// Copyright (C) 2011-2012  The OpenTSDB Authors.
-////
-//// This program is free software: you can redistribute it and/or modify it
-//// under the terms of the GNU Lesser General Public License as published by
-//// the Free Software Foundation, either version 2.1 of the License, or (at your
-//// option) any later version.  This program is distributed in the hope that it
-//// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-//// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
-//// General Public License for more details.  You should have received a copy
-//// of the GNU Lesser General Public License along with this program.  If not,
-//// see <http://www.gnu.org/licenses/>.
-//package net.opentsdb.tsd;
+// This file is part of OpenTSDB.
+// Copyright (C) 2011-2021  The OpenTSDB Authors.
 //
-//import java.io.File;
-//import java.lang.reflect.Method;
-//
-//import org.jboss.netty.channel.Channel;
-//import org.junit.Test;
-//import org.junit.runner.RunWith;
-//
-//import static org.junit.Assert.assertFalse;
-//import static org.junit.Assert.assertTrue;
-//import static org.mockito.Matchers.anyString;
-//import static org.mockito.Mockito.times;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-//import org.powermock.api.mockito.PowerMockito;
-//import org.powermock.core.classloader.annotations.PowerMockIgnore;
-//import org.powermock.core.classloader.annotations.PrepareForTest;
-//import org.powermock.modules.junit4.PowerMockRunner;
-//import org.powermock.reflect.Whitebox;
-//
-//import static org.powermock.api.mockito.PowerMockito.mock;
-//
-//@RunWith(PowerMockRunner.class)
-//// "Classloader hell"...  It's real.  Tell PowerMock to ignore these classes
-//// because they fiddle with the class loader.  We don't test them anyway.
-//@PowerMockIgnore({"javax.management.*", "javax.xml.*",
-//                  "ch.qos.*", "org.slf4j.*",
-//                  "com.sum.*", "org.xml.*"})
-//@PrepareForTest({ GraphHandler.class, HttpQuery.class })
-//public final class TestGraphHandler {
-//
-//  private final static Method sm;
-//  static {
-//    try {
-//      sm = GraphHandler.class.getDeclaredMethod("staleCacheFile",
-//          HttpQuery.class, long.class, long.class, File.class);
-//      sm.setAccessible(true);
-//    } catch (Exception e) {
-//      throw new RuntimeException("Failed in static initializer", e);
-//    }
-//  }
-//  
-//  @Test  // If the file doesn't exist, we don't use it, obviously.
-//  public void staleCacheFileDoesntExist() throws Exception {
-//    final File cachedfile = fakeFile("/cache/fake-file");
-//    // From the JDK manual: "returns 0L if the file does not exist
-//    // or if an I/O error occurs"
-//    when(cachedfile.lastModified()).thenReturn(0L);
-//
-//    assertTrue("File is stale", staleCacheFile(null, 0, 10, cachedfile));
-//
-//    verify(cachedfile).lastModified();  // Ensure we do a single stat() call.
-//  }
-//
-//  @Test  // If the mtime of a file is in the future, we don't use it.
-//  public void staleCacheFileInTheFuture() throws Exception {
-//    PowerMockito.mockStatic(System.class);
-//
-//    final HttpQuery query = fakeHttpQuery();
-//    final File cachedfile = fakeFile("/cache/fake-file");
-//
-//    final long now = 1000L;
-//    when(System.currentTimeMillis()).thenReturn(now);
-//    when(cachedfile.lastModified()).thenReturn(now + 1000L);
-//    final long end_time = now;
-//
-//    assertTrue("File is stale",
-//               staleCacheFile(query, end_time, 10, cachedfile));
-//
-//    verify(cachedfile).lastModified();  // Ensure we do a single stat() call.
-//    PowerMockito.verifyStatic(); // Verify that ...
-//    System.currentTimeMillis();  // ... this was called only once.
-//  }
-//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or (at your
+// option) any later version.  This program is distributed in the hope that it
+// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.  You should have received a copy
+// of the GNU Lesser General Public License along with this program.  If not,
+// see <http://www.gnu.org/licenses/>.
+package net.opentsdb.tsd;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.netty.channel.Channel;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import net.opentsdb.graph.Plot;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+@RunWith(PowerMockRunner.class)
+// "Classloader hell"...  It's real.  Tell PowerMock to ignore these classes
+// because they fiddle with the class loader.  We don't test them anyway.
+@PowerMockIgnore({"javax.management.*", "javax.xml.*",
+                  "ch.qos.*", "org.slf4j.*",
+                  "com.sum.*", "org.xml.*"})
+@PrepareForTest({ GraphHandler.class, HttpQuery.class, Plot.class })
+public final class TestGraphHandler {
+
+  private final static Method sm;
+  static {
+    try {
+      sm = GraphHandler.class.getDeclaredMethod("staleCacheFile",
+          HttpQuery.class, long.class, long.class, File.class);
+      sm.setAccessible(true);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed in static initializer", e);
+    }
+  }
+  
+  @Test  
+  public void setPlotParams() throws Exception {
+    Plot plot = mock(Plot.class);
+    HttpQuery query = mock(HttpQuery.class);
+    Map<String, List<String>> params = Maps.newHashMap();
+    when(query.getQueryString()).thenReturn(params);
+    
+    params.put("yrange", Lists.newArrayList("[0:42]"));
+    GraphHandler.setPlotParams(query, plot);
+    
+    params.put("yrange", Lists.newArrayList("[33:system('touch /tmp/poc.txt')]"));
+    try {
+      GraphHandler.setPlotParams(query, plot);
+      fail("Expected BadRequestException");
+    } catch (BadRequestException e) { }
+  }
+  
+  @Test  // If the file doesn't exist, we don't use it, obviously.
+  public void staleCacheFileDoesntExist() throws Exception {
+    final File cachedfile = fakeFile("/cache/fake-file");
+    // From the JDK manual: "returns 0L if the file does not exist
+    // or if an I/O error occurs"
+    when(cachedfile.lastModified()).thenReturn(0L);
+
+    assertTrue("File is stale", staleCacheFile(null, 0, 10, cachedfile));
+
+    verify(cachedfile).lastModified();  // Ensure we do a single stat() call.
+  }
+
+  @Test  // If the mtime of a file is in the future, we don't use it.
+  public void staleCacheFileInTheFuture() throws Exception {
+    PowerMockito.mockStatic(System.class);
+
+    final HttpQuery query = fakeHttpQuery();
+    final File cachedfile = fakeFile("/cache/fake-file");
+
+    final long now = 1000L;
+    when(System.currentTimeMillis()).thenReturn(now);
+    when(cachedfile.lastModified()).thenReturn(now + 1000L);
+    final long end_time = now;
+
+    assertTrue("File is stale",
+               staleCacheFile(query, end_time, 10, cachedfile));
+
+    verify(cachedfile).lastModified();  // Ensure we do a single stat() call.
+    PowerMockito.verifyStatic(); // Verify that ...
+    System.currentTimeMillis();  // ... this was called only once.
+  }
+
 //  @Test  // End time in the future => OK to serve stale file up to max_age.
 //  public void staleCacheFileEndTimeInFuture() throws Exception {
 //    PowerMockito.mockStatic(System.class);
@@ -110,7 +137,7 @@
 //    PowerMockito.verifyStatic(times(3));
 //    System.currentTimeMillis();
 //  }
-//
+
 //  @Test  // No end time = end time is now.
 //  public void staleCacheFileEndTimeIsNow() throws Exception {
 //    PowerMockito.mockStatic(System.class);
@@ -136,27 +163,27 @@
 //    PowerMockito.verifyStatic(times(3));
 //    System.currentTimeMillis();
 //  }
-//
-//  @Test  // End time in the past, file's mtime predates it.
-//  public void staleCacheFileEndTimeInPastOlderFile() throws Exception {
-//    PowerMockito.mockStatic(System.class);
-//
-//    final HttpQuery query = fakeHttpQuery();
-//    final File cachedfile = fakeFile("/cache/fake-file");
-//
-//    final long end_time = 8000L;
-//    final long now = end_time + 2000L;
-//    when(System.currentTimeMillis()).thenReturn(now);
-//    when(cachedfile.lastModified()).thenReturn(5000L);
-//
-//    assertTrue("File predates end-time and cannot be re-used",
-//               staleCacheFile(query, end_time, 4, cachedfile));
-//
-//    verify(cachedfile).lastModified();  // Ensure we do a single stat() call.
-//    PowerMockito.verifyStatic(); // Verify that ...
-//    System.currentTimeMillis();  // ... this was called only once.
-//  }
-//
+
+  @Test  // End time in the past, file's mtime predates it.
+  public void staleCacheFileEndTimeInPastOlderFile() throws Exception {
+    PowerMockito.mockStatic(System.class);
+
+    final HttpQuery query = fakeHttpQuery();
+    final File cachedfile = fakeFile("/cache/fake-file");
+
+    final long end_time = 8000L;
+    final long now = end_time + 2000L;
+    when(System.currentTimeMillis()).thenReturn(now);
+    when(cachedfile.lastModified()).thenReturn(5000L);
+
+    assertTrue("File predates end-time and cannot be re-used",
+               staleCacheFile(query, end_time, 4, cachedfile));
+
+    verify(cachedfile).lastModified();  // Ensure we do a single stat() call.
+    PowerMockito.verifyStatic(); // Verify that ...
+    System.currentTimeMillis();  // ... this was called only once.
+  }
+
 //  @Test  // End time in the past, file's mtime is after it.
 //  public void staleCacheFileEndTimeInPastCacheableFile() throws Exception {
 //    PowerMockito.mockStatic(System.class);
@@ -176,41 +203,41 @@
 //    PowerMockito.verifyStatic(); // Verify that ...
 //    System.currentTimeMillis();  // ... this was called only once.
 //  }
-//
-//  /**
-//   * Helper to call private static method.
-//   * There's one slight difference: the {@code end_time} parameter is in
-//   * milliseconds here, instead of seconds.
-//   */
-//  private static boolean staleCacheFile(final HttpQuery query,
-//                                        final long end_time,
-//                                        final long max_age,
-//                                        final File cachedfile) throws Exception {
-//    PowerMockito.mockStatic(System.class);
-//    PowerMockito.when(System.getProperty(anyString(), anyString())).thenReturn("");
-//    PowerMockito.when(System.getProperty(anyString())).thenReturn("");
-//    PowerMockito.spy(GraphHandler.class);
-//    PowerMockito.doReturn("").when(GraphHandler.class, "findGnuplotHelperScript");
-//    
-//    return Whitebox.<Boolean>invokeMethod(GraphHandler.class, "staleCacheFile",
-//                                          query, end_time / 1000, max_age,
-//                                          cachedfile);
-//    
-//    //return (Boolean)sm.invoke(null, query, end_time / 1000, max_age, cachedfile);
-//  }
-//
-//  private static HttpQuery fakeHttpQuery() {
-//    final HttpQuery query = mock(HttpQuery.class);
-//    final Channel chan = NettyMocks.fakeChannel();
-//    when(query.channel()).thenReturn(chan);
-//    return query;
-//  }
-//
-//  private static File fakeFile(final String path) {
-//    final File file = mock(File.class);
-//    when(file.getPath()).thenReturn(path);
-//    when(file.toString()).thenReturn(path);
-//    return file;
-//  }
-//
-//}
+
+  /**
+   * Helper to call private static method.
+   * There's one slight difference: the {@code end_time} parameter is in
+   * milliseconds here, instead of seconds.
+   */
+  private static boolean staleCacheFile(final HttpQuery query,
+                                        final long end_time,
+                                        final long max_age,
+                                        final File cachedfile) throws Exception {
+    PowerMockito.mockStatic(System.class);
+    PowerMockito.when(System.getProperty(anyString(), anyString())).thenReturn("");
+    PowerMockito.when(System.getProperty(anyString())).thenReturn("");
+    PowerMockito.spy(GraphHandler.class);
+    PowerMockito.doReturn("").when(GraphHandler.class, "findGnuplotHelperScript");
+    
+    return Whitebox.<Boolean>invokeMethod(GraphHandler.class, "staleCacheFile",
+                                          query, end_time / 1000, max_age,
+                                          cachedfile);
+    
+    //return (Boolean)sm.invoke(null, query, end_time / 1000, max_age, cachedfile);
+  }
+
+  private static HttpQuery fakeHttpQuery() {
+    final HttpQuery query = mock(HttpQuery.class);
+    final Channel chan = NettyMocks.fakeChannel();
+    when(query.channel()).thenReturn(chan);
+    return query;
+  }
+
+  private static File fakeFile(final String path) {
+    final File file = mock(File.class);
+    when(file.getPath()).thenReturn(path);
+    when(file.toString()).thenReturn(path);
+    return file;
+  }
+
+}


### PR DESCRIPTION
Gnuplot params and introducting the tsd.gnuplot.options.allowlist
setting that is a strict matching allow list of o= values from the
query string that will be allowed through. By default tihs is empty
so if folks are using this query param, they'll different graphs
until they add the options they need.