### PR TITLE
SERVLET:

### DIFF
--- a/implementation/athenz/src/main/java/net/opentsdb/auth/AthenzMTLSAuthFilter.java
+++ b/implementation/athenz/src/main/java/net/opentsdb/auth/AthenzMTLSAuthFilter.java
@@ -28,6 +28,8 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.KeyStore;
@@ -105,6 +107,25 @@ public class AthenzMTLSAuthFilter extends BaseAuthenticationPlugin {
   protected void runFilter(final ServletRequest servletRequest,
                            final ServletResponse servletResponse,
                            final FilterChain chain) throws IOException, ServletException {
+    final AuthState state = authenticate(servletRequest);
+    if (state != null) {
+      servletRequest.setAttribute(AUTH_STATE_KEY, state);
+      HttpServletRequestWrapper wrapper =
+              new HttpServletRequestWrapper((HttpServletRequest) servletRequest) {
+                @Override
+                public java.security.Principal getUserPrincipal() {
+                  return state.getPrincipal();
+                }
+              };
+      chain.doFilter(wrapper, servletResponse);
+    }
+
+    sendResponse((HttpServletResponse) servletResponse, 403,
+            "Missing or invalid certificate.");
+  }
+
+  @Override
+  public AuthState authenticate(final ServletRequest servletRequest) {
     X509Certificate[] certs = (X509Certificate[]) servletRequest.getAttribute(
             JAVAX_CERT_ATTR);
     StringBuilder errorMsg = new StringBuilder();
@@ -124,18 +145,12 @@ public class AthenzMTLSAuthFilter extends BaseAuthenticationPlugin {
       }
 
       if (!matched) {
-        sendResponse((HttpServletResponse) servletResponse, 403,
-                "Invalid certificate.");
-        return;
+        return null;
       }
 
-      final AthenzAuthState state = new AthenzAuthState(principal);
-      servletRequest.setAttribute(AUTH_STATE_KEY, state);
-      chain.doFilter(servletRequest, servletResponse);
+      return new AthenzAuthState(principal);
     }
-
-    sendResponse((HttpServletResponse) servletResponse, 403,
-            "Missing certificate.");
+    return null;
   }
 
   /**

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/filter/AuthFilter.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/filter/AuthFilter.java
@@ -15,7 +15,9 @@
 package net.opentsdb.servlet.filter;
 
 import javax.servlet.Filter;
+import javax.servlet.ServletRequest;
 
+import net.opentsdb.auth.AuthState;
 import net.opentsdb.auth.Authentication;
 
 /**
@@ -28,5 +30,17 @@ public interface AuthFilter extends Filter, Authentication {
 
   /** The key used to lookup the AuthState object in the request attributes. */
   public static String AUTH_STATE_KEY = "tsdb.authstate";
-  
+
+  /**
+   * Method used for multi-auth where the plugin must try to auth and return a
+   * null the required data wasn't found or an auth state if something _was_
+   * found to attempt authentication.
+   *
+   * @param servletRequest The non-null servlet request to look at for auth
+   *                       data.
+   * @return Null if not enough data was found, a non-null auth state if enough
+   * data was found to make a judgement. The state could be good or bad.
+   */
+  public AuthState authenticate(final ServletRequest servletRequest);
+
 }

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/filter/MultiAuthFilter.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/filter/MultiAuthFilter.java
@@ -1,0 +1,154 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2021  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package net.opentsdb.servlet.filter;
+
+import com.google.common.collect.Lists;
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+import net.opentsdb.auth.AuthState;
+import net.opentsdb.auth.AuthState.AuthStatus;
+import net.opentsdb.auth.Authorization;
+import net.opentsdb.configuration.ConfigurationEntrySchema;
+import net.opentsdb.configuration.ConfigurationEntrySchema.Builder;
+import net.opentsdb.core.TSDB;
+import net.opentsdb.servlet.auth.BaseAuthenticationPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.List;
+
+/**
+ * A filter that takes a list of two or more {@link AuthFilter}s and examines
+ * each in order until it finds a valid auth state or they all fail. Filters
+ * are processed in order. If none of the filters are valid then the last filter
+ * in the list is called to respond to the client.
+ *
+ * @since 3.0
+ */
+public class MultiAuthFilter extends BaseAuthenticationPlugin {
+  protected static final Logger LOG = LoggerFactory.getLogger(MultiAuthFilter.class);
+
+  public static final String TYPE = "MultiAuthFilter";
+  public static final String FILTERS_KEY = "multiauth.filter.filters";
+
+  private List<AuthFilter> filters;
+
+  @Override
+  public Deferred<Object> initialize(final TSDB tsdb, final String id) {
+    return super.initialize(tsdb, id).addCallback(new Callback<Object, Object>() {
+      @Override
+      public Object call(Object arg) throws Exception {
+        registerConfigs(tsdb);
+
+        final List<String> filterIds = tsdb.getConfig().getTyped(FILTERS_KEY, List.class);
+        if (filterIds == null || filterIds.isEmpty()) {
+          return Deferred.fromError(new IllegalArgumentException(
+                  "Filter IDs list must have one or more entries."));
+        }
+        filters = Lists.newArrayListWithExpectedSize(filterIds.size());
+        for (final String plugin : filterIds) {
+          final AuthFilter authFilter = tsdb.getRegistry().getPlugin(AuthFilter.class, plugin);
+          if (authFilter == null) {
+            LOG.error("No auth filter plugin found for {}", plugin);
+            return Deferred.fromError(new IllegalArgumentException(
+                    "No auth filter plugin found for " + plugin));
+          }
+
+          // recursion is a no-no
+          if (authFilter instanceof MultiAuthFilter) {
+            return Deferred.fromError(new IllegalArgumentException(
+                    "Recursive or nested multi-auth filters are not allowed."));
+          }
+
+          filters.add(authFilter);
+          LOG.info("Loaded plugin {} for multi-auth.", plugin);
+        }
+        return null;
+      }
+    });
+  }
+
+  @Override
+  protected void runFilter(final ServletRequest servletRequest,
+                           final ServletResponse servletResponse,
+                           final FilterChain chain) throws IOException, ServletException {
+    for (int i = 0; i < filters.size(); i++) {
+      final AuthFilter filter = filters.get(i);
+      final AuthState state = filter.authenticate(servletRequest);
+      if (state == null) {
+        continue;
+      }
+
+      if (state.getStatus() != AuthStatus.SUCCESS) {
+        continue;
+      }
+
+      // yay!
+      servletRequest.setAttribute(AUTH_STATE_KEY, state);
+      HttpServletRequestWrapper wrapper =
+              new HttpServletRequestWrapper((HttpServletRequest) servletRequest) {
+        @Override
+        public Principal getUserPrincipal() {
+          return state.getPrincipal();
+        }
+      };
+
+      chain.doFilter(wrapper, servletResponse);
+    }
+
+    // nothing so re-do the last one.
+    filters.get(filters.size() - 1).doFilter(servletRequest, servletResponse, chain);
+  }
+
+  @Override
+  public Authorization authorization() {
+    return null;
+  }
+
+  @Override
+  public String type() {
+    return TYPE;
+  }
+
+  @Override
+  protected void registerConfigs(final TSDB tsdb) {
+    super.registerConfigs(tsdb);
+
+    if (!tsdb.getConfig().hasProperty(FILTERS_KEY)) {
+      tsdb.getConfig().register(ConfigurationEntrySchema.newBuilder()
+              .setKey(FILTERS_KEY)
+              .setDefaultValue(Lists.newArrayList())
+              .setDescription("A list of auth filter plugin IDs to be " +
+                      "processed in order.")
+              .setType(List.class)
+              .build());
+    }
+  }
+
+  @Override
+  public AuthState authenticate(ServletRequest servletRequest) {
+    throw new IllegalStateException(
+            "Nested or recursive multi-auth filters are not allowed.");
+  }
+}

--- a/implementation/servlet/src/main/java/net/opentsdb/servlet/filter/NoAuthFilter.java
+++ b/implementation/servlet/src/main/java/net/opentsdb/servlet/filter/NoAuthFilter.java
@@ -1,5 +1,20 @@
+// This file is part of OpenTSDB.
+// Copyright (C) 2021  The OpenTSDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package net.opentsdb.servlet.filter;
 
+import net.opentsdb.auth.AuthState;
 import net.opentsdb.auth.Authorization;
 
 import javax.servlet.FilterChain;
@@ -12,14 +27,67 @@ import javax.servlet.http.HttpServletRequestWrapper;
 import java.io.IOException;
 import java.security.Principal;
 
+/**
+ * Simple filter that sets a "NoAuth" principal.
+ *
+ * @since 3.0
+ */
 public class NoAuthFilter implements AuthFilter {
   private final Principal principal;
+  private final AuthState authState;
 
   public NoAuthFilter() {
     principal = new Principal() {
       @Override
       public String getName() {
         return "NoAuth";
+      }
+    };
+
+    authState = new AuthState() {
+      @Override
+      public String getUser() {
+        return principal.getName();
+      }
+
+      @Override
+      public Principal getPrincipal() {
+        return principal;
+      }
+
+      @Override
+      public AuthStatus getStatus() {
+        return AuthStatus.UNAUTHORIZED;
+      }
+
+      @Override
+      public String getMessage() {
+        return "NoAuth filter is loaded.";
+      }
+
+      @Override
+      public Throwable getException() {
+        return null;
+      }
+
+      @Override
+      public String getTokenType() {
+        return null;
+      }
+
+      @Override
+      public byte[] getToken() {
+        return null;
+      }
+
+      @Override
+      public boolean hasRole(String role) {
+        return false;
+      }
+
+      @Override
+      public boolean hasPermission(String action) {
+        return false;
       }
     };
   }
@@ -37,6 +105,7 @@ public class NoAuthFilter implements AuthFilter {
         return principal;
       }
     };
+    request.setAttribute(AUTH_STATE_KEY, authState);
     chain.doFilter(wrapper, response);
   }
 
@@ -48,5 +117,10 @@ public class NoAuthFilter implements AuthFilter {
   @Override
   public Authorization authorization() {
     return null;
+  }
+
+  @Override
+  public AuthState authenticate(ServletRequest servletRequest) {
+    return authState;
   }
 }


### PR DESCRIPTION
- Add a MultiAuthFilter to chain across multiple auth filters in case
  we need to accept more than one type, e.g. a cookie and MTLS.

OKTA/ATHENZ:
- Implement the new method for the chain filter.