### PR TITLE
Fixed a deadlock in BaseAnomalyNode.class

### DIFF
--- a/core/src/main/java/net/opentsdb/query/anomaly/BaseAnomalyNode.java
+++ b/core/src/main/java/net/opentsdb/query/anomaly/BaseAnomalyNode.java
@@ -226,7 +226,9 @@ public class BaseAnomalyNode extends AbstractQueryNode {
           LOG.info("******* Sending out to cache...");
         } else {
           LOG.info("****** Fetching training data!");
-          fetchTrainingData(0);
+          for (int i = 0; i < predictions.length; i++) {
+            fetchTrainingData(i);
+          }
         }
         return null;
       }
@@ -285,7 +287,7 @@ public class BaseAnomalyNode extends AbstractQueryNode {
       
       return null;
     }
-    
+
   }
   
   public class CacheErrCB implements Callback<Void, Exception> {


### PR DESCRIPTION
In the following code, we found a problem where if LATCH > 2 is calculated (predictions.length >= 2), countdown() is not called more than 3 times and LATCH = 0 is not reached, resulting in a deadlock and failure to execute the query.

Calculate LATCH : 
https://github.com/OpenTSDB/opentsdb/blob/7cce3a270b32a07b077a383553c0696105f19b61/core/src/main/java/net/opentsdb/query/anomaly/BaseAnomalyNode.java#L160-L173

countdonw():
https://github.com/OpenTSDB/opentsdb/blob/7cce3a270b32a07b077a383553c0696105f19b61/core/src/main/java/net/opentsdb/query/anomaly/BaseAnomalyNode.java#L502-L508

This PR will fix the above issue.

We believe that there are various ways to fix this issue.
If you have a better solution, please let us discuss it in this PR.

---

Before the following change, I was running fetchTrainingData() for each member of predictions.
OlympicScoringNode.java, line: 262 
https://github.com/OpenTSDB/opentsdb/commit/3b3765a529aead4755b22424d735cbb1fa6e5dc9#diff-e74f94e8de15a9648b905a5533b52fc8L262

After the change, fetchTrainingData() will be executed only once.
https://github.com/OpenTSDB/opentsdb/blob/7cce3a270b32a07b077a383553c0696105f19b61/core/src/main/java/net/opentsdb/query/anomaly/BaseAnomalyNode.java#L229

In the modified code, there is a mismatch between the precomputed LATCH and the actual number of BaselineQuery to be executed, resulting in a deadlock.

To fix this problem, change the code to execute fetchTrainingData() for each member of predictions.
(Same as the code before the change)