### PR TITLE
Fix race condition in UID lookup

### DIFF
--- a/src/core/SaltScanner.java
+++ b/src/core/SaltScanner.java
@@ -646,8 +646,7 @@ public class SaltScanner {
           // TODO - more efficient resolution
           // TODO - byte set instead of a string for the uid may be faster
           if (filters != null && !filters.isEmpty()) {
-            lookups.clear();
-            final String tsuid = 
+            final String tsuid =
                 UniqueId.uidToString(UniqueId.getTSUIDFromKey(key, 
                 TSDB.metrics_width(), Const.TIMESTAMP_BYTES));
             if (skips.contains(tsuid)) {


### PR DESCRIPTION
Ensure the scanner callback waits for all the UIDs to resolve before calling scan to retrieve the next set of results.  If we clear lookups between each row, we only ensure the lookups have resolved for the last row in the iterator.

Not waiting can cause the scanner to close prematurely and return incomplete results.

Fixes #2175 