### PR TITLE
CORE:

### DIFF
--- a/common/src/main/java/net/opentsdb/query/plan/QueryPlanner.java
+++ b/common/src/main/java/net/opentsdb/query/plan/QueryPlanner.java
@@ -151,6 +151,18 @@ public interface QueryPlanner {
     public String downsampleInterval;
     public String windowInterval;
     public int previousIntervals;
+
+    @Override
+    public String toString() {
+      return new StringBuilder()
+              .append("ds=")
+              .append(downsampleInterval)
+              .append(", wi=")
+              .append(windowInterval)
+              .append(", pi=")
+              .append(previousIntervals)
+              .toString();
+    }
   }
 
 }

--- a/core/src/main/java/net/opentsdb/query/plan/DefaultQueryPlanner.java
+++ b/core/src/main/java/net/opentsdb/query/plan/DefaultQueryPlanner.java
@@ -871,11 +871,14 @@ public class DefaultQueryPlanner implements QueryPlanner {
       if (predecessor instanceof DownsampleConfig) {
         if (adjustments == null) {
           adjustments = new TimeAdjustments();
+        }
+
+        if (adjustments.downsampleInterval == null) {
           adjustments.downsampleInterval =
                   ((DownsampleConfig) predecessor).getInterval();
           if (adjustments.downsampleInterval.equals(DownsampleConfig.AUTO)) {
-            final long deltaSeconds = context.query().endTime().epoch() -
-                    context.query().startTime().epoch();
+            final long deltaSeconds = context.query().endTime().msEpoch() -
+                    context.query().startTime().msEpoch();
             adjustments.downsampleInterval =
                     DownsampleFactory.getAutoInterval(context().tsdb(),
                             deltaSeconds,
@@ -884,8 +887,6 @@ public class DefaultQueryPlanner implements QueryPlanner {
             adjustments.downsampleInterval = null;
           }
         }
-
-        adjustments = recursiveAdjustments(predecessor, adjustments);
         continue;
       }
 
@@ -931,7 +932,9 @@ public class DefaultQueryPlanner implements QueryPlanner {
           }
         }
       }
+    }
 
+    for (final QueryNodeConfig predecessor : predecessors) {
       // TODO - figure out the best traversal for this.
       adjustments = recursiveAdjustments(predecessor, adjustments);
     }

--- a/core/src/main/java/net/opentsdb/query/processor/merge/MergerConfig.java
+++ b/core/src/main/java/net/opentsdb/query/processor/merge/MergerConfig.java
@@ -29,6 +29,7 @@ import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import net.opentsdb.core.Const;
 import net.opentsdb.core.TSDB;
+import net.opentsdb.data.TimeStamp;
 import net.opentsdb.query.BaseQueryNodeConfigWithInterpolators;
 import net.opentsdb.query.DefaultQueryResultId;
 import net.opentsdb.query.QueryResultId;
@@ -69,6 +70,9 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
   
   /** The raw aggregator. */
   private final String aggregator;
+  private final int aggregatorArraySize;
+  private final TimeStamp firstDataTimestamp;
+  private final String aggregatorInterval;
   
   /** Whether or not NaNs are infectious. */
   private final boolean infectious_nan;
@@ -97,6 +101,9 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
     mode = builder.mode;
     data_source = builder.dataSource;
     aggregator = builder.aggregator;
+    aggregatorArraySize = builder.aggregatorArraySize;
+    firstDataTimestamp = builder.firstDataTimestamp;
+    aggregatorInterval = builder.aggregatorInterval;
     sortedDataSources = builder.sortedDataSources;
     timeouts = builder.timeouts;
     infectious_nan = builder.infectious_nan;
@@ -120,6 +127,10 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
   public String getAggregator() {
     return aggregator;
   }
+
+  public int getAggregatorArraySize() {
+    return aggregatorArraySize;
+  }
   
   /** @return Whether or not NaNs should be treated as sentinels or considered 
    * in arithmetic. */
@@ -135,6 +146,14 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
     return timeouts;
   }
 
+  public TimeStamp firstDataTimestamp() {
+    return firstDataTimestamp;
+  }
+
+  public String aggregatorInterval() {
+    return aggregatorInterval;
+  }
+
   public boolean getAllowPartialResults() {
     return allowPartialResults;
   }
@@ -145,6 +164,9 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
         .setMode(mode)
         .setDataSource(data_source)
         .setAggregator(aggregator)
+        .setAggregatorArraySize(aggregatorArraySize)
+        .setAggregatorInterval(aggregatorInterval)
+        .setFirstDataTimestamp(firstDataTimestamp)
         .setSortedDataSources(sortedDataSources)
         .setTimeouts(timeouts)
         .setInfectiousNan(infectious_nan)
@@ -170,6 +192,7 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
     return Objects.equal(mode, merger.mode) &&
            Objects.equal(id, merger.getId()) &&
            Objects.equal(aggregator, merger.getAggregator()) &&
+           Objects.equal(aggregatorArraySize, merger.getAggregatorArraySize()) &&
            Objects.equal(infectious_nan, merger.getInfectiousNan() &&
            Objects.equal(sortedDataSources, merger.sortedSources()) &&
            Objects.equal(timeouts, merger.timeouts())) &&
@@ -188,6 +211,7 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
     final HashCode hc = Const.HASH_FUNCTION().newHasher()
             .putInt(mode.ordinal())
             .putString(Strings.nullToEmpty(aggregator), Const.UTF8_CHARSET)
+            .putInt(aggregatorArraySize)
             .putBoolean(infectious_nan)
             .putBoolean(allowPartialResults)
             .hash();
@@ -231,6 +255,11 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
       builder.setAggregator(temp.asText());
     }
 
+    temp = node.get("aggregatorInterval");
+    if (temp != null && !temp.isNull()) {
+      builder.setAggregatorArraySize(temp.asInt());
+    }
+
     temp = node.get("dataSource");
     if (temp != null && !temp.isNull()) {
       builder.setDataSource(temp.asText());
@@ -266,6 +295,9 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
     private boolean infectious_nan;
     @JsonProperty
     private boolean allowPartialResults;
+    private int aggregatorArraySize;
+    private String aggregatorInterval;
+    private TimeStamp firstDataTimestamp;
     private List<String> sortedDataSources;
     private List<String> timeouts;
     
@@ -314,6 +346,21 @@ public class MergerConfig extends BaseQueryNodeConfigWithInterpolators<MergerCon
 
     public Builder setAllowPartialResults(final boolean allowPartialResults) {
       this.allowPartialResults = allowPartialResults;
+      return this;
+    }
+
+    public Builder setAggregatorArraySize(final int aggregatorArraySize) {
+      this.aggregatorArraySize = aggregatorArraySize;
+      return this;
+    }
+
+    public Builder setFirstDataTimestamp(final TimeStamp firstDataTimestamp) {
+      this.firstDataTimestamp = firstDataTimestamp;
+      return this;
+    }
+
+    public Builder setAggregatorInterval(final String aggregatorInterval) {
+      this.aggregatorInterval = aggregatorInterval;
       return this;
     }
 

--- a/core/src/main/java/net/opentsdb/query/processor/merge/MergerFactory.java
+++ b/core/src/main/java/net/opentsdb/query/processor/merge/MergerFactory.java
@@ -202,6 +202,7 @@ public class MergerFactory extends BaseQueryNodeFactory<MergerConfig, Merger> {
                                                final TypeToken<? extends TimeSeriesDataType> type) {
       switch (((MergerConfig) node.config()).getMode()) {
         case HA:
+        case SHARD:
           return new MergerNumericArrayIterator(node, result, sources);
         case SPLIT:
           return new SplitNumericArrayIterator(node, result, sources);

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerResult.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestMergerResult.java
@@ -182,8 +182,8 @@ public class TestMergerResult {
     assertTrue(ts.sources.contains(ts2));
     assertTrue(ts.sources.contains(ts4));
 
-    assertEquals(result_a, merger.next.get(0));
-    assertEquals(result_b, merger.next.get(1));
+    assertEquals(result_a, merger.queryResults.get(0));
+    assertEquals(result_b, merger.queryResults.get(1));
   }
 
   @Test
@@ -207,8 +207,8 @@ public class TestMergerResult {
     assertTrue(ts.sources.contains(ts2));
     assertTrue(ts.sources.contains(ts4));
 
-    assertEquals(result_a, merger.next.get(0));
-    assertEquals(result_b, merger.next.get(1));
+    assertEquals(result_a, merger.queryResults.get(0));
+    assertEquals(result_b, merger.queryResults.get(1));
   }
 
   @Test

--- a/core/src/test/java/net/opentsdb/query/processor/merge/TestSplitNumericArrayIterator.java
+++ b/core/src/test/java/net/opentsdb/query/processor/merge/TestSplitNumericArrayIterator.java
@@ -35,6 +35,7 @@ import net.opentsdb.utils.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -106,6 +107,15 @@ public class TestSplitNumericArrayIterator {
     NumericTestUtils.assertArrayEqualsNaNs(
             new double[] { 1, 5, 2, 1, 4, Double.NaN, 9, 0, 2, 3, 4},
             nai.value().doubleArray(), 0.0001);
+  }
+
+  @Test
+  public void paddingBothEndsAvg() throws Exception {
+    setupQuery(BASE_TS + (60 * 2), BASE_TS + (60 * 8), "1m", "avg");
+    SplitNumericArrayIterator nai = new SplitNumericArrayIterator(node, result, overlapped());
+    assertFalse(nai.value().isInteger());
+    assertArrayEquals(new double[] { 2, 1, 4, 8, 9, 0 },
+            nai.value().doubleArray(), 0.001);
   }
 
   void setupQuery(long start, long end, String interval, String agg) throws Exception {

--- a/core/src/test/java/net/opentsdb/query/router/TestTimeRouterFactorySplitIntegration.java
+++ b/core/src/test/java/net/opentsdb/query/router/TestTimeRouterFactorySplitIntegration.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of OpenTSDB.
+ * Copyright (C) 2021  The OpenTSDB Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.opentsdb.query.router;
+
+import net.opentsdb.core.MockTSDB;
+
+public class TestTimeRouterFactorySplitIntegration {
+
+  protected static MockTSDB TSDB;
+
+}


### PR DESCRIPTION
- Tweak HAClusterFactory to handle pushdowns in the config coming into
  setupQuery.
- Let HACluster check sources to see if they support pushdown.
- Fix a bug in the time adjustment search for DefaultQueryPlanner.
- Add downsample settings to the MergerConfig that we need when handling
  split queries with arrays.
- Fix the TimeSpec for MergerResult so that it reflects the split query time
  properly.