### PR TITLE
CORE:

### DIFF
--- a/core/src/main/java/net/opentsdb/data/BaseTimeSeriesByteId.java
+++ b/core/src/main/java/net/opentsdb/data/BaseTimeSeriesByteId.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2018  The OpenTSDB Authors.
+// Copyright (C) 2018-2021  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,8 @@ import net.opentsdb.utils.Bytes.ByteMap;
  * @since 3.0
  */
 public class BaseTimeSeriesByteId implements TimeSeriesByteId {
-  
+  public static final ByteMap<byte[]> EMPTY_MAP = new ByteMap<byte[]>();
+
   /** The data store used to resolve the encoded ID to strings. */
   protected final TimeSeriesDataSourceFactory data_store; 
   
@@ -72,7 +73,11 @@ public class BaseTimeSeriesByteId implements TimeSeriesByteId {
   
   /** Whether or not to skip the metric during decoding. */
   protected boolean skip_metric;
-  
+
+  protected BaseTimeSeriesByteId(final TimeSeriesDataSourceFactory data_store) {
+    this.data_store = data_store;
+  }
+
   /**
    * Private CTor used by the builder. Converts the Strings to byte arrays
    * using UTF8.
@@ -157,7 +162,7 @@ public class BaseTimeSeriesByteId implements TimeSeriesByteId {
 
   @Override
   public ByteMap<byte[]> tags() {
-    return tags;
+    return tags == null ? EMPTY_MAP: tags;
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/data/BaseTimeSeriesStringId.java
+++ b/core/src/main/java/net/opentsdb/data/BaseTimeSeriesStringId.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018  The OpenTSDB Authors.
+// Copyright (C) 2017-2021  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -82,6 +82,10 @@ public class BaseTimeSeriesStringId implements TimeSeriesStringId {
   /** An optional total number of search hits */
   protected long hits;
 
+  protected BaseTimeSeriesStringId() {
+    // empty ctor for overrides without a builder.
+  }
+
   /**
    * Private CTor used by the builder. Converts the Strings to byte arrays
    * using UTF8.
@@ -151,7 +155,7 @@ public class BaseTimeSeriesStringId implements TimeSeriesStringId {
 
   @Override
   public Map<String, String> tags() {
-    return tags;
+    return tags == null ? Collections.emptyMap() : tags;
   }
 
   @Override

--- a/core/src/main/java/net/opentsdb/data/MergedTimeSeriesId.java
+++ b/core/src/main/java/net/opentsdb/data/MergedTimeSeriesId.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017  The OpenTSDB Authors.
+// Copyright (C) 2017-2021  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 // limitations under the License.
 package net.opentsdb.data;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -22,10 +23,9 @@ import java.util.Set;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.reflect.TypeToken;
-
 import net.opentsdb.common.Const;
 import net.opentsdb.utils.ByteSet;
 import net.opentsdb.utils.Bytes;
@@ -33,24 +33,24 @@ import net.opentsdb.utils.Bytes.ByteMap;
 
 /**
  * An ID that can be used to merge multiple time series into one. Use by
- * calling {@link #newBuilder()}, setting an opitonal Alias and calling 
- * {@link Builder#addSeries(TimeSeriesStringId)} as many times as needed. It has the
+ * calling {@link #newBuilder()} and calling
+ * {@link Builder#addSeries(TimeSeriesId)} as many times as needed. The metric,
+ * alias and namespace are carried over from the FIRST ID added. Future IDs
+ * are not checked for similar fields to avoid unnecessary checks. It has the
  * following logic:
  * <p>
  * <ul>
- * <li>Alias' for the individual IDs are ignored. Use 
- * {@link Builder#setAlias(byte[])}.</li>
- * <li>Namespaces are merged into a unique set of values.</li>
- * <li>Metrics are merged into a unique set of values.</li>
  * <li>Tags, Aggregated Tags and Disjoint Tags are merged in the following way:
  *   <ul>
  *   <li>Tag pairs with the same key and value across all IDs are merged in the
- *   {@link #tags()} map.</li>
- *   <li>Tag keys that appear across all IDs (or in the {@link #aggregatedTags()}
- *   list) are placed in the {@link #aggregatedTags()} list.</li>
+ *   {@link TimeSeriesStringId#tags()} map.</li>
+ *   <li>Tag keys that appear across all IDs (or in the
+ *   {@link TimeSeriesStringId#aggregatedTags()} list) are placed in the
+ *   {@link TimeSeriesStringId#aggregatedTags()} list.</li>
  *   <li>Tag keys that do NOT appear consistently across all IDs in the 
- *   {@link #tags()} or {@link #aggregatedTags()} sets are moved to the 
- *   {@link #disjointTags()} list.</li> 
+ *   {@link TimeSeriesStringId#tags()} or
+ *   {@link TimeSeriesStringId#aggregatedTags()} sets are moved to the
+ *   {@link TimeSeriesStringId#disjointTags()} list.</li>
  *   </ul></li>
  * </ul>
  * 
@@ -64,127 +64,34 @@ public class MergedTimeSeriesId {
   }
 
   public static class Builder {
-    protected List<TimeSeriesId> ids;
-    protected byte[] alias;
-    protected byte[] namespace;
-    protected byte[] metric;
     protected boolean full_merge;
-    protected TypeToken<? extends TimeSeriesId> type;
-    protected TimeSeriesDataSourceFactory data_store;
-    
+    protected MergingTimeSeriesId id;
+
     /**
-     * Sets the alias override to the given string or null.
-     * @param alias A non-empty string or null to clear the override.
+     * Adds the given ID to the merged set, demoting tags to the aggregate or
+     * disjoint fields if appropriate.
+     *
+     * @param id A non-null byte or string time series ID
      * @return The builder.
-     */
-    public Builder setAlias(final String alias) {
-      if (!Strings.isNullOrEmpty(alias)) {
-        this.alias = alias.getBytes(Const.UTF8_CHARSET);
-      } else {
-        this.alias = null;
-      }
-      return this;
-    }
-    
-    /**
-     * Sets the alias override for byte time series IDs.
-     * @param alias A non-empty byte array or null to clear the override.
-     * @return The builder.
-     */
-    public Builder setAlias(final byte[] alias) {
-      this.alias = alias;
-      return this;
-    }
-    
-    /**
-     * Sets the namespace override to the given string or null.
-     * @param namespace A non-empty string or null to clear the override.
-     * @return The builder.
-     */
-    public Builder setNamespace(final String namespace) {
-      if (!Strings.isNullOrEmpty(namespace)) {
-        this.namespace = namespace.getBytes(Const.UTF8_CHARSET);
-      } else {
-        this.namespace = null;
-      }
-      return this;
-    }
-    
-    /**
-     * Sets the namespace override for byte time series IDs
-     * @param namespace A non-empty byte array or null to clear the override.
-     * @return The builder.
-     */
-    public Builder setNamespace(final byte[] namespace) {
-      this.namespace = namespace;
-      return this;
-    }
-    
-    /**
-     * Sets the metric override to the given string or null.
-     * @param metric A non-empty string or null to clear the override.
-     * @return The builder.
-     */
-    public Builder setMetric(final String metric) {
-      if (!Strings.isNullOrEmpty(metric)) {
-        this.metric = metric.getBytes(Const.UTF8_CHARSET);
-      } else {
-        this.metric = null;
-      }
-      return this;
-    }
-    
-    /**
-     * Sets the metric override for byte time series IDs.
-     * @param metric A non-empty string or null to clear the override.
-     * @return The builder.
-     */
-    public Builder setMetric(final byte[] metric) {
-      this.metric = metric;
-      return this;
-    }
-    
-    /**
-     * Adds the given time series to the merge list. The first ID added
-     * will set the ID type for the set. If an ID of a different time is
-     * passed as an argument, an exception will be thrown. All ID types
-     * must be the same.
-     * @param id A non-null ID
-     * @return The builder.
-     * @throws IllegalArgumentException if the ID was null.
-     * @throws RuntimeException if an ID of a different type than existing
-     * IDs was provided.
+     * @throws IllegalArgumentException if the ID was null or it wasn't a known
+     * type of ID (e.g. byte or string).
      */
     public Builder addSeries(final TimeSeriesId id) {
       if (id == null) {
         throw new IllegalArgumentException("ID cannot be null.");
       }
-      if (ids == null) {
-        ids = Lists.newArrayListWithExpectedSize(2);
-      }
-      if (type == null) {
-        type = id.type();
-        if (id instanceof TimeSeriesByteId) {
-          data_store = ((TimeSeriesByteId) id).dataStore();
-        }
-      } else {
-        if (!type.equals(id.type())) {
-          // TODO - proper exception type
-          throw new RuntimeException("Attempted to add an ID of type " 
-              + id.type() + " that was not the same as the first "
-              + "ID's type: " + type);
-        }
-        if (id instanceof TimeSeriesByteId) {
-          if (!data_store.equals(((TimeSeriesByteId) id).dataStore())) {
-            // TODO - proper exception type
-            throw new RuntimeException("Attempted to add an ID with a " 
-                + "different schema " + ((TimeSeriesByteId) id).dataStore() 
-                + " that was not the same as the first "
-                + "ID's schema: " + data_store);
-          }
+
+      if (this.id == null) {
+        if (id.type() == Const.TS_BYTE_ID) {
+          this.id = new MergingByteId(((TimeSeriesByteId) id).dataStore(), full_merge);
+        } else if (id.type() == Const.TS_STRING_ID) {
+          this.id = new MergingStringId(full_merge);
+        } else {
+          throw new IllegalArgumentException("Unknown ID data type: " + id.type());
         }
       }
-      ids.add(id);
+
+      this.id.addSeries(id);
       return this;
     }
 
@@ -195,453 +102,508 @@ public class MergedTimeSeriesId {
     
     /** @return The merged time series ID. */
     public TimeSeriesId build() {
-      if (type.equals(Const.TS_STRING_ID)) {
-        if (full_merge) {
-          return mergeStringIds();
-        } else {
-          return mergeStringIdsWODisjoint();
-        }
-      } else if (type.equals(Const.TS_BYTE_ID)) {
-        return mergeByteIds();
-      }
-      // TODO - proper exception
-      throw new RuntimeException("Unhandled ID type: " + type);
-    }
-    
-    /**
-     * Alternate method that saves a ton of CPU time by just computing
-     * the tags and agg tags.
-     * @return
-     */
-    private TimeSeriesId mergeStringIdsWODisjoint() {
-      if (ids.size() == 1) {
-        return ids.get(0);
-      }
-      
-      TimeSeriesStringId first_id = (TimeSeriesStringId) ids.get(0);
-      final BaseTimeSeriesStringId.Builder builder = 
-          BaseTimeSeriesStringId.newBuilder()
-          .setNamespace(first_id.namespace())
-          .setMetric(first_id.metric());
-      
-      Set<String> agg = Sets.newHashSet();
-      if (first_id.tags() != null && !first_id.tags().isEmpty()) {
-        builder.setTags(Maps.newHashMap(first_id.tags()));
-      }
-      if (first_id.aggregatedTags() != null && 
-          !first_id.aggregatedTags().isEmpty()) {
-        agg.addAll(first_id.aggregatedTags());
-      }
-      
-      for (final TimeSeriesId raw_id : ids) {
-        final TimeSeriesStringId id = (TimeSeriesStringId) raw_id;
-        for (final Entry<String, String> entry : id.tags().entrySet()) {
-          final String extant = builder.tags().get(entry.getKey());
-          if (extant == null) {
-            agg.add(entry.getKey());
-          } else if (!extant.equals(entry.getValue())) {
-            builder.tags().remove(entry.getKey());
-            agg.add(entry.getKey());
-          }
-        }
-      }
-      
-      if (!agg.isEmpty()) {
-        builder.setAggregatedTags(Lists.newArrayList(agg));
-      }
-      return builder.build();
-    }
-    
-    /**
-     * Merges the time series into a new ID, promoting tags to aggregated or 
-     * disjoint tags and combining namespaces, metrics and unique IDs.
-     * @return A non-null time series ID.
-     */
-    private TimeSeriesId mergeStringIds() {
-      if (ids.size() == 1) {
-        return ids.get(0);
-      }
-      
-      String first_namespace = null;
-      String first_metric = null;
-      Map<String, String> tags = null;
-      Set<String> aggregated_tags = null;
-      Set<String> disjoint_tags = null;
-      Set<String> unique_ids = null;
-      
-      int i = 0;
-      for (final TimeSeriesId raw_id : ids) {
-        final TimeSeriesStringId id = (TimeSeriesStringId) raw_id;
-        if (Strings.isNullOrEmpty(first_namespace)) {
-          first_namespace = id.namespace();
-        }
-        
-        if (Strings.isNullOrEmpty(first_metric)) {
-          first_metric = id.metric();
-        }
-        
-        // agg and disjoint BEFORE tags
-        if (id.aggregatedTags() != null && !id.aggregatedTags().isEmpty()) {
-          for (final String tag : id.aggregatedTags()) {
-            if (!Strings.isNullOrEmpty(tag) && tags != null && tags.containsKey(tag)) {
-              tags.remove(tag);
-              if (aggregated_tags == null) {
-                aggregated_tags = Sets.newHashSetWithExpectedSize(1);
-              }
-              aggregated_tags.add(tag);
-            } else {
-              if (disjoint_tags != null && disjoint_tags.contains(tag)) {
-                // no-op
-              } else {
-                if (aggregated_tags == null) {
-                  aggregated_tags = Sets.newHashSetWithExpectedSize(1);
-                }
-                if (i < 1) {
-                  aggregated_tags.add(tag);
-                } else {
-                  if (aggregated_tags != null && !aggregated_tags.contains(tag)) {
-                    if (disjoint_tags == null) {
-                      disjoint_tags = Sets.newHashSetWithExpectedSize(1);
-                    }
-                    disjoint_tags.add(tag);
-                  }
-                }
-              }
-            }
-          }
-        }
-        
-        if (id.disjointTags() != null && !id.disjointTags().isEmpty()) {
-          for (final String tag : id.disjointTags()) {
-            if (tags != null && tags.containsKey(tag)) {
-              tags.remove(tag);
-            }
-            if (aggregated_tags != null && aggregated_tags.contains(tag)) {
-              aggregated_tags.remove(tag);
-            }
-            if (disjoint_tags == null) {
-              disjoint_tags = Sets.newHashSetWithExpectedSize(1);
-            }
-            disjoint_tags.add(tag);
-          }
-        }
-        
-        if (id.tags() != null && !id.tags().isEmpty()) {
-          if (tags == null) {
-            tags = Maps.newHashMapWithExpectedSize(id.tags().size());
-          }
-          
-          for (final Entry<String, String> pair : id.tags().entrySet()) {
-            if (disjoint_tags != null && disjoint_tags.contains(pair.getKey())) {
-              continue;
-            }
-            if (aggregated_tags != null && aggregated_tags.contains(pair.getKey())) {
-              continue;
-            }
-            
-            // check tag and values!
-            final String existing_value = tags.get(pair.getKey());
-            if (existing_value == null) {
-              if (i > 0) {
-                // disjoint!
-                if (disjoint_tags == null) {
-                  disjoint_tags = Sets.newHashSetWithExpectedSize(1);
-                }
-                disjoint_tags.add(pair.getKey());
-              } else {
-                tags.put(pair.getKey(), pair.getValue());
-              }
-            } else if (!existing_value.equals(pair.getValue())) {
-              // move to agg
-              if (aggregated_tags == null) {
-                aggregated_tags = Sets.newHashSetWithExpectedSize(1);
-              }
-              aggregated_tags.add(pair.getKey());
-              tags.remove(pair.getKey());
-            }
-          }
-          
-          // reverse
-          if (tags != null) {
-            final Iterator<Entry<String, String>> it = tags.entrySet().iterator();
-            while (it.hasNext()) {
-              final Entry<String, String> pair = it.next();
-              if (!id.tags().containsKey(pair.getKey())) {
-                // disjoint!
-                if (disjoint_tags == null) {
-                  disjoint_tags = Sets.newHashSetWithExpectedSize(1);
-                }
-                disjoint_tags.add(pair.getKey());
-                it.remove();
-              }
-            }
-          }
-        } // end id tags check
-        
-        // reverse agg
-        if (aggregated_tags != null && i > 0) {
-          final Iterator<String> it = aggregated_tags.iterator();
-          while(it.hasNext()) {
-            final String tag = it.next();
-            if (id.tags() != null && id.tags().containsKey(tag)) {
-              // good, keep it
-              continue;
-            }
-            if (id.aggregatedTags() != null && !id.aggregatedTags().isEmpty()) {
-              boolean matched = false;
-              for (final String other : id.aggregatedTags()) {
-                if (tag.equals(other)) {
-                  matched = true;
-                  break;
-                }
-              }
-              if (matched) {
-                continue;
-              }
-            }
-            
-            if (disjoint_tags == null) {
-              disjoint_tags = Sets.newHashSetWithExpectedSize(1);
-            }
-            disjoint_tags.add(tag);
-            it.remove();
-          }
-        } // end reverse agg check
-        
-        if (id.uniqueIds() != null && !id.uniqueIds().isEmpty()) {
-          if (unique_ids == null) {
-            unique_ids = Sets.newHashSetWithExpectedSize(1);
-          }
-          unique_ids.addAll(id.uniqueIds());
-        }
-        i++;
-      }
-      
-      final BaseTimeSeriesStringId.Builder builder = BaseTimeSeriesStringId.newBuilder();
-      if (alias != null && alias.length > 0) {
-        builder.setAlias(new String(alias, Const.UTF8_CHARSET));
-      }
-      if (namespace == null || namespace.length < 1) {
-        builder.setNamespace(first_namespace);
-      } else {
-        builder.setNamespace(new String(namespace, Const.UTF8_CHARSET));
-      }
-      if (metric == null || metric.length < 1) {
-        builder.setMetric(first_metric);
-      } else {
-        builder.setMetric(new String(metric, Const.UTF8_CHARSET));
-      }
-      if (tags != null && !tags.isEmpty()) {
-        builder.setTags(tags);
-      }
-      if (aggregated_tags != null && !aggregated_tags.isEmpty()) {
-        for (final String tag : aggregated_tags) {
-          builder.addAggregatedTag(tag);
-        }
-      }
-      if (disjoint_tags != null && !disjoint_tags.isEmpty()) {
-        for (final String tag : disjoint_tags) {
-          builder.addDisjointTag(tag);
-        }
-      }
-      return builder.build();
+      return id;
     }
 
+  }
+
+  protected interface MergingTimeSeriesId extends TimeSeriesId {
+
     /**
-     * Merges the time series into a new ID, promoting tags to aggregated or 
-     * disjoint tags and combining namespaces, metrics and unique IDs.
-     * @return A non-null time series ID.
+     * Adds a non-null ID, merging and promoting tags per the rules.
+     *
+     * @param id A non-null ID to merge.
      */
-    private TimeSeriesId mergeByteIds() {
-      if (ids.size() == 1) {
-        return ids.get(0);
+    void addSeries(final TimeSeriesId id);
+
+  }
+
+  /**
+   * The ByteID version of a mergeing ID.
+   */
+  protected static class MergingByteId extends BaseTimeSeriesByteId
+          implements MergingTimeSeriesId {
+
+    protected boolean fullMerge;
+    protected ByteSet aggTags;
+    protected ByteSet disjointTags;
+
+    public MergingByteId(final TimeSeriesDataSourceFactory data_store,
+                         final boolean fullMerge) {
+      super(data_store);
+      this.fullMerge = fullMerge;
+    }
+
+    @Override
+    public List<byte[]> aggregatedTags() {
+      if (aggregated_tags == null) {
+        aggregated_tags = aggTags == null ? Collections.emptyList() :
+                Lists.newArrayList(aggTags);
       }
-      
-      byte[] first_namespace = null;
-      byte[] first_metric = null;
-      ByteMap<byte[]> tags = null;
-      ByteSet aggregated_tags = null;
-      ByteSet disjoint_tags = null;
-      ByteSet unique_ids = null;
-      
-      int i = 0;
-      for (final TimeSeriesId raw_id : ids) {
-        final TimeSeriesByteId id = (TimeSeriesByteId) raw_id;
-        if (Bytes.isNullOrEmpty(first_namespace)) {
-          first_namespace = id.namespace();
-        }
-        
-        if (Bytes.isNullOrEmpty(first_metric)) {
-          first_metric = id.metric();
-        }
-        
-        // agg and disjoint BEFORE tags
-        if (id.aggregatedTags() != null && !id.aggregatedTags().isEmpty()) {
-          for (final byte[] tag : id.aggregatedTags()) {
-            if (!Bytes.isNullOrEmpty(tag) && tags != null && tags.containsKey(tag)) {
-              tags.remove(tag);
-              if (aggregated_tags == null) {
-                aggregated_tags = new ByteSet();
+      return aggregated_tags;
+    }
+
+    @Override
+    public List<byte[]> disjointTags() {
+      if (disjoint_tags == null) {
+        disjoint_tags = disjointTags == null ? Collections.emptyList() :
+                Lists.newArrayList(disjointTags);
+      }
+      return disjoint_tags;
+    }
+
+    @Override
+    public long buildHashCode() {
+      if (aggregated_tags == null) {
+        aggregated_tags = aggTags == null ? Collections.emptyList() :
+                Lists.newArrayList(aggTags);
+      }
+
+      if (disjoint_tags == null) {
+        disjoint_tags = disjointTags == null ? Collections.emptyList() :
+                Lists.newArrayList(disjointTags);
+      }
+
+      return super.buildHashCode();
+    }
+
+    @Override
+    public void addSeries(final TimeSeriesId raw_id) {
+      // TODO - validations
+      if (metric == null) {
+        // first ID
+        copyInitial((TimeSeriesByteId) raw_id);
+        return;
+      }
+
+      // merge!
+      // TODO - validations
+      TimeSeriesByteId id = (TimeSeriesByteId) raw_id;
+      if (id.aggregatedTags() != null && !id.aggregatedTags().isEmpty()) {
+        for (int i = 0; i < id.aggregatedTags().size(); i++) {
+          final byte[] tag = id.aggregatedTags().get(i);
+
+          // migrate from the tags set if present.
+          if (tags != null && tags.containsKey(tag)) {
+            tags.remove(tag);
+            if (aggTags == null) {
+              aggTags = new ByteSet();
+            }
+            aggTags.add(tag);
+          } else if (fullMerge && disjointTags != null && disjointTags.contains(tag)) {
+            // No-op
+          } else {
+            if (aggTags == null) {
+              aggTags = new ByteSet();
+              aggTags.add(tag);
+            } else if (fullMerge && !aggTags.contains(tag)) {
+              if (disjointTags == null) {
+                disjointTags = new ByteSet();
               }
-              aggregated_tags.add(tag);
-            } else {
-              if (disjoint_tags != null && disjoint_tags.contains(tag)) {
-                // no-op
-              } else {
-                if (aggregated_tags == null) {
-                  aggregated_tags = new ByteSet();
-                }
-                if (i < 1) {
-                  aggregated_tags.add(tag);
-                } else {
-                  if (aggregated_tags != null && !aggregated_tags.contains(tag)) {
-                    if (disjoint_tags == null) {
-                      disjoint_tags = new ByteSet();
-                    }
-                    disjoint_tags.add(tag);
-                  }
-                }
-              }
-            }
-          }
-        }
-        
-        if (id.disjointTags() != null && !id.disjointTags().isEmpty()) {
-          for (final byte[] tag : id.disjointTags()) {
-            if (tags != null && tags.containsKey(tag)) {
-              tags.remove(tag);
-            }
-            if (aggregated_tags != null && aggregated_tags.contains(tag)) {
-              aggregated_tags.remove(tag);
-            }
-            if (disjoint_tags == null) {
-              disjoint_tags = new ByteSet();
-            }
-            disjoint_tags.add(tag);
-          }
-        }
-        
-        if (id.tags() != null && !id.tags().isEmpty()) {
-          if (tags == null) {
-            tags = new ByteMap<byte[]>();
-          }
-          
-          for (final Entry<byte[], byte[]> pair : id.tags().entrySet()) {
-            if (disjoint_tags != null && disjoint_tags.contains(pair.getKey())) {
-              continue;
-            }
-            if (aggregated_tags != null && aggregated_tags.contains(pair.getKey())) {
-              continue;
-            }
-            
-            // check tag and values!
-            final byte[] existing_value = tags.get(pair.getKey());
-            if (Bytes.isNullOrEmpty(existing_value)) {
-              if (i > 0) {
-                // disjoint!
-                if (disjoint_tags == null) {
-                  disjoint_tags = new ByteSet();
-                }
-                disjoint_tags.add(pair.getKey());
-              } else {
-                tags.put(pair.getKey(), pair.getValue());
-              }
-            } else if (Bytes.memcmp(existing_value, pair.getValue()) != 0) {
-              // move to agg
-              if (aggregated_tags == null) {
-                aggregated_tags = new ByteSet();
-              }
-              aggregated_tags.add(pair.getKey());
-              tags.remove(pair.getKey());
-            }
-          }
-          
-          // reverse
-          if (tags != null) {
-            final Iterator<Entry<byte[], byte[]>> it = tags.entrySet().iterator();
-            while (it.hasNext()) {
-              final Entry<byte[], byte[]> pair = it.next();
-              if (!id.tags().containsKey(pair.getKey())) {
-                // disjoint!
-                if (disjoint_tags == null) {
-                  disjoint_tags = new ByteSet();
-                }
-                disjoint_tags.add(pair.getKey());
-                it.remove();
+
+              if (!disjointTags.contains(tag)) {
+                disjointTags.add(tag);
               }
             }
           }
-        } // end id tags check
-        
-        // reverse agg
-        if (aggregated_tags != null && i > 0) {
-          final Iterator<byte[]> it = aggregated_tags.iterator();
-          while(it.hasNext()) {
-            final byte[] tag = it.next();
-            if (id.tags() != null && id.tags().containsKey(tag)) {
-              // good, keep it
-              continue;
-            }
-            if (id.aggregatedTags() != null && !id.aggregatedTags().isEmpty()) {
-              boolean matched = false;
-              for (final byte[] other : id.aggregatedTags()) {
-                if (Bytes.memcmp(tag, other) == 0) {
-                  matched = true;
-                  break;
-                }
-              }
-              if (matched) {
-                continue;
-              }
-            }
-            
-            if (disjoint_tags == null) {
-              disjoint_tags = new ByteSet();
-            }
-            disjoint_tags.add(tag);
-            it.remove();
+        }
+      }
+
+      // check disjoints.
+      if (fullMerge && id.disjointTags() != null && !id.disjointTags().isEmpty()) {
+        for (int i = 0; i < id.disjointTags().size(); i++) {
+          final byte[] tag = id.disjointTags().get(i);
+
+          // migrate from the tags set.
+          if (tags != null && tags.containsKey(tag)) {
+            tags.remove(tag);
           }
-        } // end reverse agg check
-        
-        if (id.uniqueIds() != null && !id.uniqueIds().isEmpty()) {
-          if (unique_ids == null) {
-            unique_ids = new ByteSet();
+
+          if (aggTags != null && aggTags.contains(tag)) {
+            aggTags.remove(tag);
           }
-          unique_ids.addAll(id.uniqueIds());
-        }
-        i++;
-      }
-      
-      final BaseTimeSeriesByteId.Builder builder = 
-          BaseTimeSeriesByteId.newBuilder(data_store);
-      if (Bytes.isNullOrEmpty(alias)) {
-        builder.setAlias(alias);
-      }
-      if (Bytes.isNullOrEmpty(namespace)) {
-        builder.setNamespace(first_namespace);
-      } else {
-        builder.setNamespace(namespace);
-      }
-      if (metric == null || metric.length < 1) {
-        builder.setMetric(first_metric);
-      } else {
-        builder.setMetric(metric);
-      }
-      if (tags != null && !tags.isEmpty()) {
-        builder.setTags(tags);
-      }
-      if (aggregated_tags != null && !aggregated_tags.isEmpty()) {
-        for (final byte[] tag : aggregated_tags) {
-          builder.addAggregatedTag(tag);
+
+          if (disjointTags == null) {
+            disjointTags = new ByteSet();
+          }
+          if (!disjointTags.contains(tag)) {
+            disjointTags.add(tag);
+          }
         }
       }
-      if (disjoint_tags != null && !disjoint_tags.isEmpty()) {
-        for (final byte[] tag : disjoint_tags) {
-          builder.addDisjointTag(tag);
+
+      // now check tags
+      if (id.tags() != null && !id.tags().isEmpty()) {
+        if (tags == null) {
+          tags = new ByteMap<byte[]>();
+        }
+
+        for (Map.Entry<byte[], byte[]> pair : id.tags().entrySet()) {
+          final byte[] key = pair.getKey();
+          if (fullMerge && disjointTags != null && disjointTags.contains(key)) {
+            continue;
+          }
+          if (aggTags != null && aggTags.contains(key)) {
+            continue;
+          }
+
+          final byte[] extant = tags.get(key);
+          if (Bytes.isNullOrEmpty(extant)) {
+            if (fullMerge) {
+              // disjoint!
+              if (disjointTags == null) {
+                disjointTags = new ByteSet();
+              }
+              disjointTags.add(key);
+            }
+          } else if (Bytes.memcmp(extant, pair.getValue()) != 0) {
+            // different value so we need to move to aggs
+            if (aggTags == null) {
+              aggTags = new ByteSet();
+            }
+            aggTags.add(key);
+            tags.remove(key);
+          }
         }
       }
-      return builder.build();
+
+      // reverse verify the tags
+      if (tags != null) {
+        final Iterator<Entry<byte[], byte[]>> iterator = tags.entrySet().iterator();
+        while (iterator.hasNext()) {
+          final Entry<byte[], byte[]> pair = iterator.next();
+          final byte[] key = pair.getKey();
+          if (!id.tags().containsKey(key)) {
+            // disjoint!
+            if (fullMerge) {
+              if (disjointTags == null) {
+                disjointTags = new ByteSet();
+              }
+              disjointTags.add(key);
+            }
+            iterator.remove();
+          }
+        }
+      }
+
+      // reverse agg
+      if (aggTags != null) {
+        final Iterator<byte[]> iterator = aggTags.iterator();
+        OuterLoop:
+        while (iterator.hasNext()) {
+          final byte[] tag = iterator.next();
+          if (id.tags() != null && id.tags().containsKey(tag)) {
+            // good keep it.
+            continue;
+          }
+
+          if (id.aggregatedTags() != null && !id.aggregatedTags().isEmpty()) {
+            for (final byte[] other : id.aggregatedTags()) {
+              if (Bytes.memcmp(tag, other) == 0) {
+                continue OuterLoop;
+              }
+            }
+          }
+
+          // disjoint!
+          if (disjointTags == null) {
+            disjointTags = new ByteSet();
+          }
+          disjointTags.add(tag);
+          iterator.remove();
+        }
+      }
+
+      if (id.uniqueIds() != null && !id.uniqueIds().isEmpty()) {
+        if (unique_ids == null) {
+          unique_ids = new ByteSet();
+        }
+        unique_ids.addAll(id.uniqueIds());
+      }
+    }
+
+    void copyInitial(final TimeSeriesByteId id) {
+      if (id.alias() != null) {
+        alias = id.alias();
+      }
+      if (id.namespace() != null) {
+        namespace = id.namespace();
+      }
+      if (id.metric() != null) {
+        metric = id.metric();
+      }
+
+      if (id.tags() != null && !id.tags().isEmpty()) {
+        tags = new ByteMap<byte[]>();
+        for (Map.Entry<byte[], byte[]> entry : id.tags().entrySet()) {
+          tags.put(entry.getKey(), entry.getValue());
+        }
+      }
+
+      if (id.aggregatedTags() != null && !id.aggregatedTags().isEmpty()) {
+        aggTags = new ByteSet();
+        for (int i = 0; i < id.aggregatedTags().size(); i++) {
+          aggTags.add(id.aggregatedTags().get(i));
+        }
+      }
+
+      if (id.disjointTags() != null && !id.disjointTags().isEmpty()) {
+        disjointTags = new ByteSet();
+        for (int i = 0; i < id.disjointTags().size(); i++) {
+          disjointTags.add( id.disjointTags().get(i));
+        }
+      }
+
+      if (id.uniqueIds() != null && !id.uniqueIds().isEmpty()) {
+        if (unique_ids == null) {
+          unique_ids = new ByteSet();
+        }
+        unique_ids.addAll(id.uniqueIds());
+      }
     }
   }
-  
+
+  /**
+   * String version of the merging ID.
+   */
+  protected static class MergingStringId extends BaseTimeSeriesStringId
+          implements MergingTimeSeriesId {
+
+    protected boolean fullMerge;
+    protected Set<String> aggTags;
+    protected Set<String> disjointTags;
+
+    public MergingStringId(final boolean fullMerge) {
+      super();
+      this.fullMerge = fullMerge;
+    }
+
+    @Override
+    public List<String> aggregatedTags() {
+      if (aggregated_tags == null) {
+        aggregated_tags = aggTags == null ? Collections.emptyList() :
+                Lists.newArrayList(aggTags);
+      }
+      return aggregated_tags;
+    }
+
+    @Override
+    public List<String> disjointTags() {
+      if (disjoint_tags == null) {
+        disjoint_tags = disjointTags == null ? Collections.emptyList() :
+                Lists.newArrayList(disjointTags);
+      }
+      return disjoint_tags;
+    }
+
+    @Override
+    public long buildHashCode() {
+      if (aggregated_tags == null) {
+        aggregated_tags = aggTags == null ? Collections.emptyList() :
+                Lists.newArrayList(aggTags);
+      }
+
+      if (disjoint_tags == null) {
+        disjoint_tags = disjointTags == null ? Collections.emptyList() :
+                Lists.newArrayList(disjointTags);
+      }
+
+      return super.buildHashCode();
+    }
+
+    @Override
+    public void addSeries(final TimeSeriesId raw_id) {
+      // TODO - validations
+      if (metric == null) {
+        // first ID
+        copyInitial((TimeSeriesStringId) raw_id);
+        return;
+      }
+
+      // merge!
+      // TODO - validations
+      TimeSeriesStringId id = (TimeSeriesStringId) raw_id;
+      if (id.aggregatedTags() != null && !id.aggregatedTags().isEmpty()) {
+        for (int i = 0; i < id.aggregatedTags().size(); i++) {
+          final String tag = id.aggregatedTags().get(i);
+
+          // migrate from the tags set if present.
+          if (tags != null && tags.containsKey(tag)) {
+            tags.remove(tag);
+            if (aggTags == null) {
+              aggTags = Sets.newHashSet();
+            }
+            aggTags.add(tag);
+          } else if (fullMerge && disjointTags != null && disjointTags.contains(tag)) {
+            // No-op
+          } else {
+            if (aggTags == null) {
+              aggTags = Sets.newHashSet();
+              aggTags.add(tag);
+            } else if (fullMerge && !aggTags.contains(tag)) {
+              if (disjointTags == null) {
+                disjointTags = Sets.newHashSet();
+              }
+
+              if (!disjointTags.contains(tag)) {
+                disjointTags.add(tag);
+              }
+            }
+          }
+        }
+      }
+
+      // check disjoints.
+      if (fullMerge && id.disjointTags() != null && !id.disjointTags().isEmpty()) {
+        for (int i = 0; i < id.disjointTags().size(); i++) {
+          final String tag = id.disjointTags().get(i);
+
+          // migrate from the tags set.
+          if (tags != null && tags.containsKey(tag)) {
+            tags.remove(tag);
+          }
+
+          if (aggTags != null && aggTags.contains(tag)) {
+            aggTags.remove(tag);
+          }
+
+          if (disjointTags == null) {
+            disjointTags = Sets.newHashSet();
+          }
+          if (!disjointTags.contains(tag)) {
+            disjointTags.add(tag);
+          }
+        }
+      }
+
+      // now check tags
+      if (id.tags() != null && !id.tags().isEmpty()) {
+        if (tags == null) {
+          tags = Maps.newHashMap();
+        }
+
+        for (Map.Entry<String, String> pair : id.tags().entrySet()) {
+          final String key = pair.getKey();
+          if (fullMerge && disjointTags != null && disjointTags.contains(key)) {
+            continue;
+          }
+          if (aggTags != null && aggTags.contains(key)) {
+            continue;
+          }
+
+          final String extant = tags.get(key);
+          if (Strings.isNullOrEmpty(extant)) {
+            if (fullMerge) {
+              // disjoint!
+              if (disjointTags == null) {
+                disjointTags = Sets.newHashSet();
+              }
+              disjointTags.add(key);
+            }
+          } else if (!extant.equals(pair.getValue())) {
+            // different value so we need to move to aggs
+            if (aggTags == null) {
+              aggTags = Sets.newHashSet();
+            }
+            aggTags.add(key);
+            tags.remove(key);
+          }
+        }
+      }
+
+      // reverse verify the tags
+      if (tags != null) {
+        final Iterator<Entry<String, String>> iterator = tags.entrySet().iterator();
+        while (iterator.hasNext()) {
+          final Entry<String, String> pair = iterator.next();
+          final String key = pair.getKey();
+          if (!id.tags().containsKey(key)) {
+            // disjoint!
+            if (fullMerge) {
+              if (disjointTags == null) {
+                disjointTags = Sets.newHashSet();
+              }
+              disjointTags.add(key);
+            }
+            iterator.remove();
+          }
+        }
+      }
+
+      // reverse agg
+      if (aggTags != null) {
+        final Iterator<String> iterator = aggTags.iterator();
+        OuterLoop:
+        while (iterator.hasNext()) {
+          final String tag = iterator.next();
+          if (id.tags() != null && id.tags().containsKey(tag)) {
+            // good keep it.
+            continue;
+          }
+
+          if (id.aggregatedTags() != null && !id.aggregatedTags().isEmpty()) {
+            for (final String other : id.aggregatedTags()) {
+              if (tag.equals(other)) {
+                continue OuterLoop;
+              }
+            }
+          }
+
+          // disjoint!
+          if (disjointTags == null) {
+            disjointTags = Sets.newHashSet();
+          }
+          disjointTags.add(tag);
+          iterator.remove();
+        }
+      }
+
+      if (id.uniqueIds() != null && !id.uniqueIds().isEmpty()) {
+        if (unique_ids == null) {
+          unique_ids = Sets.newHashSet();
+        }
+        unique_ids.addAll(id.uniqueIds());
+      }
+    }
+
+    void copyInitial(final TimeSeriesStringId id) {
+      if (id.alias() != null) {
+        alias = id.alias();
+      }
+      if (id.namespace() != null) {
+        namespace = id.namespace();
+      }
+      if (id.metric() != null) {
+        metric = id.metric();
+      }
+
+      if (id.tags() != null && !id.tags().isEmpty()) {
+        tags = Maps.newHashMap();
+        for (Map.Entry<String, String> entry : id.tags().entrySet()) {
+          tags.put(entry.getKey(), entry.getValue());
+        }
+      }
+
+      if (id.aggregatedTags() != null && !id.aggregatedTags().isEmpty()) {
+        aggTags = Sets.newHashSet();
+        for (int i = 0; i < id.aggregatedTags().size(); i++) {
+          aggTags.add(id.aggregatedTags().get(i));
+        }
+      }
+
+      if (id.disjointTags() != null && !id.disjointTags().isEmpty()) {
+        disjointTags = Sets.newHashSet();
+        for (int i = 0; i < id.disjointTags().size(); i++) {
+          disjointTags.add( id.disjointTags().get(i));
+        }
+      }
+
+      if (id.uniqueIds() != null && !id.uniqueIds().isEmpty()) {
+        if (unique_ids == null) {
+          unique_ids = Sets.newHashSet();
+        }
+        unique_ids.addAll(id.uniqueIds());
+      }
+    }
+  }
 }

--- a/core/src/test/java/net/opentsdb/data/TestMergedTimeSeriesId.java
+++ b/core/src/test/java/net/opentsdb/data/TestMergedTimeSeriesId.java
@@ -1,5 +1,5 @@
 // This file is part of OpenTSDB.
-// Copyright (C) 2017-2018  The OpenTSDB Authors.
+// Copyright (C) 2017-2021  The OpenTSDB Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,15 +16,12 @@ package net.opentsdb.data;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import net.opentsdb.common.Const;
 
 public class TestMergedTimeSeriesId {
   private static final byte[] BYTES_1 = "Tyrell".getBytes();
@@ -49,52 +46,7 @@ public class TestMergedTimeSeriesId {
   public void before() throws Exception {
     data_store = mock(TimeSeriesDataSourceFactory.class);
   }
-  
-  @Test
-  public void setAlias() throws Exception {
-    MergedTimeSeriesId.Builder builder = MergedTimeSeriesId.newBuilder();
-    assertNull(builder.alias);
-    
-    builder.setAlias("alias");
-    assertArrayEquals("alias".getBytes(Const.UTF8_CHARSET), builder.alias);
-    
-    builder.setAlias((String) null);
-    assertNull(builder.alias);
-    
-    builder.setAlias(new byte[] { 'h', 'i' });
-    assertArrayEquals("hi".getBytes(Const.UTF8_CHARSET), builder.alias);
-  }
-  
-  @Test
-  public void setNamespace() throws Exception {
-    MergedTimeSeriesId.Builder builder = MergedTimeSeriesId.newBuilder();
-    assertNull(builder.namespace);
-    
-    builder.setNamespace("namespace");
-    assertArrayEquals("namespace".getBytes(Const.UTF8_CHARSET), builder.namespace);
-    
-    builder.setNamespace((String) null);
-    assertNull(builder.namespace);
-    
-    builder.setNamespace(new byte[] { 'n', 's' });
-    assertArrayEquals("ns".getBytes(Const.UTF8_CHARSET), builder.namespace);
-  }
-  
-  @Test
-  public void setMetric() throws Exception {
-    MergedTimeSeriesId.Builder builder = MergedTimeSeriesId.newBuilder();
-    assertNull(builder.metric);
-    
-    builder.setMetric("metric");
-    assertArrayEquals("metric".getBytes(Const.UTF8_CHARSET), builder.metric);
-    
-    builder.setMetric((String) null);
-    assertNull(builder.metric);
-    
-    builder.setMetric(new byte[] { 'm', 'e', 't' });
-    assertArrayEquals("met".getBytes(Const.UTF8_CHARSET), builder.metric);
-  }
-  
+
   @Test
   public void addSeries() throws Exception {
     TimeSeriesStringId a = BaseTimeSeriesStringId.newBuilder()
@@ -110,22 +62,17 @@ public class TestMergedTimeSeriesId {
         .setFullMerge(true)
       .addSeries(a)
       .addSeries(b);
-    assertEquals(2, builder.ids.size());
-    assertEquals(Const.TS_STRING_ID, builder.type);
     
     try {
       builder.addSeries(mock(TimeSeriesByteId.class));
       fail("Expected RuntimeException");
     } catch (RuntimeException e) { }
-    assertEquals(2, builder.ids.size());
-    assertEquals(Const.TS_STRING_ID, builder.type);
     
     try {
       builder.addSeries(null);
       fail("Expected RuntimeException");
     } catch (RuntimeException e) { }
-    assertEquals(2, builder.ids.size());
-    assertEquals(Const.TS_STRING_ID, builder.type);
+
     
     TimeSeriesByteId c = BaseTimeSeriesByteId.newBuilder(data_store)
         .setNamespace(BYTES_1)
@@ -139,176 +86,18 @@ public class TestMergedTimeSeriesId {
         .setFullMerge(true)
         .addSeries(c)
         .addSeries(d);
-      assertEquals(2, builder.ids.size());
-      assertEquals(Const.TS_BYTE_ID, builder.type);
-      
-      d = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataSourceFactory.class))
-          .setNamespace(BYTES_2_ALT)
-          .setMetric(METRIC)
-          .build();
-      try {
-        MergedTimeSeriesId.newBuilder()
+
+    d = BaseTimeSeriesByteId.newBuilder(mock(TimeSeriesDataSourceFactory.class))
+        .setNamespace(BYTES_2_ALT)
+        .setMetric(METRIC)
+        .build();
+    MergedTimeSeriesId.newBuilder()
         .setFullMerge(true)
           .addSeries(c)
           .addSeries(d)
           .build();
-        fail("Expected RuntimeException");
-      } catch (RuntimeException e) { }
-  }
-  
-  @Test
-  public void alias() throws Exception {
-    TimeSeriesStringId a = BaseTimeSeriesStringId.newBuilder()
-        .setAlias("Series A")
-        .setMetric("ice.dragon")
-        .build();
-    TimeSeriesStringId b = BaseTimeSeriesStringId.newBuilder()
-        .setAlias("Series B")
-        .setMetric("ice.dragon")
-        .build();
-    
-    TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .addSeries(a)
-        .addSeries(b)
-        .build();
-    assertNull(merged.alias());
-    
-    merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .addSeries(a)
-        .addSeries(b)
-        .setAlias("Merged!")
-        .build();
-    assertEquals("Merged!", merged.alias());
-    
-    merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .addSeries(a)
-        .addSeries(b)
-        .setAlias("")
-        .build();
-    assertNull(merged.alias());
-    
-    merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .addSeries(a)
-        .addSeries(b)
-        .setAlias((String) null)
-        .build();
-    assertNull(merged.alias());
-    
-    merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .addSeries(a)
-        .addSeries(b)
-        .setAlias("Merged!")
-        .build();
-    assertEquals("Merged!", merged.alias());
-    
-    merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .addSeries(a)
-        .addSeries(b)
-        .setAlias("000001")
-        .build();
-    assertEquals("000001", merged.alias());
-  }
-  
-  @Test
-  public void mergeNameSpaces() throws Exception {
-    TimeSeriesStringId a = BaseTimeSeriesStringId.newBuilder()
-        .setNamespace("Tyrell")
-        .setMetric("ice.dragon")
-        .build();
-    TimeSeriesStringId b = BaseTimeSeriesStringId.newBuilder()
-        .setNamespace("Lanister")
-        .setMetric("ice.dragon")
-        .build();
-    TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .addSeries(a)
-        .addSeries(b)
-        .build();
-    assertEquals("Tyrell", merged.namespace());
-
-    merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .addSeries(a)
-        .addSeries(b)
-        .setNamespace("Dorne")
-        .build();
-    assertEquals("Dorne", merged.namespace());
-    
-    TimeSeriesByteId c = BaseTimeSeriesByteId.newBuilder(data_store)
-        .setNamespace(BYTES_1)
-        .setMetric(METRIC)
-        .build();
-    TimeSeriesByteId d = BaseTimeSeriesByteId.newBuilder(data_store)
-        .setNamespace(BYTES_2)
-        .setMetric(METRIC_ALT)
-        .build();
-    TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .addSeries(c)
-        .addSeries(d)
-        .build();
-    assertArrayEquals(BYTES_1, merged_bytes.namespace());
-    
-    merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .setNamespace(BYTES_3)
-        .addSeries(c)
-        .addSeries(d)
-        .build();
-    assertArrayEquals(BYTES_3, merged_bytes.namespace());
   }
 
-  @Test
-  public void mergeMetrics() throws Exception {
-    TimeSeriesStringId a = BaseTimeSeriesStringId.newBuilder()
-        .setMetric("Tyrell")
-        .build();
-    TimeSeriesStringId b = BaseTimeSeriesStringId.newBuilder()
-        .setMetric("Lanister")
-        .build();
-    TimeSeriesStringId merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .addSeries(a)
-        .addSeries(b)
-        .build();
-    assertEquals("Tyrell", merged.metric());
-
-    merged = (TimeSeriesStringId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .addSeries(a)
-        .addSeries(b)
-        .setMetric("Stark")
-        .build();
-    assertEquals("Stark", merged.metric());
-    
-    TimeSeriesByteId c = BaseTimeSeriesByteId.newBuilder(data_store)
-        .setMetric(BYTES_1)
-        .build();
-    TimeSeriesByteId d = BaseTimeSeriesByteId.newBuilder(data_store)
-        .setMetric(BYTES_2)
-        .build();
-    TimeSeriesByteId merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .addSeries(c)
-        .addSeries(d)
-        .build();
-    assertArrayEquals(BYTES_1, merged_bytes.metric());
-    
-    merged_bytes = (TimeSeriesByteId) MergedTimeSeriesId.newBuilder()
-        .setFullMerge(true)
-        .setMetric(BYTES_3)
-        .addSeries(c)
-        .addSeries(d)
-        .build();
-    assertArrayEquals(BYTES_3, merged_bytes.metric());
-  }
-  
   @Test
   public void mergeTagsSame() throws Exception {
     TimeSeriesStringId a = BaseTimeSeriesStringId.newBuilder()
@@ -661,10 +450,8 @@ public class TestMergedTimeSeriesId {
         merged.tags().get("host"));
     assertTrue(merged.aggregatedTags().isEmpty());
     assertEquals(2, merged.disjointTags().size());
-    assertEquals("colo", 
-        merged.disjointTags().get(0));
-    assertEquals("owner", 
-        merged.disjointTags().get(1));
+    assertTrue(merged.disjointTags().contains("colo"));
+    assertTrue(merged.disjointTags().contains("owner"));
     
     TimeSeriesByteId c = BaseTimeSeriesByteId.newBuilder(data_store)
         .addTags(FAMILY, BYTES_1)
@@ -709,14 +496,10 @@ public class TestMergedTimeSeriesId {
     assertTrue(merged.tags().isEmpty());
     assertTrue(merged.aggregatedTags().isEmpty());
     assertEquals(4, merged.disjointTags().size());
-    assertEquals("colo", 
-        merged.disjointTags().get(0));
-    assertEquals("dept", 
-        merged.disjointTags().get(1));
-    assertEquals("host", 
-        merged.disjointTags().get(2));
-    assertEquals("owner", 
-        merged.disjointTags().get(3));
+    assertTrue(merged.disjointTags().contains("colo"));
+    assertTrue(merged.disjointTags().contains("dept"));
+    assertTrue(merged.disjointTags().contains("host"));
+    assertTrue(merged.disjointTags().contains("owner"));
     
     TimeSeriesByteId c = BaseTimeSeriesByteId.newBuilder(data_store)
         .addTags(FAMILY, BYTES_1)
@@ -966,10 +749,8 @@ public class TestMergedTimeSeriesId {
     assertEquals("host", 
         merged.aggregatedTags().get(0));
     assertEquals(2, merged.disjointTags().size());
-    assertEquals("colo", 
-        merged.disjointTags().get(0));
-    assertEquals("owner", 
-        merged.disjointTags().get(1));
+    assertTrue(merged.disjointTags().contains("colo"));
+    assertTrue(merged.disjointTags().contains("owner"));
     
     TimeSeriesByteId c = BaseTimeSeriesByteId.newBuilder(data_store)
         .addAggregatedTag(FAMILY)
@@ -1014,14 +795,10 @@ public class TestMergedTimeSeriesId {
     assertTrue(merged.tags().isEmpty());
     assertTrue(merged.aggregatedTags().isEmpty());
     assertEquals(4, merged.disjointTags().size());
-    assertEquals("colo", 
-        merged.disjointTags().get(0));
-    assertEquals("dept", 
-        merged.disjointTags().get(1));
-    assertEquals("host", 
-        merged.disjointTags().get(2));
-    assertEquals("owner", 
-        merged.disjointTags().get(3));
+    assertTrue(merged.disjointTags().contains("colo"));
+    assertTrue(merged.disjointTags().contains("dept"));
+    assertTrue(merged.disjointTags().contains("host"));
+    assertTrue(merged.disjointTags().contains("owner"));
     
     TimeSeriesByteId c = BaseTimeSeriesByteId.newBuilder(data_store)
         .addAggregatedTag(FAMILY)
@@ -1067,12 +844,9 @@ public class TestMergedTimeSeriesId {
     assertTrue(merged.tags().isEmpty());
     assertTrue(merged.aggregatedTags().isEmpty());
     assertEquals(3, merged.disjointTags().size());
-    assertEquals("colo", 
-        merged.disjointTags().get(0));
-    assertEquals("host", 
-        merged.disjointTags().get(1));
-    assertEquals("owner", 
-        merged.disjointTags().get(2));
+    assertTrue(merged.disjointTags().contains("colo"));
+    assertTrue(merged.disjointTags().contains("host"));
+    assertTrue(merged.disjointTags().contains("owner"));
     
     TimeSeriesByteId c = BaseTimeSeriesByteId.newBuilder(data_store)
         .addDisjointTag(FAMILY)

--- a/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByTimeSeries.java
+++ b/core/src/test/java/net/opentsdb/query/processor/groupby/TestGroupByTimeSeries.java
@@ -134,11 +134,7 @@ public class TestGroupByTimeSeries {
   @Test
   public void ctor() throws Exception {
     GroupByTimeSeries ts = new GroupByTimeSeries(node, result);
-    try {
-      ts.id();
-      fail("Expected NullPointerException");
-    } catch (NullPointerException e) { }
-    
+
     try {
       new GroupByTimeSeries(null, result);
       fail("Expected IllegalArgumentException");

--- a/executors/http/src/main/java/net/opentsdb/utils/DefaultSharedHttpClient.java
+++ b/executors/http/src/main/java/net/opentsdb/utils/DefaultSharedHttpClient.java
@@ -216,7 +216,8 @@ public class DefaultSharedHttpClient extends BaseTSDBPlugin
     }
     // TODO - parse out the exception
     throw new RemoteQueryExecutionException(content, remote_host, 
-        response.getStatusLine().getStatusCode(), order);
+        response != null ? response.getStatusLine().getStatusCode() : 500,
+            order);
   }
 
   String getConfigKey(final String key) {


### PR DESCRIPTION
- Rework the MergedTimeSeriesId to merge on add in the builder call.
  The reason being a time series ID could be released (in Aura now)
  before the final merged ID is read.

HTTP:
- Had an NPE in the error path.