### PR TITLE
DISTRIBUTION:

### DIFF
--- a/implementation/egads/pom.xml
+++ b/implementation/egads/pom.xml
@@ -42,6 +42,12 @@
            <groupId>com.yahoo.egads</groupId>
            <artifactId>egads</artifactId>
            <version>0.4.4</version>
+            <exclusions>
+               <exclusion>
+                  <groupId>org.apache.logging.log4j</groupId>
+                  <artifactId>log4j-core</artifactId>
+               </exclusion>
+            </exclusions>
          </dependency>
          <dependency>
            <groupId>org.slf4j</groupId>


### PR DESCRIPTION
- Drop the log4j-core dependency from EGADS in the final build.