### PR TITLE
upgrade jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10</version>
+            <version>2.9.10.8</version>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
### Motivation
jackson-databind-2.9.10 is vulnerable and we want to upgrade it to eliminate the vulnerability.
https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind

### Changed
Upgraded jackson-databind to 2.9.10.8