### PR TITLE
From security review

### DIFF
--- a/implementation/okta/src/main/java/net/opentsdb/auth/OktaIDCookieAuthFilter.java
+++ b/implementation/okta/src/main/java/net/opentsdb/auth/OktaIDCookieAuthFilter.java
@@ -63,6 +63,7 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 import java.util.Random;
+import java.util.SecureRandom;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -138,7 +139,7 @@ public class OktaIDCookieAuthFilter extends BaseAuthenticationPlugin {
    */
   public OktaIDCookieAuthFilter() {
     super();
-    random = new Random(System.currentTimeMillis());
+    random = new SecureRandom();
   }
 
   @Override

--- a/implementation/okta/src/main/java/net/opentsdb/auth/OktaIDCookieAuthFilter.java
+++ b/implementation/okta/src/main/java/net/opentsdb/auth/OktaIDCookieAuthFilter.java
@@ -57,13 +57,13 @@ import java.security.Key;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
+import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 import java.util.Random;
-import java.util.SecureRandom;
 import java.util.concurrent.ExecutionException;
 
 /**


### PR DESCRIPTION
Per documentation, the argumentless `SecureRandom` constructor seems sufficient to seed the PRNG instance with true-random information. Thoughts?

https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html