### PR TITLE
Fixed incorrect result of Count Downsampler when setting Rollup data

### DIFF
--- a/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericSummaryIterator.java
+++ b/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleNumericSummaryIterator.java
@@ -134,6 +134,12 @@ public class DownsampleNumericSummaryIterator implements QueryIterator {
               "sum");
       summary = -1;
       dp.resetValue(avg_id, Double.NaN);
+    } else if (config.getAggregator().equalsIgnoreCase("count")) {
+      agg_factory = node.pipelineContext().tsdb()
+          .getRegistry().getPlugin(NumericAggregatorFactory.class,
+              "sum");
+      summary = count_id;
+      dp.resetValue(count_id, Double.NaN);
     } else {
       agg_factory = node.pipelineContext().tsdb()
           .getRegistry().getPlugin(NumericAggregatorFactory.class, 


### PR DESCRIPTION
### Issue
When using Count Downsampler in an environment where Rollup data is pre-aggregated, incorrect results are returned.

In the case of Raw data, the number of valid data that existed during the time of the Downsample target is being counted.
This implementation is considered correct.

However, for Rollup data, this value should be output since pre-aggregated data already exists.

The existing implementation does not yield the correct aggregate data because Count Downsample is done in the same process as Raw data, even in cases where Rollup data is used.

### Resolution
When Count Downsample is used and Rollup data is used, fixed to output the value of pre-aggregated data.