### PR TITLE
Separate config for high cardinality and no records from meta.

### DIFF
--- a/common/src/main/java/net/opentsdb/meta/MetaDataStorageResult.java
+++ b/common/src/main/java/net/opentsdb/meta/MetaDataStorageResult.java
@@ -35,6 +35,7 @@ public interface MetaDataStorageResult {
     DATA,
     NO_DATA_FALLBACK,
     NO_DATA,
+    HIGH_CARDINALITY_FALLBACK,
     EXCEPTION_FALLBACK,
     EXCEPTION
   }

--- a/implementation/elasticsearch/src/main/java/net/opentsdb/meta/NamespacedAggregatedDocumentSchema.java
+++ b/implementation/elasticsearch/src/main/java/net/opentsdb/meta/NamespacedAggregatedDocumentSchema.java
@@ -56,6 +56,7 @@ public class NamespacedAggregatedDocumentSchema extends BaseTSDBPlugin implement
   public static final String TYPE = "NamespacedAggregatedDocumentSchema";
   public static final String FALLBACK_ON_EX_KEY = "fallback.exception";
   public static final String FALLBACK_ON_NO_DATA_KEY = "fallback.no_data";
+  public static final String FALLBACK_ON_HIGH_CARDINALITY_DATA_KEY = "fallback.high_cardinality_data";
   public static final String MAX_CARD_KEY = "max.cardinality";
   public static final String TAGS_STRING = "tags";
   public static final String CLIENT_ID = "client.id";
@@ -95,6 +96,14 @@ public class NamespacedAggregatedDocumentSchema extends BaseTSDBPlugin implement
               true,
               "Whether or not to fall back to scans when the meta "
                   + "query returns an empty data set.");
+    }
+    if (!tsdb.getConfig().hasProperty(getConfigKey(FALLBACK_ON_HIGH_CARDINALITY_DATA_KEY))) {
+      tsdb.getConfig()
+          .register(
+              getConfigKey(FALLBACK_ON_HIGH_CARDINALITY_DATA_KEY),
+              false,
+              true,
+              "Whether or not to fall back to scans when the meta query returns more than 5k records.");
     }
     if (!tsdb.getConfig().hasProperty(getConfigKey(FALLBACK_ON_EX_KEY))) {
       tsdb.getConfig()
@@ -196,6 +205,7 @@ public class NamespacedAggregatedDocumentSchema extends BaseTSDBPlugin implement
             false, 
             tsdb.getConfig().getInt(getConfigKey(MAX_CARD_KEY)),
             tsdb.getConfig().getBoolean(getConfigKey(FALLBACK_ON_NO_DATA_KEY)),
+            tsdb.getConfig().getBoolean(getConfigKey(FALLBACK_ON_HIGH_CARDINALITY_DATA_KEY)),
             child);
       }
 
@@ -315,6 +325,7 @@ public class NamespacedAggregatedDocumentSchema extends BaseTSDBPlugin implement
               true, 
               tsdb.getConfig().getInt(getConfigKey(MAX_CARD_KEY)),
               tsdb.getConfig().getBoolean(getConfigKey(FALLBACK_ON_NO_DATA_KEY)),
+              tsdb.getConfig().getBoolean(getConfigKey(FALLBACK_ON_HIGH_CARDINALITY_DATA_KEY)),
               child);
           return parse.entrySet().iterator().next().getValue();
         }

--- a/implementation/elasticsearch/src/main/java/net/opentsdb/meta/impl/MetaResponse.java
+++ b/implementation/elasticsearch/src/main/java/net/opentsdb/meta/impl/MetaResponse.java
@@ -33,5 +33,6 @@ public interface MetaResponse {
       final boolean is_multi_get,
       final int max_cardinality,
       final boolean fallback_on_no_data,
+      final boolean fallback_on_high_cardinality_data,
       final Span span);
 }

--- a/implementation/elasticsearch/src/main/java/net/opentsdb/meta/impl/es/ESMetaResponse.java
+++ b/implementation/elasticsearch/src/main/java/net/opentsdb/meta/impl/es/ESMetaResponse.java
@@ -18,7 +18,6 @@ package net.opentsdb.meta.impl.es;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import java.time.temporal.ChronoUnit;
-import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Sets;
 import net.opentsdb.core.TSDB;
@@ -61,7 +60,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 public class ESMetaResponse implements MetaResponse {
@@ -82,6 +80,7 @@ public class ESMetaResponse implements MetaResponse {
       final boolean isMultiGet,
       final int max_cardinality,
       final boolean fallback_on_no_data,
+      final boolean fallback_on_high_cardinality_data,
       final Span child) {
     final Map<NamespacedKey, MetaDataStorageResult> final_results = new LinkedHashMap<>();
 
@@ -137,8 +136,8 @@ public class ESMetaResponse implements MetaResponse {
                         + max_cardinality);
           }
           result =
-              new NamespacedAggregatedDocumentResult(fallback_on_no_data
-                      ? MetaDataStorageResult.MetaResult.NO_DATA_FALLBACK
+              new NamespacedAggregatedDocumentResult(fallback_on_high_cardinality_data
+                      ? MetaResult.HIGH_CARDINALITY_FALLBACK
                       : MetaDataStorageResult.MetaResult.NO_DATA,
                   null,
                   query);

--- a/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseQueryNode.java
+++ b/storage/asynchbase/src/main/java/net/opentsdb/storage/Tsdb1xHBaseQueryNode.java
@@ -54,7 +54,6 @@ import net.opentsdb.query.QueryNodeFactory;
 import net.opentsdb.query.QueryPipelineContext;
 import net.opentsdb.query.QueryResult;
 import net.opentsdb.query.TimeSeriesDataSourceConfig;
-import net.opentsdb.rollup.DefaultRollupInterval;
 import net.opentsdb.rollup.RollupUtils.RollupUsage;
 import net.opentsdb.stats.QueryStats;
 import net.opentsdb.stats.Span;
@@ -620,6 +619,12 @@ public class Tsdb1xHBaseQueryNode implements Tsdb1xQueryNode, Runnable {
       case NO_DATA_FALLBACK:
         if (LOG.isDebugEnabled()) {
           LOG.debug("No data returned from meta store." 
+              + " Falling back to scans.");
+        }
+        break; // fall through to scans
+      case HIGH_CARDINALITY_FALLBACK:
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("More than 5k records returned from meta store."
               + " Falling back to scans.");
         }
         break; // fall through to scans


### PR DESCRIPTION
* this gives and option to control the scans for separately.