### PR TITLE
remove protobug-java from the distribution.

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -31,6 +31,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>2.5.0</version>
+        <scope>provided</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Even tough protobuf-java has been shaded and relocated in opentsdb-asynchbase, the assembly plugin is still adding it to the distribution. This defeats the purpose of shading/relocating the protobuf-java.