### PR TITLE
Fix for #2269 and #2267 XSS vulnerability.

### DIFF
--- a/src/tsd/HttpQuery.java
+++ b/src/tsd/HttpQuery.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 
+import com.google.common.html.HtmlEscapers;
 import net.opentsdb.core.Const;
 import net.opentsdb.core.TSDB;
 import net.opentsdb.graph.Plot;
@@ -373,6 +374,10 @@ final class HttpQuery extends AbstractHttpQuery {
       buf.append("\"}");
       sendReply(HttpResponseStatus.INTERNAL_SERVER_ERROR, buf);
     } else {
+      String response = "";
+      if (pretty_exc != null) {
+        response = HtmlEscapers.htmlEscaper().escape(pretty_exc);
+      }
       sendReply(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                 makePage("Internal Server Error", "Houston, we have a problem",
                          "<blockquote>"
@@ -380,7 +385,7 @@ final class HttpQuery extends AbstractHttpQuery {
                          + "Oops, sorry but your request failed due to a"
                          + " server error.<br/><br/>"
                          + "Please try again in 30 seconds.<pre>"
-                         + pretty_exc
+                         + response
                          + "</pre></blockquote>"));
     }
   }
@@ -420,6 +425,10 @@ final class HttpQuery extends AbstractHttpQuery {
       buf.append("\"}");
       sendReply(HttpResponseStatus.BAD_REQUEST, buf);
     } else {
+      String response = "";
+      if (exception.getMessage() != null) {
+        response = HtmlEscapers.htmlEscaper().escape(exception.getMessage());
+      }
       sendReply(HttpResponseStatus.BAD_REQUEST,
                 makePage("Bad Request", "Looks like it's your fault this time",
                          "<blockquote>"
@@ -427,7 +436,7 @@ final class HttpQuery extends AbstractHttpQuery {
                          + "Sorry but your request was rejected as being"
                          + " invalid.<br/><br/>"
                          + "The reason provided was:<blockquote>"
-                         + exception.getMessage()
+                         + response
                          + "</blockquote></blockquote>"));
     }
   }

--- a/test/tsd/TestHttpQuery.java
+++ b/test/tsd/TestHttpQuery.java
@@ -795,6 +795,18 @@ public final class TestHttpQuery {
         query.response().getContent().toString(Charset.forName("UTF-8"))
         .substring(0, 15));
   }
+
+  @Test
+  public void internalErrorDeprecatedHTMLEscaped() {
+    HttpQuery query = NettyMocks.getQuery(tsdb, "");
+    query.internalError(new Exception("<script>alert(document.cookie)</script>"));
+
+    assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+        query.response().getStatus());
+    assertTrue(query.response().getContent().toString(Charset.forName("UTF-8")).contains(
+        "&lt;script&gt;alert(document.cookie)&lt;/script&gt;"
+    ));
+  }
   
   @Test
   public void internalErrorDeprecatedJSON() {
@@ -848,6 +860,17 @@ public final class TestHttpQuery {
         "<!DOCTYPE html>", 
         query.response().getContent().toString(Charset.forName("UTF-8"))
         .substring(0, 15));
+  }
+
+  @Test
+  public void badRequestDeprecatedHTMLEscaped() {
+    HttpQuery query = NettyMocks.getQuery(tsdb, "/");
+    query.badRequest(new BadRequestException("<script>alert(document.cookie)</script>"));
+
+    assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus());
+    assertTrue(query.response().getContent().toString(Charset.forName("UTF-8")).contains(
+        "The reason provided was:<blockquote>&lt;script&gt;alert(document.cookie)&lt;/script&gt;"
+    ));
   }
   
   @Test

--- a/test/tsd/TestQueryRpc.java
+++ b/test/tsd/TestQueryRpc.java
@@ -518,7 +518,7 @@ public final class TestQueryRpc {
     assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus());
     final String json =
         query.response().getContent().toString(Charset.forName("UTF-8"));
-    assertTrue(json.contains("No such name for 'foo': 'metrics'"));
+    assertTrue(json.contains("No such name for &#39;foo&#39;: &#39;metrics&#39;"));
   }
 
   @Test
@@ -579,7 +579,7 @@ public final class TestQueryRpc {
     assertEquals(HttpResponseStatus.BAD_REQUEST, query.response().getStatus());
     final String json =
         query.response().getContent().toString(Charset.forName("UTF-8"));
-    assertTrue(json.contains("No such name for 'foo': 'metrics'"));
+    assertTrue(json.contains("No such name for &#39;foo&#39;: &#39;metrics&#39;"));
   }
 
   @Test


### PR DESCRIPTION
Escaping the user supplied input when outputing the HTML for the old BadRequest HTML handlers should help. Thanks to the reporters. Fixes CVE-2018-13003.