### PR TITLE
upgrade undertow version

### DIFF
--- a/implementation/server-undertow/pom.xml
+++ b/implementation/server-undertow/pom.xml
@@ -17,7 +17,7 @@
     <packaging>jar</packaging>
     
     <properties>
-      <undertow.version>2.0.21.Final</undertow.version>
+      <undertow.version>2.2.25.Final</undertow.version>
     </properties>
     
     <dependencyManagement>


### PR DESCRIPTION
- undertow version `2.0.21` will not work with JDK 17 regarding retrieving the `javax.servlet.request.X509Certificate` from servlet request, `2.2.25` version works both with JDK 8 and 17