### PR TITLE
Add opentsdb.service file to local install and rpm, addresses #2306

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -741,10 +741,10 @@ install-data-etc:
 	init_file="$(top_srcdir)/build-aux/rpm/init.d/opentsdb" ; \
 	echo " $(INSTALL_SCRIPT)" $$init_file "$$destdatainitdir" ; \
 	$(INSTALL_SCRIPT) $$init_file "$$destdatainitdir" || exit 1; \
-	systemd_file="$(top_srcdir)/build-aux/rpm/systemd/opentsdb.service" ; \
-	systemd_file="$(top_srcdir)/build-aux/rpm/systemd/opentsdb@.service" ; \
-	echo " $(INSTALL_SCRIPT)" $$systemd_file "$$destdatasystemddir" ; \
-	$(INSTALL_SCRIPT) $$systemd_file "$$destdatasystemddir" || exit 1;
+	systemd_files="$$systemd_files $(top_srcdir)/build-aux/rpm/systemd/opentsdb.service" ; \
+	systemd_files="$$systemd_files $(top_srcdir)/build-aux/rpm/systemd/opentsdb@.service" ; \
+	echo " $(INSTALL_SCRIPT)" $$systemd_files "$$destdatasystemddir" ; \
+	$(INSTALL_SCRIPT) $$systemd_files "$$destdatasystemddir" || exit 1;
 
 uninstall-data-etc:
 	@$(NORMAL_UNINSTALL)

--- a/opentsdb.spec.in
+++ b/opentsdb.spec.in
@@ -72,6 +72,7 @@ rm -rf %{buildroot}
 %attr(0755,root,root) %{_datarootdir}/opentsdb/plugins
 %attr(0755,root,root) %{_datarootdir}/opentsdb/tools/*
 %attr(0755,root,root) %{_datarootdir}/opentsdb/etc/init.d/opentsdb
+%attr(0644,root,root) %{_datarootdir}/opentsdb/etc/systemd/system/opentsdb.service
 %attr(0644,root,root) %{_datarootdir}/opentsdb/etc/systemd/system/opentsdb@.service
 %config %{_datarootdir}/opentsdb/etc/opentsdb/opentsdb.conf
 %config %{_datarootdir}/opentsdb/etc/opentsdb/logback.xml


### PR DESCRIPTION
The standard systemd opentsdb.service file is not included in the built rpm which can result in a broken opentsdb service.  The install-data-local make target does not install this file as well.

This change addresses #2306